### PR TITLE
feat(rsbinder): route Weak<I>::upgrade through cache resurrection

### DIFF
--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -432,14 +432,51 @@ impl SIBinder {
 
     /// Construct a weak reference to this binder.
     ///
-    /// Pure `Arc::downgrade` — no kernel command, no trait dispatch. The
-    /// resulting `WIBinder::upgrade()` is now legitimately fallible and
-    /// returns `Err(DeadObject)` once the last `Arc<dyn IBinder>` is
-    /// dropped (for proxies that means the last `Arc<ProxyHandle>` —
-    /// the cache holds only a `sync::Weak`).
+    /// Pure `Arc::downgrade` — no kernel command, no trait dispatch.
+    ///
+    /// For proxies, the resulting `WIBinder` snapshots `(handle,
+    /// stability, generation)` so a later `WIBinder::upgrade()` can
+    /// route through the process-wide proxy cache. As long as the
+    /// cache pin is alive (no obituary yet), `upgrade()` succeeds via
+    /// case-(b) resurrection — matching Android `wp<BpBinder>::promote()`
+    /// semantics. If the cache entry was removed (obituary) or the
+    /// handle id was recycled to a different binder_node (generation
+    /// mismatch), `upgrade()` returns `Err(DeadObject)`.
+    ///
+    /// For native binders, the `WIBinder` is a plain
+    /// `sync::Weak<dyn IBinder>` — `upgrade()` succeeds iff some
+    /// `Arc<dyn IBinder>` to the inner binder is still alive.
     pub fn downgrade(this: &Self) -> WIBinder {
-        WIBinder {
-            inner: Arc::downgrade(&this.inner),
+        let weak = Arc::downgrade(&this.inner);
+        if let Some(proxy_handle) = this.inner.as_any().downcast_ref::<proxy::ProxyHandle>() {
+            // For proxies, capture handle/stability/generation. The cache
+            // entry MUST exist at this point — `Arc<ProxyHandle>` is alive,
+            // and `strong_proxy_for_handle_stability` always inserts the
+            // entry alongside allocating the Arc under the same write lock.
+            // If we somehow miss it (race window during obituary), fall
+            // back to Native — `upgrade` will then see a dangling weak and
+            // return DeadObject, which is the correct contract.
+            let handle = proxy_handle.handle();
+            let stability = proxy_handle.stability();
+            let generation =
+                crate::process_state::ProcessState::as_self().cache_generation_for(handle);
+            match generation {
+                Some(generation) => WIBinder {
+                    inner: WIBinderInner::Proxy {
+                        handle,
+                        stability,
+                        generation,
+                        weak,
+                    },
+                },
+                None => WIBinder {
+                    inner: WIBinderInner::Native(weak),
+                },
+            }
+        } else {
+            WIBinder {
+                inner: WIBinderInner::Native(weak),
+            }
         }
     }
 
@@ -517,49 +554,159 @@ impl Eq for SIBinder {}
 
 /// Weak reference to a binder object.
 ///
-/// `upgrade()` is legitimately fallible: it returns `Err(DeadObject)` once
-/// the last `Arc<dyn IBinder>` to the inner binder has been dropped. For
-/// proxies that corresponds to the last `Arc<ProxyHandle>` — the
-/// process-wide handle cache stores only a `sync::Weak<ProxyHandle>`, so
-/// when no user-visible strong ref remains the cache entry's `Weak`
-/// becomes dangling. A subsequent lookup goes through
-/// `ProcessState::strong_proxy_for_handle_stability`'s slow-path case (b)
-/// (entry present, dead Arc) which resurrects a fresh `Arc<ProxyHandle>`
-/// without re-issuing `INTERFACE_TRANSACTION`.
+/// `upgrade()` is fallible. The conditions under which it succeeds
+/// depend on whether the underlying binder is a proxy (remote) or a
+/// native (local) one:
+///
+/// **Proxy.** `upgrade()` succeeds as long as the process-wide proxy
+/// cache entry for this binder is alive (no obituary yet) and the
+/// handle id has not been recycled to a different binder_node since
+/// this `WIBinder` was created. Specifically:
+///   - If some `Arc<ProxyHandle>` is still alive in the process,
+///     `upgrade()` returns it directly (analogous to a cache hit).
+///   - Otherwise the cache pin (`BC_INCREFS` taken at first
+///     resolution) keeps the kernel `binder_ref` slot alive, so a
+///     fresh `BC_ACQUIRE` succeeds and `upgrade()` returns a freshly
+///     allocated `Arc<ProxyHandle>` (case-(b) resurrection). The
+///     resurrected `Arc` is a different allocation than the original,
+///     but refers to the same kernel binder_node.
+///   - If `BR_DEAD_BINDER` was processed for this handle, the cache
+///     entry is gone and `upgrade()` returns `Err(DeadObject)`.
+///   - If the handle id was recycled to a different binder_node since
+///     this `WIBinder` was created, the snapshotted generation does
+///     not match the live entry's, and `upgrade()` returns
+///     `Err(DeadObject)`.
+///
+/// This matches Android `wp<BpBinder>::promote()` semantics: weak
+/// references can be promoted to strong as long as the binder is
+/// still alive in the kernel, even if every user-side strong ref has
+/// been dropped.
+///
+/// **Native.** `upgrade()` succeeds iff some `Arc<dyn IBinder>` to the
+/// inner binder is still alive in the process. This is plain
+/// `sync::Weak::upgrade` semantics — natives have no process-wide
+/// cache, so when the last strong is dropped, the binder is gone.
 pub struct WIBinder {
-    inner: sync::Weak<dyn IBinder>,
+    inner: WIBinderInner,
+}
+
+pub(crate) enum WIBinderInner {
+    /// Proxy weak reference. Carries `(handle, stability, generation)`
+    /// snapshot so `upgrade` can route through the proxy cache for
+    /// resurrection.
+    Proxy {
+        handle: u32,
+        stability: Stability,
+        generation: u64,
+        weak: sync::Weak<dyn IBinder>,
+    },
+    /// Native weak reference. Plain `sync::Weak`.
+    Native(sync::Weak<dyn IBinder>),
 }
 
 impl WIBinder {
     pub fn upgrade(&self) -> Result<SIBinder> {
-        match self.inner.upgrade() {
-            Some(arc) => Ok(SIBinder::from_arc(arc)),
-            None => Err(StatusCode::DeadObject),
+        match &self.inner {
+            WIBinderInner::Native(weak) => weak
+                .upgrade()
+                .map(SIBinder::from_arc)
+                .ok_or(StatusCode::DeadObject),
+            WIBinderInner::Proxy {
+                handle,
+                stability,
+                generation,
+                weak,
+            } => {
+                // Fast path: an `Arc<ProxyHandle>` is still alive
+                // somewhere in the process — reuse it without touching
+                // the cache lock.
+                if let Some(arc) = weak.upgrade() {
+                    return Ok(SIBinder::from_arc(arc));
+                }
+                // Slow path: drive cache-(b) resurrection. The cache
+                // pin keeps the kernel binder_ref slot alive, so the
+                // BC_ACQUIRE inside `new_acquired` is guaranteed to
+                // succeed unless the entry was obituary'd or recycled
+                // (in which case we get DeadObject).
+                crate::process_state::ProcessState::as_self().resurrect_proxy_for_handle_stability(
+                    *handle,
+                    *stability,
+                    *generation,
+                )
+            }
         }
     }
 }
 
 impl Debug for WIBinder {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        f.debug_struct("WIBinder")
-            .field("self", &(self as *const WIBinder))
-            .field("strong_count", &self.inner.strong_count())
-            .field("weak_count", &self.inner.weak_count())
-            .finish()
+        match &self.inner {
+            WIBinderInner::Native(weak) => f
+                .debug_struct("WIBinder::Native")
+                .field("strong_count", &weak.strong_count())
+                .field("weak_count", &weak.weak_count())
+                .finish(),
+            WIBinderInner::Proxy {
+                handle,
+                stability,
+                generation,
+                weak,
+            } => f
+                .debug_struct("WIBinder::Proxy")
+                .field("handle", handle)
+                .field("stability", stability)
+                .field("generation", generation)
+                .field("strong_count", &weak.strong_count())
+                .finish(),
+        }
     }
 }
 
 impl Clone for WIBinder {
     fn clone(&self) -> Self {
-        Self {
-            inner: sync::Weak::clone(&self.inner),
-        }
+        let inner = match &self.inner {
+            WIBinderInner::Native(weak) => WIBinderInner::Native(sync::Weak::clone(weak)),
+            WIBinderInner::Proxy {
+                handle,
+                stability,
+                generation,
+                weak,
+            } => WIBinderInner::Proxy {
+                handle: *handle,
+                stability: *stability,
+                generation: *generation,
+                weak: sync::Weak::clone(weak),
+            },
+        };
+        Self { inner }
     }
 }
 
 impl PartialEq for WIBinder {
+    /// Equality matches Android `BpBinder` identity. For proxies, two
+    /// `WIBinder`s are equal iff they refer to the same kernel
+    /// binder_node — i.e. same `(handle, generation)` pair. This holds
+    /// even across resurrection (the new `Arc<ProxyHandle>` is a fresh
+    /// allocation, so `sync::Weak::ptr_eq` would say "different", but
+    /// they are conceptually the same binder). For natives, equality
+    /// is `sync::Weak::ptr_eq` on the inner Arc allocation.
     fn eq(&self, other: &Self) -> bool {
-        sync::Weak::ptr_eq(&self.inner, &other.inner)
+        match (&self.inner, &other.inner) {
+            (WIBinderInner::Native(a), WIBinderInner::Native(b)) => sync::Weak::ptr_eq(a, b),
+            (
+                WIBinderInner::Proxy {
+                    handle: ha,
+                    generation: ga,
+                    ..
+                },
+                WIBinderInner::Proxy {
+                    handle: hb,
+                    generation: gb,
+                    ..
+                },
+            ) => ha == hb && ga == gb,
+            _ => false,
+        }
     }
 }
 

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::os::raw::c_void;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{self, Arc, OnceLock, RwLock};
 use std::thread;
 
@@ -48,9 +48,19 @@ fn undo_case_a_pin(handle: u32) {
 /// `handle_to_proxy`. The pin is acquired exactly once on first
 /// insertion (slow-path case (a)) and released exactly once on obituary
 /// teardown.
+///
+/// `generation` is a process-wide monotonic counter snapshotted at
+/// case-(a) insertion. It enables `WIBinder::upgrade()` to detect when
+/// the same handle id has been recycled to a different `binder_node` —
+/// resurrection through case (b) is only safe when the snapshot taken
+/// at `SIBinder::downgrade` time still matches the live entry's
+/// generation. Case (b) preserves the existing entry's generation
+/// (same kernel slot, just user-space resurrection); only case (a)
+/// allocates a new generation.
 pub(crate) struct CacheEntry {
     pub(crate) weak: sync::Weak<ProxyHandle>,
     pub(crate) descriptor: String,
+    pub(crate) generation: u64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -80,6 +90,10 @@ pub struct ProcessState {
     mmap: RwLock<MemoryMap>,
     context_manager: RwLock<Option<SIBinder>>,
     handle_to_proxy: RwLock<HashMap<u32, CacheEntry>>,
+    /// Monotonic counter for `CacheEntry::generation`. Incremented
+    /// exactly once per case-(a) cache insertion (i.e. per fresh
+    /// `BC_INCREFS` pin). Wrap-around is not a practical concern (u64).
+    next_generation: AtomicU64,
     disable_background_scheduling: AtomicBool,
     call_restriction: RwLock<CallRestriction>,
     thread_pool_started: AtomicBool,
@@ -165,6 +179,7 @@ impl ProcessState {
             }),
             context_manager: RwLock::new(None),
             handle_to_proxy: RwLock::new(HashMap::new()),
+            next_generation: AtomicU64::new(1),
             disable_background_scheduling: AtomicBool::new(false),
             call_restriction: RwLock::new(CallRestriction::None),
             thread_pool_started: AtomicBool::new(false),
@@ -284,7 +299,19 @@ impl ProcessState {
         // pin (BC_INCREFS) issued at first insertion is still active so
         // BC_ACQUIRE below will succeed. On (a) the entry is absent — we
         // pin first, then query, then insert.
-        let cached_descriptor = handle_to_proxy.get(&handle).map(|e| e.descriptor.clone());
+        //
+        // Generation handling:
+        //   - Case (a): allocate a fresh generation (new BC_INCREFS pin
+        //     means a fresh kernel binder_ref slot from the user's POV;
+        //     even if the handle id is being recycled in the kernel,
+        //     the generation snapshot held by any old WIBinder will not
+        //     match, correctly returning DeadObject on resurrection).
+        //   - Case (b): preserve the existing entry's generation —
+        //     same kernel slot (cache pin held), same binder_node,
+        //     same descriptor; this is just user-space resurrection.
+        let cached = handle_to_proxy
+            .get(&handle)
+            .map(|e| (e.descriptor.clone(), e.generation));
 
         if handle == 0 {
             let original_call_restriction = thread_state::call_restriction();
@@ -293,13 +320,13 @@ impl ProcessState {
             thread_state::set_call_restriction(original_call_restriction);
         }
 
-        let descriptor = match cached_descriptor {
-            Some(desc) => {
+        let (descriptor, generation) = match cached {
+            Some((desc, gen)) => {
                 // Sub-case (b): entry present, dead Arc. Skip BC_INCREFS
                 // (would double-pin) and skip INTERFACE_TRANSACTION
                 // (descriptor immutable for the binder_ref slot's
-                // lifetime).
-                desc
+                // lifetime). Preserve the existing generation.
+                (desc, gen)
             }
             None => {
                 // Sub-case (a): entry absent. Pin the kernel binder_ref
@@ -324,13 +351,15 @@ impl ProcessState {
                 // Step 3: pin is live in the kernel. Query the interface
                 // descriptor. On failure we MUST undo the pin so the
                 // kernel does not leak a binder_ref slot.
-                match thread_state::query_interface(handle) {
+                let desc = match thread_state::query_interface(handle) {
                     Ok(s) => s,
                     Err(err) => {
                         undo_case_a_pin(handle);
                         return Err(err);
                     }
-                }
+                };
+                let gen = self.next_generation.fetch_add(1, Ordering::Relaxed);
+                (desc, gen)
             }
         };
 
@@ -358,6 +387,94 @@ impl ProcessState {
             CacheEntry {
                 weak: Arc::downgrade(&arc),
                 descriptor,
+                generation,
+            },
+        );
+        Ok(SIBinder::from_arc(arc as Arc<dyn IBinder>))
+    }
+
+    /// Snapshot the cache entry's generation for `handle`, if present.
+    ///
+    /// Called from `SIBinder::downgrade` when constructing a proxy
+    /// `WIBinder` so the resulting weak reference carries the
+    /// generation it observed at construction time. A subsequent
+    /// `WIBinder::upgrade` rejects (returns `DeadObject`) if the live
+    /// entry's generation differs — i.e. the original binder_node was
+    /// obituary'd and the same handle id was later recycled to a
+    /// different node.
+    pub(crate) fn cache_generation_for(&self, handle: u32) -> Option<u64> {
+        self.handle_to_proxy
+            .read()
+            .expect("Handle to proxy lock poisoned")
+            .get(&handle)
+            .map(|e| e.generation)
+    }
+
+    /// Resurrection-only proxy lookup. Companion to
+    /// `strong_proxy_for_handle_stability` but **never** enters
+    /// case (a) (fresh `BC_INCREFS` pin) — if no cache entry exists for
+    /// `handle`, returns `Err(StatusCode::DeadObject)`.
+    ///
+    /// Used by `WIBinder::upgrade` to promote a weak proxy reference to
+    /// a strong one without reissuing the cache pin. Three outcomes:
+    ///
+    ///   - `expected_generation` mismatch ⟹ the original binder_node
+    ///     was obituary'd and the handle id was recycled. Return
+    ///     `DeadObject`.
+    ///   - cache entry alive (some other thread/holder has a strong
+    ///     `Arc<ProxyHandle>`) ⟹ reuse it (analogous to case (c)).
+    ///   - cache entry's `weak` is dangling ⟹ resurrection (case (b)):
+    ///     allocate a fresh `Arc<ProxyHandle>`, issue `BC_ACQUIRE`. The
+    ///     cache pin invariant guarantees the kernel `binder_ref` slot
+    ///     is still alive, so this `BC_ACQUIRE` cannot race against a
+    ///     freed slot.
+    pub(crate) fn resurrect_proxy_for_handle_stability(
+        &self,
+        handle: u32,
+        stability: Stability,
+        expected_generation: u64,
+    ) -> Result<SIBinder> {
+        // Read fast path with generation check.
+        if let Some(arc) = self
+            .handle_to_proxy
+            .read()
+            .expect("Handle to proxy lock poisoned")
+            .get(&handle)
+            .filter(|e| e.generation == expected_generation)
+            .and_then(|e| e.weak.upgrade())
+        {
+            return Ok(SIBinder::from_arc(arc as Arc<dyn IBinder>));
+        }
+
+        // Slow path: write lock so insert in case (b) is atomic against
+        // concurrent resurrections / lookups.
+        let mut handle_to_proxy = self
+            .handle_to_proxy
+            .write()
+            .expect("Handle to proxy lock poisoned");
+
+        let (descriptor, generation) = match handle_to_proxy.get(&handle) {
+            None => return Err(StatusCode::DeadObject),
+            Some(entry) if entry.generation != expected_generation => {
+                return Err(StatusCode::DeadObject);
+            }
+            Some(entry) => {
+                if let Some(arc) = entry.weak.upgrade() {
+                    return Ok(SIBinder::from_arc(arc as Arc<dyn IBinder>));
+                }
+                (entry.descriptor.clone(), entry.generation)
+            }
+        };
+
+        // Case (b) resurrection. Cache pin (BC_INCREFS) is still active
+        // for this entry, so BC_ACQUIRE will succeed.
+        let arc = ProxyHandle::new_acquired(handle, descriptor.clone(), stability)?;
+        handle_to_proxy.insert(
+            handle,
+            CacheEntry {
+                weak: Arc::downgrade(&arc),
+                descriptor,
+                generation,
             },
         );
         Ok(SIBinder::from_arc(arc as Arc<dyn IBinder>))

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -172,6 +172,18 @@ impl BinderDerefs {
         // may result in something being added to mPendingWeakDerefs,
         // which could be delayed until the next incoming command
         // from the driver if we don't process it now.
+        //
+        // Order matters: process pending derefs in **FIFO** order so the
+        // sequence of destructor side effects (further outgoing
+        // transactions, further deref additions, native-binder cleanup
+        // hooks) matches the order the kernel observed BR_RELEASE /
+        // BR_DECREFS for these objects. Android's libbinder uses the
+        // same FIFO discipline (`mPendingStrongDerefs.removeAt(0)` /
+        // `mPendingWeakDerefs.removeAt(0)`); a LIFO `Vec::pop()` here
+        // would silently reverse the ordering and could break callers
+        // that rely on it (e.g. when a strong-deref's destructor queues
+        // a weak-deref that the outer loop is then supposed to drain
+        // before the next strong).
         while !self.pending_weak_derefs.is_empty() || !self.pending_strong_derefs.is_empty() {
             for raw_pointer in self.pending_weak_derefs.drain(..) {
                 // BR_DECREFS reflects the kernel releasing a weak ref it
@@ -186,7 +198,16 @@ impl BinderDerefs {
                 let _ = strong.dec_weak();
             }
 
-            if let Some(raw_pointer) = self.pending_strong_derefs.pop() {
+            // FIFO front-pop on strong derefs (`remove(0)`). Process
+            // exactly one before re-checking the outer loop so a
+            // destructor-queued weak-deref is drained ahead of the next
+            // pending strong — same pattern as Android's libbinder.
+            // The pending queue is bounded (at most one entry per
+            // recently-received BR_RELEASE), so the O(n) front-remove
+            // cost is negligible and the linear scan keeps the data
+            // structure simple (a `VecDeque` would also work).
+            if !self.pending_strong_derefs.is_empty() {
+                let raw_pointer = self.pending_strong_derefs.remove(0);
                 let strong = raw_pointer_to_strong_binder(raw_pointer);
                 SIBinder::decrease_drop(strong)?;
             }

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -1903,6 +1903,77 @@ fn test_cache_pin_case_b_resurrection_round_trip() {
     }
 }
 
+/// `WIBinder::upgrade()` for proxies must succeed across user-side
+/// `drop(strong)` as long as the cache entry (and therefore the
+/// kernel `binder_ref` slot's `BC_INCREFS` pin) is alive — matching
+/// Android `wp<BpBinder>::promote()` semantics.
+///
+/// Pre-PR `WIBinder::upgrade()` succeeded *unconditionally* because
+/// `WIBinder` held a strong Arc in disguise. The cache-pin refactor
+/// initially made it `sync::Weak::upgrade` only, which returned
+/// `DeadObject` once every user-side `Strong` was dropped — too
+/// strict, because the cache pin had already structurally guaranteed
+/// the kernel slot stayed alive. This test verifies the corrected
+/// semantics: `upgrade()` routes through the proxy cache and yields
+/// a freshly resurrected `Arc<ProxyHandle>` (different allocation,
+/// same kernel binder_node).
+#[test]
+fn test_weak_upgrade_resurrects_proxy_after_strong_drop() {
+    init_test();
+
+    let canonical = <BpTestService as ITestService::ITestService>::descriptor().to_string();
+    let svc = get_test_service();
+    let weak: WIBinder = SIBinder::downgrade(&svc.as_binder());
+    drop(svc);
+
+    // After `drop(svc)` the only `Arc<ProxyHandle>` is gone, but the
+    // cache entry is still there with its BC_INCREFS pin keeping
+    // `binder_ref(handle).weak >= 1`. `upgrade()` must succeed via
+    // case-(b) resurrection.
+    let resurrected = weak
+        .upgrade()
+        .expect("weak.upgrade must succeed while cache entry alive");
+
+    // Descriptor preserved across resurrection (cached, no new
+    // INTERFACE_TRANSACTION).
+    assert_eq!(
+        resurrected.descriptor(),
+        canonical,
+        "resurrected proxy must carry the original descriptor"
+    );
+
+    // Transaction succeeds, proving the resurrected proxy refers to
+    // the same kernel binder_node.
+    resurrected
+        .ping_binder()
+        .expect("ping after resurrection must succeed");
+}
+
+/// Two `WIBinder` clones for the same underlying handle compare
+/// equal under `PartialEq`, even after the original strong is
+/// dropped and resurrection has produced a different `Arc<ProxyHandle>`.
+/// Identity is `(handle, generation)`, matching Android `BpBinder`
+/// identity (stable across resurrection).
+#[test]
+fn test_weak_partial_eq_handle_identity_across_resurrection() {
+    init_test();
+
+    let svc1 = get_test_service();
+    let weak1: WIBinder = SIBinder::downgrade(&svc1.as_binder());
+    drop(svc1);
+
+    // Resurrect and downgrade again — fresh Arc<ProxyHandle>, but the
+    // cache entry's generation is preserved (same kernel slot), so the
+    // new WIBinder snapshots the same generation.
+    let svc2 = get_test_service();
+    let weak2: WIBinder = SIBinder::downgrade(&svc2.as_binder());
+
+    assert_eq!(
+        weak1, weak2,
+        "WIBinder for the same kernel binder_node must be equal across resurrection"
+    );
+}
+
 /// Test plan #3 second bullet — `WIBinder::upgrade()` `Err(DeadObject)`
 /// branch coverage on the in-tree death-recipient path.
 ///


### PR DESCRIPTION
## Summary

Builds on top of #101. Closes the residual API gap that PR's cache-pin
model created: `Weak<I>::upgrade()` is now routed through the proxy
cache so it succeeds across user-side `drop(strong)` while the cache pin
keeps the kernel `binder_ref` slot alive — matching Android
`wp<BpBinder>::promote()` semantics.

Bundled fix: `process_pending_derefs` switched from LIFO to FIFO on the
strong-deref queue, matching Android's libbinder ordering discipline.

## Why

PR #101 made `WIBinder` a genuine `sync::Weak<dyn IBinder>`. That
correctly fixed the strong-Arc-in-disguise anomaly, but `upgrade()`
became strictly weaker than Android's `wp<>::promote()`: it returned
`DeadObject` once every user-side `Strong` was dropped, even though
the cache pin had structurally guaranteed the kernel slot was alive
and `BC_ACQUIRE` would always succeed.

Reference: Android's `IPCThreadState::attemptIncStrongHandle` is gated
behind `HAS_BC_ATTEMPT_ACQUIRE` which is **undefined in shipping
builds** — the kernel `BC_ATTEMPT_ACQUIRE` command is dead in modern
mainline Android. `wp<BpBinder>::promote()` is implemented entirely in
user-space via `RefBase`/`attemptIncStrong`. PR #101's outbound
`BC_ATTEMPT_ACQUIRE` removal correctly mirrored this; this PR closes
the loop by reinstating the *semantic* in user space, on top of the
cache-pin invariant rather than via a kernel handshake.

## Public API changes

- `WIBinder` is now an enum:
  `Proxy { handle, stability, generation, weak }` and `Native(weak)`.
  Constructor surface unchanged — `SIBinder::downgrade` detects
  proxies via `as_any().downcast_ref::<ProxyHandle>()` and snapshots
  `(handle, stability, generation)` for routing.
- `WIBinder::upgrade()` for proxies: fast-path tries the inner
  `sync::Weak::upgrade` (cheap when an `Arc<ProxyHandle>` is still
  alive), slow-path drives `ProcessState::resurrect_proxy_for_handle_stability`
  (case-(b) resurrection — fresh `Arc<ProxyHandle>`, descriptor reused
  from cache, no new `INTERFACE_TRANSACTION`, no new `BC_INCREFS`,
  cache pin guarantees `BC_ACQUIRE` validity). For natives: unchanged
  (`sync::Weak::upgrade`).
- `WIBinder::PartialEq` for proxies compares `(handle, generation)`,
  matching Android `BpBinder` identity (stable across resurrection).
  For natives: unchanged (`sync::Weak::ptr_eq`).
- `IBinder` trait surface unchanged.

## Internal changes

- `CacheEntry { weak, descriptor }` →
  `CacheEntry { weak, descriptor, generation: u64 }`.
- `ProcessState` gains `next_generation: AtomicU64` (initialized to 1).
- `strong_proxy_for_handle_stability`:
    - case (a) (entry absent) allocates a fresh generation via
      `next_generation.fetch_add(1, Relaxed)`;
    - case (b) (entry present, dead Arc) preserves the existing entry's
      generation — same kernel slot, same binder_node, same descriptor;
- New `ProcessState::cache_generation_for(handle) -> Option<u64>`
  helper; called from `SIBinder::downgrade` when constructing a proxy
  `WIBinder`.
- New `ProcessState::resurrect_proxy_for_handle_stability(handle,
  stability, expected_generation) -> Result<SIBinder>`: read fast-path
  with generation check; write-locked slow path; **never enters case
  (a)** — if no cache entry, returns `DeadObject`. Generation mismatch
  also returns `DeadObject`, correctly rejecting "old weak ref to a
  handle id that was obituary'd and recycled to a different
  binder_node".

## Bundled fix: `process_pending_derefs` FIFO ordering

Surfaced during code review against Android's `binder-linux` source.
Pre-existing issue, not introduced by either PR #101 or this PR's
main change, but rolled in because the diff is one line + commentary
and the existing verification matrix already exercises the path.

`process_pending_derefs` previously used `Vec::pop()` on
`pending_strong_derefs`, removing from the BACK (LIFO). Android's
libbinder uses `mPendingStrongDerefs.removeAt(0)` (FIFO). The
outer-loop "process all weak derefs, then exactly one strong deref,
then re-check" pattern (preserved from the original code) only
constrains the interleaving between strong and weak — it doesn't
specify within-class order. `Vec::pop()` silently inverted the
within-class order vs. Android. A strong deref's destructor can
queue further derefs / outgoing transactions / native-binder cleanup
hooks; LIFO meant those side effects ran in reverse of the order the
kernel observed BR_RELEASE.

Fix: switch strong to `Vec::remove(0)` so both queues drain FIFO.
`O(n)` but the queue is bounded by one entry per BR_RELEASE in the
current driver round-trip, so the cost is negligible. A `VecDeque`
would also work; `Vec` keeps consistency with the weak-deref
`drain(..)` pattern already in place.

## Why generation counter

Without it, an old `WIBinder` could resurrect against a *different*
kernel binder_node if the same handle id was recycled after its
original obituary. `binder_ref(h)` slot allocation is kernel-controlled;
recycling is benign for fresh lookups but unsafe for stale weak refs.
The counter is a per-process monotonic; case (b) preserves it (same
slot), case (a) allocates a fresh one (new slot). Snapshot at
downgrade, compare at upgrade. Two-line check, exact correctness.

## Verification

- Workspace `cargo build` / `cargo clippy --workspace --all-targets -- -D warnings`
  / `cargo fmt --all --check` clean.
- All existing rsbinder lib tests pass (`binder::tests::*`):
    - `test_wibinder_upgrade_after_strong_drop_returns_dead_object`
    - `test_wibinder_clone_and_ptr_eq_after_drop`

  These use a `MockBinder` IBinder impl which becomes the Native
  variant under the new enum. Their semantics — `sync::Weak::upgrade`
  yields None after Arc drop, `sync::Weak::ptr_eq` stable across
  clones — are exactly Native variant behavior. No test changes
  required.
- New integration tests in `tests/src/test_client.rs`:
    - `test_weak_upgrade_resurrects_proxy_after_strong_drop` — drop
      the only `Strong`, verify `upgrade()` succeeds and the
      resurrected proxy `ping_binder()`s + carries the original
      descriptor.
    - `test_weak_partial_eq_handle_identity_across_resurrection` —
      two `WIBinder`s for the same handle (one taken before
      `drop(strong)`, one after via fresh `get_test_service`) compare
      equal under the new `(handle, generation)` identity.
- Existing `test_wibinder_upgrade_after_obituary` (`#[ignore]`'d in CI)
  remains valid: post-obituary the cache entry is gone, so
  `resurrect_proxy_for_handle_stability` returns `DeadObject`.
- FIFO fix is exercised by the existing soak loop and
  `test_death_recipient` (which triggers BR_RELEASE on cleanup); a
  separate pure regression test is hard to write deterministically
  because the kernel's BR_RELEASE batching is non-deterministic.
- Integration test workflow (Linux, 100 iterations sync + 1 async +
  destructive batch) ran green on the previous tip; will re-run on
  this updated branch.

## Stacking

- **Base:** `feat/cache-pin-kernel-ref-lifecycle` (PR #101).
- **Diff visible:** only the changes in this PR's commits.
- After #101 merges, GitHub will rebase this PR's base to `master`
  automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)