### PR TITLE
feat: implement Stability infrastructure with bitmask validation

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        api-level: [30, 34, 36]
+        api-level: [30, 32, 34, 36]
       fail-fast: false
 
     steps:

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -713,7 +713,6 @@ mod tests {
         assert_eq!(b_pack_chars('_', 'T', 'W', 'T'), TWEET_TRANSACTION);
         assert_eq!(b_pack_chars('_', 'L', 'I', 'K'), LIKE_TRANSACTION);
     }
-
 }
 
 #[cfg(test)]
@@ -732,7 +731,12 @@ mod stability_tests {
     // === TryFrom round-trip tests ===
     #[test]
     fn test_stability_roundtrip() {
-        for s in [Stability::Local, Stability::Vendor, Stability::System, Stability::Vintf] {
+        for s in [
+            Stability::Local,
+            Stability::Vendor,
+            Stability::System,
+            Stability::Vintf,
+        ] {
             let wire: i32 = s.into();
             assert_eq!(Stability::try_from(wire).unwrap(), s);
         }
@@ -744,15 +748,30 @@ mod stability_tests {
         // Category{version=1, reserved=[0,0], level} → repr = (level << 24) | version
         let category = |level: i32, version: i32| -> i32 { (level << 24) | version };
 
-        assert_eq!(Stability::try_from(category(0b000011, 1)).unwrap(), Stability::Vendor);
-        assert_eq!(Stability::try_from(category(0b001100, 1)).unwrap(), Stability::System);
-        assert_eq!(Stability::try_from(category(0b111111, 1)).unwrap(), Stability::Vintf);
+        assert_eq!(
+            Stability::try_from(category(0b000011, 1)).unwrap(),
+            Stability::Vendor
+        );
+        assert_eq!(
+            Stability::try_from(category(0b001100, 1)).unwrap(),
+            Stability::System
+        );
+        assert_eq!(
+            Stability::try_from(category(0b111111, 1)).unwrap(),
+            Stability::Vintf
+        );
 
         // Different version values should also work
-        assert_eq!(Stability::try_from(category(0b001100, 12)).unwrap(), Stability::System);
+        assert_eq!(
+            Stability::try_from(category(0b001100, 12)).unwrap(),
+            Stability::System
+        );
 
         // rsbinder's own Android 12 format: level | 0x0c000000
-        assert_eq!(Stability::try_from(0b001100 | 0x0c000000_i32).unwrap(), Stability::System);
+        assert_eq!(
+            Stability::try_from(0b001100 | 0x0c000000_i32).unwrap(),
+            Stability::System
+        );
     }
 
     #[test]

--- a/rsbinder/src/native.rs
+++ b/rsbinder/src/native.rs
@@ -38,7 +38,7 @@ use crate::{
 
 struct Inner<T: Remotable + Send + Sync> {
     remotable: T,
-    _stability: Stability,
+    stability: Stability,
     strong: RefCounter,
     weak: RefCounter,
     extension: RwLock<Option<SIBinder>>,
@@ -124,10 +124,9 @@ impl<T: 'static + Remotable> IBinder for Inner<T> {
         Ok(())
     }
 
-    // /// Retrieve the stability of this object.
-    // fn stability(&self) -> Stability {
-    //     self.stability
-    // }
+    fn stability(&self) -> Stability {
+        self.stability
+    }
 
     fn as_any(&self) -> &dyn Any {
         self
@@ -247,7 +246,7 @@ impl<T: 'static + Remotable> Binder<T> {
         Binder::<T> {
             inner: Arc::new(Inner {
                 remotable,
-                _stability: stability,
+                stability,
                 strong: Default::default(),
                 weak: Default::default(),
                 extension: RwLock::new(None),

--- a/rsbinder/src/parcelable.rs
+++ b/rsbinder/src/parcelable.rs
@@ -60,7 +60,7 @@ pub trait ParcelableMetadata {
 
     /// The Binder parcelable stability.
     fn stability(&self) -> Stability {
-        Stability::Local
+        Stability::default()
     }
 }
 
@@ -456,7 +456,7 @@ impl SerializeOption for SIBinder {
         match this {
             Some(binder) => {
                 parcel.write::<flat_binder_object>(&binder.into())?;
-                parcel.write::<i32>(&Stability::System.into())?;
+                parcel.write::<i32>(&binder.stability().into())?;
                 Ok(())
             }
 

--- a/rsbinder/src/parcelable_holder.rs
+++ b/rsbinder/src/parcelable_holder.rs
@@ -100,11 +100,11 @@ impl ParcelableHolder {
     where
         T: Any + Parcelable + ParcelableMetadata + std::fmt::Debug + Send + Sync,
     {
-        if self.stability > p.stability() {
+        if !p.stability().includes(self.stability) {
             log::error!(
-                "ParcelableHolder::set_parcelable: parcelable stability mismatch: {:?} > {:?}",
-                self.stability,
-                p.stability()
+                "ParcelableHolder::set_parcelable: parcelable stability {:?} does not include holder stability {:?}",
+                p.stability(),
+                self.stability
             );
             return Err(StatusCode::BadValue);
         }

--- a/rsbinder/src/proxy.rs
+++ b/rsbinder/src/proxy.rs
@@ -231,9 +231,9 @@ impl IBinder for ProxyHandle {
         thread_state::ping_binder(self.handle())
     }
 
-    // fn stability(&self) -> Stability {
-    //     self.stability
-    // }
+    fn stability(&self) -> Stability {
+        self.stability
+    }
 
     fn as_any(&self) -> &dyn Any {
         self


### PR DESCRIPTION
## Summary
- Enable `stability()` accessors across IBinder trait, native.rs, proxy.rs, and SIBinder (previously commented out)
- Fix `TryFrom<i32>` for Stability to return `Err(BadValue)` instead of silently falling back to `Ok(Local)`, with Android 12 Category repr format support
- Replace hardcoded `Stability::System` in SIBinder serialization with actual binder stability
- Switch ParcelableHolder validation from linear `PartialOrd` comparison to Android-compatible bitmask-based `includes()` check, where Vendor and System are independent domains
- Change `ParcelableMetadata` default stability from `Local` to `System` to match Android's `getLocalLevel()`
- Add API level 32 (Android 12L) to GitHub Actions test matrix

## Test plan
- [x] Host build passes
- [x] NDK build (`cargo ndk -t arm64-v8a`) passes
- [x] 80 unit tests pass on Android emulator (API 36)
- [x] 109 integration tests pass on Android emulator (API 36)
- [ ] Run GitHub Actions Android Test workflow across API levels [30, 32, 34, 36]