### PR TITLE
Add Android Features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,7 +859,6 @@ dependencies = [
  "async-trait",
  "downcast-rs",
  "env_logger",
- "lazy_static",
  "log",
  "pretty-hex",
  "rsbinder-aidl",
@@ -873,7 +872,6 @@ name = "rsbinder-aidl"
 version = "0.3.3"
 dependencies = [
  "convert_case",
- "lazy_static",
  "pest",
  "pest_derive",
  "serde",
@@ -888,7 +886,6 @@ dependencies = [
  "anstyle",
  "clap",
  "env_logger",
- "lazy_static",
  "log",
  "rsbinder",
 ]

--- a/rsbinder-aidl/Cargo.toml
+++ b/rsbinder-aidl/Cargo.toml
@@ -20,7 +20,6 @@ async = []
 pest = { workspace = true }
 pest_derive = { workspace = true }
 convert_case = { workspace = true }
-lazy_static = { workspace = true }
 serde = { workspace = true }
 tera = { workspace = true }
 

--- a/rsbinder-aidl/src/lib.rs
+++ b/rsbinder-aidl/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-#[macro_use]
-extern crate lazy_static;
+// #[macro_use]
+// extern crate lazy_static;
 
 use std::error::Error;
 use std::fs;

--- a/rsbinder-tools/Cargo.toml
+++ b/rsbinder-tools/Cargo.toml
@@ -13,7 +13,6 @@ keywords.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lazy_static.workspace = true
 rsbinder.workspace = true
 log.workspace = true
 env_logger.workspace = true

--- a/rsbinder/Cargo.toml
+++ b/rsbinder/Cargo.toml
@@ -13,10 +13,20 @@ keywords.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["tokio"]
+default = ["tokio", "android_11_plus"]
 sync = ["rsbinder-aidl/sync"]
 tokio = ["async", "tokio/full"]
 async = ["rsbinder-aidl/async", "async-trait"]
+android_11 = []
+android_12 = []
+android_13 = []
+android_14 = []
+android_16 = []
+android_11_plus = ["android_11", "android_12", "android_13", "android_14", "android_16"]
+android_12_plus = ["android_12", "android_13", "android_14", "android_16"]
+android_13_plus = ["android_13", "android_14", "android_16"]
+android_14_plus = ["android_14", "android_16"]
+android_16_plus = ["android_16"]
 
 [dependencies]
 rustix = { workspace = true, features = ["process", "param", "mm"] }

--- a/rsbinder/Cargo.toml
+++ b/rsbinder/Cargo.toml
@@ -34,7 +34,6 @@ log = { workspace = true }
 pretty_hex = { workspace = true }
 downcast-rs = { workspace = true }
 async-trait = { workspace = true, optional = true }
-lazy_static = { workspace = true }
 tokio = { workspace = true, optional = true }
 rsproperties.workspace = true
 

--- a/rsbinder/src/hub/mod.rs
+++ b/rsbinder/src/hub/mod.rs
@@ -3,16 +3,16 @@
 
 use std::sync::{Arc, OnceLock};
 
-#[cfg(target_os = "android")]
+#[cfg(all(target_os = "android", feature = "android_11"))]
 mod servicemanager_11;
-#[cfg(target_os = "android")]
+#[cfg(all(target_os = "android", feature = "android_11"))]
 pub mod android_11 {
     pub use super::servicemanager_11::*;
 }
 
-#[cfg(target_os = "android")]
+#[cfg(all(target_os = "android", feature = "android_12"))]
 mod servicemanager_12;
-#[cfg(target_os = "android")]
+#[cfg(all(target_os = "android", feature = "android_12"))]
 pub mod android_12 {
     pub use super::servicemanager_12::*;
 }
@@ -22,16 +22,16 @@ pub mod android_13 {
     pub use super::servicemanager_13::*;
 }
 
-#[cfg(target_os = "android")]
+#[cfg(all(target_os = "android", feature = "android_14"))]
 mod servicemanager_14;
-#[cfg(target_os = "android")]
+#[cfg(all(target_os = "android", feature = "android_14"))]
 pub mod android_14 {
     pub use super::servicemanager_14::*;
 }
 
-#[cfg(target_os = "android")]
+#[cfg(all(target_os = "android", feature = "android_16"))]
 mod servicemanager_16;
-#[cfg(target_os = "android")]
+#[cfg(all(target_os = "android", feature = "android_16"))]
 pub mod android_16 {
     pub use super::servicemanager_16::*;
 }
@@ -49,6 +49,8 @@ pub use android_13::{
 pub mod sdk_versions {
     /// Android 16 (API level 36)
     pub const ANDROID_16: u32 = 36;
+    /// Android 15 (API level 35)
+    pub const ANDROID_15: u32 = 35;
     /// Android 14 (API level 34)
     pub const ANDROID_14: u32 = 34;
     /// Android 13 (API level 33)
@@ -65,14 +67,14 @@ pub mod sdk_versions {
 }
 
 pub enum ServiceManager {
-    #[cfg(target_os = "android")]
+    #[cfg(all(target_os = "android", feature = "android_11"))]
     Android11(android_11::BpServiceManager),
-    #[cfg(target_os = "android")]
+    #[cfg(all(target_os = "android", feature = "android_12"))]
     Android12(android_12::BpServiceManager),
     Android13(android_13::BpServiceManager),
-    #[cfg(target_os = "android")]
+    #[cfg(all(target_os = "android", feature = "android_14"))]
     Android14(android_14::BpServiceManager),
-    #[cfg(target_os = "android")]
+    #[cfg(all(target_os = "android", feature = "android_16"))]
     Android16(android_16::BpServiceManager),
 }
 
@@ -96,18 +98,17 @@ pub fn default() -> Arc<ServiceManager> {
                 };
             }
 
-            if sdk_version >= sdk_versions::ANDROID_16 {
-                create_service_manager!(Android16, android_16)
-            } else if sdk_version >= sdk_versions::ANDROID_14 {
-                create_service_manager!(Android14, android_14)
-            } else if sdk_version >= sdk_versions::ANDROID_13 {
-                create_service_manager!(Android13, android_13)
-            } else if sdk_version >= sdk_versions::ANDROID_12 {
-                create_service_manager!(Android12, android_12)
-            } else if sdk_version >= sdk_versions::ANDROID_11 {
-                create_service_manager!(Android11, android_11)
-            } else {
-                panic!("default: Unsupported Android SDK version: {}", sdk_version);
+            match sdk_version {
+                #[cfg(feature = "android_16")]
+                sdk_versions::ANDROID_16 => create_service_manager!(Android16, android_16),
+                #[cfg(feature = "android_14")]
+                sdk_versions::ANDROID_14 | sdk_versions::ANDROID_15 => create_service_manager!(Android14, android_14),
+                sdk_versions::ANDROID_13 => create_service_manager!(Android13, android_13),
+                #[cfg(feature = "android_12")]
+                sdk_versions::ANDROID_12 => create_service_manager!(Android12, android_12),
+                #[cfg(feature = "android_11")]
+                sdk_versions::ANDROID_11 => create_service_manager!(Android11, android_11),
+                _ => panic!("default: Unsupported Android SDK version: {}", sdk_version),
             }
         };
 
@@ -122,14 +123,14 @@ pub fn default() -> Arc<ServiceManager> {
 impl ServiceManager {
     pub fn get_service(&self, name: &str) -> Option<SIBinder> {
         match self {
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_11"))]
             ServiceManager::Android11(sm) => android_11::get_service(sm, name),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_12"))]
             ServiceManager::Android12(sm) => android_12::get_service(sm, name),
             ServiceManager::Android13(sm) => android_13::get_service(sm, name),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_14"))]
             ServiceManager::Android14(sm) => android_14::get_service(sm, name),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_16"))]
             ServiceManager::Android16(sm) => {
                 android_16::get_service(sm, name).and_then(|s| s.service)
             }
@@ -138,58 +139,57 @@ impl ServiceManager {
 
     pub fn get_interface<T: FromIBinder + ?Sized>(&self, name: &str) -> Result<Strong<T>> {
         match self {
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_11"))]
             ServiceManager::Android11(sm) => android_11::get_interface(sm, name),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_12"))]
             ServiceManager::Android12(sm) => android_12::get_interface(sm, name),
             ServiceManager::Android13(sm) => android_13::get_interface(sm, name),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_14"))]
             ServiceManager::Android14(sm) => android_14::get_interface(sm, name),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_16"))]
             ServiceManager::Android16(sm) => android_16::get_interface(sm, name),
         }
     }
 
     pub fn check_service(&self, name: &str) -> Option<SIBinder> {
         match self {
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_11"))]
             ServiceManager::Android11(sm) => android_11::check_service(sm, name),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_12"))]
             ServiceManager::Android12(sm) => android_12::check_service(sm, name),
             ServiceManager::Android13(sm) => android_13::check_service(sm, name),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_14"))]
             ServiceManager::Android14(sm) => android_14::check_service(sm, name),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_16"))]
             ServiceManager::Android16(sm) => {
                 android_16::check_service(sm, name).and_then(|s| s.service)
             }
         }
     }
-
     pub fn is_declared(&self, name: &str) -> bool {
         match self {
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_11"))]
             ServiceManager::Android11(sm) => android_11::is_declared(sm, name),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_12"))]
             ServiceManager::Android12(sm) => android_12::is_declared(sm, name),
             ServiceManager::Android13(sm) => android_13::is_declared(sm, name),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_14"))]
             ServiceManager::Android14(sm) => android_14::is_declared(sm, name),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_16"))]
             ServiceManager::Android16(sm) => android_16::is_declared(sm, name),
         }
     }
 
     pub fn list_services(&self, dump_priority: i32) -> Vec<String> {
         match self {
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_11"))]
             ServiceManager::Android11(sm) => android_11::list_services(sm, dump_priority),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_12"))]
             ServiceManager::Android12(sm) => android_12::list_services(sm, dump_priority),
             ServiceManager::Android13(sm) => android_13::list_services(sm, dump_priority),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_14"))]
             ServiceManager::Android14(sm) => android_14::list_services(sm, dump_priority),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_16"))]
             ServiceManager::Android16(sm) => android_16::list_services(sm, dump_priority),
         }
     }
@@ -200,21 +200,20 @@ impl ServiceManager {
         binder: SIBinder,
     ) -> std::result::Result<(), Status> {
         match self {
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_11"))]
             ServiceManager::Android11(sm) => android_11::add_service(sm, identifier, binder),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_12"))]
             ServiceManager::Android12(sm) => android_12::add_service(sm, identifier, binder),
             ServiceManager::Android13(sm) => android_13::add_service(sm, identifier, binder),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_14"))]
             ServiceManager::Android14(sm) => android_14::add_service(sm, identifier, binder),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_16"))]
             ServiceManager::Android16(sm) => android_16::add_service(sm, identifier, binder),
         }
     }
-
     pub fn get_service_debug_info(&self) -> Result<Vec<ServiceDebugInfo>> {
         match self {
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_11"))]
             ServiceManager::Android11(_) => {
                 log::error!(
                     "get_service_debug_info: Unsupported Android SDK version: {}",
@@ -222,7 +221,7 @@ impl ServiceManager {
                 );
                 Err(StatusCode::UnknownTransaction)
             }
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_12"))]
             ServiceManager::Android12(sm) => {
                 // SAFETY: Converting android_12::ServiceDebugInfo to android_13::ServiceDebugInfo is safe because:
                 // 1. Both types represent identical AIDL parcelable definitions (android.os.ServiceDebugInfo)
@@ -233,7 +232,7 @@ impl ServiceManager {
                 Ok(a13_result)
             }
             ServiceManager::Android13(sm) => android_13::get_service_debug_info(sm),
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_14"))]
             ServiceManager::Android14(sm) => {
                 // SAFETY: Converting android_14::ServiceDebugInfo to android_13::ServiceDebugInfo is safe because:
                 // 1. Both types represent identical AIDL parcelable definitions (android.os.ServiceDebugInfo)
@@ -243,7 +242,7 @@ impl ServiceManager {
                 let a13_result: Vec<ServiceDebugInfo> = unsafe { std::mem::transmute(a14_result) };
                 Ok(a13_result)
             }
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_16"))]
             ServiceManager::Android16(sm) => {
                 // SAFETY: Converting android_16::ServiceDebugInfo to android_13::ServiceDebugInfo is safe because:
                 // 1. Both types represent identical AIDL parcelable definitions (android.os.ServiceDebugInfo)
@@ -262,7 +261,7 @@ impl ServiceManager {
         callback: &crate::Strong<dyn IServiceCallback>,
     ) -> Result<()> {
         match self {
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_11"))]
             ServiceManager::Android11(sm) => {
                 // SAFETY: This transmutation is safe because both types represent the same AIDL interface
                 let callback = unsafe {
@@ -271,7 +270,7 @@ impl ServiceManager {
                 };
                 android_11::register_for_notifications(sm, name, callback)
             }
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_12"))]
             ServiceManager::Android12(sm) => {
                 // SAFETY: This transmutation is safe because both types represent the same AIDL interface
                 let callback = unsafe {
@@ -283,7 +282,7 @@ impl ServiceManager {
             ServiceManager::Android13(sm) => {
                 android_13::register_for_notifications(sm, name, callback)
             }
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_14"))]
             ServiceManager::Android14(sm) => {
                 // SAFETY: This transmutation is safe because both types represent the same AIDL interface
                 let callback = unsafe {
@@ -292,7 +291,7 @@ impl ServiceManager {
                 };
                 android_14::register_for_notifications(sm, name, callback)
             }
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_16"))]
             ServiceManager::Android16(sm) => {
                 // SAFETY: This transmutation is safe because both types represent the same AIDL interface
                 let callback = unsafe {
@@ -310,7 +309,7 @@ impl ServiceManager {
         callback: &crate::Strong<dyn IServiceCallback>,
     ) -> Result<()> {
         match self {
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_11"))]
             ServiceManager::Android11(sm) => {
                 // SAFETY: This transmutation is safe because both types represent the same AIDL interface
                 let callback = unsafe {
@@ -319,7 +318,7 @@ impl ServiceManager {
                 };
                 android_11::unregister_for_notifications(sm, name, callback)
             }
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_12"))]
             ServiceManager::Android12(sm) => {
                 // SAFETY: This transmutation is safe because both types represent the same AIDL interface
                 let callback = unsafe {
@@ -331,7 +330,7 @@ impl ServiceManager {
             ServiceManager::Android13(sm) => {
                 android_13::unregister_for_notifications(sm, name, callback)
             }
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_14"))]
             ServiceManager::Android14(sm) => {
                 // SAFETY: This transmutation is safe because both types represent the same AIDL interface
                 let callback = unsafe {
@@ -340,7 +339,7 @@ impl ServiceManager {
                 };
                 android_14::unregister_for_notifications(sm, name, callback)
             }
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", feature = "android_16"))]
             ServiceManager::Android16(sm) => {
                 // SAFETY: This transmutation is safe because both types represent the same AIDL interface
                 let callback = unsafe {

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -954,7 +954,7 @@ impl ITestServiceDefault for TestDefaultImpl {
 #[test]
 fn test_default_impl() {
     let service = get_test_service();
-    let di: ITestServiceDefaultRef = Some(Arc::new(TestDefaultImpl));
+    let di: ITestServiceDefaultRef = Arc::new(TestDefaultImpl);
     <BpTestService as ITestService::ITestService>::setDefaultImpl(di);
 
     let result = service.UnimplementedMethod(EXPECTED_ARG_VALUE);


### PR DESCRIPTION
This pull request refactors the `rsbinder` codebase to replace the use of the `lazy_static` crate with `std::sync::OnceLock` for thread-safe static initialization and introduces finer-grained feature flags for Android API levels. These changes improve code maintainability, reduce dependencies, and enable more precise control over Android-specific functionality.

### Dependency and Initialization Refactor:
* Removed the `lazy_static` dependency from `Cargo.toml` files and replaced its usage with `std::sync::OnceLock` for static initialization of shared data structures, such as `DEFAULT_IMPL` and `TEMPLATES`. (`[[1]](diffhunk://#diff-80ef60ff412ce038d5c5839fe1769692cb6ff60c22264f0d79d4eac323c64e5cL23)`, `[[2]](diffhunk://#diff-76fc44b742fc7890f1ec99adea3ef00cf7bfff573fe56cd02bdcfacfeda203feL16)`, `[[3]](diffhunk://#diff-80322bebbe43365a079935dd93d0595fb64a09cb6ccca04c9552c9ea551d3660L247-R248)`, `[[4]](diffhunk://#diff-80322bebbe43365a079935dd93d0595fb64a09cb6ccca04c9552c9ea551d3660L399-R399)`, `[[5]](diffhunk://#diff-69b2e405557c9c38e305a26b76d661a52671b2e7b445767fcb0699bc0c49b061L4-R5)`)

### Android API Level Feature Flags:
* Introduced feature flags for specific Android API levels (e.g., `android_11`, `android_12`, etc.) and composite flags (e.g., `android_11_plus`) to enable selective compilation of Android-specific modules. (`[[1]](diffhunk://#diff-386b34e929c3077194b65d8726fc8d75ce74422bd381e3b8a414515922005dddL16-L27)`, `[[2]](diffhunk://#diff-93accac1fb72633da22afa474a94302aa2f2afb374093d28416b5dbeb90f6e30L6-R15)`, `[[3]](diffhunk://#diff-93accac1fb72633da22afa474a94302aa2f2afb374093d28416b5dbeb90f6e30L25-R34)`)
* Updated `ServiceManager` and its methods to use these feature flags for conditional compilation, ensuring compatibility with specific Android versions. (`[[1]](diffhunk://#diff-93accac1fb72633da22afa474a94302aa2f2afb374093d28416b5dbeb90f6e30L68-R77)`, `[[2]](diffhunk://#diff-93accac1fb72633da22afa474a94302aa2f2afb374093d28416b5dbeb90f6e30L99-R111)`, `[[3]](diffhunk://#diff-93accac1fb72633da22afa474a94302aa2f2afb374093d28416b5dbeb90f6e30L125-R133)`)

### Code Simplification and Cleanup:
* Replaced `lazy_static`-based mutexes with `OnceLock` for cleaner and more efficient initialization logic in the `rsbinder-aidl` generator module. (`[[1]](diffhunk://#diff-80322bebbe43365a079935dd93d0595fb64a09cb6ccca04c9552c9ea551d3660L247-R248)`, `[[2]](diffhunk://#diff-80322bebbe43365a079935dd93d0595fb64a09cb6ccca04c9552c9ea551d3660L684-R698)`, `[[3]](diffhunk://#diff-80322bebbe43365a079935dd93d0595fb64a09cb6ccca04c9552c9ea551d3660L898-R912)`)
* Removed commented-out legacy code and unused `lazy_static` references to streamline the codebase. (`[[1]](diffhunk://#diff-80322bebbe43365a079935dd93d0595fb64a09cb6ccca04c9552c9ea551d3660L411-R427)`, `[[2]](diffhunk://#diff-69b2e405557c9c38e305a26b76d661a52671b2e7b445767fcb0699bc0c49b061L4-R5)`)

### Android SDK Version Handling:
* Improved handling of Android SDK versions in `ServiceManager::default` by using a match statement with feature flags, allowing better granularity and extensibility for future API levels. (`[rsbinder/src/hub/mod.rsL99-R111](diffhunk://#diff-93accac1fb72633da22afa474a94302aa2f2afb374093d28416b5dbeb90f6e30L99-R111)`)

### Safety and Compatibility:
* Ensured safe type conversions between Android versions by documenting and maintaining compatibility for AIDL parcelable definitions (e.g., `ServiceDebugInfo`). (`[[1]](diffhunk://#diff-93accac1fb72633da22afa474a94302aa2f2afb374093d28416b5dbeb90f6e30L236-R235)`, `[[2]](diffhunk://#diff-93accac1fb72633da22afa474a94302aa2f2afb374093d28416b5dbeb90f6e30L246-R245)`)