### PR TITLE
skip panic if enable oneway spam detection failed

### DIFF
--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -298,8 +298,9 @@ fn open_driver(driver: &Path, max_threads: u32) -> std::result::Result<File, Box
         log::info!("Binder driver max threads set to {}", max_threads);
 
         let enable = DEFAULT_ENABLE_ONEWAY_SPAM_DETECTION;
-        binder::enable_oneway_spam_detection(raw_fd, &enable)
-            .map_err(|e| format!("Binder ioctl to enable oneway spam detection failed: {}", e))?;
+        if let Err(e) = binder::enable_oneway_spam_detection(raw_fd, &enable){
+            log::warn!("Binder ioctl to enable oneway spam detection failed: {}", e)
+        }
     }
 
     Ok(fd)


### PR DESCRIPTION
enable_oneway_spam_detection maybe failed in some android device, and skip panic works ok 

## panic message
```
thread 'main' panicked at 'Error in init(): Binder ioctl to enable oneway spam detection failed: EINVAL: Invalid argument', rsbinder/rsbinder/src/process_state.rs:130:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
## android version
```
127|RE5473:/ # cat /proc/version
Linux version 4.19.125-perf+ (root@ubuntu-8-194) (clang version 10.0.7 for Android NDK, GNU ld (binutils-2.27-bd24d23f) 2.27.0.20170315) #1 SMP PREEMPT Mon Feb 21 19:08:20 CST 2022
RE5473:/ # 
```