### PR TITLE
feat: implement binder extension support (Issue #8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -132,9 +132,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -181,18 +181,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
@@ -295,9 +295,9 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "env_filter"
-version = "0.1.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
 dependencies = [
  "log",
  "regex",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -450,9 +450,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89a5b5e10d5a9ad6e5d1f4bd58225f655d6fe9767575a5e8ac5a6fe64e04495"
+checksum = "c867c356cc096b33f4981825ab281ecba3db0acefe60329f044c1789d94c6543"
 dependencies = [
  "jiff-static",
  "log",
@@ -463,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7a39c8862fc1369215ccf0a8f12dd4598c7f6484704359f0351bd617034dbf"
+checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -490,9 +490,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libm"
@@ -1002,9 +1002,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1108,9 +1108,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1370,6 +1370,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -190,6 +190,16 @@ pub trait IBinder: Any + Send + Sync {
     /// Retrieve if this object is remote.
     fn is_remote(&self) -> bool;
 
+    /// Return the extension binder object, if set. Returns None if no extension is set.
+    fn get_extension(&self) -> Result<Option<SIBinder>> {
+        Ok(None)
+    }
+
+    /// Set the extension binder object.
+    fn set_extension(&self, _extension: &SIBinder) -> Result<()> {
+        Err(StatusCode::InvalidOperation)
+    }
+
     fn inc_strong(&self, strong: &SIBinder) -> Result<()>;
     fn attempt_inc_strong(&self) -> bool;
     fn dec_strong(&self, strong: Option<ManuallyDrop<SIBinder>>) -> Result<()>;

--- a/rsbinder/src/native.rs
+++ b/rsbinder/src/native.rs
@@ -32,9 +32,8 @@ use std::os::fd::FromRawFd;
 use std::sync::{Arc, RwLock, Weak};
 
 use crate::{
-    binder::*, error::*, parcel::*,
-    parcelable::SerializeOption,
-    ref_counter::RefCounter, thread_state,
+    binder::*, error::*, parcel::*, parcelable::SerializeOption, ref_counter::RefCounter,
+    thread_state,
 };
 
 struct Inner<T: Remotable + Send + Sync> {
@@ -94,7 +93,11 @@ impl<T: Remotable> Inner<T> {
 
 impl<T: 'static + Remotable> IBinder for Inner<T> {
     fn get_extension(&self) -> Result<Option<SIBinder>> {
-        Ok(self.extension.read().expect("Extension lock poisoned").clone())
+        Ok(self
+            .extension
+            .read()
+            .expect("Extension lock poisoned")
+            .clone())
     }
 
     fn set_extension(&self, extension: &SIBinder) -> Result<()> {

--- a/rsbinder/src/proxy.rs
+++ b/rsbinder/src/proxy.rs
@@ -15,8 +15,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{self, Arc, RwLock};
 
 use crate::{
-    binder::*, binder_object::*, error::*, parcel::*,
-    parcelable::DeserializeOption,
+    binder::*, binder_object::*, error::*, parcel::*, parcelable::DeserializeOption,
     process_state::ProcessState, ref_counter::RefCounter, thread_state,
 };
 
@@ -168,12 +167,10 @@ impl IBinder for ProxyHandle {
         // 2. Remote query (EXTENSION_TRANSACTION)
         let data = Parcel::new();
         let ext: Option<SIBinder> = match self.submit_transact(EXTENSION_TRANSACTION, &data, 0) {
-            Ok(Some(mut reply)) => {
-                match DeserializeOption::deserialize_option(&mut reply) {
-                    Ok(ext) => ext,
-                    Err(_) => return Ok(None),
-                }
-            }
+            Ok(Some(mut reply)) => match DeserializeOption::deserialize_option(&mut reply) {
+                Ok(ext) => ext,
+                Err(_) => return Ok(None),
+            },
             _ => return Ok(None),
         };
 

--- a/tests/src/bin/test_service.rs
+++ b/tests/src/bin/test_service.rs
@@ -692,6 +692,11 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     let service_name = <BpTestService as ITestService::ITestService>::descriptor();
     let service = BnTestService::new_binder(TestService::default());
+
+    // Set a NamedCallback as binder extension for testing get_extension/set_extension
+    let ext_service = INamedCallback::BnNamedCallback::new_binder(NamedCallback("binder_ext".into()));
+    service.as_binder().set_extension(&ext_service.as_binder()).expect("Could not set extension");
+
     hub::add_service(service_name, service.as_binder()).expect("Could not register service");
 
     log::warn!("Intentional error output for testing purposes.");

--- a/tests/src/bin/test_service.rs
+++ b/tests/src/bin/test_service.rs
@@ -694,8 +694,12 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let service = BnTestService::new_binder(TestService::default());
 
     // Set a NamedCallback as binder extension for testing get_extension/set_extension
-    let ext_service = INamedCallback::BnNamedCallback::new_binder(NamedCallback("binder_ext".into()));
-    service.as_binder().set_extension(&ext_service.as_binder()).expect("Could not set extension");
+    let ext_service =
+        INamedCallback::BnNamedCallback::new_binder(NamedCallback("binder_ext".into()));
+    service
+        .as_binder()
+        .set_extension(&ext_service.as_binder())
+        .expect("Could not set extension");
 
     hub::add_service(service_name, service.as_binder()).expect("Could not register service");
 

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -24,9 +24,9 @@ use android::aidl::tests::unstable::{
 use android::aidl::tests::vintf::{
     VintfExtendableParcelable::VintfExtendableParcelable, VintfParcelable::VintfParcelable,
 };
+use android::aidl::tests::INamedCallback;
 use android::aidl::tests::INewName::{self, BpNewName};
 use android::aidl::tests::IOldName::{self, BpOldName};
-use android::aidl::tests::INamedCallback;
 use android::aidl::tests::ITestService::{
     self, BpTestService, Empty::Empty, ITestServiceDefault, ITestServiceDefaultRef,
 };
@@ -1560,7 +1560,10 @@ fn test_binder_extension_local_set_get() {
     assert!(got.is_ok());
     let got = got.unwrap();
     assert!(got.is_some(), "Extension should be set");
-    assert_eq!(got.unwrap().descriptor(), "android.aidl.tests.INamedCallback");
+    assert_eq!(
+        got.unwrap().descriptor(),
+        "android.aidl.tests.INamedCallback"
+    );
 }
 
 // Test 2: Local binder without extension returns None
@@ -1571,7 +1574,10 @@ fn test_binder_extension_local_default_none() {
 
     let ext = binder.get_extension();
     assert!(ext.is_ok());
-    assert!(ext.unwrap().is_none(), "Extension should be None by default");
+    assert!(
+        ext.unwrap().is_none(),
+        "Extension should be None by default"
+    );
 }
 
 // Test 3: Remote get_extension with extension set (EXTENSION_TRANSACTION round-trip)
@@ -1588,7 +1594,10 @@ fn test_binder_extension_get_from_remote() {
 
     // Verify the extension is a valid remote binder
     let ext_binder = ext.unwrap();
-    assert!(ext_binder.is_remote(), "Extension should be a remote binder");
+    assert!(
+        ext_binder.is_remote(),
+        "Extension should be a remote binder"
+    );
     assert_eq!(ext_binder.descriptor(), "android.aidl.tests.INamedCallback");
 }
 
@@ -1603,7 +1612,10 @@ fn test_binder_extension_none_from_remote() {
 
     let ext = service.as_binder().get_extension();
     assert!(ext.is_ok());
-    assert!(ext.unwrap().is_none(), "Extension should be None for service without extension");
+    assert!(
+        ext.unwrap().is_none(),
+        "Extension should be None for service without extension"
+    );
 }
 
 // Test 5: Proxy cache hit (extension exists)
@@ -1649,8 +1661,9 @@ fn test_binder_extension_use_as_interface() {
     let ext = service.as_binder().get_extension().unwrap().unwrap();
 
     // Cast extension to INamedCallback and call GetName()
-    let named_callback: rsbinder::Strong<dyn INamedCallback::INamedCallback> =
-        ext.into_interface().expect("Extension should be castable to INamedCallback");
+    let named_callback: rsbinder::Strong<dyn INamedCallback::INamedCallback> = ext
+        .into_interface()
+        .expect("Extension should be castable to INamedCallback");
     let name = named_callback.GetName().expect("GetName should succeed");
     assert_eq!(name, "binder_ext");
 }

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -26,6 +26,7 @@ use android::aidl::tests::vintf::{
 };
 use android::aidl::tests::INewName::{self, BpNewName};
 use android::aidl::tests::IOldName::{self, BpOldName};
+use android::aidl::tests::INamedCallback;
 use android::aidl::tests::ITestService::{
     self, BpTestService, Empty::Empty, ITestServiceDefault, ITestServiceDefaultRef,
 };
@@ -812,7 +813,6 @@ fn test_vintf_parcelable_holder_cannot_contain_unstable_parcelable() {
 }
 
 #[test]
-#[ignore]
 fn test_read_write_extension() {
     let ext = Arc::new(MyExt {
         a: 42,
@@ -1532,4 +1532,125 @@ fn test_issue_47_cached_interface_string() {
     );
 
     println!("\n=== Test passed: All services have correct descriptors ===\n");
+}
+
+// Binder extension tests (Issue #8)
+
+// Local helper for binder extension tests
+struct ExtNamedCallback(String);
+
+impl rsbinder::Interface for ExtNamedCallback {}
+
+impl INamedCallback::INamedCallback for ExtNamedCallback {
+    fn GetName(&self) -> std::result::Result<String, Status> {
+        Ok(self.0.clone())
+    }
+}
+
+// Test 1: Local binder set/get extension
+#[test]
+fn test_binder_extension_local_set_get() {
+    let service = INamedCallback::BnNamedCallback::new_binder(ExtNamedCallback("main".into()));
+    let ext = INamedCallback::BnNamedCallback::new_binder(ExtNamedCallback("ext".into()));
+
+    let binder = service.as_binder();
+    assert!(binder.set_extension(&ext.as_binder()).is_ok());
+
+    let got = binder.get_extension();
+    assert!(got.is_ok());
+    let got = got.unwrap();
+    assert!(got.is_some(), "Extension should be set");
+    assert_eq!(got.unwrap().descriptor(), "android.aidl.tests.INamedCallback");
+}
+
+// Test 2: Local binder without extension returns None
+#[test]
+fn test_binder_extension_local_default_none() {
+    let service = INamedCallback::BnNamedCallback::new_binder(ExtNamedCallback("main".into()));
+    let binder = service.as_binder();
+
+    let ext = binder.get_extension();
+    assert!(ext.is_ok());
+    assert!(ext.unwrap().is_none(), "Extension should be None by default");
+}
+
+// Test 3: Remote get_extension with extension set (EXTENSION_TRANSACTION round-trip)
+#[test]
+fn test_binder_extension_get_from_remote() {
+    let service = get_test_service();
+    let binder = service.as_binder();
+
+    // The test_service sets a NamedCallback("binder_ext") as extension
+    let ext = binder.get_extension();
+    assert!(ext.is_ok());
+    let ext = ext.unwrap();
+    assert!(ext.is_some(), "Extension should be set on test_service");
+
+    // Verify the extension is a valid remote binder
+    let ext_binder = ext.unwrap();
+    assert!(ext_binder.is_remote(), "Extension should be a remote binder");
+    assert_eq!(ext_binder.descriptor(), "android.aidl.tests.INamedCallback");
+}
+
+// Test 4: Remote get_extension without extension (null binder round-trip)
+#[test]
+fn test_binder_extension_none_from_remote() {
+    init_test();
+    // The versioned service does NOT set any extension
+    let service: rsbinder::Strong<dyn IFooInterface::IFooInterface> =
+        hub::get_interface(<BpFooInterface as IFooInterface::IFooInterface>::descriptor())
+            .expect("did not get binder service");
+
+    let ext = service.as_binder().get_extension();
+    assert!(ext.is_ok());
+    assert!(ext.unwrap().is_none(), "Extension should be None for service without extension");
+}
+
+// Test 5: Proxy cache hit (extension exists)
+#[test]
+fn test_binder_extension_proxy_cache_with_ext() {
+    let service = get_test_service();
+    let binder = service.as_binder();
+
+    // First call: triggers EXTENSION_TRANSACTION
+    let ext1 = binder.get_extension().unwrap();
+    assert!(ext1.is_some());
+
+    // Second call: should return cached result (no remote query)
+    let ext2 = binder.get_extension().unwrap();
+    assert!(ext2.is_some());
+
+    // Both should return the same extension descriptor
+    assert_eq!(ext1.unwrap().descriptor(), ext2.unwrap().descriptor());
+}
+
+// Test 6: Proxy cache hit (no extension)
+#[test]
+fn test_binder_extension_proxy_cache_without_ext() {
+    init_test();
+    let service: rsbinder::Strong<dyn IFooInterface::IFooInterface> =
+        hub::get_interface(<BpFooInterface as IFooInterface::IFooInterface>::descriptor())
+            .expect("did not get binder service");
+    let binder = service.as_binder();
+
+    // First call: triggers EXTENSION_TRANSACTION, caches None
+    let ext1 = binder.get_extension().unwrap();
+    assert!(ext1.is_none());
+
+    // Second call: should return cached None (no remote query)
+    let ext2 = binder.get_extension().unwrap();
+    assert!(ext2.is_none());
+}
+
+// Test 8: Extension binder can be used as a typed interface
+#[test]
+fn test_binder_extension_use_as_interface() {
+    let service = get_test_service();
+    let ext = service.as_binder().get_extension().unwrap().unwrap();
+
+    // Cast extension to INamedCallback and call GetName()
+    let named_callback: rsbinder::Strong<dyn INamedCallback::INamedCallback> =
+        ext.into_interface().expect("Extension should be castable to INamedCallback");
+    let name = named_callback.GetName().expect("GetName should succeed");
+    assert_eq!(name, "binder_ext");
 }


### PR DESCRIPTION
## Summary
- Add `get_extension`/`set_extension` to IBinder trait with default implementations
- Implement extension storage (`RwLock<Option<SIBinder>>`) in `Inner<T>` (server side) and `ExtensionCache` enum with lazy caching in `ProxyHandle` (client side)
- Replace `EXTENSION_TRANSACTION` error stub with proper `SerializeOption`/`DeserializeOption` round-trip handler
- Add 7 integration tests (local set/get, remote round-trip, null binder, proxy cache, interface cast) and enable previously ignored `test_read_write_extension`

## Details

Closes #8

This implements the Binder extension mechanism compatible with AOSP's `BpBinder::getExtension()`/`BBinder::setExtension()`. It allows downstream developers to attach extension interfaces to binder objects without modifying original AIDL interfaces.

**Key design decisions:**
- `ExtensionCache` enum (`NotQueried`/`Queried(Option<SIBinder>)`) instead of `Option<Option<SIBinder>>` for readability
- Proxy caches only on successful remote query; errors return `Ok(None)` without caching (allows retry)
- Sync-only API (consistent with AOSP; async can be added as a follow-up)

## Test plan
- [x] 7 binder extension tests pass on Android emulator (109 total, 0 failures)
- [x] Local binder: set/get extension, default None
- [x] Remote IPC: EXTENSION_TRANSACTION round-trip with and without extension
- [x] Proxy cache: consistent results on repeated calls
- [x] Extension binder castable to typed interface (`INamedCallback::GetName()` returns expected value)
- [x] Previously ignored `test_read_write_extension` now enabled and passing