### PR TITLE
Fix: is_new_stability for Android 12

### DIFF
--- a/rsbinder/src/lib.rs
+++ b/rsbinder/src/lib.rs
@@ -68,11 +68,11 @@ pub fn set_android_version(version: i32) {
 pub fn is_new_stability() -> bool {
     #[cfg(target_os = "android")]
     match ANDROID_VERSION.get() {
-        Some(version) => *version >= 12,
-        None => true,   // Support the latest version by default.
+        Some(version) => *version == 12,
+        None => false,   // Support the latest version by default.
     }
     #[cfg(not(target_os = "android"))]
-    true
+    false
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Only Android 12 version uses "Category" as the stability format for passing on the wire lines. Android 13 and 14 versions remain the same as before.

I believe we should proactively detect the Android version and make the necessary compatibility adjustments, rather than burdening the user with that responsibility. So please carefully consider my previous submission.