### PR TITLE
Update rsproperties dependency to version 0.2.1 and simplify SDK vers…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "rsproperties"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac3faaf25327e4497fa832f7bd6c816c37bb30bf8e834b16730728ec603d3fc"
+checksum = "181f8ff1dc3c40000d888a593e2819d6ee12fb46147d80f6a8a04e9faed53b7d"
 dependencies = [
  "log",
  "pretty-hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,4 @@ pretty_hex = { version = "0.4", package = "pretty-hex" }
 downcast-rs = "2.0"
 rustix = "1.0"
 clap = "4.5"
-rsproperties = "0.1"
+rsproperties = "0.2.1"

--- a/rsbinder/src/lib.rs
+++ b/rsbinder/src/lib.rs
@@ -62,13 +62,7 @@ static ANDROID_SDK_VERSION: std::sync::OnceLock<u32> = std::sync::OnceLock::new(
 #[cfg(target_os = "android")]
 pub fn get_android_sdk_version() -> u32 {
     *ANDROID_SDK_VERSION.get_or_init(|| {
-        match rsproperties::get_with_result("ro.build.version.sdk") {
-            Ok(version) => version.parse::<u32>().unwrap_or(0),
-            Err(_) => {
-                log::warn!("Failed to get Android SDK version, defaulting to 0");
-                0
-            }
-        }
+        rsproperties::get_or("ro.build.version.sdk", 0)
     })
 }
 


### PR DESCRIPTION
This pull request updates the `rsproperties` dependency and simplifies the code for retrieving the Android SDK version. The most important changes include upgrading the `rsproperties` crate and refactoring the `get_android_sdk_version` function to use a more concise API.

### Dependency Update:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L41-R41): Upgraded the `rsproperties` dependency from version `0.1` to `0.2.1`.

### Code Simplification:
* [`rsbinder/src/lib.rs`](diffhunk://#diff-4e25dbdf82b479777b3c04675566b31b23f812e07d627fcfa6ba794aa1ef142bL65-R65): Refactored the `get_android_sdk_version` function to use the new `rsproperties::get_or` API, simplifying error handling and default value assignment.…ion retrieval logic