### PR TITLE
Supports both Binder Stability changes in Android 12 and Stability for other Android versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-properties"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,7 +798,6 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 name = "rsbinder"
 version = "0.2.1"
 dependencies = [
- "android-properties",
  "async-trait",
  "downcast-rs",
  "env_logger",

--- a/example-hello/src/bin/hello_client.rs
+++ b/example-hello/src/bin/hello_client.rs
@@ -32,6 +32,8 @@ impl DeathRecipient for MyDeathRecipient {
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
 
+    process_with_args();
+
     // Initialize ProcessState with the default binder path and the default max threads.
     ProcessState::init_default();
 

--- a/example-hello/src/bin/hello_service.rs
+++ b/example-hello/src/bin/hello_service.rs
@@ -29,6 +29,8 @@ impl IHello for IHelloService {
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
 
+    process_with_args();
+
     // Initialize ProcessState with the default binder path and the default max threads.
     ProcessState::init_default();
 

--- a/example-hello/src/lib.rs
+++ b/example-hello/src/lib.rs
@@ -9,3 +9,13 @@ pub use crate::hello::IHello::*;
 
 // Define the name of the service to be registered in the HUB(service manager).
 pub const SERVICE_NAME: &str = "my.hello";
+
+pub fn process_with_args() {
+    std::env::args().for_each(|_arg| {
+        #[cfg(target_os = "android")]
+        if _arg.starts_with("--android-version=") {
+            let version = _arg.split('=').collect::<Vec<&str>>()[1];
+            set_android_version(version.parse().expect("Invalid version"));
+        }
+    });
+}

--- a/rsbinder/Cargo.toml
+++ b/rsbinder/Cargo.toml
@@ -26,9 +26,6 @@ async-trait = { version = "0.1", optional = true }
 lazy_static = "1.4"
 tokio = { version = "1.35", optional = true, default-features = false }
 
-[target.'cfg(target_os = "android")'.dependencies]
-android-properties = "0.2.2"
-
 [build-dependencies]
 rsbinder-aidl = { version = "0.2.1", path = "../rsbinder-aidl", default-features = false }
 

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -272,19 +272,6 @@ pub enum Stability {
     Vintf,
 }
 
-#[cfg(not(target_os = "android"))]
-impl From<Stability> for i32 {
-    fn from(stability: Stability) -> i32 {
-        use Stability::*;
-        match stability {
-            Local => 0,
-            Vendor => 0b000011,
-            System => 0b001100,
-            Vintf => 0b111111,
-        }
-    }
-}
-
 // Android 12 version uses "Category" as the stability format for passed on the wire lines,
 // whereas other versions do not. Therefore, we can use the android_properties crate
 // to determine the Android version and perform different handling accordingly.
@@ -292,68 +279,27 @@ impl From<Stability> for i32 {
 // http://aospxref.com/android-12.0.0_r3/xref/frameworks/native/include/binder/Stability.h
 // http://aospxref.com/android-13.0.0_r3/xref/frameworks/native/libs/binder/include/binder/Stability.h
 // http://aospxref.com/android-14.0.0_r2/xref/frameworks/native/libs/binder/include/binder/Stability.h
-#[cfg(target_os = "android")]
-use android_properties::AndroidProperty;
-
-#[cfg(target_os = "android")]
-use lazy_static::lazy_static;
-
-#[cfg(target_os = "android")]
-lazy_static! {
-    #[derive(Debug)]
-    static ref ANDROID_VERSION: String  = {
-            let mut android_version = AndroidProperty::new("ro.build.version.release");
-            match android_version.value() {
-                Some(value) => value,
-                None => "".to_string(),
-            }
-    };
-}
-
-#[cfg(target_os = "android")]
 impl From<Stability> for i32 {
     fn from(stability: Stability) -> i32 {
         use Stability::*;
-        match ANDROID_VERSION.as_str() {
-            "12" => {
-                match stability {
-                    Local => 0,
-                    Vendor => 0x0c000003,
-                    System => 0x0c00000c,
-                    Vintf => 0x0c00003f,
-                }
+        if crate::is_new_stability() {
+            match stability {
+                Local => 0,
+                Vendor => 0x0c000003,
+                System => 0x0c00000c,
+                Vintf => 0x0c00003f,
             }
-            _ => {
-                match stability {
-                    Local => 0,
-                    Vendor => 0b000011,
-                    System => 0b001100,
-                    Vintf => 0b111111,
-                }
+        } else {
+            match stability {
+                Local => 0,
+                Vendor => 0b000011,
+                System => 0b001100,
+                Vintf => 0b111111,
             }
         }
     }
 }
 
-#[cfg(not(target_os = "android"))]
-impl TryFrom<i32> for Stability {
-    type Error = StatusCode;
-    fn try_from(stability: i32) -> Result<Stability> {
-        use Stability::*;
-        match stability {
-            stability if stability == Local.into() => Ok(Local),
-            stability if stability == Vendor.into() => Ok(Vendor),
-            stability if stability == System.into() => Ok(System),
-            stability if stability == Vintf.into() => Ok(Vintf),
-            _ => {
-                log::error!("Stability value is invalid: {}", stability);
-                Err(StatusCode::BadValue)
-            }
-        }
-    }
-}
-
-#[cfg(target_os = "android")]
 impl TryFrom<i32> for Stability {
     type Error = StatusCode;
     fn try_from(stability: i32) -> Result<Stability> {

--- a/rsbinder/src/lib.rs
+++ b/rsbinder/src/lib.rs
@@ -55,6 +55,24 @@ pub const DEFAULT_BINDER_CONTROL_PATH: &str = "/dev/binderfs/binder-control";
 pub const DEFAULT_BINDER_PATH: &str = "/dev/binderfs/binder";
 pub const DEFAULT_BINDERFS_PATH: &str = "/dev/binderfs";
 
+#[cfg(target_os = "android")]
+static ANDROID_VERSION: std::sync::OnceLock<i32> = std::sync::OnceLock::new();
+
+#[cfg(target_os = "android")]
+pub fn set_android_version(version: i32) {
+    ANDROID_VERSION.set(version).expect("Android version is already set.");
+}
+
+pub fn is_new_stability() -> bool {
+    #[cfg(target_os = "android")]
+    match ANDROID_VERSION.get() {
+        Some(version) => *version >= 12,
+        None => true,   // Support the latest version by default.
+    }
+    #[cfg(not(target_os = "android"))]
+    true
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(target_os = "linux")]


### PR DESCRIPTION

- Supports rsbinder::set_android_version() in the Android build environment.
- Modified to allow adding version information like --android-version=12 when running the example.