### PR TITLE
Release 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -120,7 +120,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
@@ -162,9 +162,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
@@ -211,18 +211,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -348,17 +348,17 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "example-hello"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "env_logger",
@@ -467,6 +467,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,9 +491,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
 dependencies = [
  "jiff-static",
  "log",
@@ -493,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -520,9 +531,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libm"
@@ -628,7 +639,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -648,9 +659,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror",
@@ -659,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -669,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
@@ -682,11 +693,10 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -815,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
@@ -853,7 +863,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rsbinder"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "downcast-rs",
@@ -868,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "rsbinder-aidl"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "convert_case",
  "pest",
@@ -880,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "rsbinder-tools"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anstyle",
  "clap",
@@ -1020,6 +1030,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "slab"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
 name = "slug"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,9 +1069,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1086,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "env_logger",
@@ -1119,17 +1135,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -1352,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -1380,7 +1398,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1389,7 +1407,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1398,14 +1425,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1415,10 +1458,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1427,10 +1482,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1439,10 +1506,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1451,25 +1530,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "zerocopy"
-version = "0.8.25"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Jeff Kim <hiking90@gmail.com>"]
@@ -22,15 +22,15 @@ rust-version = "1.77"
 keywords = ["android", "binder", "aidl", "linux"]
 
 [workspace.dependencies]
-rsbinder = { version = "0.4.0", path = "rsbinder" }
+rsbinder = { version = "0.4.1", path = "rsbinder" }
 log = "0.4"
 env_logger = "0.11"
 anstyle = "1.0"
 tokio = { version = "1.45", default-features = false }
 async-trait = "0.1"
-rsbinder-aidl = { version = "0.4.0", path = "rsbinder-aidl" }
-pest = "2.7"
-pest_derive = "2.7"
+rsbinder-aidl = { version = "0.4.1", path = "rsbinder-aidl" }
+pest = "2.8"
+pest_derive = "2.8"
 convert_case = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 tera = "1.19"

--- a/example-hello/src/bin/hello_client.rs
+++ b/example-hello/src/bin/hello_client.rs
@@ -36,7 +36,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     println!("list services:");
     // This is an example of how to use service manager.
     for name in hub::list_services(hub::DUMP_FLAG_PRIORITY_DEFAULT) {
-        println!("{}", name);
+        println!("{name}");
     }
 
     let service_callback = BnServiceCallback::new_binder(MyServiceCallback {});

--- a/rsbinder-aidl/src/const_expr.rs
+++ b/rsbinder-aidl/src/const_expr.rs
@@ -222,7 +222,7 @@ impl ValueType {
                 }
                 ConstExpr::new(ValueType::Array(list))
             }
-            _ => panic!("Can't apply unary operator '~' or \"!\" to {:?}", self),
+            _ => panic!("Can't apply unary operator '~' or \"!\" to {self:?}"),
         }
     }
 
@@ -249,7 +249,7 @@ impl ValueType {
 
                 ConstExpr::new(ValueType::Array(list))
             }
-            _ => panic!("Can't apply unary operator '-' to {:?}", self),
+            _ => panic!("Can't apply unary operator '-' to {self:?}"),
         }
     }
 
