### PR TITLE
FiX alignment checks for pointer dereferences when debug assertions

### DIFF
--- a/rsbinder/src/binder_object.rs
+++ b/rsbinder/src/binder_object.rs
@@ -173,13 +173,13 @@ impl From<&SIBinder> for flat_binder_object {
 
 impl From<(*const u8, usize)> for &flat_binder_object {
     fn from(pointer: (*const u8, usize)) -> Self {
-        unsafe { & *(pointer.0.add(pointer.1) as *const flat_binder_object) }
+        unsafe { std::mem::transmute::<*const u8, &flat_binder_object>(&*(pointer.0.add(pointer.1))) }
     }
 }
 
 impl From<(*mut u8, usize)> for &mut flat_binder_object {
     fn from(pointer: (*mut u8, usize)) -> Self {
-        unsafe { &mut *(pointer.0.add(pointer.1) as *mut flat_binder_object) }
+        unsafe { std::mem::transmute::<*const u8, &mut flat_binder_object>(&*(pointer.0.add(pointer.1))) }
     }
 }
 


### PR DESCRIPTION

<img width="828" alt="截屏2024-03-04 14 47 53" src="https://github.com/hiking90/rsbinder/assets/148511745/7c3923fe-7bda-4986-825d-bb4107394e9e">


panic on Android 13  in debug mode


https://github.com/rust-lang/rust/pull/98112/files 

alignment checks for pointer dereferences when debug assertions are enabled, so use std::mem::transmute instead
