### PR TITLE
Fix: Compatibility with different versions of 'Stability' in Android Binder Protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +804,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 name = "rsbinder"
 version = "0.2.1"
 dependencies = [
+ "android-properties",
  "async-trait",
  "downcast-rs",
  "env_logger",

--- a/rsbinder/Cargo.toml
+++ b/rsbinder/Cargo.toml
@@ -26,6 +26,9 @@ async-trait = { version = "0.1", optional = true }
 lazy_static = "1.4"
 tokio = { version = "1.35", optional = true, default-features = false }
 
+[target.'cfg(target_os = "android")'.dependencies]
+android-properties = "0.2.2"
+
 [build-dependencies]
 rsbinder-aidl = { version = "0.2.1", path = "../rsbinder-aidl", default-features = false }
 


### PR DESCRIPTION
panic on Android 12
```
OnePlus8T:/data/local/tmp # ./hello_service
[2024-03-11T13:37:55Z WARN  rsbinder::process_state] Binder ioctl to enable oneway spam detection failed: EINVAL: Invalid argument
[2024-03-11T13:37:55Z WARN  rsbinder::thread_state] binder::BR_REPLY (BadType)
Error: TransactionFailed / BadType:
```

Android 12 version uses "Category" as the stability format for passed on the wire lines, whereas other versions do not. Therefore, we can use the android_properties crate to determine the Android version and perform different handling accordingly.
http://aospxref.com/android-11.0.0_r21/xref/frameworks/native/libs/binder/include/binder/Stability.h
http://aospxref.com/android-12.0.0_r3/xref/frameworks/native/include/binder/Stability.h
http://aospxref.com/android-13.0.0_r3/xref/frameworks/native/libs/binder/include/binder/Stability.h
http://aospxref.com/android-14.0.0_r2/xref/frameworks/native/libs/binder/include/binder/Stability.h