### PR TITLE
fix(aidl): resolve incorrect enum type for default values with shared member names (fixes #71)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "example-hello"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "env_logger",
@@ -802,7 +802,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rsbinder"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "downcast-rs",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "rsbinder-aidl"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "convert_case",
  "pest",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "rsbinder-tools"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "anstyle",
  "clap",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Jeff Kim <hiking90@gmail.com>"]
@@ -22,13 +22,13 @@ rust-version = "1.85"
 keywords = ["android", "binder", "aidl", "linux"]
 
 [workspace.dependencies]
-rsbinder = { version = "0.5.1", path = "rsbinder" }
+rsbinder = { version = "0.5.2", path = "rsbinder" }
 log = "0.4"
 env_logger = "0.11"
 anstyle = "1.0"
 tokio = { version = "1.49", default-features = false }
 async-trait = "0.1"
-rsbinder-aidl = { version = "0.5.1", path = "rsbinder-aidl" }
+rsbinder-aidl = { version = "0.5.2", path = "rsbinder-aidl" }
 pest = "2.8"
 pest_derive = "2.8"
 convert_case = "0.11"


### PR DESCRIPTION
## Summary
- Fix enum default value resolution bug where multiple enums sharing the same constant name (e.g., `UNKNOWN`) caused parcelable fields to reference the wrong enum type
- Pre-register all enum symbols across all AIDL documents before code generation begins (2-pass approach), making resolution independent of file processing order
- Bump workspace version to 0.5.2

## Test plan
- [x] Added `test_multiple_enums_with_same_member_name` regression test that reproduces the exact scenario from issue #71
- [x] Verified generated code produces correct enum references (`OperationReason::UNKNOWN`, `WakeReason::UNKNOWN`, etc.) instead of incorrect `FoldState::UNKNOWN`
- [x] All 39 existing tests pass

Fixes #71