### PR TITLE
feat: support explicit transaction code assignment in AIDL

### DIFF
--- a/rsbinder-aidl/src/generator.rs
+++ b/rsbinder-aidl/src/generator.rs
@@ -718,7 +718,9 @@ impl Generator {
 
             // === Transaction code validation (before fn_members loop) ===
             {
-                let explicit_count = decl.method_list.iter()
+                let explicit_count = decl
+                    .method_list
+                    .iter()
                     .filter(|m| m.intvalue.is_some())
                     .count();
 
@@ -728,7 +730,8 @@ impl Generator {
                         "Interface {}: either all methods must have explicitly assigned \
                          transaction IDs or none of them should",
                         decl.name
-                    ).into());
+                    )
+                    .into());
                 }
 
                 if explicit_count > 0 {
@@ -740,7 +743,8 @@ impl Generator {
                                 return Err(format!(
                                     "Interface {}: method '{}' has negative transaction code {}",
                                     decl.name, method.identifier, code
-                                ).into());
+                                )
+                                .into());
                             }
                             if code > u32::MAX as i64 {
                                 return Err(format!(
@@ -753,7 +757,8 @@ impl Generator {
                                     "Interface {}: methods '{}' and '{}' have the same \
                                      transaction code {}",
                                     decl.name, prev_name, method.identifier, code
-                                ).into());
+                                )
+                                .into());
                             }
                         }
                     }

--- a/rsbinder-aidl/src/parser.rs
+++ b/rsbinder-aidl/src/parser.rs
@@ -477,7 +477,7 @@ pub struct MethodDecl {
     pub r#type: Type,
     pub identifier: String,
     pub arg_list: Vec<Arg>,
-    pub intvalue: i64,
+    pub intvalue: Option<i64>,
 }
 
 #[derive(Debug, Clone)]
@@ -1175,7 +1175,7 @@ fn parse_method_decl(pairs: pest::iterators::Pairs<Rule>) -> MethodDecl {
             }
             Rule::INTVALUE => {
                 let expr = parse_intvalue(pair.as_str()).calculate();
-                decl.intvalue = match expr.value {
+                decl.intvalue = Some(match expr.value {
                     ValueType::Byte(v) => v as _,
                     ValueType::Int32(v) => v as _,
                     ValueType::Int64(v) => v,
@@ -1184,7 +1184,7 @@ fn parse_method_decl(pairs: pest::iterators::Pairs<Rule>) -> MethodDecl {
                         pair,
                         pair.as_str()
                     ),
-                };
+                });
             }
             _ => unreachable!(
                 "Unexpected rule in parse_method_decl(): {}, \"{}\"",

--- a/rsbinder-aidl/tests/test_interfaces.rs
+++ b/rsbinder-aidl/tests/test_interfaces.rs
@@ -243,7 +243,8 @@ fn aidl_generator_should_fail(input: &str, expected_error_substring: &str) {
     assert!(
         err_msg.contains(expected_error_substring),
         "Error message '{}' does not contain '{}'",
-        err_msg, expected_error_substring
+        err_msg,
+        expected_error_substring
     );
 }
 


### PR DESCRIPTION
## Summary
- Support AOSP AIDL syntax `void method() = 10;` for explicit transaction code assignment (fixes #76)
- Change `MethodDecl.intvalue` from `i64` to `Option<i64>` to distinguish explicit `= 0` from unspecified
- Add validation: all-or-nothing rule, duplicate detection, negative/overflow checks
- Update Tera template to conditionally use explicit or sequential transaction codes

## Test plan
- [x] `cargo test -p rsbinder-aidl` — all 40 tests pass (6 new tests added)
- [x] `cargo build` — full workspace build succeeds
- [x] `cargo clippy -p rsbinder-aidl` — no warnings

Closes #76