### PR TITLE
fix(rsbinder): FOLLOW_UP_PR_104 correctness — death-notification, extension, dump, panic isolation

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -204,6 +204,63 @@ jobs:
           RUST_BACKTRACE=1 cargo test --package tests -- --ignored \
             test_client::test_wibinder_upgrade_after_obituary
 
+      - name: Restart test_service for test_death_recipient_panic_does_not_starve_others
+        run: |
+          [ -f test_service.pid ] && sudo kill "$(cat test_service.pid)" 2>/dev/null || true
+          sleep 1
+          RUST_LOG=info nohup target/debug/test_service > test_service.log 2>&1 &
+          echo $! > test_service.pid
+          sleep 2
+          kill -0 "$(cat test_service.pid)" || { echo "::error::test_service failed to restart"; cat test_service.log; exit 1; }
+
+      - name: Run test_death_recipient_panic_does_not_starve_others (destructive)
+        run: |
+          # FOLLOW_UP_PR_104 Item 6 — panic in one DeathRecipient must
+          # not abort the binder worker thread or starve other
+          # recipients. Real obituary path; the unit test in
+          # `proxy.rs` covers the dispatch-loop in isolation, this
+          # one verifies the same guarantee end-to-end through the
+          # kernel BR_DEAD_BINDER handshake.
+          RUST_BACKTRACE=1 cargo test --package tests -- --ignored \
+            test_client::test_death_recipient_panic_does_not_starve_others
+
+      - name: Restart test_service for test_unlink_to_death_single_remove_via_obituary
+        run: |
+          [ -f test_service.pid ] && sudo kill "$(cat test_service.pid)" 2>/dev/null || true
+          sleep 1
+          RUST_LOG=info nohup target/debug/test_service > test_service.log 2>&1 &
+          echo $! > test_service.pid
+          sleep 2
+          kill -0 "$(cat test_service.pid)" || { echo "::error::test_service failed to restart"; cat test_service.log; exit 1; }
+
+      - name: Run test_unlink_to_death_single_remove_via_obituary (destructive)
+        run: |
+          # FOLLOW_UP_PR_104 Item 1 — `unlink_to_death` must remove a
+          # single matching entry, mirroring C++
+          # `BpBinder::unlinkToDeath`'s `removeAt(i)`. Register the
+          # same recipient twice, unlink once, then verify exactly
+          # one `binder_died` fires after killService.
+          RUST_BACKTRACE=1 cargo test --package tests -- --ignored \
+            test_client::test_unlink_to_death_single_remove_via_obituary
+
+      - name: Restart test_service for test_dump_fast_fails_on_dead_proxy_closes_fd
+        run: |
+          [ -f test_service.pid ] && sudo kill "$(cat test_service.pid)" 2>/dev/null || true
+          sleep 1
+          RUST_LOG=info nohup target/debug/test_service > test_service.log 2>&1 &
+          echo $! > test_service.pid
+          sleep 2
+          kill -0 "$(cat test_service.pid)" || { echo "::error::test_service failed to restart"; cat test_service.log; exit 1; }
+
+      - name: Run test_dump_fast_fails_on_dead_proxy_closes_fd (destructive)
+        run: |
+          # FOLLOW_UP_PR_104 Item 4 — `dump` on an obituary'd proxy
+          # must fast-fail with DeadObject before consuming the fd,
+          # so the caller's fd is closed via RAII. Verified via pipe
+          # EOF on the read end after `dump` drops the write end.
+          RUST_BACKTRACE=1 cargo test --package tests -- --ignored \
+            test_client::test_dump_fast_fails_on_dead_proxy_closes_fd
+
       - name: Stop background services
         if: always()
         run: |

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -147,6 +147,28 @@ pub trait FromIBinder: Interface {
 ///
 /// Implement this trait to receive notifications when a remote binder object dies.
 /// This is essential for cleanup and error handling in distributed systems.
+///
+/// # Panic safety
+///
+/// `binder_died` is invoked from the binder worker thread that processes
+/// `BR_DEAD_BINDER` from the kernel. rsbinder catches panics from
+/// `binder_died` per-recipient and logs them, so:
+///
+/// - A panic in one recipient does **not** prevent other recipients
+///   registered against the same binder from receiving their own
+///   `binder_died` callback.
+/// - A panic in `binder_died` does **not** terminate the binder worker
+///   thread.
+///
+/// rsbinder does **not** repair the panicking recipient's own internal
+/// state across the unwind boundary — implementations should keep
+/// `binder_died` panic-free to begin with, and use this guard only as a
+/// safety net.
+///
+/// The guard relies on `panic = "unwind"` (Rust's default). Builds that
+/// use `panic = "abort"` abort the whole process on any panic, including
+/// from `binder_died`, and the per-recipient isolation degrades to the
+/// abort behavior.
 pub trait DeathRecipient: Send + Sync {
     /// Called when the monitored binder object has died.
     fn binder_died(&self, who: &WIBinder);
@@ -196,11 +218,43 @@ pub trait IBinder: Any + Send + Sync {
     }
 
     /// Return the extension binder object, if set. Returns None if no extension is set.
+    ///
+    /// On a proxy this issues a remote `EXTENSION_TRANSACTION` and
+    /// caches the result; subsequent calls return the cached value.
+    /// On a native binder it returns the locally-stored extension.
+    ///
+    /// **Staleness on proxy.** The proxy cache holds a strong
+    /// `SIBinder` for the parent's lifetime in the common case (see
+    /// `ProxyHandle`'s `ExtensionCache` doc for the cache shape and
+    /// the `BC_RELEASE`/`BC_ACQUIRE` thrash motivation). The cache
+    /// is **not** invalidated when the extension itself is
+    /// obituary'd: subsequent `get_extension()` calls return the same
+    /// dead `SIBinder`, and IPC through it fast-fails with
+    /// `DeadObject` via `submit_transact`'s obituary check. A server
+    /// that re-publishes a fresh extension after the previous one
+    /// died is invisible to the client until the parent itself is
+    /// dropped and re-acquired. Matches Android C++ `BpBinder` —
+    /// not a correctness bug, but worth knowing for clients that
+    /// rely on dynamic re-publication.
     fn get_extension(&self) -> Result<Option<SIBinder>> {
         Ok(None)
     }
 
     /// Set the extension binder object.
+    ///
+    /// **Server-side only.** A service publishes its extension binder
+    /// via this call so clients can discover it through
+    /// `get_extension()`. Native binder implementations store the
+    /// extension locally; the default returns
+    /// `Err(StatusCode::InvalidOperation)`.
+    ///
+    /// Calling this on a **proxy** (client-side `ProxyHandle`) is a
+    /// programming error — a proxy has no way to inform the remote
+    /// service of the new extension, so the call would only mutate
+    /// the local cache and (after PR #104's §4 scope-down) silently
+    /// pin an unrelated `Arc<dyn IBinder>` for the parent's lifetime.
+    /// `ProxyHandle::set_extension` therefore rejects with
+    /// `InvalidOperation`.
     fn set_extension(&self, _extension: &SIBinder) -> Result<()> {
         Err(StatusCode::InvalidOperation)
     }
@@ -258,6 +312,33 @@ pub trait Remotable: Send + Sync {
 }
 
 /// A transactable object that can be used to process Binder commands.
+///
+/// # Panic safety
+///
+/// `transact` is invoked from the binder worker thread that processes
+/// incoming `BR_TRANSACTION` from the kernel. rsbinder catches panics
+/// from `transact` and converts them to `Err(StatusCode::Unknown)`, so:
+///
+/// - A panic in `transact` does **not** terminate the binder worker
+///   thread; subsequent transactions on the same thread continue to be
+///   processed.
+/// - For non-oneway calls, the calling client receives a deterministic
+///   error reply (`StatusCode::Unknown`) instead of hanging on a never-
+///   sent `BR_REPLY`. Any partially-written reply parcel is discarded
+///   before the error is returned, so the client does not misparse
+///   half-formed data.
+/// - For oneway calls, the panic is logged and the transaction is
+///   dropped (matching the existing oneway `Err` path).
+///
+/// rsbinder does **not** repair the panicking transactable's own
+/// internal state across the unwind boundary — implementations should
+/// keep `transact` panic-free to begin with, and use this guard only
+/// as a safety net.
+///
+/// The guard relies on `panic = "unwind"` (Rust's default). Builds that
+/// use `panic = "abort"` abort the whole process on any panic,
+/// including from `transact`, and the per-transaction isolation
+/// degrades to the abort behavior.
 pub trait Transactable: Send + Sync {
     fn transact(
         &self,

--- a/rsbinder/src/proxy.rs
+++ b/rsbinder/src/proxy.rs
@@ -74,6 +74,24 @@ pub struct ProxyHandle {
     handle: u32,
     descriptor: String,
     stability: Stability,
+    /// Set once when `send_obituary` runs to publish "this proxy is
+    /// dead" to all observers.
+    ///
+    /// Three call sites read this flag with three different orderings.
+    /// All three are correct — a future reader who sees `Relaxed` and
+    /// "fixes" it to `Acquire` would add a fence with no benefit.
+    ///
+    /// | Call site                       | Lock state             | Ordering | Why                                                                            |
+    /// |---------------------------------|------------------------|----------|--------------------------------------------------------------------------------|
+    /// | `submit_transact`, `dump`       | none (lock-free)       | `Acquire`| Pairs with `Release` store in `send_obituary` to publish recipients teardown.  |
+    /// | `link_to_death`/`unlink_to_death`| inside `recipients` write lock | `Relaxed`| RwLock acquire/release supplies happens-before against `send_obituary`'s store.|
+    /// | `send_obituary`                 | inside `recipients` write lock | `Relaxed`| Same — the store's `Release` is for the *lock-free* readers, not the lock-protected ones. |
+    ///
+    /// In short: the `Acquire`/`Release` pair on `obituary_sent`
+    /// itself is what protects the **lock-free** `submit_transact` /
+    /// `dump` fast-fail paths. The lock-protected paths get their
+    /// happens-before from the surrounding `RwLock` and so the
+    /// atomic load can be `Relaxed` there.
     obituary_sent: AtomicBool,
     recipients: RwLock<Vec<sync::Weak<dyn DeathRecipient>>>,
     extension: RwLock<ExtensionCache>,
@@ -221,14 +239,11 @@ impl ProxyHandle {
 
         // Callbacks first — these are the user-visible contract.
         // Dispatching before the flush below ensures a transient
-        // ioctl failure cannot swallow death notifications.
-        for weak in &recipients_snapshot {
-            if let Some(recipient) = weak.upgrade() {
-                recipient.binder_died(who);
-            }
-            // Dead `Weak`s are dropped with the snapshot at scope end —
-            // the source vector was already cleared by `mem::take`.
-        }
+        // ioctl failure cannot swallow death notifications. Panics
+        // inside individual recipients are caught and logged so a
+        // single buggy recipient cannot terminate the binder worker
+        // thread or starve the remaining recipients.
+        self.dispatch_obituary_callbacks(&recipients_snapshot, who);
 
         // Flush the queued BC_CLEAR_DEATH_NOTIFICATION outside the
         // lock. If this fails, the command remains in out_parcel and
@@ -241,7 +256,70 @@ impl ProxyHandle {
         Ok(())
     }
 
+    /// Invoke `binder_died` on every live recipient in `snapshot`,
+    /// isolating panics so a single buggy recipient cannot abort the
+    /// binder worker thread or starve the remaining recipients.
+    ///
+    /// Guarantees:
+    /// - One recipient panicking does not prevent later recipients from
+    ///   receiving `binder_died`.
+    /// - The binder worker thread continues running after a recipient
+    ///   panic; the panic is logged and discarded.
+    ///
+    /// Not guaranteed: the panicking recipient's own internal state
+    /// consistency. `AssertUnwindSafe` is a deliberate assertion that
+    /// rsbinder does not attempt to repair user state across the
+    /// unwind boundary — `recipients_snapshot` was already detached
+    /// from `self.recipients` and `obituary_sent` was already
+    /// published before this call, so rsbinder's own invariants are
+    /// unaffected.
+    ///
+    /// `panic = "abort"` builds turn this guard into a no-op (the
+    /// process aborts on any panic, including from a buggy
+    /// recipient). Documented on the `DeathRecipient` trait.
+    fn dispatch_obituary_callbacks(
+        &self,
+        snapshot: &[sync::Weak<dyn DeathRecipient>],
+        who: &WIBinder,
+    ) {
+        for weak in snapshot {
+            // Dead `Weak`s are dropped with the snapshot at scope end —
+            // the source vector was already cleared by `mem::take`.
+            let Some(recipient) = weak.upgrade() else {
+                continue;
+            };
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                recipient.binder_died(who);
+            }));
+            if let Err(payload) = result {
+                let msg = payload
+                    .downcast_ref::<&'static str>()
+                    .copied()
+                    .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+                    .unwrap_or("<non-string panic payload>");
+                log::error!(
+                    "DeathRecipient panicked during binder_died for handle {:X}: {msg}",
+                    self.handle,
+                );
+            }
+        }
+    }
+
     pub fn dump<F: IntoRawFd>(&self, fd: F, args: &[String]) -> Result<()> {
+        // Fast-fail BEFORE consuming the fd. `submit_transact` would
+        // also short-circuit on `obituary_sent` (PR #104 §1), but by
+        // the time we reach it, `fd.into_raw_fd()` has already
+        // detached the raw fd from `F`'s RAII; an early `Err` from
+        // `submit_transact` would then leak the fd. Mirroring the
+        // `submit_transact` Acquire-load here lets `F` drop naturally
+        // (closing the fd) when the proxy is already dead. The non-
+        // fast-fail error paths (parcel-write failures, in-`transact`
+        // errors after the kernel sees the fd) still exhibit the
+        // pre-existing leak shape — see FOLLOW_UP_PR_104.md Item 4
+        // "Follow-up scope" for the wider fix.
+        if self.obituary_sent.load(Ordering::Acquire) {
+            return Err(StatusCode::DeadObject);
+        }
         let mut send = Parcel::new();
         let obj = flat_binder_object::new_with_fd(fd.into_raw_fd(), true);
         send.write_object(&obj, true)?;
@@ -338,11 +416,20 @@ impl IBinder for ProxyHandle {
         Ok(ext)
     }
 
-    fn set_extension(&self, extension: &SIBinder) -> Result<()> {
-        let entry = self.classify_extension(extension);
-        let mut ext = self.extension.write().expect("Extension lock poisoned");
-        *ext = ExtensionCache::Queried(Some(entry));
-        Ok(())
+    fn set_extension(&self, _extension: &SIBinder) -> Result<()> {
+        // `set_extension` is a server-side operation: a service
+        // publishes its extension binder for clients to discover via
+        // `get_extension()`. Calling it on a client proxy used to
+        // succeed silently, caching locally without telling the
+        // remote service — and after PR #104's §4 scope-down the
+        // local cache holds a strong `Arc<dyn IBinder>` for the
+        // parent's lifetime, silently pinning an unrelated binder.
+        // Reject with `InvalidOperation`, matching the default trait
+        // impl in `binder.rs`. In-tree callers operate on native
+        // `Binder`, not `ProxyHandle`, so this reject is safe (see
+        // `tests/src/test_client.rs`, `tests/src/bin/test_service.rs`,
+        // `tests/src/bin/test_service_async.rs`).
+        Err(StatusCode::InvalidOperation)
     }
 
     /// Register a death notification for this object.
@@ -358,9 +445,35 @@ impl IBinder for ProxyHandle {
         if self.obituary_sent.load(Ordering::Relaxed) {
             return Err(StatusCode::DeadObject);
         }
+        // Reject a recipient whose strong count is already zero — a
+        // common mistake when the caller drops the
+        // `Arc<dyn DeathRecipient>` before passing the weak. Without
+        // this check `send_obituary` would silently skip the
+        // recipient via `weak.upgrade() == None`, leaving the user
+        // with the false impression that they successfully
+        // registered. Placed before `request_death_notification` so
+        // a dead weak never consumes a kernel subscription. Does
+        // *not* protect against the recipient's `Arc` being dropped
+        // *between* `link_to_death` returning and `binder_died`
+        // firing — that's a legitimate use of `Weak` semantics.
+        if recipient.upgrade().is_none() {
+            return Err(StatusCode::BadValue);
+        }
         if recipients.is_empty() {
+            // Match C++ `BpBinder::linkToDeath` (BpBinder.cpp:415-434):
+            // queue `BC_REQUEST_DEATH_NOTIFICATION` and best-effort
+            // flush. The parcel-write of `BC_REQUEST_DEATH_NOTIFICATION`
+            // itself can fail (out_parcel corruption — rare, e.g. OOM)
+            // and propagates because that signals state corruption,
+            // not a driver round-trip issue. The subsequent
+            // `flush_commands` is intentionally **not** propagated —
+            // ignoring it (a) matches Android's symmetric behavior
+            // (C++ ignores `flushCommands`'s return value) and (b)
+            // closes the prior leak window where a flush failure
+            // skipped `recipients.push` and left the kernel with a
+            // subscription that no user-side recipient could service.
             thread_state::request_death_notification(self.handle())?;
-            thread_state::flush_commands()?;
+            let _ = thread_state::flush_commands();
         }
         recipients.push(recipient);
         Ok(())
@@ -369,6 +482,13 @@ impl IBinder for ProxyHandle {
     /// Remove a previously registered death notification.
     /// The recipient will no longer be called if this object
     /// dies.
+    ///
+    /// Returns `Err(StatusCode::NameNotFound)` if no matching
+    /// recipient is registered. Removes only the first matching
+    /// entry, mirroring C++ `BpBinder::unlinkToDeath`'s
+    /// `mObituaries->removeAt(i); return NO_ERROR;` (BpBinder.cpp:443-484)
+    /// — a user that registered the same recipient twice and unlinks
+    /// once expects one callback to remain.
     fn unlink_to_death(&self, recipient: sync::Weak<dyn DeathRecipient>) -> Result<()> {
         // Acquire the lock FIRST, then check `obituary_sent` — same
         // ordering as C++ `BpBinder::unlinkToDeath` (BpBinder.cpp:456
@@ -377,10 +497,29 @@ impl IBinder for ProxyHandle {
         if self.obituary_sent.load(Ordering::Relaxed) {
             return Err(StatusCode::DeadObject);
         }
-        recipients.retain(|r| !sync::Weak::ptr_eq(r, &recipient));
+        // Single-position removal (O(n), order-preserving). Matches
+        // C++ `removeAt(i)` semantics; a `retain` here would remove
+        // every duplicate registration of the same recipient and
+        // silently drop the user's remaining subscription. The
+        // `clear_death_notification` IPC fires only when this call
+        // actually transitions the list from non-empty to empty —
+        // unlinking from an already-empty list (NameNotFound path)
+        // must not queue a `BC_CLEAR_DEATH_NOTIFICATION` for a
+        // subscription that was never requested.
+        let Some(i) = recipients
+            .iter()
+            .position(|r| sync::Weak::ptr_eq(r, &recipient))
+        else {
+            return Err(StatusCode::NameNotFound);
+        };
+        recipients.remove(i);
         if recipients.is_empty() {
+            // Symmetric with `link_to_death`: queue
+            // `BC_CLEAR_DEATH_NOTIFICATION`, propagate parcel-write
+            // failure (state corruption), ignore `flush_commands`'s
+            // return value (best-effort, matches C++).
             thread_state::clear_death_notification(self.handle())?;
-            thread_state::flush_commands()?;
+            let _ = thread_state::flush_commands();
         }
         Ok(())
     }
@@ -491,9 +630,21 @@ mod tests {
         fn binder_died(&self, _who: &WIBinder) {}
     }
 
-    fn noop_recipient_weak() -> sync::Weak<dyn DeathRecipient> {
+    /// Build a `(strong, weak)` recipient pair. The caller binds the
+    /// returned `Arc` for the test's duration; dropping it would
+    /// turn the returned `Weak` into a dangling reference that
+    /// `Weak::upgrade()` and the production-side liveness check
+    /// would treat as already-dead.
+    ///
+    /// Older tests used `noop_recipient_weak()` which returned a
+    /// dangling weak directly. That was benign for fast-fail tests
+    /// (the obituary check fired first) but masked the upgrade
+    /// liveness check added in Item 8 — a future test added against
+    /// the dangling form would fail mysteriously.
+    fn live_recipient_pair() -> (Arc<dyn DeathRecipient>, sync::Weak<dyn DeathRecipient>) {
         let arc: Arc<dyn DeathRecipient> = Arc::new(NoopRecipient);
-        Arc::downgrade(&arc)
+        let weak = Arc::downgrade(&arc);
+        (arc, weak)
     }
 
     #[test]
@@ -538,7 +689,7 @@ mod tests {
     #[test]
     fn test_link_to_death_returns_dead_object_after_obituary() {
         let handle = synthetic_proxy(true);
-        let weak_recipient = noop_recipient_weak();
+        let (_arc, weak_recipient) = live_recipient_pair();
         let result = handle.link_to_death(weak_recipient);
         assert!(
             matches!(result, Err(StatusCode::DeadObject)),
@@ -552,13 +703,382 @@ mod tests {
     #[test]
     fn test_unlink_to_death_returns_dead_object_after_obituary() {
         let handle = synthetic_proxy(true);
-        let weak_recipient = noop_recipient_weak();
+        let (_arc, weak_recipient) = live_recipient_pair();
         let result = handle.unlink_to_death(weak_recipient);
         assert!(
             matches!(result, Err(StatusCode::DeadObject)),
             "expected DeadObject, got {result:?}"
         );
         std::mem::forget(handle);
+    }
+
+    /// Registering the same recipient twice and unlinking once must
+    /// remove only one entry — the user's remaining registration is
+    /// silently lost if `unlink_to_death` removes every match (the
+    /// `Vec::retain` bug fixed here). Mirrors C++
+    /// `BpBinder::unlinkToDeath` returning after a single
+    /// `mObituaries->removeAt(i)`. The recipients vector is
+    /// populated directly so the test does not require ProcessState
+    /// init for `link_to_death`'s `request_death_notification` IPC.
+    #[test]
+    fn test_unlink_to_death_removes_only_one_match() {
+        let proxy = synthetic_proxy(false);
+        let (_arc, weak) = live_recipient_pair();
+        {
+            let mut recipients = proxy.recipients.write().expect("recipients lock");
+            recipients.push(weak.clone());
+            recipients.push(weak.clone());
+        }
+
+        let result = proxy.unlink_to_death(weak.clone());
+        assert!(matches!(result, Ok(())), "expected Ok, got {result:?}");
+
+        let recipients = proxy.recipients.read().expect("recipients lock");
+        assert_eq!(
+            recipients.len(),
+            1,
+            "exactly one duplicate must remain (single-position remove)"
+        );
+        assert!(
+            sync::Weak::ptr_eq(&recipients[0], &weak),
+            "remaining entry must be the same recipient that was registered twice"
+        );
+        drop(recipients);
+        std::mem::forget(proxy);
+    }
+
+    /// `unlink_to_death` on an empty recipients list must return
+    /// `NameNotFound` and must not queue a
+    /// `BC_CLEAR_DEATH_NOTIFICATION` to the kernel — there is no
+    /// subscription to clear. The position check happens before any
+    /// IPC, so this test runs without ProcessState init.
+    #[test]
+    fn test_unlink_to_death_empty_list_returns_name_not_found() {
+        let proxy = synthetic_proxy(false);
+        let (_arc, weak) = live_recipient_pair();
+
+        let result = proxy.unlink_to_death(weak);
+        assert!(
+            matches!(result, Err(StatusCode::NameNotFound)),
+            "expected NameNotFound, got {result:?}"
+        );
+        assert!(
+            proxy.recipients.read().expect("recipients lock").is_empty(),
+            "recipients vec must remain empty"
+        );
+        std::mem::forget(proxy);
+    }
+
+    /// Locks down the documented staleness behavior of the strong
+    /// extension cache: when the *extension* (not the parent) is
+    /// obituary'd, the parent's `get_extension()` keeps returning
+    /// the cached (now dead) `SIBinder`. The cache is **not**
+    /// auto-invalidated. IPC through the dead extension fast-fails
+    /// with `DeadObject` via `submit_transact`'s obituary check, so
+    /// the dead reference is well-behaved — but a server that
+    /// re-publishes a fresh extension is invisible to the client
+    /// until the parent is dropped and re-acquired. Matches Android
+    /// C++ `BpBinder` semantics. A future "auto-invalidate" change
+    /// would deliberately flip this assertion.
+    #[test]
+    fn test_get_extension_strong_cache_does_not_auto_invalidate_on_dead_extension() {
+        let ext_proxy = synthetic_proxy(true); // extension already obituary'd
+        let ext_arc_dyn: Arc<dyn IBinder> = ext_proxy.clone();
+        let ext_sibinder = SIBinder::from_arc(ext_arc_dyn);
+
+        let parent = synthetic_proxy(false);
+        {
+            let mut cache = parent.extension.write().expect("Extension lock poisoned");
+            *cache = ExtensionCache::Queried(Some(CachedExtension::Strong(ext_sibinder)));
+        }
+
+        // get_extension returns the cached (dead) extension via the
+        // cache-hit path — no remote query attempted.
+        let returned = parent
+            .get_extension()
+            .expect("get_extension")
+            .expect("cache hit should return Some");
+
+        // The returned SIBinder is the same dead ProxyHandle. IPC
+        // through it must fast-fail.
+        let returned_proxy = (*returned).as_proxy().expect("extension is a proxy");
+        assert_eq!(returned_proxy.handle(), ext_proxy.handle());
+        let parcel = Parcel::new();
+        assert!(
+            matches!(
+                returned_proxy.submit_transact(0, &parcel, 0),
+                Err(StatusCode::DeadObject)
+            ),
+            "calls through cached dead extension must fast-fail with DeadObject"
+        );
+
+        // Cache must remain Strong — staleness is the documented
+        // contract. A regression to "auto-invalidate" would flip the
+        // variant to NotQueried (or remove the entry) and trip this
+        // assertion.
+        let cache = parent.extension.read().expect("Extension lock poisoned");
+        assert!(
+            matches!(
+                *cache,
+                ExtensionCache::Queried(Some(CachedExtension::Strong(_)))
+            ),
+            "cache must remain Strong after get_extension on a dead extension"
+        );
+        drop(cache);
+
+        // Drop order: `returned` first so its strong count decrement
+        // doesn't race with cache teardown. The cache still holds
+        // one strong via the parent — `parent` is then forgotten so
+        // the synthetic ProxyHandle's `BC_RELEASE` Drop never runs.
+        drop(returned);
+        std::mem::forget(parent);
+        std::mem::forget(ext_proxy);
+    }
+
+    /// `link_to_death` must reject a recipient whose strong count
+    /// is already zero with `BadValue`, **before** queuing
+    /// `BC_REQUEST_DEATH_NOTIFICATION`. Otherwise the kernel would
+    /// register a subscription that no user-side recipient can ever
+    /// service (silent registration of a dead recipient is a
+    /// misleading API). The recipients vec must remain unchanged.
+    #[test]
+    fn test_link_to_death_rejects_already_dead_weak() {
+        let proxy = synthetic_proxy(false); // obituary not sent
+
+        // Build a Weak whose strong count starts at zero.
+        let arc: Arc<dyn DeathRecipient> = Arc::new(NoopRecipient);
+        let dead_weak = Arc::downgrade(&arc);
+        drop(arc);
+        assert!(
+            dead_weak.upgrade().is_none(),
+            "fixture sanity: weak must be dangling"
+        );
+
+        let result = proxy.link_to_death(dead_weak);
+        assert!(
+            matches!(result, Err(StatusCode::BadValue)),
+            "expected BadValue, got {result:?}"
+        );
+        assert!(
+            proxy.recipients.read().expect("recipients lock").is_empty(),
+            "dead-weak rejection must not push a recipient"
+        );
+        std::mem::forget(proxy);
+    }
+
+    /// `ProxyHandle::set_extension` must reject with
+    /// `InvalidOperation` — the operation is server-side only and a
+    /// proxy has no way to inform the remote service. Silent
+    /// success would (a) leave the remote unaware of the new
+    /// extension and (b) after PR #104's §4 scope-down, pin an
+    /// unrelated `Arc<dyn IBinder>` for the parent's lifetime via
+    /// the strong-cache common case. The cache must remain
+    /// `NotQueried` after the rejected call.
+    #[test]
+    fn test_set_extension_on_proxy_rejects_with_invalid_operation() {
+        let proxy = synthetic_proxy(false);
+        let ext = SIBinder::new(Arc::new(MockBinder)).expect("SIBinder::new");
+
+        let result = proxy.set_extension(&ext);
+        assert!(
+            matches!(result, Err(StatusCode::InvalidOperation)),
+            "expected InvalidOperation, got {result:?}"
+        );
+
+        // Cache must not have been mutated. Constructing the
+        // synthetic proxy started in NotQueried; verify it stayed
+        // there.
+        let cache = proxy.extension.read().expect("Extension lock poisoned");
+        assert!(
+            matches!(*cache, ExtensionCache::NotQueried),
+            "extension cache must remain NotQueried after a rejected set_extension"
+        );
+        drop(cache);
+        std::mem::forget(proxy);
+    }
+
+    /// `dump` must fast-fail when the proxy is already obituary'd,
+    /// **before** calling `fd.into_raw_fd()` — otherwise the raw fd
+    /// is detached from `F`'s RAII and an early `Err` from
+    /// `submit_transact` leaks the fd. The synthetic `DropFlag`
+    /// implements `IntoRawFd` so the function's bound is satisfied,
+    /// but its `Drop` records observation; the assertion checks that
+    /// the fast-fail path leaves the fd to RAII (Drop fires) rather
+    /// than consuming it.
+    #[test]
+    fn test_dump_fast_fails_and_drops_fd_when_obituary_sent() {
+        use std::os::fd::RawFd;
+
+        struct DropFlag {
+            dropped: Arc<AtomicBool>,
+        }
+        impl std::os::fd::IntoRawFd for DropFlag {
+            fn into_raw_fd(self) -> RawFd {
+                // In the real success path the kernel takes ownership
+                // of the raw fd, so suppress Drop. The fast-fail path
+                // must NOT reach this method — the test would silently
+                // miss the Drop assertion below if it did.
+                std::mem::forget(self);
+                -1
+            }
+        }
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.dropped.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let proxy = synthetic_proxy(true); // obituary_sent
+        let dropped = Arc::new(AtomicBool::new(false));
+        let result = proxy.dump(
+            DropFlag {
+                dropped: dropped.clone(),
+            },
+            &[],
+        );
+
+        assert!(
+            matches!(result, Err(StatusCode::DeadObject)),
+            "expected DeadObject fast-fail, got {result:?}"
+        );
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "DropFlag's Drop must fire — fast-fail path must not call into_raw_fd"
+        );
+
+        std::mem::forget(proxy);
+    }
+
+    /// Unlinking a recipient that was never registered (while
+    /// another, different recipient *is* registered) must return
+    /// `NameNotFound` and leave the existing registration
+    /// untouched — `Vec::retain` would also do nothing in this case
+    /// but with the buggy "remove all matches" semantic, a future
+    /// regression that re-introduces it would fail this assertion
+    /// only via the registered-twice variant. Belt-and-suspenders.
+    #[test]
+    fn test_unlink_to_death_unregistered_returns_name_not_found() {
+        let proxy = synthetic_proxy(false);
+        let (_a_arc, a_weak) = live_recipient_pair();
+        let (_b_arc, b_weak) = live_recipient_pair();
+        {
+            let mut recipients = proxy.recipients.write().expect("recipients lock");
+            recipients.push(a_weak.clone());
+        }
+
+        let result = proxy.unlink_to_death(b_weak);
+        assert!(
+            matches!(result, Err(StatusCode::NameNotFound)),
+            "expected NameNotFound, got {result:?}"
+        );
+
+        let recipients = proxy.recipients.read().expect("recipients lock");
+        assert_eq!(recipients.len(), 1, "registered recipient must survive");
+        assert!(
+            sync::Weak::ptr_eq(&recipients[0], &a_weak),
+            "surviving entry must be the originally registered recipient"
+        );
+        drop(recipients);
+        std::mem::forget(proxy);
+    }
+
+    /// Minimal native `IBinder` impl used to build a `WIBinder` for
+    /// tests that need a `who` argument but don't care about the
+    /// binder's identity. `SIBinder::downgrade` takes the Native
+    /// branch for this type, so no `ProcessState` init is required.
+    struct MockBinder;
+
+    impl IBinder for MockBinder {
+        fn link_to_death(&self, _: sync::Weak<dyn DeathRecipient>) -> Result<()> {
+            Err(StatusCode::InvalidOperation)
+        }
+        fn unlink_to_death(&self, _: sync::Weak<dyn DeathRecipient>) -> Result<()> {
+            Err(StatusCode::InvalidOperation)
+        }
+        fn ping_binder(&self) -> Result<()> {
+            Ok(())
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn as_transactable(&self) -> Option<&dyn Transactable> {
+            None
+        }
+        fn descriptor(&self) -> &str {
+            "rsbinder.test.MockBinder"
+        }
+        fn is_remote(&self) -> bool {
+            false
+        }
+        fn inc_strong(&self, _: &SIBinder) -> Result<()> {
+            Ok(())
+        }
+        fn attempt_inc_strong(&self) -> bool {
+            true
+        }
+        fn dec_strong(&self, _: Option<ManuallyDrop<SIBinder>>) -> Result<()> {
+            Ok(())
+        }
+        fn inc_weak(&self, _: &WIBinder) -> Result<()> {
+            Ok(())
+        }
+        fn dec_weak(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A panicking recipient must not abort the binder worker thread
+    /// or starve subsequent recipients in the same `send_obituary`
+    /// snapshot. Drives `dispatch_obituary_callbacks` directly with a
+    /// two-element snapshot — the panicking entry is placed first so a
+    /// regression that drops the `catch_unwind` guard would unwind
+    /// past the loop and leave the counting recipient untouched, which
+    /// the assertion would then catch. Captured panic output is
+    /// printed to stderr by the default panic hook; cargo test buffers
+    /// it per-test so it only surfaces if this test itself fails.
+    #[test]
+    fn test_dispatch_obituary_callbacks_isolates_panic() {
+        use std::sync::Mutex;
+
+        struct PanickingRecipient;
+        impl DeathRecipient for PanickingRecipient {
+            fn binder_died(&self, _who: &WIBinder) {
+                panic!("simulated recipient panic");
+            }
+        }
+
+        struct CountingRecipient {
+            count: Arc<Mutex<u32>>,
+        }
+        impl DeathRecipient for CountingRecipient {
+            fn binder_died(&self, _who: &WIBinder) {
+                *self.count.lock().expect("count lock") += 1;
+            }
+        }
+
+        let panic_arc: Arc<dyn DeathRecipient> = Arc::new(PanickingRecipient);
+        let count = Arc::new(Mutex::new(0u32));
+        let counting_arc: Arc<dyn DeathRecipient> = Arc::new(CountingRecipient {
+            count: count.clone(),
+        });
+
+        let snapshot: Vec<sync::Weak<dyn DeathRecipient>> =
+            vec![Arc::downgrade(&panic_arc), Arc::downgrade(&counting_arc)];
+
+        let mock_strong = SIBinder::new(Arc::new(MockBinder)).expect("SIBinder::new");
+        let who = SIBinder::downgrade(&mock_strong);
+
+        let proxy = synthetic_proxy(false);
+        proxy.dispatch_obituary_callbacks(&snapshot, &who);
+
+        assert_eq!(
+            *count.lock().expect("count lock"),
+            1,
+            "counting recipient must fire after panicking recipient \
+             (catch_unwind guard regression)"
+        );
+
+        std::mem::forget(proxy);
     }
 
     /// Verifies `ExtensionCache::Queried` admits both a strong-cache

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -551,6 +551,112 @@ fn wait_for_response(until: UntilResponse) -> Result<Option<Parcel>> {
     })
 }
 
+/// Drive the kernel handshake for `BR_DEAD_BINDER` so that a
+/// user-side `send_obituary` failure cannot strand the kernel
+/// `binder_ref` slot.
+///
+/// The kernel slot is leaked permanently if either:
+///   1. `BC_DEAD_BINDER_DONE` is not written to `out_parcel`, or
+///   2. `release_obituary_pin`'s `BC_DECREFS` is not flushed.
+///
+/// So phases 2 (`queue_done`) and 3 (`pin_release`) always run
+/// regardless of phase 1's (`obituary`) outcome. The user-visible
+/// obituary error takes priority over the pin-release error;
+/// the pin error is also logged so it is not lost when both fail.
+///
+/// Residual edge: if `queue_done` itself fails (rare — `out_parcel`
+/// is unhealthy under e.g. allocator OOM), phase 3 is skipped and the
+/// pin leak still occurs. Documented; the next ioctl on this thread
+/// will fail anyway.
+fn drive_dead_binder_handshake<O, Q, P>(
+    handle: binder::binder_uintptr_t,
+    obituary: O,
+    queue_done: Q,
+    pin_release: P,
+) -> Result<()>
+where
+    O: FnOnce() -> Result<()>,
+    Q: FnOnce() -> Result<()>,
+    P: FnOnce() -> Result<()>,
+{
+    // Phase 1: dispatch recipients. Capture the result; do NOT
+    // short-circuit — kernel handshake must always complete.
+    let obituary_result = obituary();
+
+    // Phase 2: queue BC_DEAD_BINDER_DONE unconditionally. A failure
+    // here means out_parcel is unhealthy; propagate immediately
+    // because the next ioctl will surface it anyway. Phase 3 is
+    // skipped in this rare path (acknowledged residual edge). Log
+    // the obituary error first if it would otherwise be swallowed
+    // by the queue error — the obituary diagnostic is most valuable
+    // exactly when the kernel handshake is also breaking.
+    if let Err(qe) = queue_done() {
+        if let Err(oe) = &obituary_result {
+            error!(
+                "BR_DEAD_BINDER: queue BC_DEAD_BINDER_DONE failed ({qe:?}) \
+                 swallowing obituary error {oe:?} for handle {handle:X}"
+            );
+        }
+        return Err(qe);
+    }
+
+    // Phase 3: release the cache pin (BC_DECREFS via flush). Always
+    // attempted, even if obituary errored. A pin-release error is
+    // logged here so the diagnostic is not swallowed when the
+    // obituary error is surfaced below.
+    let pin_result = pin_release();
+    if let Err(e) = &pin_result {
+        error!(
+            "release_obituary_pin failed for handle {handle:X}: {e:?}; \
+             obituary_result: {obituary_result:?}"
+        );
+    }
+
+    // Surface obituary error first (user-visible — death recipient
+    // observed the failure). Fall back to pin error when obituary
+    // succeeded but pin failed.
+    obituary_result?;
+    pin_result?;
+    Ok(())
+}
+
+/// Invoke `Transactable::transact`, catching panics so a buggy
+/// service handler cannot terminate the binder worker thread.
+///
+/// On panic, the partial reply (if any) is discarded and the caller
+/// receives `StatusCode::Unknown`, so the existing `BR_TRANSACTION`
+/// reply path synthesizes a deterministic error reply for the
+/// calling client (rather than leaving the client hung waiting for
+/// `BR_REPLY`). Mirrors the panic guard around `DeathRecipient`
+/// callbacks in `ProxyHandle::dispatch_obituary_callbacks`. See the
+/// `Transactable` trait doc for the full guarantee scope.
+fn dispatch_transact_caught(
+    transactable: &dyn Transactable,
+    code: TransactionCode,
+    reader: &mut Parcel,
+    reply: &mut Parcel,
+) -> Result<()> {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        transactable.transact(code, reader, reply)
+    }));
+    match result {
+        Ok(transact_result) => transact_result,
+        Err(payload) => {
+            let msg = payload
+                .downcast_ref::<&'static str>()
+                .copied()
+                .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+                .unwrap_or("<non-string panic payload>");
+            error!("Transactable::transact panicked for code {code}: {msg}");
+            // Discard any partially-written reply so the client does
+            // not misparse half-formed data; the reply path below
+            // turns `Err` into a clean error status.
+            *reply = Parcel::new();
+            Err(StatusCode::Unknown)
+        }
+    }
+}
+
 fn execute_command(cmd: i32) -> Result<()> {
     let cmd: std::os::raw::c_uint = cmd as _;
 
@@ -619,10 +725,12 @@ fn execute_command(cmd: i32) -> Result<()> {
                             tr_secctx.transaction_data.cookie,
                         ));
                         if strong.attempt_increase() {
-                            let result = strong
-                                .as_transactable()
-                                .expect("Transactable is None.")
-                                .transact(tr_secctx.transaction_data.code, &mut reader, &mut reply);
+                            let result = dispatch_transact_caught(
+                                strong.as_transactable().expect("Transactable is None."),
+                                tr_secctx.transaction_data.code,
+                                &mut reader,
+                                &mut reply,
+                            );
                             strong.decrease()?;
 
                             result
@@ -634,10 +742,12 @@ fn execute_command(cmd: i32) -> Result<()> {
                         let context = ProcessState::as_self()
                             .context_manager()
                             .expect("Transactable is None.");
-                        context
-                            .as_transactable()
-                            .expect("Transactable is None.")
-                            .transact(tr_secctx.transaction_data.code, &mut reader, &mut reply)
+                        dispatch_transact_caught(
+                            context.as_transactable().expect("Transactable is None."),
+                            tr_secctx.transaction_data.code,
+                            &mut reader,
+                            &mut reply,
+                        )
                     }
                 };
                 let flags = tr_secctx.transaction_data.flags;
@@ -753,30 +863,21 @@ fn execute_command(cmd: i32) -> Result<()> {
 
                 log::trace!("BR_DEAD_BINDER: handle {handle:X}");
 
-                // Phase 1: remove cache entry under write lock + notify
-                // recipients.
-                ProcessState::as_self().send_obituary_for_handle(handle as _)?;
-
-                // Queue BC_DEAD_BINDER_DONE first (kernel handshake).
-                {
-                    let mut state = thread_state.borrow_mut();
-                    state
-                        .out_parcel
-                        .write::<u32>(&(binder::BC_DEAD_BINDER_DONE))?;
-                    state
-                        .out_parcel
-                        .write::<binder::binder_uintptr_t>(&handle)?;
-                }
-
-                // Phase 2: release the cache pin AFTER the death-done
-                // handshake is queued. `release_obituary_pin` flushes
-                // (commits BC_DEAD_BINDER_DONE plus any BC_RELEASEs
-                // already queued in this thread), then issues
-                // BC_DECREFS, then flushes again. Concurrent
-                // BC_RELEASEs from Drops on other threads can still
-                // arrive after our BC_DECREFS — the kernel rejects
-                // those with -EINVAL (logged but harmless).
-                ProcessState::as_self().release_obituary_pin(handle as _)?;
+                drive_dead_binder_handshake(
+                    handle,
+                    || ProcessState::as_self().send_obituary_for_handle(handle as _),
+                    || {
+                        let mut state = thread_state.borrow_mut();
+                        state
+                            .out_parcel
+                            .write::<u32>(&(binder::BC_DEAD_BINDER_DONE))?;
+                        state
+                            .out_parcel
+                            .write::<binder::binder_uintptr_t>(&handle)?;
+                        Ok(())
+                    },
+                    || ProcessState::as_self().release_obituary_pin(handle as _),
+                )?;
             }
             binder::BR_CLEAR_DEATH_NOTIFICATION_DONE => {
                 let mut state = thread_state.borrow_mut();
@@ -1383,5 +1484,212 @@ mod tests {
             "BC_TRANSACTION_SG"
         );
         assert_eq!(command_to_str(binder::BC_REPLY_SG), "BC_REPLY_SG");
+    }
+
+    /// A panicking `Transactable::transact` must not unwind through
+    /// `dispatch_transact_caught` and must surface as
+    /// `Err(StatusCode::Unknown)` so the existing `BR_TRANSACTION`
+    /// reply path can synthesize a deterministic error reply for the
+    /// client. The partial reply (if any) must also be reset so the
+    /// client does not misparse half-formed bytes.
+    #[test]
+    fn test_dispatch_transact_caught_isolates_panic() {
+        struct PanickingTransactable;
+        impl Transactable for PanickingTransactable {
+            fn transact(
+                &self,
+                _code: TransactionCode,
+                _reader: &mut Parcel,
+                reply: &mut Parcel,
+            ) -> Result<()> {
+                // Write a few bytes then panic, so the test verifies
+                // the partial reply is discarded.
+                reply.write::<i32>(&0x6EAD_BEEFi32).ok();
+                panic!("simulated transactable panic");
+            }
+        }
+
+        let mut reader = Parcel::new();
+        let mut reply = Parcel::new();
+        let result = dispatch_transact_caught(&PanickingTransactable, 1, &mut reader, &mut reply);
+
+        assert!(
+            matches!(result, Err(StatusCode::Unknown)),
+            "expected Err(StatusCode::Unknown), got {result:?}"
+        );
+        assert_eq!(
+            reply.data_size(),
+            0,
+            "partial reply must be discarded after a panic so the \
+             client does not misparse half-formed data"
+        );
+    }
+
+    /// A non-panicking `Transactable::transact` must propagate its
+    /// `Result` unchanged through `dispatch_transact_caught` —
+    /// regression check that the panic guard does not interfere with
+    /// the normal path.
+    #[test]
+    fn test_dispatch_transact_caught_propagates_normal_result() {
+        struct OkTransactable;
+        impl Transactable for OkTransactable {
+            fn transact(
+                &self,
+                _code: TransactionCode,
+                _reader: &mut Parcel,
+                reply: &mut Parcel,
+            ) -> Result<()> {
+                reply.write::<i32>(&42i32)?;
+                Ok(())
+            }
+        }
+
+        struct ErrTransactable;
+        impl Transactable for ErrTransactable {
+            fn transact(
+                &self,
+                _code: TransactionCode,
+                _reader: &mut Parcel,
+                _reply: &mut Parcel,
+            ) -> Result<()> {
+                Err(StatusCode::PermissionDenied)
+            }
+        }
+
+        let mut reader = Parcel::new();
+        let mut reply = Parcel::new();
+        assert!(dispatch_transact_caught(&OkTransactable, 1, &mut reader, &mut reply).is_ok());
+        assert_eq!(reply.data_size(), std::mem::size_of::<i32>());
+
+        let mut reply = Parcel::new();
+        let err = dispatch_transact_caught(&ErrTransactable, 1, &mut reader, &mut reply);
+        assert!(matches!(err, Err(StatusCode::PermissionDenied)));
+    }
+
+    /// `drive_dead_binder_handshake` orchestration must guarantee:
+    /// - Phases run in obituary → queue → pin order on success
+    /// - An obituary error does NOT short-circuit queue or pin
+    /// - A queue error skips pin (acknowledged residual edge)
+    /// - When obituary errors and pin errors, obituary takes priority
+    /// - The kernel handshake (queue + pin) runs whenever queue succeeds
+    ///
+    /// These properties protect against the kernel `binder_ref` slot
+    /// leak that motivated the refactor — losing any of them
+    /// re-introduces the leak shape that the previous `?`-based
+    /// implementation exhibited.
+    #[test]
+    fn test_drive_dead_binder_handshake_orchestration() {
+        use std::cell::RefCell;
+
+        let order = RefCell::new(Vec::<&'static str>::new());
+        let push = |label: &'static str| order.borrow_mut().push(label);
+
+        // Case A: all phases succeed.
+        let result = drive_dead_binder_handshake(
+            42,
+            || {
+                push("obituary");
+                Ok(())
+            },
+            || {
+                push("queue");
+                Ok(())
+            },
+            || {
+                push("pin");
+                Ok(())
+            },
+        );
+        assert!(result.is_ok());
+        assert_eq!(*order.borrow(), vec!["obituary", "queue", "pin"]);
+        order.borrow_mut().clear();
+
+        // Case B: obituary errors → queue and pin still run; obituary
+        // error surfaces. This is the headline guarantee: previously
+        // the kernel handshake was skipped on obituary error, leaking
+        // the binder_ref slot.
+        let result = drive_dead_binder_handshake(
+            42,
+            || {
+                push("obituary");
+                Err(StatusCode::DeadObject)
+            },
+            || {
+                push("queue");
+                Ok(())
+            },
+            || {
+                push("pin");
+                Ok(())
+            },
+        );
+        assert!(matches!(result, Err(StatusCode::DeadObject)));
+        assert_eq!(*order.borrow(), vec!["obituary", "queue", "pin"]);
+        order.borrow_mut().clear();
+
+        // Case C: queue write fails → pin is skipped (documented
+        // residual edge), queue error surfaces.
+        let result = drive_dead_binder_handshake(
+            42,
+            || {
+                push("obituary");
+                Ok(())
+            },
+            || {
+                push("queue");
+                Err(StatusCode::NoMemory)
+            },
+            || {
+                push("pin");
+                Ok(())
+            },
+        );
+        assert!(matches!(result, Err(StatusCode::NoMemory)));
+        assert_eq!(*order.borrow(), vec!["obituary", "queue"]);
+        order.borrow_mut().clear();
+
+        // Case D: obituary OK, pin errors → pin error surfaces.
+        let result = drive_dead_binder_handshake(
+            42,
+            || {
+                push("obituary");
+                Ok(())
+            },
+            || {
+                push("queue");
+                Ok(())
+            },
+            || {
+                push("pin");
+                Err(StatusCode::DeadObject)
+            },
+        );
+        assert!(matches!(result, Err(StatusCode::DeadObject)));
+        assert_eq!(*order.borrow(), vec!["obituary", "queue", "pin"]);
+        order.borrow_mut().clear();
+
+        // Case E: obituary errors AND pin errors → obituary error
+        // surfaces (priority); pin error is logged in the error path
+        // (asserting log content is out of scope for a unit test).
+        let result = drive_dead_binder_handshake(
+            42,
+            || {
+                push("obituary");
+                Err(StatusCode::PermissionDenied)
+            },
+            || {
+                push("queue");
+                Ok(())
+            },
+            || {
+                push("pin");
+                Err(StatusCode::DeadObject)
+            },
+        );
+        assert!(
+            matches!(result, Err(StatusCode::PermissionDenied)),
+            "obituary error must take priority over pin error, got {result:?}"
+        );
+        assert_eq!(*order.borrow(), vec!["obituary", "queue", "pin"]);
     }
 }

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -2056,3 +2056,338 @@ fn test_wibinder_upgrade_after_obituary() {
         }
     }
 }
+
+// =============================================================================
+// FOLLOW_UP_PR_104 integration tests
+//
+// These exercise the death-notification / extension / dump fixes through real
+// binder communication against `test_service`, complementing the in-crate unit
+// tests in `rsbinder/src/proxy.rs` and `rsbinder/src/thread_state.rs`. The
+// `#[ignore]`'d tests destroy the live `test_service` via `killService()` and
+// must each be run after a service restart — see the integration-test CI
+// workflow for the restart-then-run pattern.
+//
+// Coverage notes for items NOT exercised here:
+//   - Item 5  (BR_DEAD_BINDER kernel handshake)         — needs driver-level
+//     fault injection that rsbinder has no harness for.
+//     Practical bar: the orchestration unit test in `thread_state.rs`.
+//   - Item 10 (`Transactable::transact` panic isolation) — would need a
+//     deliberately panicking `Transactable` registered as a service. Out of
+//     scope without modifying `test_service` or `ITestService.aidl`.
+//     Practical bar: the unit test in `thread_state.rs` exercising the
+//     same `dispatch_transact_caught` code path that the BR_TRANSACTION arm
+//     calls in production.
+//   - Item 11 (extension cache staleness)               — would need an
+//     extension that can die independently of its parent service, which the
+//     test_service's `NamedCallback` extension does not support.
+//     Practical bar: the unit test in `proxy.rs` that pre-populates the cache.
+// =============================================================================
+
+/// Item 6: a panicking `DeathRecipient` must not starve other recipients
+/// registered against the same handle, and must not terminate the binder
+/// worker thread. Two recipients are registered: a panicking one (which
+/// goes first in registration order) and a writing one. After `killService`
+/// the writing recipient's pipe-write must be observable — proof that
+/// `dispatch_obituary_callbacks`'s `catch_unwind` is in effect.
+#[test]
+#[ignore]
+fn test_death_recipient_panic_does_not_starve_others() {
+    init_test();
+    let test_service = get_test_service();
+    let (mut read_file, write_file) = build_pipe();
+
+    struct PanickingRecipient;
+    impl DeathRecipient for PanickingRecipient {
+        fn binder_died(&self, _: &WIBinder) {
+            panic!("intentional test panic in binder_died");
+        }
+    }
+
+    struct WritingRecipient(Mutex<File>);
+    impl DeathRecipient for WritingRecipient {
+        fn binder_died(&self, _: &WIBinder) {
+            self.0
+                .lock()
+                .unwrap()
+                .write_all(b"survived\n")
+                .expect("pipe write");
+        }
+    }
+
+    let panic_arc: Arc<dyn DeathRecipient> = Arc::new(PanickingRecipient);
+    let writing_arc: Arc<dyn DeathRecipient> = Arc::new(WritingRecipient(Mutex::new(write_file)));
+
+    let binder = test_service.as_binder();
+    // Order matters: the panicker registers first. A regression that
+    // drops the per-recipient `catch_unwind` would unwind through the
+    // dispatch loop and the writing recipient would never fire — the
+    // `read_exact` below would then block until pipe close (Mutex<File>
+    // dropping at end of test) and surface a different failure mode.
+    binder
+        .link_to_death(Arc::downgrade(&panic_arc))
+        .expect("link panicking recipient");
+    binder
+        .link_to_death(Arc::downgrade(&writing_arc))
+        .expect("link writing recipient");
+
+    test_service.killService().expect("killService");
+
+    let mut buf = [0u8; 9];
+    read_file
+        .read_exact(&mut buf)
+        .expect("writing recipient must fire despite panicking sibling");
+    assert_eq!(&buf, b"survived\n");
+
+    // Hold both recipients alive until the assertion above runs so
+    // their `Weak`s in the recipients vec stayed upgradable for the
+    // obituary dispatch.
+    drop(panic_arc);
+    drop(writing_arc);
+}
+
+/// Item 1: registering the same recipient twice and unlinking once must
+/// remove only one entry (matching C++ `BpBinder::unlinkToDeath`'s
+/// `removeAt(i)`). After `killService` exactly one `binder_died` call
+/// must fire on the duplicated recipient.
+///
+/// The recipients vec ends up `[counted, counted, signal]` (three
+/// `link_to_death` calls in registration order). `unlink_to_death`'s
+/// position-based first-match remove is then expected to leave
+/// `[counted, signal]`. The signal recipient is the synchronization
+/// barrier: dispatch fires recipients in vec order, so the signal
+/// byte arrives **after** every preceding `counted` invocation has
+/// returned. Reading the signal therefore guarantees the atomic
+/// counter has its final value — a pipe-only design risks a
+/// false positive where the test reads one byte, drops the recipient,
+/// and silently masks a still-pending second `binder_died` call (its
+/// `weak.upgrade()` would return None after the drop).
+///
+/// Failure modes a regression would cause:
+/// - `Vec::retain` (pre-Item-1): both `counted` entries removed →
+///   counter == 0 → assert fails.
+/// - No removal at all: vec stays `[counted, counted, signal]` →
+///   counter == 2 → assert fails.
+#[test]
+#[ignore]
+fn test_unlink_to_death_single_remove_via_obituary() {
+    use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
+
+    init_test();
+    let test_service = get_test_service();
+
+    struct CountingRecipient(Arc<AtomicU32>);
+    impl DeathRecipient for CountingRecipient {
+        fn binder_died(&self, _: &WIBinder) {
+            self.0.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+    }
+    let counter = Arc::new(AtomicU32::new(0));
+    let counted: Arc<dyn DeathRecipient> = Arc::new(CountingRecipient(counter.clone()));
+
+    let (mut signal_read, signal_write) = build_pipe();
+    struct SignalRecipient(Mutex<File>);
+    impl DeathRecipient for SignalRecipient {
+        fn binder_died(&self, _: &WIBinder) {
+            self.0
+                .lock()
+                .unwrap()
+                .write_all(b"!")
+                .expect("signal pipe write");
+        }
+    }
+    let signal: Arc<dyn DeathRecipient> = Arc::new(SignalRecipient(Mutex::new(signal_write)));
+
+    let binder = test_service.as_binder();
+    // recipients vec after these three calls: [counted, counted, signal]
+    binder
+        .link_to_death(Arc::downgrade(&counted))
+        .expect("link counted (1st)");
+    binder
+        .link_to_death(Arc::downgrade(&counted))
+        .expect("link counted (2nd duplicate)");
+    binder
+        .link_to_death(Arc::downgrade(&signal))
+        .expect("link signal");
+
+    // Single-position remove of the first match → [counted, signal].
+    binder
+        .unlink_to_death(Arc::downgrade(&counted))
+        .expect("unlink one of the duplicates");
+
+    test_service.killService().expect("killService");
+
+    // Wait for the signal byte. Because `signal` is last in the
+    // recipients vec, by the time we observe its byte the binder
+    // thread has already returned from every preceding
+    // `counted.binder_died` invocation.
+    let mut sentinel = [0u8; 1];
+    signal_read
+        .read_exact(&mut sentinel)
+        .expect("read signal pipe");
+    assert_eq!(&sentinel, b"!");
+
+    let count = counter.load(AtomicOrdering::SeqCst);
+    assert_eq!(
+        count, 1,
+        "exactly one binder_died expected for the duplicated recipient (got {count}). \
+         Vec::retain regression would yield 0; missed-removal regression would yield 2."
+    );
+
+    drop(counted);
+    drop(signal);
+}
+
+/// Item 8: passing an already-dead `Weak<dyn DeathRecipient>` to
+/// `link_to_death` against a live remote proxy must reject with
+/// `BadValue`, **not** silently register a subscription that
+/// `binder_died` would skip. Non-destructive — does not call
+/// `killService`.
+#[test]
+fn test_link_to_death_rejects_already_dead_weak_remote_proxy() {
+    init_test();
+    let test_service = get_test_service();
+
+    struct NoopRecipient;
+    impl DeathRecipient for NoopRecipient {
+        fn binder_died(&self, _: &WIBinder) {}
+    }
+
+    let arc: Arc<dyn DeathRecipient> = Arc::new(NoopRecipient);
+    let dead_weak = Arc::downgrade(&arc);
+    drop(arc);
+    assert!(
+        dead_weak.upgrade().is_none(),
+        "fixture sanity: weak must be dangling"
+    );
+
+    let result = test_service.as_binder().link_to_death(dead_weak);
+    assert_eq!(
+        result,
+        Err(rsbinder::StatusCode::BadValue),
+        "link_to_death must reject a dead weak with BadValue (got {result:?})"
+    );
+}
+
+/// Item 3: `set_extension` on a remote proxy must reject with
+/// `InvalidOperation` — the operation is server-side only and a proxy
+/// has no way to inform the remote service. The post-PR-104 §4
+/// strong-cache common case would otherwise silently pin an unrelated
+/// `Arc<dyn IBinder>` for the parent's lifetime. Non-destructive —
+/// `get_extension` continues to work, returning the extension that
+/// `test_service` set on its native side.
+#[test]
+fn test_set_extension_on_remote_proxy_rejects() {
+    init_test();
+    let test_service = get_test_service();
+    let binder = test_service.as_binder();
+
+    assert!(
+        binder.is_remote(),
+        "test_service.as_binder() must be a remote proxy for this test"
+    );
+
+    let new_ext = INamedCallback::BnNamedCallback::new_binder(ExtNamedCallback("rejected".into()));
+    let result = binder.set_extension(&new_ext.as_binder());
+    assert_eq!(
+        result,
+        Err(rsbinder::StatusCode::InvalidOperation),
+        "set_extension on a remote proxy must reject (got {result:?})"
+    );
+
+    // The proxy is still usable — `get_extension` returns the
+    // extension `test_service` set on its native side.
+    let got = binder
+        .get_extension()
+        .expect("get_extension must still succeed after rejected set_extension");
+    assert!(
+        got.is_some(),
+        "test_service publishes a NamedCallback extension"
+    );
+}
+
+/// Item 4: `dump` on an obituary'd proxy must return `DeadObject`
+/// and the caller's fd must end up closed.
+///
+/// Scope of this integration test: it verifies the **user-visible
+/// contract** (DeadObject return + fd no longer open) end-to-end
+/// against a real obituary'd proxy. It does **not** distinguish
+/// between Item 4's specific fast-fail path (which closes the fd
+/// via `File::Drop` *before* any parcel work) and the pre-existing
+/// `Parcel::Drop` cleanup path (which would close via
+/// `release_objects` *after* `into_raw_fd` and the parcel write,
+/// were Item 4's check ever removed and `submit_transact`'s own
+/// fast-fail relied upon instead). Both layers result in the same
+/// observable EOF on the read end.
+///
+/// The unit test
+/// `test_dump_fast_fails_and_drops_fd_when_obituary_sent` in
+/// `rsbinder/src/proxy.rs` covers Item 4's specific path with a
+/// synthetic `IntoRawFd` type whose `Drop` is observable separately
+/// from `into_raw_fd` — that test catches a regression that
+/// reverts Item 4's check while leaving `submit_transact`'s
+/// PR-#104 fast-fail in place. This integration test catches the
+/// broader regression where neither layer closes the fd
+/// (e.g. both fast-fail checks reverted).
+#[test]
+#[ignore]
+fn test_dump_fast_fails_on_dead_proxy_closes_fd() {
+    init_test();
+    let test_service = get_test_service();
+    let binder = test_service.as_binder();
+
+    // Wait for obituary by registering a death recipient + pipe.
+    let (mut death_read, death_write) = build_pipe();
+    struct DR(Mutex<File>);
+    impl DeathRecipient for DR {
+        fn binder_died(&self, _: &WIBinder) {
+            self.0.lock().unwrap().write_all(b"died\n").unwrap();
+        }
+    }
+    let recipient: Arc<dyn DeathRecipient> = Arc::new(DR(Mutex::new(death_write)));
+    binder
+        .link_to_death(Arc::downgrade(&recipient))
+        .expect("link_to_death");
+
+    test_service.killService().expect("killService");
+
+    let mut sentinel = [0u8; 5];
+    death_read
+        .read_exact(&mut sentinel)
+        .expect("read death pipe");
+    assert_eq!(&sentinel, b"died\n");
+
+    // Now `obituary_sent` is published on the proxy. Build a fresh
+    // pipe; the write end is handed to `dump`, the read end stays in
+    // the test for EOF observation.
+    let (dump_read_owned, dump_write_owned) = rustix::pipe::pipe().expect("pipe for dump");
+    let dump_write = unsafe { File::from_raw_fd(dump_write_owned.into_raw_fd()) };
+    let mut dump_read = unsafe { File::from_raw_fd(dump_read_owned.into_raw_fd()) };
+
+    // `dump` is a `ProxyHandle` inherent method (not on the `IBinder`
+    // trait), so we go through `as_proxy` to reach it. Holding the
+    // SIBinder root in `binder` keeps the proxy reference valid.
+    let proxy = (*binder)
+        .as_proxy()
+        .expect("test_service is a remote proxy");
+    let result = proxy.dump(dump_write, &[]);
+    assert_eq!(
+        result,
+        Err(rsbinder::StatusCode::DeadObject),
+        "dump on obituary'd proxy must fast-fail with DeadObject (got {result:?})"
+    );
+
+    // `dump` dropped its `F` parameter without calling `into_raw_fd`,
+    // so File::Drop closed the fd. Reading from the other end must
+    // EOF — pipe semantics guarantee EOF on read once all write ends
+    // are closed.
+    let mut tail = [0u8; 16];
+    let n = dump_read
+        .read(&mut tail)
+        .expect("read dump pipe after fast-fail");
+    assert_eq!(
+        n, 0,
+        "dump's fd must have been closed by RAII (got {n} unexpected bytes)"
+    );
+
+    drop(recipient);
+}


### PR DESCRIPTION
## Summary

Implements all 11 follow-up items from the PR #104 side-by-side review against [binder-linux](https://github.com/hiking90/binder-linux)'s `BpBinder`. None are introduced by PR #104; each is a pre-existing edge surfaced by the audit. Sized as a single PR rather than 11 small ones because several items share helpers / files and the cross-cutting verification is cleaner together.

## Changes by theme

### Panic isolation (Items 6, 10) — High severity
A user panic in `DeathRecipient::binder_died` or `Transactable::transact` no longer terminates the binder worker thread. Per-callback `catch_unwind` guards are added in:

- `ProxyHandle::dispatch_obituary_callbacks` (extracted from `send_obituary` for testability)
- `dispatch_transact_caught` (wraps the `BR_TRANSACTION` arm's transactable call; on panic returns `StatusCode::Unknown` with reset reply, preventing client hang)

Bonus: the `BR_TRANSACTION` refactor also closes a pre-existing `strong.decrease()?` ref-count leak that lived on the panic-unwind path.

`DeathRecipient` and `Transactable` traits gain "Panic safety" doc-sections.

### `BR_DEAD_BINDER` kernel handshake (Item 5) — High severity
`drive_dead_binder_handshake` orchestrates obituary → `BC_DEAD_BINDER_DONE` queue → `release_obituary_pin` so a `send_obituary_for_handle` error never short-circuits the kernel-side accounting (which would leak a `binder_ref` slot). Obituary error is surfaced first; pin error is logged so it isn't swallowed.

### Death-notification protocol (Items 1, 2, 8) — Medium / Low
- **Item 1:** `unlink_to_death` uses `position` + `Vec::remove` (single first-match) instead of `Vec::retain` (remove-all). No-match returns `NameNotFound`. Mirrors C++ `BpBinder::unlinkToDeath`'s `removeAt(i)`.
- **Item 2:** `link_to_death` / `unlink_to_death` ignore `flush_commands` errors (best-effort, matches C++); parcel-write errors still propagate. Closes the prior leak window where flush failure left kernel with an unservicable subscription.
- **Item 8:** `link_to_death` rejects already-dead `Weak` with `BadValue` *before* queuing the kernel subscription — silent registration of a never-firing recipient is misleading.

### `dump` fast-fail on dead proxy (Item 4) — Medium
`ProxyHandle::dump` reads `obituary_sent` (Acquire) and returns `DeadObject` *before* `fd.into_raw_fd()`, letting the caller's `F` Drop close the fd via RAII. The non-fast-fail error paths still exhibit the pre-existing leak shape — see `dump`'s comment for the wider follow-up scope.

### Extension semantics (Items 3, 11) — Medium / Trivial
- **Item 3:** `ProxyHandle::set_extension` rejects with `InvalidOperation` (matching trait default). Server-side operation called on a client proxy can never inform the remote service; after PR #104 §4's strong-cache scope-down, silent success would also pin an unrelated `Arc<dyn IBinder>` for the parent's lifetime.
- **Item 11:** `IBinder::get_extension` doc gains a "Staleness on proxy" section explaining the strong cache is not auto-invalidated on extension obituary; IPC through the cached dead extension fast-fails with `DeadObject` (matches Android C++).

### Documentation + test ergonomics (Items 9, 7) — Trivial
- **Item 9:** `ProxyHandle::obituary_sent` field doc-comment gains an ordering table mapping each call site → lock state → atomic ordering. Prevents a future reader from "fixing" `Relaxed` to `Acquire` for no benefit.
- **Item 7:** `noop_recipient_weak()` (dangling weak) replaced by `live_recipient_pair()` (returns `(Arc, Weak)` so caller binds the strong).

## Integration tests (5)

`tests/src/test_client.rs` adds binder-IPC end-to-end tests against a real `test_service`:

| Item | Test | Destructive |
|---|---|---|
| 6 | `test_death_recipient_panic_does_not_starve_others` | ✅ `#[ignore]` |
| 1 | `test_unlink_to_death_single_remove_via_obituary` | ✅ `#[ignore]` |
| 8 | `test_link_to_death_rejects_already_dead_weak_remote_proxy` | ❌ |
| 3 | `test_set_extension_on_remote_proxy_rejects` | ❌ |
| 4 | `test_dump_fast_fails_on_dead_proxy_closes_fd` | ✅ `#[ignore]` |

Item 1's test uses an atomic counter + a separate \"signal\" recipient as a happens-before barrier to eliminate a false-positive race that a pipe-only design would have. The other tests' design considerations are documented inline.

`.github/workflows/integration-test.yml` adds three restart-then-run CI step pairs (one per destructive test), following the existing `test_death_recipient` / `test_wibinder_upgrade_after_obituary` pattern.

## Items NOT exercised end-to-end

Documented in the integration-test file header:

- **Item 5** — needs driver-level fault injection (no harness in rsbinder); the orchestration unit test in `thread_state.rs` is the practical bar.
- **Item 10** — needs a deliberately panicking `Transactable` registered as a service; AIDL / `test_service` change required.
- **Item 11** — needs an extension that can die independently of its parent (the test_service's `NamedCallback` extension does not).

In all three cases the unit test exercises the same code path that the production BR_* arm calls; the gap is "real obituary path through binderfs" which is plan-acknowledged out of scope.

## Test plan

- [ ] CI: Linux integration test loop (sync) — full sweep including new non-destructive tests
- [ ] CI: Linux integration test loop (async) — same
- [ ] CI: 3 new destructive tests (`#[ignore]`'d, each with restart): `test_death_recipient_panic_does_not_starve_others`, `test_unlink_to_death_single_remove_via_obituary`, `test_dump_fast_fails_on_dead_proxy_closes_fd`
- [ ] CI: 2 existing destructive tests still pass (`test_death_recipient`, `test_wibinder_upgrade_after_obituary`)
- [ ] CI: Android matrix
- [ ] Local verification (already done): `cargo build --workspace --all-targets`, `cargo test -p rsbinder --lib` (93 pass + 6 pre-existing macOS env failures), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `cargo doc --no-deps -p rsbinder`

🤖 Generated with [Claude Code](https://claude.com/claude-code)