### PR TITLE
fix: resolve build failure without async feature (fixes #52)

### DIFF
--- a/example-hello/Cargo.toml
+++ b/example-hello/Cargo.toml
@@ -6,10 +6,6 @@ edition = { workspace = true }
 license = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-# [features]
-# default = ["async"]
-# sync = ["rsbinder/sync", "rsbinder-aidl/sync"]
-# async = ["rsbinder/async", "rsbinder-aidl/async"]
 
 [dependencies]
 rsbinder = { workspace = true, features = ["android_11_plus"] }
@@ -17,4 +13,4 @@ env_logger = { workspace = true }
 async-trait = { workspace = true }
 
 [build-dependencies]
-rsbinder-aidl = { workspace = true }
+rsbinder-aidl = { workspace = true, features = ["async"] }

--- a/rsbinder-aidl/Cargo.toml
+++ b/rsbinder-aidl/Cargo.toml
@@ -12,8 +12,7 @@ keywords.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["async"]
-sync = []
+default = []
 async = []
 
 [dependencies]

--- a/rsbinder-aidl/README.md
+++ b/rsbinder-aidl/README.md
@@ -2,22 +2,38 @@
 This is an AIDL compiler for **rsbinder**.
 
 ## How to use the AIDL Code Generator
-* Add the build-dependencies to Cargo.toml:
-```
+Add dependencies to Cargo.toml:
+```toml
+[dependencies]
+rsbinder = "0.5"
+
 [build-dependencies]
-rsbinder-aidl = "0.4.0"
+rsbinder-aidl = { version = "0.5", features = ["async"] }
 ```
-* Create a build.rs file in the root folder of the crate.
-* Add use std::path::PathBuf; to build.rs.
-* Add the following content:
+
+Create a build.rs file:
+```rust
+use std::path::PathBuf;
+
+fn main() {
+    rsbinder_aidl::Builder::new()
+        .source(PathBuf::from("aidl/IMyService.aidl"))
+        .output(PathBuf::from("my_service.rs"))
+        .generate()
+        .unwrap();
+}
 ```
-rsbinder_aidl::Builder::new()
-    .source(PathBuf::from("aidl/....")
-    .source(PathBuf::from("aidl/....")
-    .source(PathBuf::from("aidl/....")
-    .output(PathBuf::from("aidl_name.rs")
-    .generate().unwrap()
+
+### Sync-only Setup
+For environments without async runtime:
+```toml
+[dependencies]
+rsbinder = { version = "0.5", default-features = false }
+
+[build-dependencies]
+rsbinder-aidl = "0.5"
 ```
+
 ## How to create AIDL file
 Please read Android AIDL documents.
 

--- a/rsbinder/Cargo.toml
+++ b/rsbinder/Cargo.toml
@@ -14,7 +14,6 @@ keywords.workspace = true
 
 [features]
 default = ["tokio"]
-sync = ["rsbinder-aidl/sync"]
 tokio = ["async", "tokio/full"]
 async = ["rsbinder-aidl/async", "async-trait"]
 android_11 = []
@@ -38,7 +37,7 @@ tokio = { workspace = true, optional = true }
 rsproperties.workspace = true
 
 [build-dependencies]
-rsbinder-aidl = { workspace = true }
+rsbinder-aidl = { workspace = true, features = ["async"] }
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -16,4 +16,4 @@ async-trait = { workspace = true }
 log.workspace = true
 
 [build-dependencies]
-rsbinder-aidl = { workspace = true }
+rsbinder-aidl = { workspace = true, features = ["async"] }


### PR DESCRIPTION
Change rsbinder-aidl default features from ["async"] to [] to prevent async code generation when users don't need it.

Changes:
- rsbinder-aidl: Set default features to empty (sync-only by default)
- rsbinder-aidl: Remove unused `sync` feature
- rsbinder: Remove unused `sync` feature
- rsbinder: Add explicit `features = ["async"]` to build-dependency
- tests, example-hello: Add explicit `features = ["async"]` to build-dependency
- rsbinder-aidl/README.md: Update documentation with async/sync usage examples

This ensures that users who disable async in rsbinder won't get async code generated by rsbinder-aidl, preventing compilation errors like "cannot find type BoxFuture" or "could not find async_trait".