@@ -318,7 +318,7 @@ impl ValueType {
             ValueType::Int64(v) => *v as _,
             ValueType::Float(v) | ValueType::Double(v) => *v as _,
             ValueType::Array(_) => {
-                panic!("to_i64() for List is not supported. {:?}", self);
+                panic!("to_i64() for List is not supported. {self:?}");
             }
             ValueType::Name(_) => {
                 panic!("to_i64() for Name is not supported.");
@@ -368,7 +368,7 @@ impl ValueType {
                     let some_str = if let ValueType::Array(_) = v.value {
                         init_str
                     } else if param.is_nullable {
-                        format!("Some({})", init_str)
+                        format!("Some({init_str})")
                     } else {
                         init_str
                     };
@@ -381,7 +381,7 @@ impl ValueType {
                 res
             }
             ValueType::Holder => {
-                println!("Init Holder: {:?}", param);
+                println!("Init Holder: {param:?}");
                 if param.is_vintf {
                     format!(
                         "{}::ParcelableHolder::new({}::Stability::Vintf)",
@@ -718,7 +718,7 @@ impl ConstExpr {
                     if let Some(ch) = char::from_u32(ch) {
                         Self::new(ValueType::Char(ch as _))
                     } else {
-                        panic!("0x{:x} is invalid unicode.", ch)
+                        panic!("0x{ch:x} is invalid unicode.")
                     }
                 }
                 ValueType::Array(_) => {

--- a/rsbinder-aidl/src/generator.rs
+++ b/rsbinder-aidl/src/generator.rs
@@ -469,7 +469,7 @@ fn make_fn_member(method: &parser::MethodDecl) -> Result<FnMembers, Box<dyn Erro
             } else {
                 format!("&{}", generator.identifier)
             };
-            write_funcs.push(format!("data.write({})?;", param));
+            write_funcs.push(format!("data.write({param})?;"));
         } else if generator.is_variable_array() {
             if generator.is_nullable {
                 write_funcs.push(format!(
@@ -741,7 +741,7 @@ impl Generator {
             // Parse struct variables only.
             for decl in &decl.members {
                 if let Some(var) = decl.is_variable() {
-                    println!("Parcelable variable: {:?}", var);
+                    println!("Parcelable variable: {var:?}");
                     let generator = var.r#type.to_generator();
 
                     if var.constant {

--- a/rsbinder-aidl/src/lib.rs
+++ b/rsbinder-aidl/src/lib.rs
@@ -156,7 +156,7 @@ impl Builder {
     }
 
     fn parse_file(filename: &Path) -> Result<(String, parser::Document), Box<dyn Error>> {
-        println!("Parsing: {:?}", filename);
+        println!("Parsing: {filename:?}");
         let unparsed_file = fs::read_to_string(filename)?;
         let document = parser::parse_document(&unparsed_file)?;
 
@@ -205,7 +205,7 @@ impl Builder {
 
                 for r#mod in &mod_list[start..] {
                     content += &indent_space(mod_count);
-                    content += &format!("pub mod {} {{\n", r#mod);
+                    content += &format!("pub mod {mod} {{\n");
                     mod_count += 1;
                 }
             }

--- a/rsbinder-aidl/src/parser.rs
+++ b/rsbinder-aidl/src/parser.rs
@@ -617,8 +617,7 @@ fn parse_intvalue(arg_value: &str) -> ConstExpr {
             let parsed_value = u8::from_str_radix(value, radix)
                 .map_err(|err| {
                     eprintln!(
-                        "{:?}\nparse_intvalue() - Invalid u8 value: {}, radix: {}\n",
-                        err, arg_value, radix
+                        "{err:?}\nparse_intvalue() - Invalid u8 value: {arg_value}, radix: {radix}\n"
                     );
                     err
                 })
@@ -631,8 +630,7 @@ fn parse_intvalue(arg_value: &str) -> ConstExpr {
                 let parsed_value = u64::from_str_radix(value, radix)
                     .map_err(|err| {
                         eprintln!(
-                            "{:?}\nparse_intvalue() - Invalid u64 value: {}, radix: {}\n",
-                            err, arg_value, radix
+                            "{err:?}\nparse_intvalue() - Invalid u64 value: {arg_value}, radix: {radix}\n"
                         );
                         err
                     })
@@ -643,8 +641,7 @@ fn parse_intvalue(arg_value: &str) -> ConstExpr {
             let parsed_value = u64::from_str_radix(value, radix)
                 .map_err(|err| {
                     eprintln!(
-                        "{:?}\nparse_intvalue() - Invalid u64 value: {}, radix: {}\n",
-                        err, arg_value, radix
+                        "{err:?}\nparse_intvalue() - Invalid u64 value: {arg_value}, radix: {radix}\n"
                     );
                     err
                 })
@@ -655,15 +652,14 @@ fn parse_intvalue(arg_value: &str) -> ConstExpr {
         let parsed_value = i64::from_str_radix(value, radix)
             .map_err(|err| {
                 eprintln!(
-                    "{:?}\nparse_intvalue() - Invalid int value: {}, radix: {}\n",
-                    err, arg_value, radix
+                    "{err:?}\nparse_intvalue() - Invalid int value: {arg_value}, radix: {radix}\n"
                 );
                 err
             })
             .unwrap();
         if is_u8 {
             if parsed_value > u8::MAX.into() || parsed_value < 0 {
-                panic!("u8 is overflowed. {}", parsed_value);
+                panic!("u8 is overflowed. {parsed_value}");
             }
             ConstExpr::new(ValueType::Byte(parsed_value as i8 as _))
         } else if is_long {
@@ -1434,7 +1430,7 @@ mod tests {
     fn test_parse_string_expr() -> Result<(), Box<dyn Error>> {
         let mut res =
             AIDLParser::parse(Rule::string_expr, r##""Hello" + " World""##).map_err(|err| {
-                println!("{}", err);
+                println!("{err}");
                 err
             })?;
 
@@ -1455,7 +1451,7 @@ mod tests {
     fn test_parse_expression() -> Result<(), Box<dyn Error>> {
         let mut res =
             AIDLParser::parse(Rule::expression, r##"1 + -3 * 2 << 2 | 4"##).map_err(|err| {
-                println!("{}", err);
+                println!("{err}");
                 err
             })?;
 

--- a/rsbinder-aidl/src/type_generator.rs
+++ b/rsbinder-aidl/src/type_generator.rs
@@ -145,7 +145,7 @@ impl TypeGenerator {
         } else {
             let name: String = lookup_decl.name.ns.last().unwrap().to_owned();
             if curr_ns.ns.last().unwrap() == name.as_str() {
-                format!("Box<{}>", name) // To avoid, recursive type issue.
+                format!("Box<{name}>") // To avoid, recursive type issue.
             } else {
                 name
             }
@@ -226,7 +226,7 @@ impl TypeGenerator {
     }
 
     pub fn identifier(mut self, ident: &str) -> Self {
-        self.identifier = format!("_arg_{}", ident);
+        self.identifier = format!("_arg_{ident}");
         self
     }
 
@@ -270,7 +270,7 @@ impl TypeGenerator {
 
         let value_str = if is_struct {
             if self.is_nullable && Self::is_aidl_nullable(&array_info.value_type) {
-                format!("Option<{}>", type_name)
+                format!("Option<{type_name}>")
             } else {
                 type_name
             }
@@ -280,7 +280,7 @@ impl TypeGenerator {
                     if self.is_nullable
                         || !Self::can_be_defaulted(&array_info.value_type, is_struct)
                     {
-                        format!("Option<{}>", type_name)
+                        format!("Option<{type_name}>")
                     } else {
                         type_name
                     }
@@ -291,7 +291,7 @@ impl TypeGenerator {
 
         array_info.sizes.iter().rev().skip(1).fold(
             format!("[{}; {}]", value_str, array_info.sizes.last().unwrap()),
-            |acc, size| format!("[{}; {}]", acc, size),
+            |acc, size| format!("[{acc}; {size}]"),
         )
     }
 
@@ -301,21 +301,21 @@ impl TypeGenerator {
         match self.direction {
             Direction::Out => {
                 if self.is_nullable {
-                    format!("Option<{}>", fixed_array)
+                    format!("Option<{fixed_array}>")
                 } else {
                     fixed_array
                 }
             }
             Direction::Inout => {
                 if self.is_nullable {
-                    format!("Option<{}>", fixed_array)
+                    format!("Option<{fixed_array}>")
                 } else {
                     fixed_array
                 }
             }
             _ => {
                 if self.is_nullable {
-                    format!("Option<{}>", fixed_array)
+                    format!("Option<{fixed_array}>")
                 } else {
                     fixed_array
                 }
@@ -333,37 +333,37 @@ impl TypeGenerator {
         match self.direction {
             Direction::Out => {
                 if self.is_nullable {
-                    format!("Vec<Option<{}>>", type_name)
+                    format!("Vec<Option<{type_name}>>")
                 } else if Self::can_be_defaulted(&sub_type.value_type, is_struct) {
-                    format!("Vec<{}>", type_name)
+                    format!("Vec<{type_name}>")
                 } else {
-                    format!("Vec<Option<{}>>", type_name)
+                    format!("Vec<Option<{type_name}>>")
                 }
             }
             Direction::Inout => {
                 if self.is_nullable {
-                    format!("Vec<Option<{}>>", type_name)
+                    format!("Vec<Option<{type_name}>>")
                 } else if Self::can_be_defaulted(&sub_type.value_type, true) {
-                    format!("Vec<{}>", type_name)
+                    format!("Vec<{type_name}>")
                 } else {
-                    format!("Vec<Option<{}>>", type_name)
+                    format!("Vec<Option<{type_name}>>")
                 }
             }
             _ => {
                 if is_struct {
                     if self.is_nullable && Self::is_aidl_nullable(&sub_type.value_type) {
-                        format!("Vec<Option<{}>>", type_name)
+                        format!("Vec<Option<{type_name}>>")
                     } else {
-                        format!("Vec<{}>", type_name)
+                        format!("Vec<{type_name}>")
                     }
                 } else if self.is_nullable {
                     if Self::is_primitive(&sub_type.value_type) {
-                        format!("Option<Vec<{}>>", type_name)
+                        format!("Option<Vec<{type_name}>>")
                     } else {
-                        format!("Option<Vec<Option<{}>>>", type_name)
+                        format!("Option<Vec<Option<{type_name}>>>")
                     }
                 } else {
-                    format!("Vec<{}>", type_name)
+                    format!("Vec<{type_name}>")
                 }
             }
         }
@@ -418,23 +418,23 @@ impl TypeGenerator {
         match self.direction {
             Direction::Out => {
                 if self.is_nullable {
-                    format!("&mut Option<{}>", fixed_array)
+                    format!("&mut Option<{fixed_array}>")
                 } else {
-                    format!("&mut {}", fixed_array)
+                    format!("&mut {fixed_array}")
                 }
             }
             Direction::Inout => {
                 if self.is_nullable {
-                    format!("&mut Option<{}>", fixed_array)
+                    format!("&mut Option<{fixed_array}>")
                 } else {
-                    format!("&mut {}", fixed_array)
+                    format!("&mut {fixed_array}")
                 }
             }
             _ => {
                 if self.is_nullable {
-                    format!("Option<&{}>", fixed_array)
+                    format!("Option<&{fixed_array}>")
                 } else {
-                    format!("&{}", fixed_array)
+                    format!("&{fixed_array}")
                 }
             }
         }
@@ -450,36 +450,36 @@ impl TypeGenerator {
             Direction::Out => {
                 if self.is_nullable {
                     // if nullable, it means that the array can have null elements.
-                    format!("&mut Option<Vec<Option<{}>>>", type_name)
+                    format!("&mut Option<Vec<Option<{type_name}>>>")
                 } else if Self::can_be_defaulted(&sub_type.value_type, false)
                     || Self::is_primitive(&sub_type.value_type)
                 {
                     // Enum is a primitive type.
-                    format!("&mut Vec<{}>", type_name)
+                    format!("&mut Vec<{type_name}>")
                 } else {
-                    format!("&mut Vec<Option<{}>>", type_name)
+                    format!("&mut Vec<Option<{type_name}>>")
                 }
             }
             Direction::Inout => {
                 if self.is_nullable {
                     if Self::can_be_defaulted(&sub_type.value_type, false) {
-                        format!("&mut Option<Vec<{}>>", type_name)
+                        format!("&mut Option<Vec<{type_name}>>")
                     } else {
-                        format!("&mut Option<Vec<Option<{}>>>", type_name)
+                        format!("&mut Option<Vec<Option<{type_name}>>>")
                     }
                 } else {
-                    format!("&mut Vec<{}>", type_name)
+                    format!("&mut Vec<{type_name}>")
                 }
             }
             _ => {
                 if self.is_nullable {
                     if Self::is_primitive(&sub_type.value_type) {
-                        format!("Option<&[{}]>", type_name)
+                        format!("Option<&[{type_name}]>")
                     } else {
-                        format!("Option<&[Option<{}>]>", type_name)
+                        format!("Option<&[Option<{type_name}>]>")
                     }
                 } else {
-                    format!("&[{}]", type_name)
+                    format!("&[{type_name}]")
                 }
             }
         }
@@ -507,9 +507,9 @@ impl TypeGenerator {
                     }
                     let name = self.type_decl(&self.value_type);
                     if self.is_nullable {
-                        format!("&mut Option<{}>", name)
+                        format!("&mut Option<{name}>")
                     } else {
-                        format!("&mut {}", name)
+                        format!("&mut {name}")
                     }
                 }
                 _ => {
@@ -518,9 +518,9 @@ impl TypeGenerator {
                     } else {
                         let name = self.type_decl(&self.value_type);
                         if self.is_nullable {
-                            format!("Option<&{}>", name)
+                            format!("Option<&{name}>")
                         } else {
-                            format!("&{}", name)
+                            format!("&{name}")
                         }
                     }
                 }
@@ -572,8 +572,8 @@ impl TypeGenerator {
 
         let (mutable, init) = match self.direction {
             Direction::Out => ("mut ", "Default::default()".to_owned()),
-            Direction::Inout => ("mut ", format!("{}.read()?", reader)),
-            _ => ("", format!("{}.read()?", reader)),
+            Direction::Inout => ("mut ", format!("{reader}.read()?")),
+            _ => ("", format!("{reader}.read()?")),
         };
 
         format!(
@@ -625,7 +625,7 @@ impl TypeGenerator {
                         .to_init(param.with_fixed_array(false).with_nullable(false))
                 };
                 if self.is_nullable {
-                    format!("Some({})", init_str)
+                    format!("Some({init_str})")
                 } else {
                     init_str
                 }

--- a/rsbinder-aidl/tests/test_aidl.rs
+++ b/rsbinder-aidl/tests/test_aidl.rs
@@ -15,7 +15,7 @@ fn aidl_generator(input: &str, expect: &str) -> Result<(), Box<dyn Error>> {
             ChangeTag::Insert => "+ ",
             ChangeTag::Equal => "  ",
         };
-        print!("{}{}", sign, change);
+        print!("{sign}{change}");
     }
     assert_eq!(res.1.trim(), expect.trim());
     Ok(())

--- a/rsbinder-tools/src/bin/rsb_device.rs
+++ b/rsbinder-tools/src/bin/rsb_device.rs
@@ -20,7 +20,7 @@ fn log_ok(msg: &str) {
 }
 
 fn log_err(msg: &str) {
-    log::error!("{}", msg);
+    log::error!("{msg}");
     std::process::exit(1);
 }
 
@@ -82,7 +82,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             .arg(binderfs_path)
             .status()
             .map(|_| log_ok(&format!("BinderFS mounted at {}.", binderfs_path.display())))
-            .map_err(|err| log_err(&format!("Failed to mount binderfs\n{}", err)))
+            .map_err(|err| log_err(&format!("Failed to mount binderfs\n{err}")))
             .ok();
     } else {
         log_ok(&format!(
@@ -100,9 +100,9 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         })
         .map_err(|err| {
             if err.kind() == std::io::ErrorKind::AlreadyExists {
-                log_ok(&format!("Device {} already exists", device_name));
+                log_ok(&format!("Device {device_name} already exists"));
             } else {
-                log_err(&format!("Failed to allocate new binder device\n{}", err));
+                log_err(&format!("Failed to allocate new binder device\n{err}"));
             }
         }).ok();
 
@@ -150,10 +150,9 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     println!("\nSummary:");
     println!(
-        "The binder device '{}' has been successfully created \
-        and is accessible at /dev/binderfs/{} with full permissions (read/write by all users). \
-        This setup facilitates IPC mechanisms within the Linux kernel.\n",
-        device_name, device_name
+        "The binder device '{device_name}' has been successfully created \
+        and is accessible at /dev/binderfs/{device_name} with full permissions (read/write by all users). \
+        This setup facilitates IPC mechanisms within the Linux kernel.\n"
     );
 
     Ok(())

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -330,7 +330,7 @@ impl TryFrom<i32> for Stability {
             stability if stability == System.into() => Ok(System),
             stability if stability == Vintf.into() => Ok(Vintf),
             _ => {
-                log::error!("Stability value is invalid: {:X}", stability);
+                log::error!("Stability value is invalid: {stability:X}");
                 // Err(StatusCode::BadValue)
                 Ok(Local)
             }
@@ -420,7 +420,7 @@ impl Drop for SIBinder {
     fn drop(&mut self) {
         self.decrease()
             .map_err(|err| {
-                log::error!("Error in SIBinder::drop() is {:?}", err);
+                log::error!("Error in SIBinder::drop() is {err:?}");
             })
             .ok();
     }

--- a/rsbinder/src/binderfs.rs
+++ b/rsbinder/src/binderfs.rs
@@ -37,12 +37,12 @@ pub fn add_device(driver: &Path, name: &str) -> std::io::Result<(u32, u32)> {
 
     #[cfg(not(test))]
     binder::binder_ctl_add(fd, &mut device).inspect_err(|e| {
-        log::error!("Binder ioctl to add binder failed: {}", e);
+        log::error!("Binder ioctl to add binder failed: {e}");
     })?;
 
     #[cfg(test)]
     tests::binder_ctl_add(fd, &mut device).inspect_err(|e| {
-        log::error!("Binder ioctl to add binder failed: {}", e);
+        log::error!("Binder ioctl to add binder failed: {e}");
     })?;
 
     Ok((device.major, device.minor))

--- a/rsbinder/src/hub/servicemanager_16.rs
+++ b/rsbinder/src/hub/servicemanager_16.rs
@@ -23,12 +23,12 @@ pub fn get_service(
         Ok(service) => match service {
             android::os::Service::Service::ServiceWithMetadata(service) => Some(service),
             android::os::Service::Service::Accessor(_accessor) => {
-                log::warn!("Service {} is an Accessor, not a ServiceWithMetadata", name);
+                log::warn!("Service {name} is an Accessor, not a ServiceWithMetadata");
                 None
             }
         },
         Err(err) => {
-            log::error!("Failed to get service {}: {}", name, err);
+            log::error!("Failed to get service {name}: {err}");
             None
         }
     }
@@ -45,12 +45,12 @@ pub fn check_service(
         Ok(service) => match service {
             android::os::Service::Service::ServiceWithMetadata(service) => Some(service),
             android::os::Service::Service::Accessor(_accessor) => {
-                log::warn!("Service {} is an Accessor, not a ServiceWithMetadata", name);
+                log::warn!("Service {name} is an Accessor, not a ServiceWithMetadata");
                 None
             }
         },
         Err(err) => {
-            log::error!("Failed to check service {}: {}", name, err);
+            log::error!("Failed to check service {name}: {err}");
             None
         }
     }
@@ -61,7 +61,7 @@ pub fn list_services(sm: &BpServiceManager, dump_priority: i32) -> Vec<String> {
     match sm.listServices(dump_priority) {
         Ok(result) => result,
         Err(err) => {
-            log::error!("Failed to list services: {}", err);
+            log::error!("Failed to list services: {err}");
             Vec::new()
         }
     }
@@ -102,7 +102,7 @@ pub fn is_declared(sm: &BpServiceManager, name: &str) -> bool {
     match sm.isDeclared(name) {
         Ok(result) => result,
         Err(err) => {
-            log::error!("Failed to is_declared({}): {}", name, err);
+            log::error!("Failed to is_declared({name}): {err}");
             false
         }
     }
@@ -116,12 +116,12 @@ pub fn get_interface<T: FromIBinder + ?Sized>(
         Some(service) => match service.service {
             Some(service) => FromIBinder::try_from(service),
             None => {
-                log::error!("Service {} is not a valid IBinder", name);
+                log::error!("Service {name} is not a valid IBinder");
                 Err(StatusCode::NameNotFound)
             }
         },
         None => {
-            log::error!("Failed to get interface {}", name);
+            log::error!("Failed to get interface {name}");
             Err(StatusCode::NameNotFound)
         }
     }

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -306,7 +306,7 @@ impl Parcel {
 
     pub fn data_avail(&self) -> usize {
         let result = self.data.len() - self.pos;
-        assert!(result < i32::MAX as _, "data too big: {}", result);
+        assert!(result < i32::MAX as _, "data too big: {result}");
 
         result
     }
@@ -342,7 +342,7 @@ impl Parcel {
         let mut opos = self.next_object_hint;
 
         if count > 0 {
-            log::trace!("Parcel looking for obj at {}, hint={}", data_pos, opos);
+            log::trace!("Parcel looking for obj at {data_pos}, hint={opos}");
             if opos < count {
                 while opos < (count - 1) && objects[opos] < data_pos {
                     opos += 1;
@@ -364,7 +364,7 @@ impl Parcel {
                 return Ok(obj);
             }
         }
-        log::error!("Parcel: unable to find object at index {}", data_pos);
+        log::error!("Parcel: unable to find object at index {data_pos}");
         Err(StatusCode::BadType)
     }
 
@@ -385,12 +385,12 @@ impl Parcel {
         let start = self.data_position();
         let parcelable_size: i32 = self.read()?;
         if parcelable_size < 4 {
-            log::error!("Parcel: bad size for object: {}", parcelable_size);
+            log::error!("Parcel: bad size for object: {parcelable_size}");
             return Err(StatusCode::BadValue);
         }
 
         let end = start.checked_add(parcelable_size as _).ok_or_else(|| {
-            log::error!("Parcel: check_add error: {}", parcelable_size);
+            log::error!("Parcel: check_add error: {parcelable_size}");
             StatusCode::BadValue
         })?;
         if end > self.data_size() {
@@ -410,7 +410,7 @@ impl Parcel {
     pub(crate) fn read_array<D: Deserialize>(&mut self) -> Result<Option<Vec<D>>> {
         let len: i32 = self.read()?;
         if len < -1 {
-            log::error!("Parcel: bad array length: {}", len);
+            log::error!("Parcel: bad array length: {len}");
             return Err(StatusCode::BadValue);
         }
         if len <= 0 {
@@ -459,7 +459,7 @@ impl Parcel {
     ) -> Result<Option<Vec<<D as CharType>::Output>>> {
         let len: i32 = self.read()?;
         if len < -1 {
-            log::error!("Parcel: bad array length: {}", len);
+            log::error!("Parcel: bad array length: {len}");
             return Err(StatusCode::BadValue);
         }
         if len <= 0 {
@@ -715,13 +715,12 @@ impl Parcel {
             return Ok(());
         }
         if size > i32::MAX as usize {
-            log::error!("Parcel::append_from: the size is too large: {}", size);
+            log::error!("Parcel::append_from: the size is too large: {size}");
             return Err(StatusCode::BadValue);
         }
         let other_len = other.data_size();
         if offset > other_len || size > other_len || (offset + size) > other_len {
-            log::error!("Parcel::append_from: The given offset({}) and size({}) exceed the data range of the parcel.",
-                offset, size);
+            log::error!("Parcel::append_from: The given offset({offset}) and size({size}) exceed the data range of the parcel.");
             return Err(StatusCode::BadValue);
         }
 
@@ -789,7 +788,7 @@ impl Parcel {
         for pos in self.objects.as_slice() {
             let obj: &flat_binder_object = (self.data.as_ptr(), *pos as usize).into();
             obj.release()
-                .map_err(|e| log::error!("Parcel: unable to release object: {:?}", e))
+                .map_err(|e| log::error!("Parcel: unable to release object: {e:?}"))
                 .ok();
         }
     }
@@ -916,7 +915,7 @@ mod tests {
         parcel.write_array(&array).unwrap();
         parcel.write_array(&reverse).unwrap();
 
-        println!("{:?}", parcel);
+        println!("{parcel:?}");
 
         parcel.set_data_position(0);
 

--- a/rsbinder/src/parcelable.rs
+++ b/rsbinder/src/parcelable.rs
@@ -403,7 +403,7 @@ impl DeserializeOption for String {
                 std::slice::from_raw_parts(data.as_ptr() as *const u16, len as _)
             })
             .map_err(|e| {
-                log::error!("Deserialize for Option<String16>: {}", e);
+                log::error!("Deserialize for Option<String16>: {e}");
                 StatusCode::BadValue
             })?;
 
@@ -681,7 +681,7 @@ pub trait DeserializeArray: Deserialize {
     fn deserialize_array(parcel: &mut Parcel) -> Result<Option<Vec<Self>>> {
         let len: i32 = parcel.read()?;
         if len < -1 {
-            log::error!("Negative array size given in parcel: {}", len);
+            log::error!("Negative array size given in parcel: {len}");
             return Err(StatusCode::BadValue);
         }
         if len <= 0 {

--- a/rsbinder/src/parcelable_holder.rs
+++ b/rsbinder/src/parcelable_holder.rs
@@ -141,17 +141,13 @@ impl ParcelableHolder {
             } => {
                 if name != parcelable_desc {
                     log::error!(
-                        "ParcelableHolder::get_parcelable: parcelable descriptor mismatch: {:?} != {:?}",
-                        name,
-                        parcelable_desc);
+                        "ParcelableHolder::get_parcelable: parcelable descriptor mismatch: {name:?} != {parcelable_desc:?}");
                     return Err(StatusCode::BadValue);
                 }
 
                 match Arc::clone(parcelable).downcast_arc::<T>() {
                     Err(_) => {
-                        log::error!("ParcelableHolder::get_parcelable: parcelable type mismatch: {:?} != {:?}",
-                            parcelable,
-                            parcelable_desc);
+                        log::error!("ParcelableHolder::get_parcelable: parcelable type mismatch: {parcelable:?} != {parcelable_desc:?}");
                         Err(StatusCode::BadValue)
                     }
                     Ok(x) => Ok(Some(x)),

--- a/rsbinder/src/proxy.rs
+++ b/rsbinder/src/proxy.rs
@@ -220,7 +220,7 @@ impl IBinder for ProxyHandle {
             false,
             || {
                 if let Err(err) = thread_state::attempt_inc_strong_handle(self.handle()) {
-                    log::error!("Error in attempt_inc_strong_handle() is {:?}", err);
+                    log::error!("Error in attempt_inc_strong_handle() is {err:?}");
                     false
                 } else {
                     true
@@ -275,7 +275,7 @@ mod tests {
         assert!(handle.is_remote());
 
         // Test for Debug trait
-        let debug_str = format!("{:?}", handle);
+        let debug_str = format!("{handle:?}");
         assert_eq!(
             debug_str,
             "Inner { handle: 1, descriptor: \"test\", stability: Local, obituary_sent: false }"

--- a/rsbinder/src/status.rs
+++ b/rsbinder/src/status.rs
@@ -282,7 +282,7 @@ fn read_check_header_size(parcel: &mut Parcel) -> error::Result<()> {
     let header_size = parcel.read::<i32>()?;
 
     if header_size < 0 || header_size as usize > header_avail {
-        log::error!("0x534e4554:132650049 Invalid header_size({}).", header_size);
+        log::error!("0x534e4554:132650049 Invalid header_size({header_size}).");
         return Err(StatusCode::Unknown);
     }
     parcel.set_data_position(header_start + (header_size as usize));
@@ -306,8 +306,7 @@ impl Deserialize for Status {
                 || remote_stack_trace_header_size as usize > parcel.data_avail()
             {
                 log::error!(
-                    "0x534e4554:132650049 Invalid remote_stack_trace_header_size({}).",
-                    remote_stack_trace_header_size
+                    "0x534e4554:132650049 Invalid remote_stack_trace_header_size({remote_stack_trace_header_size})."
                 );
                 return Err(StatusCode::Unknown);
             }
@@ -346,12 +345,12 @@ mod tests {
     #[test]
     fn test_status_display() -> Result<()> {
         let unknown = Status::from(StatusCode::Unknown);
-        assert_eq!(format!("{}", unknown), "TransactionFailed / Unknown: ");
+        assert_eq!(format!("{unknown}"), "TransactionFailed / Unknown: ");
 
         let service_specific =
             Status::new_service_specific_error(1, Some("Service specific error".to_owned()));
         assert_eq!(
-            format!("{}", service_specific),
+            format!("{service_specific}"),
             "ServiceSpecific / ServiceSpecific(1): Service specific error"
         );
 
@@ -361,7 +360,7 @@ mod tests {
             Some("Bad parcelable".to_owned()),
         );
         assert_eq!(
-            format!("{}", exception),
+            format!("{exception}"),
             "BadParcelable / Unknown: Bad parcelable"
         );
 

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -471,7 +471,7 @@ fn wait_for_response(until: UntilResponse) -> Result<Option<Parcel>> {
                                     );
                                     StatusCode::BadValue
                                 };
-                            log::trace!("binder::BR_REPLY ({})", status);
+                            log::trace!("binder::BR_REPLY ({status})");
                             free_buffer(
                                 None,
                                 buffer,
@@ -481,7 +481,7 @@ fn wait_for_response(until: UntilResponse) -> Result<Option<Parcel>> {
                             )?;
 
                             if status != StatusCode::Ok {
-                                log::warn!("binder::BR_REPLY ({})", status);
+                                log::warn!("binder::BR_REPLY ({status})");
                                 return Err(status);
                             }
                         }
@@ -511,7 +511,7 @@ fn execute_command(cmd: i32) -> Result<()> {
         match cmd {
             binder::BR_ERROR => {
                 let other: StatusCode = thread_state.borrow_mut().in_parcel.read::<i32>()?.into();
-                log::error!("binder::BR_ERROR ({})", other);
+                log::error!("binder::BR_ERROR ({other})");
                 return Err(other);
             }
             binder::BR_OK => {}
@@ -615,12 +615,12 @@ fn execute_command(cmd: i32) -> Result<()> {
                         tr_secctx.transaction_data.code,
                         unsafe { tr_secctx.transaction_data.target.ptr }
                     );
-                    log += &format!(" will be dropped but finished with status {}", err);
+                    log += &format!(" will be dropped but finished with status {err}");
 
                     if reply.data_size() != 0 {
                         log += &format!(" and reply parcel size {}", reply.data_size());
                     }
-                    log::error!("{}", log);
+                    log::error!("{log}");
                 }
 
                 thread_state.borrow_mut().transaction = transaction_old;
@@ -696,7 +696,7 @@ fn execute_command(cmd: i32) -> Result<()> {
                     state.in_parcel.read::<binder::binder_uintptr_t>()?
                 };
 
-                log::trace!("BR_DEAD_BINDER: handle {:X}", handle);
+                log::trace!("BR_DEAD_BINDER: handle {handle:X}");
                 ProcessState::as_self().send_obituary_for_handle(handle as _)?;
 
                 {
@@ -714,7 +714,7 @@ fn execute_command(cmd: i32) -> Result<()> {
                 state.in_parcel.read::<binder::binder_uintptr_t>()?;
             }
             _ => {
-                log::error!("*** BAD COMMAND {} received from Binder driver\n", cmd);
+                log::error!("*** BAD COMMAND {cmd} received from Binder driver\n");
                 return Err(StatusCode::Unknown);
             }
         };
@@ -785,7 +785,7 @@ fn talk_with_driver(do_receive: bool) -> Result<()> {
             match res {
                 Ok(_) => break,
                 Err(errno) if errno != rustix::io::Errno::INTR => {
-                    log::error!("binder::write_read() error : {}", errno);
+                    log::error!("binder::write_read() error : {errno}");
                     return Err(StatusCode::Errno(errno.raw_os_error()));
                 }
                 _ => {}
@@ -1001,11 +1001,7 @@ pub fn check_interface(reader: &mut Parcel, descriptor: &str) -> Result<bool> {
     })?;
 
     if header != INTERFACE_HEADER {
-        log::error!(
-            "Expecting header {:#x} but found {:#x}.",
-            INTERFACE_HEADER,
-            header
-        );
+        log::error!("Expecting header {INTERFACE_HEADER:#x} but found {header:#x}.");
         return Ok(false);
     }
 
@@ -1013,11 +1009,7 @@ pub fn check_interface(reader: &mut Parcel, descriptor: &str) -> Result<bool> {
     if parcel_interface.eq(descriptor) {
         Ok(true)
     } else {
-        log::error!(
-            "check_interface() expected '{}' but read '{}'",
-            descriptor,
-            parcel_interface
-        );
+        log::error!("check_interface() expected '{descriptor}' but read '{parcel_interface}'");
         Ok(false)
     }
 }
@@ -1048,13 +1040,10 @@ pub(crate) fn transact(
     if (flags & transaction_flags_TF_ONE_WAY) == 0 {
         match call_restriction {
             CallRestriction::ErrorIfNotOneway => {
-                error!(
-                    "Process making non-oneway call (code: {}) but is restricted.",
-                    code
-                )
+                error!("Process making non-oneway call (code: {code}) but is restricted.")
             }
             CallRestriction::FatalIfNotOneway => {
-                panic!("Process may not make non-oneway calls (code: {}).", code);
+                panic!("Process may not make non-oneway calls (code: {code}).");
             }
             _ => (),
         }
@@ -1153,10 +1142,7 @@ pub(crate) fn join_thread_pool(is_main: bool) -> Result<()> {
                         break;
                     }
                     _ => {
-                        panic!(
-                            "get_and_execute_command() returned unexpected error {}, aborting",
-                            e
-                        );
+                        panic!("get_and_execute_command() returned unexpected error {e}, aborting");
                     }
                 }
             }

--- a/tests/src/bin/test_service.rs
+++ b/tests/src/bin/test_service.rs
@@ -86,7 +86,7 @@ struct TestService {
 impl Interface for TestService {
     fn dump(&self, writer: &mut dyn std::io::Write, args: &[String]) -> Result<()> {
         for arg in args {
-            writeln!(writer, "{}", arg).unwrap();
+            writeln!(writer, "{arg}").unwrap();
         }
         Ok(())
     }

--- a/tests/src/bin/test_service_async.rs
+++ b/tests/src/bin/test_service_async.rs
@@ -103,7 +103,7 @@ struct TestService {
 impl Interface for TestService {
     fn dump(&self, writer: &mut dyn std::io::Write, args: &[String]) -> Result<()> {
         for arg in args {
-            writeln!(writer, "{}", arg).unwrap();
+            writeln!(writer, "{arg}").unwrap();
         }
         Ok(())
     }

--- a/tests/src/test_sm.rs
+++ b/tests/src/test_sm.rs
@@ -95,7 +95,7 @@ fn test_notifications() -> rsbinder::Result<()> {
             name: &str,
             service: &rsbinder::SIBinder,
         ) -> rsbinder::status::Result<()> {
-            println!("onRegistration: {} {:?}", name, service);
+            println!("onRegistration: {name} {service:?}");
             Ok(())
         }
     }


### PR DESCRIPTION
This pull request updates string interpolation throughout the codebase to use Rust's newer `{variable}` syntax instead of the older format strings with positional arguments. These changes improve readability and consistency across the project.

### Updates to `rsbinder-aidl/src/const_expr.rs`:

* Updated panic messages to use `{self:?}` for better readability and consistency. [[1]](diffhunk://#diff-c6693ee9005af34ef777b0b4017c581815aad804511592d1284ca3ff97980b45L225-R225) [[2]](diffhunk://#diff-c6693ee9005af34ef777b0b4017c581815aad804511592d1284ca3ff97980b45L252-R252) [[3]](diffhunk://#diff-c6693ee9005af34ef777b0b4017c581815aad804511592d1284ca3ff97980b45L321-R321) [[4]](diffhunk://#diff-c6693ee9005af34ef777b0b4017c581815aad804511592d1284ca3ff97980b45L721-R721)
* Improved string formatting for nullable and initialization logic using `{init_str}` and `{param:?}`. [[1]](diffhunk://#diff-c6693ee9005af34ef777b0b4017c581815aad804511592d1284ca3ff97980b45L371-R371) [[2]](diffhunk://#diff-c6693ee9005af34ef777b0b4017c581815aad804511592d1284ca3ff97980b45L384-R384)

### Updates to `rsbinder-aidl/src/generator.rs`:

* Enhanced formatting in code generation to use `{param}` and `{var:?}` for better clarity. [[1]](diffhunk://#diff-80322bebbe43365a079935dd93d0595fb64a09cb6ccca04c9552c9ea551d3660L472-R472) [[2]](diffhunk://#diff-80322bebbe43365a079935dd93d0595fb64a09cb6ccca04c9552c9ea551d3660L744-R744)

### Updates to `rsbinder-aidl/src/lib.rs`:

* Simplified string interpolation in parsing and module generation logic using `{filename:?}` and `{mod}`. [[1]](diffhunk://#diff-69b2e405557c9c38e305a26b76d661a52671b2e7b445767fcb0699bc0c49b061L159-R159) [[2]](diffhunk://#diff-69b2e405557c9c38e305a26b76d661a52671b2e7b445767fcb0699bc0c49b061L208-R208)

### Updates to `rsbinder-aidl/src/parser.rs`:

* Updated error messages and panic strings to use `{err:?}`, `{arg_value}`, and `{radix}` for more concise and readable output. [[1]](diffhunk://#diff-864a66565040f777d2865dc1d47c3f0aaa07e3993e73be404cfff886375b7bfcL620-R620) [[2]](diffhunk://#diff-864a66565040f777d2865dc1d47c3f0aaa07e3993e73be404cfff886375b7bfcL634-R633) [[3]](diffhunk://#diff-864a66565040f777d2865dc1d47c3f0aaa07e3993e73be404cfff886375b7bfcL646-R644) [[4]](diffhunk://#diff-864a66565040f777d2865dc1d47c3f0aaa07e3993e73be404cfff886375b7bfcL658-R662)
* Improved test logging with `{err}` for better debugging. [[1]](diffhunk://#diff-864a66565040f777d2865dc1d47c3f0aaa07e3993e73be404cfff886375b7bfcL1437-R1433) [[2]](diffhunk://#diff-864a66565040f777d2865dc1d47c3f0aaa07e3993e73be404cfff886375b7bfcL1458-R1454)

### Updates to `rsbinder-aidl/src/type_generator.rs`:

* Refactored formatting for recursive types, nullable arrays, and fixed arrays using `{name}`, `{type_name}`, `{fixed_array}`, and `{reader}`. This ensures consistent and clear syntax throughout type generation logic. [[1]](diffhunk://#diff-87300b6f5a545d9f4667a3a6a0bd0642757b67cfcfda22131cc391393b33ecf2L148-R148) [[2]](diffhunk://#diff-87300b6f5a545d9f4667a3a6a0bd0642757b67cfcfda22131cc391393b33ecf2L229-R229) [[3]](diffhunk://#diff-87300b6f5a545d9f4667a3a6a0bd0642757b67cfcfda22131cc391393b33ecf2L273-R273) [[4]](diffhunk://#diff-87300b6f5a545d9f4667a3a6a0bd0642757b67cfcfda22131cc391393b33ecf2L283-R283) [[5]](diffhunk://#diff-87300b6f5a545d9f4667a3a6a0bd0642757b67cfcfda22131cc391393b33ecf2L294-R294) [[6]](diffhunk://#diff-87300b6f5a545d9f4667a3a6a0bd0642757b67cfcfda22131cc391393b33ecf2L304-R318) [[7]](diffhunk://#diff-87300b6f5a545d9f4667a3a6a0bd0642757b67cfcfda22131cc391393b33ecf2L336-R366) [[8]](diffhunk://#diff-87300b6f5a545d9f4667a3a6a0bd0642757b67cfcfda22131cc391393b33ecf2L421-R437) [[9]](diffhunk://#diff-87300b6f5a545d9f4667a3a6a0bd0642757b67cfcfda22131cc391393b33ecf2L453-R482) [[10]](diffhunk://#diff-87300b6f5a545d9f4667a3a6a0bd0642757b67cfcfda22131cc391393b33ecf2L510-R512) [[11]](diffhunk://#diff-87300b6f5a545d9f4667a3a6a0bd0642757b67cfcfda22131cc391393b33ecf2L521-R523) [[12]](diffhunk://#diff-87300b6f5a545d9f4667a3a6a0bd0642757b67cfcfda22131cc391393b33ecf2L575-R576)