### PR TITLE
Add support for AIDL unstructured/custom parcelables, rust_type

### DIFF
--- a/rsbinder-aidl/src/aidl.pest
+++ b/rsbinder-aidl/src/aidl.pest
@@ -17,10 +17,15 @@ annotation_list = { annotation+ }
 
 unannotated_decl = _{ parcelable_decl | interface_decl | enum_decl | union_decl }
 
+optional_unstructured_headers = {
+    CPP_HEADER ~ C_STR |
+    NDK_HEADER ~ C_STR |
+    RUST_TYPE ~ C_STR
+}
+
 parcelable_decl = {
     PARCELABLE ~ qualified_name ~ optional_type_params ~ "{" ~ parcelable_members* ~ "}" |
-    PARCELABLE ~ qualified_name ~ optional_type_params ~ ";" |
-    PARCELABLE ~ qualified_name ~ CPP_HEADER ~ C_STR ~ ";"
+    PARCELABLE ~ qualified_name ~ optional_type_params ~ optional_unstructured_headers* ~ ";"
 }
 
 interface_decl = {
@@ -108,7 +113,7 @@ parcelable_members = { (variable_decl | constant_decl | decl)+ }
 
 keywords = @{
     (
-        INTERFACE | ONEWAY | CONST | INOUT | IN | OUT | ENUM | UNION | CPP_HEADER | PARCELABLE |
+        INTERFACE | ONEWAY | CONST | INOUT | IN | OUT | ENUM | UNION | CPP_HEADER | NDK_HEADER | RUST_TYPE | PARCELABLE |
         TRUE_LITERAL | FALSE_LITERAL
     ) ~ &WHITESPACE
 }
@@ -125,7 +130,7 @@ annotation = {
 
 qualified_name = @{ identifier ~ ("." ~ identifier)* }
 
-identifier = { !keywords ~ (IDENTIFIER | CPP_HEADER) }
+identifier = { !keywords ~ (IDENTIFIER | CPP_HEADER | NDK_HEADER | RUST_TYPE) }
 
 constant_value_list = { const_expr ~ ("," ~ const_expr)* ~ ","? }
 
@@ -182,7 +187,9 @@ OUT = { "out" }
 INOUT = { "inout" }
 ENUM = _{ "enum" }
 UNION = _{ "union" }
-CPP_HEADER = _{ "cpp_header" }
+CPP_HEADER = { "cpp_header" }
+NDK_HEADER = { "ndk_header" }
+RUST_TYPE = { "rust_type" }
 PARCELABLE = _{ "parcelable" }
 IDENTIFIER = @{ ("_" | ASCII_ALPHA)+ ~ ("_" | ASCII_ALPHA | ASCII_DIGIT)* }
 TRUE_LITERAL = { "true" }

--- a/rsbinder-aidl/src/generator.rs
+++ b/rsbinder-aidl/src/generator.rs
@@ -850,10 +850,29 @@ impl Generator {
             is_empty = true;
             // return Ok(String::new())
         }
+
+        if !decl.rust_type.is_empty() {
+            let rendered = format!(r#"
+pub mod {mod} {{
+    #![allow(non_upper_case_globals, non_snake_case, dead_code)]
+    pub type {name} = {rust_type};
+}}
+"#, mod = &decl.name, name = &decl.name, rust_type = &decl.rust_type);
+            return Ok(add_indent(indent, rendered.trim()));
+        }
+
         if !decl.cpp_header.is_empty() {
             println!(
                 "cpp_header {} for Parcelable {} is not supported.",
                 decl.cpp_header, decl.name
+            );
+            is_empty = true;
+            // return Ok(String::new())
+        }
+        if !decl.ndk_header.is_empty() {
+            println!(
+                "ndk_header {} for Parcelable {} is not supported.",
+                decl.ndk_header, decl.name
             );
             is_empty = true;
             // return Ok(String::new())

--- a/rsbinder-aidl/src/parser.rs
+++ b/rsbinder-aidl/src/parser.rs
@@ -456,6 +456,8 @@ pub struct ParcelableDecl {
     pub name: String,
     pub type_params: Vec<String>,
     pub cpp_header: String,
+    pub ndk_header: String,
+    pub rust_type: String,
     pub members: Vec<Declaration>,
     // pub name_dict: Option<HashMap<String, ConstExpr>>,
 }
@@ -1396,6 +1398,50 @@ fn parse_optional_type_params(pairs: pest::iterators::Pairs<Rule>) -> Vec<String
     res
 }
 
+fn parse_unstructured_parcelable(
+    parcelable: &mut ParcelableDecl,
+    mut pairs: pest::iterators::Pairs<Rule>,
+) -> Result<(), AidlError> {
+    enum HeaderType {
+        CppHeader,
+        NdkHeader,
+        RustType,
+    }
+
+    let (first, second) = pairs
+        .next()
+        .zip(pairs.next())
+        .expect("Incomplete rule in parse_unstructured_parcelable()");
+
+    let header = match first.as_rule() {
+        Rule::CPP_HEADER => HeaderType::CppHeader,
+        Rule::NDK_HEADER => HeaderType::NdkHeader,
+        Rule::RUST_TYPE => HeaderType::RustType,
+        _ => unreachable!(
+            "Unexpected rule in parse_unstructured_parcelable(): {}",
+            first
+        ),
+    };
+
+    match second.as_rule() {
+        Rule::C_STR => {
+            let str = second.as_str();
+            let str = str[1..str.len() - 1].into();
+            match header {
+                HeaderType::CppHeader => parcelable.cpp_header = str,
+                HeaderType::NdkHeader => parcelable.ndk_header = str,
+                HeaderType::RustType => parcelable.rust_type = str,
+            }
+        }
+        _ => unreachable!(
+            "Unexpected rule in parse_unstructured_parcelable(): {}",
+            second
+        ),
+    }
+
+    Ok(())
+}
+
 fn parse_parcelable_decl(
     annotation_list: Vec<Annotation>,
     pairs: pest::iterators::Pairs<Rule>,
@@ -1421,8 +1467,8 @@ fn parse_parcelable_decl(
                     .append(&mut parse_parcelable_members(pair.into_inner())?);
             }
 
-            Rule::C_STR => {
-                parcelable.cpp_header = pair.as_str().into();
+            Rule::optional_unstructured_headers => {
+                parse_unstructured_parcelable(&mut parcelable, pair.into_inner())?;
             }
 
             _ => unreachable!("Unexpected rule in parse_parcelable_decl(): {}", pair),

--- a/rsbinder-aidl/tests/test_parcelables.rs
+++ b/rsbinder-aidl/tests/test_parcelables.rs
@@ -947,3 +947,21 @@ pub mod Union {
     )?;
     Ok(())
 }
+
+#[test]
+fn test_unstructured_parcelable() -> Result<(), Box<dyn Error>> {
+    aidl_generator(
+        r#"
+        package android.os;
+
+        @JavaOnlyStableParcelable @NdkOnlyStableParcelable parcelable PersistableBundle cpp_header "binder/PersistableBundle.h" ndk_header "android/persistable_bundle_aidl.h" rust_type "crate::persistable_bundle::PersistableBundle";
+        "#,
+        r#"
+pub mod PersistableBundle {
+    #![allow(non_upper_case_globals, non_snake_case, dead_code)]
+    pub type PersistableBundle = crate::persistable_bundle::PersistableBundle;
+}
+        "#,
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
This adds support for the AIDL `rust_type` declaration (as well as `ndk_header` for completeness), thus enabling use of custom/unstructured parcelables. Only affects the AIDL generator, I haven't added any traits or macros to the main crate.

Example:
```aidl
// aidl/android/os/PersistableBundle.aidl
package android.os;

parcelable PersistableBundle rust_type "crate::persistable_bundle::PersistableBundle";
```

```rust
// src/persistable_bundle.rs
#[derive(Default, Clone, PartialEq)]
pub struct PersistableBundle {
    //  ...
}


impl rsbinder::ParcelableMetadata for PersistableBundle {
    fn descriptor() -> &'static str { "android.os.PersistableBundle" }
}

impl rsbinder::Parcelable for PersistableBundle {
    fn write_to_parcel(&self, parcel: &mut rsbinder::Parcel) -> rsbinder::Result<()> {
        // ...
    }

    fn read_from_parcel(&mut self, parcel: &mut rsbinder::Parcel) -> rsbinder::Result<()> {
        // ...
    }
}

rsbinder::impl_serialize_for_parcelable!(PersistableBundle);
rsbinder::impl_deserialize_for_parcelable!(PersistableBundle);
```

My actual use case was for implementing the MidiManager AIDL, which defines `MidiDeviceInfo` in native code, in addition to the `PersistableBundle` example above.