### PR TITLE
fix(rsbinder): follow-up to PR #91 — unsafe fn and UTF-16 cleanup

### DIFF
--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -210,7 +210,11 @@ impl Parcel {
         }
     }
 
-    pub fn from_ipc_parts(
+    /// # Safety
+    /// - `data` must be valid for reads/writes of `length` bytes, or null if `length` is 0
+    /// - `objects` must be valid for reads/writes of `object_count` elements, or null if `object_count` is 0
+    /// - The memory must remain valid until the Parcel is dropped or `free_buffer` is called
+    pub unsafe fn from_ipc_parts(
         data: *mut u8,
         length: usize,
         objects: *mut binder_size_t,
@@ -224,8 +228,8 @@ impl Parcel {
         ) -> Result<()>,
     ) -> Self {
         Parcel {
-            data: unsafe { ParcelData::from_raw_parts_mut(data, length) },
-            objects: unsafe { ParcelData::from_raw_parts_mut(objects, object_count) },
+            data: ParcelData::from_raw_parts_mut(data, length),
+            objects: ParcelData::from_raw_parts_mut(objects, object_count),
             pos: 0,
             next_object_hint: 0,
             request_header_present: false,

--- a/rsbinder/src/parcelable.rs
+++ b/rsbinder/src/parcelable.rs
@@ -309,15 +309,16 @@ impl SerializeOption for str {
                 utf16.push(0);
 
                 parcel.write::<i32>(&(len as i32))?;
-                let pad_size = crate::parcel::pad_size(utf16.len() * std::mem::size_of::<u16>());
-                utf16.resize(pad_size / std::mem::size_of::<u16>(), 0);
                 // SAFETY: We're creating a byte view of the UTF-16 encoded string.
                 // - utf16 is a valid Vec<u16> with proper alignment
-                // - pad_size was calculated with pad_size() to include padding
+                // - The byte count is exactly utf16.len() * size_of::<u16>()
                 // - The resulting byte slice will not outlive the utf16 vector
-                // - u16 data can safely be viewed as bytes
+                // - write_aligned_data handles 4-byte padding internally
                 parcel.write_aligned_data(unsafe {
-                    std::slice::from_raw_parts(utf16.as_ptr() as *const u8, pad_size)
+                    std::slice::from_raw_parts(
+                        utf16.as_ptr() as *const u8,
+                        utf16.len() * std::mem::size_of::<u16>(),
+                    )
                 });
 
                 Ok(())

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -449,14 +449,18 @@ fn wait_for_response(until: UntilResponse) -> Result<Option<Parcel>> {
                     let (buffer, offsets) = unsafe { (tr.data.ptr.buffer, tr.data.ptr.offsets) };
                     if let UntilResponse::Reply = until {
                         if (tr.flags & transaction_flags_TF_STATUS_CODE) == 0 {
-                            let reply = Parcel::from_ipc_parts(
-                                buffer as _,
-                                tr.data_size as _,
-                                offsets as _,
-                                (tr.offsets_size as usize)
-                                    / std::mem::size_of::<binder::binder_size_t>(),
-                                free_buffer,
-                            );
+                            // SAFETY: buffer and offsets are valid pointers from binder driver
+                            // transaction data, with sizes given by tr.data_size and tr.offsets_size
+                            let reply = unsafe {
+                                Parcel::from_ipc_parts(
+                                    buffer as _,
+                                    tr.data_size as _,
+                                    offsets as _,
+                                    (tr.offsets_size as usize)
+                                        / std::mem::size_of::<binder::binder_size_t>(),
+                                    free_buffer,
+                                )
+                            };
                             return Ok(Some(reply));
                         } else {
                             // SAFETY: Reading status code from binder transaction reply


### PR DESCRIPTION
## Summary
- Mark `from_ipc_parts` as `unsafe fn` to fix `clippy::not_unsafe_ptr_arg_deref` (it dereferences raw pointers)
- Add `unsafe` block at call site in `thread_state.rs` that was outside one
- Simplify UTF-16 string serialization: remove redundant `pad_size`/`resize` since `write_aligned_data` already handles 4-byte padding internally

Follow-up to #91.

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` passes (74/80; 6 failures are pre-existing binder device dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)