### PR TITLE
fix: allow empty interface string

### DIFF
--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -213,7 +213,8 @@ impl ProcessState {
             thread_state::set_call_restriction(original_call_restriction);
         }
 
-        let interface: String = thread_state::query_interface(handle)?;
+        // some binder objects do not have interface string
+        let interface: String = thread_state::query_interface(handle).unwrap_or(String::new());
 
         let proxy: Arc<dyn IBinder> = ProxyHandle::new(handle, &interface, stability);
         let weak = WIBinder::new(proxy)?;


### PR DESCRIPTION
on android, some binder services are allowed to have an empty interface string.

this was causing `get_service` to fail