### PR TITLE
fix(rsbinder): close native binder UAF in flat_binder_object encoding

### DIFF
--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -511,6 +511,17 @@ impl SIBinder {
         Self { inner }
     }
 
+    /// Borrow the underlying `Arc<dyn IBinder>`.
+    ///
+    /// Provides a non-consuming view of the inner trait-object Arc so
+    /// callers can clone it for sidecar tables (e.g.
+    /// `ProcessState::published_natives`) or compare identity via
+    /// `Arc::as_ptr` without going through the unsafe
+    /// `into_raw`/`from_raw` round trip.
+    pub(crate) fn as_arc(&self) -> &Arc<dyn IBinder> {
+        &self.inner
+    }
+
     /// Construct a weak reference to this binder.
     ///
     /// Pure `Arc::downgrade` — no kernel command, no trait dispatch.

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -499,25 +499,12 @@ impl SIBinder {
         this
     }
 
-    pub(crate) fn into_raw(self) -> *const dyn IBinder {
-        let inner = Arc::clone(&self.inner);
-        let raw = Arc::into_raw(inner);
-        std::mem::forget(self);
-        raw
-    }
-
-    pub(crate) fn from_raw(raw: *const dyn IBinder) -> Self {
-        let inner = unsafe { Arc::from_raw(raw) };
-        Self { inner }
-    }
-
     /// Borrow the underlying `Arc<dyn IBinder>`.
     ///
     /// Provides a non-consuming view of the inner trait-object Arc so
     /// callers can clone it for sidecar tables (e.g.
     /// `ProcessState::published_natives`) or compare identity via
-    /// `Arc::as_ptr` without going through the unsafe
-    /// `into_raw`/`from_raw` round trip.
+    /// `Arc::as_ptr` without an unsafe round trip through raw pointers.
     pub(crate) fn as_arc(&self) -> &Arc<dyn IBinder> {
         &self.inner
     }
@@ -587,11 +574,6 @@ impl SIBinder {
 
     pub(crate) fn decrease(&self) -> Result<()> {
         self.inner.dec_strong(None)
-    }
-
-    pub(crate) fn decrease_drop(this: ManuallyDrop<Self>) -> Result<()> {
-        let inner = Arc::clone(&this.inner);
-        inner.dec_strong(Some(this))
     }
 
     /// Try to convert this Binder object into a trait object for the given

--- a/rsbinder/src/binder_object.rs
+++ b/rsbinder/src/binder_object.rs
@@ -1,7 +1,6 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-use std::mem::ManuallyDrop;
 use std::sync::Arc;
 
 use rustix::fd::{BorrowedFd, FromRawFd, OwnedFd};
@@ -74,10 +73,6 @@ impl flat_binder_object {
 
     pub(crate) fn pointer(&self) -> binder_uintptr_t {
         unsafe { self.__bindgen_anon_1.binder }
-    }
-
-    pub(crate) fn cookie(&self) -> binder_uintptr_t {
-        self.cookie
     }
 
     pub(crate) fn set_cookie(&mut self, cookie: binder_uintptr_t) {
@@ -159,30 +154,6 @@ impl flat_binder_object {
             }
         }
     }
-}
-
-/// Splits a fat pointer (trait object) into its data and vtable components.
-///
-/// # Safety
-/// This function uses transmute to convert a fat pointer into two u64 values.
-/// This is safe because:
-/// 1. Fat pointers are always two usizes (data pointer + vtable pointer)
-/// 2. On 64-bit systems, usize == u64
-/// 3. We only use this for binder IPC serialization where we need both components
-///
-/// # Panics
-/// Will panic on 32-bit systems where usize != u64
-fn split_fat_pointer(ptr: *const dyn IBinder) -> (u64, u64) {
-    debug_assert_eq!(
-        std::mem::size_of::<*const dyn IBinder>(),
-        std::mem::size_of::<(u64, u64)>(),
-        "Fat pointer size mismatch - system not 64-bit?"
-    );
-    unsafe { std::mem::transmute(ptr) }
-}
-
-fn make_fat_pointer(raw_pointer: (binder_uintptr_t, binder_uintptr_t)) -> *const dyn IBinder {
-    unsafe { std::mem::transmute(raw_pointer) }
 }
 
 const SCHED_NORMAL: u32 = 0;
@@ -274,14 +245,4 @@ pub(crate) fn write_flat_binder(
         .ok_or(StatusCode::NotEnoughData)?;
     unsafe { std::ptr::write_unaligned(bytes.as_mut_ptr() as *mut flat_binder_object, *obj) };
     Ok(())
-}
-
-pub(crate) fn raw_pointer_to_strong_binder(
-    raw_pointer: (binder_uintptr_t, binder_uintptr_t),
-) -> ManuallyDrop<SIBinder> {
-    assert!(
-        raw_pointer.0 != 0,
-        "raw_pointer_to_strong_binder(): raw_pointer is null"
-    );
-    ManuallyDrop::new(SIBinder::from_raw(make_fat_pointer(raw_pointer)))
 }

--- a/rsbinder/src/binder_object.rs
+++ b/rsbinder/src/binder_object.rs
@@ -205,8 +205,8 @@ impl From<&SIBinder> for flat_binder_object {
             // and the first `acquire` is the only leak path under a
             // `Parcel::write_aligned` panic (typically OOM), which is
             // process-fatal anyway — see plan §5 #11.
-            let id = process_state::ProcessState::as_self()
-                .publish_native(Arc::clone(binder.as_arc()));
+            let id =
+                process_state::ProcessState::as_self().publish_native(Arc::clone(binder.as_arc()));
 
             flat_binder_object {
                 hdr: binder_object_header {

--- a/rsbinder/src/binder_object.rs
+++ b/rsbinder/src/binder_object.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::mem::ManuallyDrop;
+use std::sync::Arc;
 
 use rustix::fd::{BorrowedFd, FromRawFd, OwnedFd};
 
@@ -86,9 +87,23 @@ impl flat_binder_object {
     pub(crate) fn acquire(&self) -> Result<()> {
         match self.hdr.type_ {
             BINDER_TYPE_BINDER => {
+                // Native binder: bump publish_count for this buffer
+                // instance. Symmetric with `release()` below — every
+                // `Parcel::write_object` / `Parcel::append_from` call
+                // pairs an `acquire` here with exactly one `release`
+                // from `Parcel::release_objects` (driven by
+                // `Parcel::Drop` for caller-owned outgoing parcels).
+                // Driver-mmapped incoming parcels skip both ends
+                // symmetrically (their `Drop` calls `BC_FREE_BUFFER`
+                // instead of `release_objects`, and the deserializer
+                // does not call `acquire`), so the pairing invariant
+                // is preserved without any per-object bookkeeping.
                 if self.pointer() != 0 {
-                    let strong = raw_pointer_to_strong_binder((self.pointer(), self.cookie()));
-                    strong.increase()?;
+                    let id = self.pointer();
+                    if !process_state::ProcessState::as_self().incref_publish(id) {
+                        log::error!("flat_binder_object::acquire: unknown native id {id}");
+                        debug_assert!(false, "acquire on unknown native id {id}");
+                    }
                 }
 
                 Ok(())
@@ -110,9 +125,20 @@ impl flat_binder_object {
     pub(crate) fn release(&self) -> Result<()> {
         match self.hdr.type_ {
             BINDER_TYPE_BINDER => {
+                // Native binder: decrement publish_count. If both
+                // publish_count and kernel_refs hit zero,
+                // decref_publish removes the entry, which drives
+                // RefCounter.strong / RefCounter.weak 1→0 and drops
+                // the canonical Arc<dyn IBinder> (Inner<T>::drop runs
+                // cleanly — kernel guaranteed no further BR_* will
+                // reference this id since kernel_refs was 0 at
+                // removal).
                 if self.pointer() != 0 {
-                    let strong = raw_pointer_to_strong_binder((self.pointer(), self.cookie()));
-                    strong.decrease()?;
+                    let id = self.pointer();
+                    if !process_state::ProcessState::as_self().decref_publish(id) {
+                        log::error!("flat_binder_object::release: unknown native id {id}");
+                        debug_assert!(false, "release on unknown native id {id}");
+                    }
                 }
                 Ok(())
             }
@@ -188,18 +214,36 @@ impl From<&SIBinder> for flat_binder_object {
                 cookie: 0,
             }
         } else {
-            let strong = binder.clone();
-            let (binder, cookie) = split_fat_pointer(strong.into_raw());
+            // Native binder. Acquire (or dedup-resolve) an id via the
+            // sidecar table on `ProcessState`; the table holds an
+            // `Arc<dyn IBinder>` strong reference for the duration
+            // either an outgoing parcel (`publish_count > 0`) or any
+            // kernel-held ref (`kernel_refs > 0`) references this
+            // binder. Replaces the previous fat-pointer encoding
+            // (data ptr in `binder`, vtable ptr in `cookie`) which
+            // could dangle once `Inner<T>` was dropped while a
+            // `BR_DECREFS` was still in flight — Android closes the
+            // same window with a two-allocation
+            // (`weakref_type*` / `BBinder*`) design; we reach the
+            // same invariant via id-indirection.
+            //
+            // The entry is created with `publish_count = 0`; the
+            // immediately-following `Parcel::write_object` →
+            // `flat_binder_object::acquire` brings it to 1. The
+            // single-statement window between this `From` returning
+            // and the first `acquire` is the only leak path under a
+            // `Parcel::write_aligned` panic (typically OOM), which is
+            // process-fatal anyway — see plan §5 #11.
+            let id = process_state::ProcessState::as_self()
+                .publish_native(Arc::clone(binder.as_arc()));
 
             flat_binder_object {
                 hdr: binder_object_header {
                     type_: BINDER_TYPE_BINDER,
                 },
                 flags: FLAT_BINDER_FLAG_ACCEPTS_FDS | sched_bits,
-                __bindgen_anon_1: flat_binder_object__bindgen_ty_1 {
-                    binder: binder as _,
-                },
-                cookie: cookie as _,
+                __bindgen_anon_1: flat_binder_object__bindgen_ty_1 { binder: id },
+                cookie: 0,
             }
         }
     }

--- a/rsbinder/src/native.rs
+++ b/rsbinder/src/native.rs
@@ -311,11 +311,20 @@ impl<B: Remotable + 'static> TryFrom<SIBinder> for Binder<B> {
             return Err(StatusCode::BadType);
         }
 
-        // SAFETY: We just verified through downcast_ref that this IBinder
-        // is actually an Inner<B>, so the cast is safe. The into_raw()
-        // gives us the underlying Arc pointer which we reconstruct here.
         if ibinder.as_any().downcast_ref::<Inner<B>>().is_some() {
-            let inner_raw = ibinder.into_raw() as *const Inner<B>;
+            // SAFETY: `downcast_ref::<Inner<B>>` confirmed the
+            // underlying allocation is `Inner<B>`. The trait-object
+            // Arc's data pointer addresses that `Inner<B>` value
+            // directly, so casting `*const dyn IBinder` to
+            // `*const Inner<B>` is layout-correct. Cloning the
+            // trait-object Arc and consuming it via `Arc::into_raw`
+            // leaks one strong ref; `Arc::from_raw` on the cast
+            // pointer reclaims that ref as `Arc<Inner<B>>`, conserving
+            // the total strong count after `ibinder` drops at the end
+            // of this function.
+            let arc_dyn = Arc::clone(ibinder.as_arc());
+            let raw_dyn = Arc::into_raw(arc_dyn);
+            let inner_raw = raw_dyn as *const Inner<B>;
             let inner = unsafe { Arc::from_raw(inner_raw) };
 
             Ok(Self { inner })

--- a/rsbinder/src/parcelable.rs
+++ b/rsbinder/src/parcelable.rs
@@ -23,7 +23,7 @@
 //! serialized and deserialized in binder parcels, providing the foundation
 //! for AIDL-generated types and custom parcelable implementations.
 
-use crate::{binder::*, binder_object::*, error::*, parcel::Parcel, process_state::*, sys::*};
+use crate::{binder::*, error::*, parcel::Parcel, process_state::*, sys::*};
 
 /// Core trait for types that can be serialized to and from parcels.
 ///

--- a/rsbinder/src/parcelable.rs
+++ b/rsbinder/src/parcelable.rs
@@ -495,10 +495,25 @@ impl DeserializeOption for SIBinder {
 
         match flat.header_type() {
             BINDER_TYPE_BINDER => {
-                let pointer = flat.pointer();
-                if pointer != 0 {
-                    let strong = raw_pointer_to_strong_binder((flat.pointer(), flat.cookie()));
-                    Ok(Some(SIBinder::clone(&strong)))
+                // Receiving BINDER_TYPE_BINDER means the kernel routed
+                // a binder back to its original publisher (us).
+                // Cross-process binder transfers reach receivers as
+                // BINDER_TYPE_HANDLE — the kernel only emits
+                // BINDER_TYPE_BINDER on the publisher loopback path.
+                // Look up the id in our sidecar table; an unknown id
+                // here would mean either (a) a kernel bug surfacing a
+                // BINDER_TYPE_BINDER we never published, or (b) the
+                // entry was already torn down (shouldn't happen
+                // because the round-trip ride keeps `kernel_refs > 0`
+                // via the receiving process's outstanding handle).
+                // Either way it's an integrity error → DeadObject.
+                let id = flat.pointer();
+                if id != 0 {
+                    let arc = ProcessState::as_self().lookup_native(id).ok_or_else(|| {
+                        log::error!("BINDER_TYPE_BINDER for unknown native id {id}");
+                        StatusCode::DeadObject
+                    })?;
+                    Ok(Some(SIBinder::from_arc(arc)))
                 } else {
                     Ok(None)
                 }

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -1068,7 +1068,10 @@ mod tests {
         let arc: Arc<dyn IBinder> = Arc::new(MockNative);
 
         let id = process.publish_native(Arc::clone(&arc));
-        assert!(process.incref_publish(id), "incref on freshly published id must succeed");
+        assert!(
+            process.incref_publish(id),
+            "incref on freshly published id must succeed"
+        );
 
         // Drop the user-side Arc clone; only the table's binder_pin
         // SIBinder keeps the inner Arc alive now.

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -684,6 +684,18 @@ impl ProcessState {
                 .expect("Published natives lock poisoned");
             match map.get_mut(&id) {
                 Some(entry) => {
+                    // `saturating_sub` is the production safety net for
+                    // an unpaired `release` (which would otherwise wrap
+                    // u32 → 4 billion); the `debug_assert` makes the
+                    // unpaired call loud during dev/CI so a future
+                    // `acquire`/`release` pairing bug doesn't slip
+                    // through silently.
+                    debug_assert!(
+                        entry.publish_count > 0,
+                        "decref_publish on id {id} with publish_count == 0 \
+                         (unpaired release; check From<&SIBinder> ↔ \
+                         flat_binder_object::release pairing)"
+                    );
                     entry.publish_count = entry.publish_count.saturating_sub(1);
                     entry.publish_count == 0 && entry.kernel_refs == 0
                 }
@@ -724,6 +736,19 @@ impl ProcessState {
                 .write()
                 .expect("Published natives lock poisoned");
             let entry = map.get_mut(&id)?;
+            // Mirror `decref_publish`: `saturating_sub` is the
+            // production safety net; `debug_assert` catches an
+            // unpaired BR_RELEASE / BR_DECREFS during dev/CI. Kernel
+            // ordering guarantees `BR_INCREFS` ≤ `BR_DECREFS` count
+            // and `BR_ACQUIRE` ≤ `BR_RELEASE` count, so reaching this
+            // path with `kernel_refs == 0` would mean a kernel/
+            // bookkeeping divergence.
+            debug_assert!(
+                entry.kernel_refs > 0,
+                "deref_native_kernel on id {id} with kernel_refs == 0 \
+                 (unpaired BR_RELEASE / BR_DECREFS; check ref_native_kernel \
+                 pairing)"
+            );
             entry.kernel_refs = entry.kernel_refs.saturating_sub(1);
             let arc = Arc::clone(entry.binder_pin.as_arc());
             let trigger = entry.publish_count == 0 && entry.kernel_refs == 0;

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -736,19 +736,26 @@ impl ProcessState {
                 .write()
                 .expect("Published natives lock poisoned");
             let entry = map.get_mut(&id)?;
-            // Mirror `decref_publish`: `saturating_sub` is the
-            // production safety net; `debug_assert` catches an
-            // unpaired BR_RELEASE / BR_DECREFS during dev/CI. Kernel
-            // ordering guarantees `BR_INCREFS` ≤ `BR_DECREFS` count
-            // and `BR_ACQUIRE` ≤ `BR_RELEASE` count, so reaching this
-            // path with `kernel_refs == 0` would mean a kernel/
-            // bookkeeping divergence.
-            debug_assert!(
-                entry.kernel_refs > 0,
-                "deref_native_kernel on id {id} with kernel_refs == 0 \
-                 (unpaired BR_RELEASE / BR_DECREFS; check ref_native_kernel \
-                 pairing)"
-            );
+            // `saturating_sub` clamps at 0 under a cross-thread race
+            // where `BR_DECREFS` is processed before its matching
+            // `BR_INCREFS`. The kernel queues `BR_INCREFS` /
+            // `BR_DECREFS` to `proc->todo` (process-wide FIFO), so
+            // distinct binder threads can pop the matching pair in
+            // FIFO order but dispatch out of order if the
+            // `BR_INCREFS` thread is preempted before reaching
+            // `ref_native_kernel`. Under that race the late
+            // `BR_INCREFS` will bump `kernel_refs` from 0 to 1 (we
+            // missed the dec that should have followed), leaving a
+            // bounded off-by-one leak — one stranded entry per race
+            // occurrence. We accept this over a `debug_assert` panic:
+            // the race is a property of kernel scheduling, not our
+            // bookkeeping, so panicking would fail CI on a legitimate
+            // interleaving. (The OLD fat-pointer encoding hit the
+            // same race but masked it via `RefCounter`'s
+            // `INITIAL_STRONG_VALUE` pattern, which self-corrects the
+            // count to its initial value but silently skips the
+            // first/last-ref closures — equivalently broken in
+            // semantics, just lower-noise.) See plan §5 #7.
             entry.kernel_refs = entry.kernel_refs.saturating_sub(1);
             let arc = Arc::clone(entry.binder_pin.as_arc());
             let trigger = entry.publish_count == 0 && entry.kernel_refs == 0;

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -958,4 +958,196 @@ mod tests {
             1
         );
     }
+
+    /// Minimal `IBinder` impl for the `published_natives` bookkeeping
+    /// tests below. Ref-count methods are no-ops — these tests exercise
+    /// the table's accounting (publish_count / kernel_refs and entry
+    /// removal-on-zero) without relying on `RefCounter` state.
+    struct MockNative;
+
+    impl IBinder for MockNative {
+        fn link_to_death(&self, _: sync::Weak<dyn DeathRecipient>) -> Result<()> {
+            Err(StatusCode::InvalidOperation)
+        }
+        fn unlink_to_death(&self, _: sync::Weak<dyn DeathRecipient>) -> Result<()> {
+            Err(StatusCode::InvalidOperation)
+        }
+        fn ping_binder(&self) -> Result<()> {
+            Ok(())
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn as_transactable(&self) -> Option<&dyn crate::Transactable> {
+            None
+        }
+        fn descriptor(&self) -> &str {
+            "rsbinder.test.MockNative"
+        }
+        fn is_remote(&self) -> bool {
+            false
+        }
+        fn inc_strong(&self, _: &SIBinder) -> Result<()> {
+            Ok(())
+        }
+        fn attempt_inc_strong(&self) -> bool {
+            true
+        }
+        fn dec_strong(&self, _: Option<std::mem::ManuallyDrop<SIBinder>>) -> Result<()> {
+            Ok(())
+        }
+        fn inc_weak(&self, _: &WIBinder) -> Result<()> {
+            Ok(())
+        }
+        fn dec_weak(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    /// End-to-end of the table-controlled lifecycle that closes the UAF
+    /// window. Mirrors plan §4 "test_native_uaf_window_closed":
+    ///
+    ///   1. publish a native binder → entry created, `publish_count = 0`,
+    ///      `kernel_refs = 0`, RefCounter floor armed.
+    ///   2. `incref_publish` (mirrors the first `acquire()` that
+    ///      `Parcel::write_object` would call): `publish_count = 1`.
+    ///   3. drop the local user-side strong ref (under the OLD encoding
+    ///      this could dangle `Inner<T>` once the kernel finished
+    ///      releasing; under the new model the table's `binder_pin`
+    ///      keeps the canonical Arc alive).
+    ///   4. simulate `BR_INCREFS` / `BR_ACQUIRE` / `BR_RELEASE` /
+    ///      `BR_DECREFS` arrival as pure id-bookkeeping.
+    ///   5. mirror `Parcel::release_objects` → `release()` →
+    ///      `decref_publish`: `publish_count = 0`. Now both counters
+    ///      are zero and the entry is removed → `lookup_native` returns
+    ///      `None`.
+    #[test]
+    fn test_native_uaf_window_closed() {
+        let process = ProcessState::init_default();
+        let arc: Arc<dyn IBinder> = Arc::new(MockNative);
+
+        let id = process.publish_native(Arc::clone(&arc));
+        assert!(process.incref_publish(id), "incref on freshly published id must succeed");
+
+        // Drop the user-side Arc clone; only the table's binder_pin
+        // SIBinder keeps the inner Arc alive now.
+        drop(arc);
+
+        // BR_INCREFS / BR_ACQUIRE: kernel_refs goes 0→1→2.
+        assert!(process.ref_native_kernel(id).is_some());
+        assert!(process.ref_native_kernel(id).is_some());
+        // BR_RELEASE: kernel_refs 2→1. Entry still alive
+        // (publish_count=1, kernel_refs=1).
+        assert!(process.deref_native_kernel(id).is_some());
+        assert!(
+            process.lookup_native(id).is_some(),
+            "entry must remain while publish_count > 0"
+        );
+
+        // Parcel::release_objects → release() → decref_publish:
+        // publish_count 1→0; kernel_refs still 1.
+        assert!(process.decref_publish(id));
+        assert!(
+            process.lookup_native(id).is_some(),
+            "entry must remain while kernel_refs > 0"
+        );
+
+        // BR_DECREFS: kernel_refs 1→0. Both zero → entry removed.
+        assert!(process.deref_native_kernel(id).is_some());
+        assert!(
+            process.lookup_native(id).is_none(),
+            "entry must be removed after both counts hit zero"
+        );
+
+        // Subsequent unknown-id ops are graceful.
+        assert!(!process.incref_publish(id));
+        assert!(!process.decref_publish(id));
+        assert!(process.ref_native_kernel(id).is_none());
+        assert!(process.deref_native_kernel(id).is_none());
+    }
+
+    /// Two `publish_native` calls with the same `Arc<dyn IBinder>`
+    /// dedup to the same id. Driving each parcel slot's
+    /// `acquire`/`release` independently keeps the entry alive until
+    /// the last `release` fires.
+    #[test]
+    fn test_native_dedup_same_arc() {
+        let process = ProcessState::init_default();
+        let arc: Arc<dyn IBinder> = Arc::new(MockNative);
+
+        let id1 = process.publish_native(Arc::clone(&arc));
+        let id2 = process.publish_native(Arc::clone(&arc));
+        assert_eq!(id1, id2, "publishing the same Arc twice must dedup");
+
+        // Two parcel slots reference the same id — `acquire` runs
+        // twice, `release` must run twice before the entry can drop.
+        assert!(process.incref_publish(id1));
+        assert!(process.incref_publish(id1));
+
+        assert!(process.decref_publish(id1));
+        assert!(
+            process.lookup_native(id1).is_some(),
+            "entry must remain while one parcel slot still holds a ref"
+        );
+
+        assert!(process.decref_publish(id1));
+        assert!(
+            process.lookup_native(id1).is_none(),
+            "entry must be removed after the last release fires"
+        );
+
+        drop(arc);
+    }
+
+    /// Distinct `Arc`s get distinct ids (no false-positive dedup via
+    /// e.g. `MockNative` being a unit struct — `Arc::ptr_eq` keys on
+    /// allocation, not type).
+    #[test]
+    fn test_native_distinct_arcs_get_distinct_ids() {
+        let process = ProcessState::init_default();
+        let arc_a: Arc<dyn IBinder> = Arc::new(MockNative);
+        let arc_b: Arc<dyn IBinder> = Arc::new(MockNative);
+        assert!(!Arc::ptr_eq(&arc_a, &arc_b));
+
+        let id_a = process.publish_native(Arc::clone(&arc_a));
+        let id_b = process.publish_native(Arc::clone(&arc_b));
+        assert_ne!(id_a, id_b);
+
+        // Cleanup.
+        for id in [id_a, id_b] {
+            assert!(process.incref_publish(id));
+            assert!(process.decref_publish(id));
+            assert!(process.lookup_native(id).is_none());
+        }
+    }
+
+    /// `lookup_native` is read-only — does not change `publish_count`
+    /// or `kernel_refs`. Exercises the BR_TRANSACTION /
+    /// `deserialize_option` round-trip path where the kernel routes a
+    /// previously-published binder back to its publisher.
+    #[test]
+    fn test_native_lookup_does_not_change_counts() {
+        let process = ProcessState::init_default();
+        let arc: Arc<dyn IBinder> = Arc::new(MockNative);
+        let id = process.publish_native(Arc::clone(&arc));
+
+        assert!(process.incref_publish(id)); // publish_count = 1
+        assert!(process.ref_native_kernel(id).is_some()); // kernel_refs = 1
+
+        // Look up multiple times — must not affect either counter.
+        for _ in 0..5 {
+            assert!(process.lookup_native(id).is_some());
+        }
+
+        // Decrement both: entry must be removed exactly once.
+        assert!(process.decref_publish(id));
+        assert!(
+            process.lookup_native(id).is_some(),
+            "lookup must not have decremented kernel_refs"
+        );
+        assert!(process.deref_native_kernel(id).is_some());
+        assert!(process.lookup_native(id).is_none());
+
+        drop(arc);
+    }
 }

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -745,17 +745,26 @@ impl ProcessState {
             // `BR_INCREFS` thread is preempted before reaching
             // `ref_native_kernel`. Under that race the late
             // `BR_INCREFS` will bump `kernel_refs` from 0 to 1 (we
-            // missed the dec that should have followed), leaving a
-            // bounded off-by-one leak — one stranded entry per race
-            // occurrence. We accept this over a `debug_assert` panic:
-            // the race is a property of kernel scheduling, not our
-            // bookkeeping, so panicking would fail CI on a legitimate
-            // interleaving. (The OLD fat-pointer encoding hit the
-            // same race but masked it via `RefCounter`'s
-            // `INITIAL_STRONG_VALUE` pattern, which self-corrects the
-            // count to its initial value but silently skips the
-            // first/last-ref closures — equivalently broken in
-            // semantics, just lower-noise.) See plan §5 #7.
+            // missed the dec that should have followed). Each race
+            // occurrence on a given id adds one to `kernel_refs`'s
+            // over-count vs the kernel's true ref count; the
+            // accumulation is **unbounded** over the binder's
+            // lifetime if races recur, leaving the entry permanently
+            // stranded with `kernel_refs >= 1` even after the kernel
+            // has fully released. Bounded only by "one entry per
+            // long-lived published binder that ever raced." We
+            // accept this over a `debug_assert` panic: the race is a
+            // property of kernel scheduling, not our bookkeeping, so
+            // panicking would fail CI on a legitimate interleaving.
+            // (The OLD fat-pointer encoding hit the same race but
+            // masked it via `RefCounter`'s `INITIAL_STRONG_VALUE`
+            // pattern, which self-corrects the count to its initial
+            // value but silently skips the first/last-ref closures —
+            // equivalently broken in semantics, just lower-noise.)
+            // See plan §5 #7. A future change could move to a
+            // signed counter + dual-direction removal trigger to
+            // bound the drift, but that introduces premature-removal
+            // hazards in multi-pair scenarios; left as a follow-up.
             entry.kernel_refs = entry.kernel_refs.saturating_sub(1);
             let arc = Arc::clone(entry.binder_pin.as_arc());
             let trigger = entry.publish_count == 0 && entry.kernel_refs == 0;

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -63,6 +63,46 @@ pub(crate) struct CacheEntry {
     pub(crate) generation: u64,
 }
 
+/// Sidecar-table entry for a native binder this process has published.
+///
+/// Replaces the previous fat-pointer encoding (`flat_binder_object.binder` =
+/// data pointer, `flat_binder_object.cookie` = vtable pointer) with a
+/// process-monotonic u64 id. The id is what the kernel echoes back in
+/// `BR_INCREFS` / `BR_ACQUIRE` / `BR_RELEASE` / `BR_DECREFS` /
+/// `BR_TRANSACTION` (`target.ptr`); lookup resolves to the live Arc via
+/// `binder_pin.as_arc()`. Closes a UAF where weak-ref BR handlers
+/// (`BR_DECREFS`) could fire after the underlying `Inner<T>` had been
+/// dropped under the old encoding — see Android's two-allocation
+/// (`weakref_type*` + `BBinder*`) design for the canonical fix shape.
+///
+/// Lifecycle: created on first `From<&SIBinder>` (BINDER_TYPE_BINDER), held
+/// as long as either parcel-side (`publish_count`) or kernel-side
+/// (`kernel_refs`) refs are outstanding, removed when both reach zero.
+/// While the entry exists, `binder_pin` keeps `Inner<T>` alive and
+/// `RefCounter.strong` / `RefCounter.weak` sit at the binary "alive"
+/// level (>= 1) so that `attempt_inc_*` succeeds.
+pub(crate) struct PublishedNative {
+    /// Owns `RefCounter.strong` >= 1 via `SIBinder::from_arc`'s
+    /// `inc_strong` (entry creation) and `SIBinder::Drop`'s
+    /// `dec_strong(None)` (entry removal). Also keeps the underlying
+    /// `Arc<dyn IBinder>` strong > 0 — this is the canonical reference
+    /// that keeps `Inner<T>` alive while the kernel or any outgoing
+    /// parcel still references the published binder.
+    pub(crate) binder_pin: SIBinder,
+    /// Number of live `flat_binder_object` instances of type
+    /// `BINDER_TYPE_BINDER` for this id across all parcel buffers in
+    /// this process. Driven by `flat_binder_object::acquire` /
+    /// `release` (the existing pair already invoked from
+    /// `Parcel::write_object`, `Parcel::append_from`, and
+    /// `Parcel::release_objects`).
+    pub(crate) publish_count: u32,
+    /// Number of outstanding kernel refs against this id.
+    /// `BR_INCREFS` / `BR_ACQUIRE` increment; `BR_RELEASE` /
+    /// `BR_DECREFS` decrement (deferred via `pending_*_derefs`,
+    /// processed FIFO).
+    pub(crate) kernel_refs: u32,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum CallRestriction {
     // all calls okay
@@ -94,6 +134,18 @@ pub struct ProcessState {
     /// exactly once per case-(a) cache insertion (i.e. per fresh
     /// `BC_INCREFS` pin). Wrap-around is not a practical concern (u64).
     next_generation: AtomicU64,
+    /// Native binders this process has published, keyed by a
+    /// process-monotonic u64 id encoded in `flat_binder_object.binder`
+    /// (replacing the previous fat-pointer encoding). Lookup resolves
+    /// the id to a live `Arc<dyn IBinder>` for `BR_TRANSACTION` /
+    /// `BR_INCREFS` / `BR_ACQUIRE` / `BR_RELEASE` / `BR_DECREFS` /
+    /// `BR_ATTEMPT_ACQUIRE` and for round-trip
+    /// `BINDER_TYPE_BINDER` deserialization. See
+    /// `PublishedNative` for entry-lifecycle invariants.
+    published_natives: RwLock<HashMap<u64, PublishedNative>>,
+    /// Monotonic id allocator for `published_natives`. u64 wrap-around
+    /// is not a practical concern.
+    next_native_id: AtomicU64,
     disable_background_scheduling: AtomicBool,
     call_restriction: RwLock<CallRestriction>,
     thread_pool_started: AtomicBool,
@@ -180,6 +232,8 @@ impl ProcessState {
             context_manager: RwLock::new(None),
             handle_to_proxy: RwLock::new(HashMap::new()),
             next_generation: AtomicU64::new(1),
+            published_natives: RwLock::new(HashMap::new()),
+            next_native_id: AtomicU64::new(1),
             disable_background_scheduling: AtomicBool::new(false),
             call_restriction: RwLock::new(CallRestriction::None),
             thread_pool_started: AtomicBool::new(false),
@@ -532,6 +586,207 @@ impl ProcessState {
         thread_state::dec_weak_handle(handle)?;
         thread_state::flush_commands()?;
         Ok(())
+    }
+
+    /// Publish a native binder into the sidecar table and return its id.
+    ///
+    /// The id is what `flat_binder_object.binder` will carry under the new
+    /// encoding (replacing the data half of the old fat-pointer pair).
+    ///
+    /// Dedup is by `Arc::ptr_eq` against existing `binder_pin` entries —
+    /// publishing the same `Arc` twice returns the same id without any
+    /// counter side effects, matching Android's behavior where a single
+    /// `binder_node` is allocated per `weakref_type*` regardless of how
+    /// many times it is sent.
+    ///
+    /// On a fresh insert, `RefCounter.strong` is driven 0→1 via
+    /// `SIBinder::from_arc` (which calls `inc_strong` once on the inner
+    /// trait object) and `RefCounter.weak` is driven 0→1 via an explicit
+    /// `arc.inc_weak(&dummy_wi)` call. Both counters stay at the binary
+    /// "alive" floor while the entry exists; user-side strong/weak
+    /// increments ride on top and never trigger the count→0 closure path
+    /// because the table-controlled +1 keeps the count above zero.
+    ///
+    /// `publish_count` starts at 0; the immediately-following
+    /// `Parcel::write_object` → `flat_binder_object::acquire` brings it
+    /// to 1. The single-statement window between this method returning
+    /// and the first `acquire` is the only leak path under
+    /// `Parcel::write_aligned` panics (typically OOM) — see plan §5
+    /// "From<&SIBinder> returning before acquire() is called".
+    pub(crate) fn publish_native(&self, arc: Arc<dyn IBinder>) -> u64 {
+        // Single write lock for dedup + insert: a read-then-write split
+        // would race two concurrent publishes of the same Arc into
+        // duplicate entries, breaking the dedup invariant.
+        let mut map = self
+            .published_natives
+            .write()
+            .expect("Published natives lock poisoned");
+        for (existing_id, entry) in map.iter() {
+            if Arc::ptr_eq(entry.binder_pin.as_arc(), &arc) {
+                return *existing_id;
+            }
+        }
+        // Drive RefCounter.strong 0→1 via SIBinder::from_arc → inc_strong.
+        let binder_pin = SIBinder::from_arc(Arc::clone(&arc));
+        // Drive RefCounter.weak 0→1 via explicit inc_weak. The dummy
+        // WIBinder satisfies the trait signature; native::inc_weak
+        // ignores it. WIBinder has no custom Drop impl, so dropping
+        // dummy_wi at scope end only decrements the std::sync::Weak's
+        // own reference count — RefCounter.weak is untouched.
+        let dummy_wi = SIBinder::downgrade(&binder_pin);
+        arc.inc_weak(&dummy_wi)
+            .expect("inc_weak on Arc<dyn IBinder> must not fail");
+        let id = self.next_native_id.fetch_add(1, Ordering::Relaxed);
+        map.insert(
+            id,
+            PublishedNative {
+                binder_pin,
+                publish_count: 0,
+                kernel_refs: 0,
+            },
+        );
+        id
+    }
+
+    /// `flat_binder_object::acquire` BINDER_TYPE_BINDER arm.
+    ///
+    /// Returns `false` if `id` is unknown — should not happen in practice
+    /// because every `acquire` is paired with a `From<&SIBinder>` that
+    /// just inserted the entry (or a buffer-clone via
+    /// `Parcel::append_from` whose source already holds an entry).
+    /// Callers `debug_assert!` in dev builds and `log::error!` + skip in
+    /// production.
+    pub(crate) fn incref_publish(&self, id: u64) -> bool {
+        let mut map = self
+            .published_natives
+            .write()
+            .expect("Published natives lock poisoned");
+        match map.get_mut(&id) {
+            Some(entry) => {
+                entry.publish_count += 1;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// `flat_binder_object::release` BINDER_TYPE_BINDER arm.
+    ///
+    /// Decrements `publish_count`. If both `publish_count` and
+    /// `kernel_refs` reach zero, the entry is removed (drives
+    /// `RefCounter.strong` / `RefCounter.weak` 1→0, drops the
+    /// `binder_pin` SIBinder). Returns `false` if `id` is unknown.
+    pub(crate) fn decref_publish(&self, id: u64) -> bool {
+        let trigger_remove = {
+            let mut map = self
+                .published_natives
+                .write()
+                .expect("Published natives lock poisoned");
+            match map.get_mut(&id) {
+                Some(entry) => {
+                    entry.publish_count = entry.publish_count.saturating_sub(1);
+                    entry.publish_count == 0 && entry.kernel_refs == 0
+                }
+                None => return false,
+            }
+        };
+        if trigger_remove {
+            self.remove_entry_if_zero(id);
+        }
+        true
+    }
+
+    /// `BR_INCREFS` / `BR_ACQUIRE` / `BR_ATTEMPT_ACQUIRE` arms: bump
+    /// `kernel_refs`. Returns `Some(arc)` while the entry is alive
+    /// (caller may dispatch methods on the arc); `None` if `id` is
+    /// unknown (kernel invariant violation in `BR_INCREFS` / `BR_ACQUIRE`,
+    /// expected race for `BR_ATTEMPT_ACQUIRE`).
+    pub(crate) fn ref_native_kernel(&self, id: u64) -> Option<Arc<dyn IBinder>> {
+        let mut map = self
+            .published_natives
+            .write()
+            .expect("Published natives lock poisoned");
+        let entry = map.get_mut(&id)?;
+        entry.kernel_refs += 1;
+        Some(Arc::clone(entry.binder_pin.as_arc()))
+    }
+
+    /// `BR_RELEASE` / `BR_DECREFS` arms (deferred via
+    /// `pending_*_derefs`): decrement `kernel_refs`. If both
+    /// `publish_count` and `kernel_refs` reach zero, the entry is
+    /// removed (RefCounter floor torn down, Arc dropped). Returns
+    /// `Some(arc)` while the entry was still present pre-removal;
+    /// `None` if `id` is unknown.
+    pub(crate) fn deref_native_kernel(&self, id: u64) -> Option<Arc<dyn IBinder>> {
+        let (arc, trigger_remove) = {
+            let mut map = self
+                .published_natives
+                .write()
+                .expect("Published natives lock poisoned");
+            let entry = map.get_mut(&id)?;
+            entry.kernel_refs = entry.kernel_refs.saturating_sub(1);
+            let arc = Arc::clone(entry.binder_pin.as_arc());
+            let trigger = entry.publish_count == 0 && entry.kernel_refs == 0;
+            (arc, trigger)
+        };
+        if trigger_remove {
+            self.remove_entry_if_zero(id);
+        }
+        Some(arc)
+    }
+
+    /// `BR_TRANSACTION` and round-trip `BINDER_TYPE_BINDER` receive
+    /// path: read-only lookup. Does not change counts. Returns `None`
+    /// if the id is unknown.
+    pub(crate) fn lookup_native(&self, id: u64) -> Option<Arc<dyn IBinder>> {
+        let map = self
+            .published_natives
+            .read()
+            .expect("Published natives lock poisoned");
+        map.get(&id).map(|e| Arc::clone(e.binder_pin.as_arc()))
+    }
+
+    /// Remove the entry for `id` and tear down the RefCounter floor —
+    /// but only if both `publish_count` and `kernel_refs` are still zero
+    /// when re-checked under the write lock. The two-phase pattern
+    /// (counter-mutate under lock, release lock, re-acquire for
+    /// removal) is required because `SIBinder::Drop` calls
+    /// `dec_strong(None)` which may run user destructor code (via
+    /// `Inner<T>::drop`) that itself calls back into `ProcessState` —
+    /// holding the write lock across that path would deadlock.
+    ///
+    /// The re-check under the new lock makes the two-phase pattern
+    /// race-free: if a concurrent `BR_INCREFS` / `From<&SIBinder>`
+    /// bumped a counter back above zero between phases, we abort the
+    /// removal. Same shape as the proxy-side `CacheEntry` removal in
+    /// `send_obituary_for_handle`.
+    fn remove_entry_if_zero(&self, id: u64) {
+        let entry = {
+            let mut map = self
+                .published_natives
+                .write()
+                .expect("Published natives lock poisoned");
+            let needs_remove = map
+                .get(&id)
+                .map(|e| e.publish_count == 0 && e.kernel_refs == 0)
+                .unwrap_or(false);
+            if !needs_remove {
+                return;
+            }
+            map.remove(&id).expect("just observed Some")
+        };
+        // Symmetric with publish_native: dec_weak first (no destructor
+        // side effect — `Inner<T>::dec_weak` only touches RefCounter.weak),
+        // then drop binder_pin which fires SIBinder::Drop →
+        // dec_strong(None) → RefCounter.strong 1→0. The Arc inside
+        // binder_pin is the canonical strong reference; if no user-side
+        // SIBinder clones survive, that drop also takes the Arc strong
+        // count to zero, triggering Inner<T>::drop CLEANLY — kernel has
+        // guaranteed no further BR_* will reference this id (kernel_refs
+        // was 0 to reach this branch).
+        let arc_for_weak = Arc::clone(entry.binder_pin.as_arc());
+        let _ = arc_for_weak.dec_weak();
+        drop(entry.binder_pin);
     }
 
     pub fn disable_background_scheduling(&self, disable: bool) {

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -26,6 +26,7 @@
 use log::error;
 use std::backtrace::Backtrace;
 use std::cell::RefCell;
+use std::collections::VecDeque;
 use std::ffi::{CStr, CString};
 use std::fmt::Debug;
 use std::fs::File;
@@ -136,80 +137,87 @@ impl TransactionState {
     }
 }
 
-// Storage for inbound BR_RELEASE / BR_DECREFS payloads (pairs of raw
-// binder pointers delivered by the kernel for native binders we
-// previously published). These are processed lazily on the next
-// driver round-trip via `process_pending_derefs`.
+// Storage for inbound BR_RELEASE / BR_DECREFS payloads — process-monotonic
+// u64 ids delivered by the kernel for native binders we previously
+// published. Processed lazily on the next driver round-trip via
+// `process_pending_derefs`.
+//
+// Under the new id-encoding model (replacing the fat-pointer scheme that
+// could dangle when `Inner<T>` was dropped between BR_RELEASE and
+// BR_DECREFS), the pending entries are pure ids — `deref_native_kernel`
+// looks them up in `ProcessState::published_natives` and drives
+// `kernel_refs--` / entry-removal-on-zero. No SIBinder reconstruction
+// from a raw pointer, no method dispatch on a possibly-freed `Inner<T>`.
 //
 // Outbound proxy ref-count (BC_ACQUIRE / BC_RELEASE / BC_INCREFS /
-// BC_DECREFS) is no longer routed through this state under the
-// cache-pin model — proxies own kernel strong refs 1-per-Arc
-// (acquire in `ProxyHandle::new_acquired`, release in
-// `ProxyHandle::Drop`) and the cache itself owns the kernel weak
-// ref. Hence `post_strong_derefs` / `post_weak_derefs` (which
-// existed only to keep `SIBinder` / `WIBinder` clones alive across
-// deferred flushes) are gone.
+// BC_DECREFS) is not routed through this state — proxies own kernel
+// strong refs 1-per-Arc (acquire in `ProxyHandle::new_acquired`, release
+// in `ProxyHandle::Drop`) and the cache pin owns the kernel weak ref.
 struct BinderDerefs {
-    pending_strong_derefs: Vec<(binder_uintptr_t, binder_uintptr_t)>,
-    pending_weak_derefs: Vec<(binder_uintptr_t, binder_uintptr_t)>,
+    pending_strong_derefs: VecDeque<u64>,
+    pending_weak_derefs: VecDeque<u64>,
 }
 
 impl BinderDerefs {
     fn new() -> Self {
         BinderDerefs {
-            pending_strong_derefs: Vec::new(),
-            pending_weak_derefs: Vec::new(),
+            pending_strong_derefs: VecDeque::new(),
+            pending_weak_derefs: VecDeque::new(),
         }
     }
 
     fn process_pending_derefs(&mut self) -> Result<()> {
-        // The decWeak()/decStrong() calls may cause a destructor to run,
-        // which in turn could have initiated an outgoing transaction,
-        // which in turn could cause us to add to the pending refs
-        // vectors; so instead of simply iterating, loop until they're empty.
+        // The deref operations may run user destructor code (when an
+        // entry's `kernel_refs` and `publish_count` both reach zero,
+        // `remove_entry_if_zero` drops the canonical Arc, which may
+        // fire `Inner<T>::drop` on the user's `Remotable` instance).
+        // That destructor could initiate outgoing transactions which
+        // in turn enqueue more pending derefs; so iterate in an outer
+        // loop until both queues are drained.
         //
-        // We do this in an outer loop, because calling decStrong()
-        // may result in something being added to mPendingWeakDerefs,
-        // which could be delayed until the next incoming command
-        // from the driver if we don't process it now.
+        // Order matters: process derefs in **FIFO** so the sequence of
+        // destructor side effects (further outgoing transactions,
+        // further deref additions, native-binder cleanup hooks) matches
+        // the order the kernel observed BR_RELEASE / BR_DECREFS.
+        // Android's libbinder uses the same FIFO discipline — a LIFO
+        // `Vec::pop()` would silently reverse the ordering and could
+        // break callers that rely on it (e.g. when a strong-deref's
+        // destructor queues a weak-deref that the outer loop is then
+        // supposed to drain before the next strong).
         //
-        // Order matters: process pending derefs in **FIFO** order so the
-        // sequence of destructor side effects (further outgoing
-        // transactions, further deref additions, native-binder cleanup
-        // hooks) matches the order the kernel observed BR_RELEASE /
-        // BR_DECREFS for these objects. Android's libbinder uses the
-        // same FIFO discipline (`mPendingStrongDerefs.removeAt(0)` /
-        // `mPendingWeakDerefs.removeAt(0)`); a LIFO `Vec::pop()` here
-        // would silently reverse the ordering and could break callers
-        // that rely on it (e.g. when a strong-deref's destructor queues
-        // a weak-deref that the outer loop is then supposed to drain
-        // before the next strong).
+        // The outer-while wrapper is defensive under the new model:
+        // `deref_native_kernel`'s entry removal hands off to
+        // `remove_entry_if_zero`, which itself releases the table lock
+        // before `SIBinder::Drop` fires — so destructors run without
+        // the table lock held, and the only re-entrant path back into
+        // the deref queues is the same thread's next ioctl, not from
+        // inside the destructor itself. The wrapper still costs little
+        // and matches Android's libbinder structure.
         while !self.pending_weak_derefs.is_empty() || !self.pending_strong_derefs.is_empty() {
-            for raw_pointer in self.pending_weak_derefs.drain(..) {
-                // BR_DECREFS reflects the kernel releasing a weak ref it
-                // held to one of our published binders (always native
-                // under the cache-pin model — proxies own one kernel
-                // strong ref per Arc and never publish themselves as
-                // weak). Dispatch directly to the IBinder trait via the
-                // reconstructed SIBinder; for natives this drives
-                // RefCounter.weak, for proxies it would be a no-op
-                // (defensive).
-                let strong = raw_pointer_to_strong_binder(raw_pointer);
-                let _ = strong.dec_weak();
+            while let Some(id) = self.pending_weak_derefs.pop_front() {
+                // BR_DECREFS reflects the kernel releasing a weak ref
+                // it held to one of our published natives. Pure id
+                // bookkeeping: decrement `kernel_refs`; if both
+                // counters now zero, the entry is removed (RefCounter
+                // floor torn down, Arc dropped) — see
+                // `deref_native_kernel`. An unknown id at this point
+                // would mean the kernel sent a BR_DECREFS for an id
+                // we never published or already torn down; skip with
+                // a trace log.
+                if ProcessState::as_self().deref_native_kernel(id).is_none() {
+                    log::trace!("BR_DECREFS for unknown native id {id}");
+                }
             }
 
-            // FIFO front-pop on strong derefs (`remove(0)`). Process
+            // FIFO front-pop on strong derefs (`pop_front`). Process
             // exactly one before re-checking the outer loop so a
-            // destructor-queued weak-deref is drained ahead of the next
-            // pending strong — same pattern as Android's libbinder.
-            // The pending queue is bounded (at most one entry per
-            // recently-received BR_RELEASE), so the O(n) front-remove
-            // cost is negligible and the linear scan keeps the data
-            // structure simple (a `VecDeque` would also work).
-            if !self.pending_strong_derefs.is_empty() {
-                let raw_pointer = self.pending_strong_derefs.remove(0);
-                let strong = raw_pointer_to_strong_binder(raw_pointer);
-                SIBinder::decrease_drop(strong)?;
+            // destructor-queued weak-deref is drained ahead of the
+            // next pending strong — same pattern as Android's
+            // libbinder.
+            if let Some(id) = self.pending_strong_derefs.pop_front() {
+                if ProcessState::as_self().deref_native_kernel(id).is_none() {
+                    log::trace!("BR_RELEASE for unknown native id {id}");
+                }
             }
         }
         Ok(())
@@ -720,23 +728,44 @@ fn execute_command(cmd: i32) -> Result<()> {
                 let result = {
                     let target_ptr = unsafe { tr_secctx.transaction_data.target.ptr };
                     if target_ptr != 0 {
-                        let strong = raw_pointer_to_strong_binder((
-                            target_ptr,
-                            tr_secctx.transaction_data.cookie,
-                        ));
-                        if strong.attempt_increase() {
-                            let result = dispatch_transact_caught(
-                                strong.as_transactable().expect("Transactable is None."),
-                                tr_secctx.transaction_data.code,
-                                &mut reader,
-                                &mut reply,
-                            );
-                            strong.decrease()?;
-
-                            result
-                        } else {
-                            log::warn!("Failed StrongBinder::attempt_increase.");
-                            Err(StatusCode::UnknownTransaction)
+                        // `target_ptr` is now the process-monotonic id
+                        // assigned by `publish_native`. Resolve via the
+                        // sidecar table (read-only, no count change) —
+                        // the table guarantees `Inner<T>` is alive
+                        // while the entry exists, so the SIBinder we
+                        // construct here can safely drive the user's
+                        // `Transactable` impl. SIBinder construction
+                        // is contained within this scope: the
+                        // `attempt_increase` / `decrease` pair is
+                        // balanced, and `strong` drops at the end of
+                        // the block (canceling the +1 that
+                        // `SIBinder::from_arc` added).
+                        let id = target_ptr;
+                        match ProcessState::as_self().lookup_native(id) {
+                            Some(arc) => {
+                                let strong = SIBinder::from_arc(arc);
+                                if strong.attempt_increase() {
+                                    let result = dispatch_transact_caught(
+                                        strong.as_transactable().expect("Transactable is None."),
+                                        tr_secctx.transaction_data.code,
+                                        &mut reader,
+                                        &mut reply,
+                                    );
+                                    strong.decrease()?;
+                                    result
+                                } else {
+                                    log::warn!(
+                                        "Failed strong.attempt_increase for native id {id}"
+                                    );
+                                    Err(StatusCode::UnknownTransaction)
+                                }
+                            }
+                            None => {
+                                log::error!(
+                                    "BR_TRANSACTION for unknown native id {id}"
+                                );
+                                Err(StatusCode::DeadObject)
+                            }
                         }
                     } else {
                         let context = ProcessState::as_self()
@@ -785,66 +814,94 @@ fn execute_command(cmd: i32) -> Result<()> {
 
             binder::BR_INCREFS => {
                 let mut state = thread_state.borrow_mut();
-                let refs = state.in_parcel.read::<binder::binder_uintptr_t>()?;
-                let obj = state.in_parcel.read::<binder::binder_uintptr_t>()?;
+                let id = state.in_parcel.read::<binder::binder_uintptr_t>()?;
+                // The cookie half is unused under the new id encoding
+                // but the kernel still emits the original `cookie`
+                // (always 0 for our published natives). Echo it back
+                // verbatim in BC_INCREFS_DONE.
+                let cookie_echo = state.in_parcel.read::<binder::binder_uintptr_t>()?;
+                drop(state);
 
-                // BR_INCREFS reflects the kernel acquiring a weak ref to
-                // one of our published binders (always native under the
-                // cache-pin model). Dispatch directly to the IBinder
-                // trait via the reconstructed SIBinder; for natives this
-                // advances RefCounter.weak, for proxies it would be a
-                // no-op (defensive). The `WIBinder` argument is unused
-                // by both impls, but the trait signature requires one —
-                // pass a synthetic downgrade.
-                let strong = raw_pointer_to_strong_binder((refs, obj));
-                let dummy = SIBinder::downgrade(&strong);
-                let _ = strong.inc_weak(&dummy);
+                // BR_INCREFS reflects the kernel acquiring a weak ref
+                // to one of our published natives. Pure id
+                // bookkeeping: bump `kernel_refs` in the table; the
+                // RefCounter.weak alive-signal is held above zero by
+                // `publish_native` for the entry's lifetime — no
+                // per-event RefCounter touch needed (and no SIBinder
+                // construction, no method dispatch on a possibly-freed
+                // `Inner<T>`, closing the UAF that the old
+                // fat-pointer encoding could expose).
+                if ProcessState::as_self().ref_native_kernel(id).is_none() {
+                    log::error!("BR_INCREFS for unknown native id {id}");
+                    debug_assert!(false, "BR_INCREFS for unknown native id {id}");
+                }
 
+                let mut state = thread_state.borrow_mut();
                 state.out_parcel.write::<u32>(&binder::BC_INCREFS_DONE)?;
-                state.out_parcel.write::<binder::binder_uintptr_t>(&refs)?;
-                state.out_parcel.write::<binder::binder_uintptr_t>(&obj)?;
+                state.out_parcel.write::<binder::binder_uintptr_t>(&id)?;
+                state
+                    .out_parcel
+                    .write::<binder::binder_uintptr_t>(&cookie_echo)?;
             }
             binder::BR_ACQUIRE => {
                 let mut state = thread_state.borrow_mut();
-                let refs = state.in_parcel.read::<binder::binder_uintptr_t>()?;
-                let obj = state.in_parcel.read::<binder::binder_uintptr_t>()?;
+                let id = state.in_parcel.read::<binder::binder_uintptr_t>()?;
+                let cookie_echo = state.in_parcel.read::<binder::binder_uintptr_t>()?;
+                drop(state);
 
-                let strong = raw_pointer_to_strong_binder((refs, obj));
-                // strong is ManuallyDrop, so increase() is called once.
-                strong.increase()?;
+                // Same shape as BR_INCREFS — bookkeeping only.
+                // `RefCounter.strong` alive-signal is held by the
+                // table's `binder_pin: SIBinder` for the entry's
+                // lifetime.
+                if ProcessState::as_self().ref_native_kernel(id).is_none() {
+                    log::error!("BR_ACQUIRE for unknown native id {id}");
+                    debug_assert!(false, "BR_ACQUIRE for unknown native id {id}");
+                }
 
+                let mut state = thread_state.borrow_mut();
                 state.out_parcel.write::<u32>(&(binder::BC_ACQUIRE_DONE))?;
-                state.out_parcel.write::<binder::binder_uintptr_t>(&refs)?;
-                state.out_parcel.write::<binder::binder_uintptr_t>(&obj)?;
+                state.out_parcel.write::<binder::binder_uintptr_t>(&id)?;
+                state
+                    .out_parcel
+                    .write::<binder::binder_uintptr_t>(&cookie_echo)?;
             }
             binder::BR_RELEASE => {
                 let mut state = thread_state.borrow_mut();
-                let refs = state.in_parcel.read::<binder::binder_uintptr_t>()?;
-                let obj = state.in_parcel.read::<binder::binder_uintptr_t>()?;
+                let id = state.in_parcel.read::<binder::binder_uintptr_t>()?;
+                // cookie echo unused on the deferred-deref path.
+                let _cookie_echo = state.in_parcel.read::<binder::binder_uintptr_t>()?;
 
                 BINDER_DEREFS.with(|binder_derefs| {
                     let mut binder_derefs = binder_derefs.borrow_mut();
-                    binder_derefs.pending_strong_derefs.push((refs, obj));
+                    binder_derefs.pending_strong_derefs.push_back(id);
                 });
             }
             binder::BR_DECREFS => {
                 let mut state = thread_state.borrow_mut();
-                let refs = state.in_parcel.read::<binder::binder_uintptr_t>()?;
-                let obj = state.in_parcel.read::<binder::binder_uintptr_t>()?;
+                let id = state.in_parcel.read::<binder::binder_uintptr_t>()?;
+                let _cookie_echo = state.in_parcel.read::<binder::binder_uintptr_t>()?;
 
                 BINDER_DEREFS.with(|binder_derefs| {
                     let mut binder_derefs = binder_derefs.borrow_mut();
-                    binder_derefs.pending_weak_derefs.push((refs, obj));
+                    binder_derefs.pending_weak_derefs.push_back(id);
                 });
             }
             binder::BR_ATTEMPT_ACQUIRE => {
                 let mut state = thread_state.borrow_mut();
-                let refs = state.in_parcel.read::<binder::binder_uintptr_t>()?;
-                let obj = state.in_parcel.read::<binder::binder_uintptr_t>()?;
+                let id = state.in_parcel.read::<binder::binder_uintptr_t>()?;
+                let _cookie_echo = state.in_parcel.read::<binder::binder_uintptr_t>()?;
+                drop(state);
 
-                let strong = raw_pointer_to_strong_binder((refs, obj));
-                let success = strong.attempt_increase();
+                // Probe the table's binary alive-signal: entry exists
+                // ⟹ promotion may proceed. If alive, bump
+                // `kernel_refs` (the kernel will hold a new strong
+                // ref on success). Unknown id is permitted here — it
+                // can race against unpublish (kernel may probe a
+                // binder that just lost its last ref); reply
+                // `success=0` without `debug_assert`.
+                let success = ProcessState::as_self().ref_native_kernel(id).is_some();
 
+                let mut state = thread_state.borrow_mut();
                 state.out_parcel.write::<u32>(&binder::BC_ACQUIRE_RESULT)?;
                 state.out_parcel.write::<i32>(&(success as _))?;
             }

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -742,11 +742,12 @@ fn execute_command(cmd: i32) -> Result<()> {
                         // while the entry exists, so the SIBinder we
                         // construct here can safely drive the user's
                         // `Transactable` impl. SIBinder construction
-                        // is contained within this scope: the
-                        // `attempt_increase` / `decrease` pair is
-                        // balanced, and `strong` drops at the end of
-                        // the block (canceling the +1 that
-                        // `SIBinder::from_arc` added).
+                        // is contained within this scope and the
+                        // RefCounter ops balance pairwise: `from_arc`
+                        // calls `inc_strong` (+1), `attempt_increase`
+                        // adds another (+1), `decrease()` cancels one
+                        // (−1), and `strong`'s `Drop` cancels the
+                        // last (−1) — net zero across the block.
                         let id = target_ptr;
                         match ProcessState::as_self().lookup_native(id) {
                             Some(arc) => {

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -201,9 +201,8 @@ fn process_pending_derefs() -> Result<()> {
         // `Inner<T>::drop` running user destructor code that
         // synchronously triggers another BR_DECREFS).
         loop {
-            let batch: VecDeque<u64> = BINDER_DEREFS.with(|d| {
-                std::mem::take(&mut d.borrow_mut().pending_weak_derefs)
-            });
+            let batch: VecDeque<u64> =
+                BINDER_DEREFS.with(|d| std::mem::take(&mut d.borrow_mut().pending_weak_derefs));
             if batch.is_empty() {
                 break;
             }
@@ -762,16 +761,12 @@ fn execute_command(cmd: i32) -> Result<()> {
                                     strong.decrease()?;
                                     result
                                 } else {
-                                    log::warn!(
-                                        "Failed strong.attempt_increase for native id {id}"
-                                    );
+                                    log::warn!("Failed strong.attempt_increase for native id {id}");
                                     Err(StatusCode::UnknownTransaction)
                                 }
                             }
                             None => {
-                                log::error!(
-                                    "BR_TRANSACTION for unknown native id {id}"
-                                );
+                                log::error!("BR_TRANSACTION for unknown native id {id}");
                                 Err(StatusCode::DeadObject)
                             }
                         }

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -32,7 +32,7 @@ use std::fmt::Debug;
 use std::fs::File;
 use std::sync::{atomic::Ordering, Arc};
 
-use crate::{binder::*, binder_object::*, error::*, parcel::*, process_state::*, sys::*};
+use crate::{binder::*, error::*, parcel::*, process_state::*, sys::*};
 
 thread_local! {
     static THREAD_STATE: RefCell<ThreadState> = RefCell::new(ThreadState::new());

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -165,62 +165,69 @@ impl BinderDerefs {
             pending_weak_derefs: VecDeque::new(),
         }
     }
+}
 
-    fn process_pending_derefs(&mut self) -> Result<()> {
-        // The deref operations may run user destructor code (when an
-        // entry's `kernel_refs` and `publish_count` both reach zero,
-        // `remove_entry_if_zero` drops the canonical Arc, which may
-        // fire `Inner<T>::drop` on the user's `Remotable` instance).
-        // That destructor could initiate outgoing transactions which
-        // in turn enqueue more pending derefs; so iterate in an outer
-        // loop until both queues are drained.
-        //
-        // Order matters: process derefs in **FIFO** so the sequence of
-        // destructor side effects (further outgoing transactions,
-        // further deref additions, native-binder cleanup hooks) matches
-        // the order the kernel observed BR_RELEASE / BR_DECREFS.
-        // Android's libbinder uses the same FIFO discipline — a LIFO
-        // `Vec::pop()` would silently reverse the ordering and could
-        // break callers that rely on it (e.g. when a strong-deref's
-        // destructor queues a weak-deref that the outer loop is then
-        // supposed to drain before the next strong).
-        //
-        // The outer-while wrapper is defensive under the new model:
-        // `deref_native_kernel`'s entry removal hands off to
-        // `remove_entry_if_zero`, which itself releases the table lock
-        // before `SIBinder::Drop` fires — so destructors run without
-        // the table lock held, and the only re-entrant path back into
-        // the deref queues is the same thread's next ioctl, not from
-        // inside the destructor itself. The wrapper still costs little
-        // and matches Android's libbinder structure.
-        while !self.pending_weak_derefs.is_empty() || !self.pending_strong_derefs.is_empty() {
-            while let Some(id) = self.pending_weak_derefs.pop_front() {
-                // BR_DECREFS reflects the kernel releasing a weak ref
-                // it held to one of our published natives. Pure id
-                // bookkeeping: decrement `kernel_refs`; if both
-                // counters now zero, the entry is removed (RefCounter
-                // floor torn down, Arc dropped) — see
-                // `deref_native_kernel`. An unknown id at this point
-                // would mean the kernel sent a BR_DECREFS for an id
-                // we never published or already torn down; skip with
-                // a trace log.
+/// Drain `BINDER_DEREFS` of pending BR_RELEASE / BR_DECREFS ids.
+///
+/// Each `deref_native_kernel(id)` call may, when an entry's counters
+/// both reach zero, trigger `remove_entry_if_zero` which drops the
+/// canonical `Arc<dyn IBinder>` and synchronously fires
+/// `Inner<T>::drop` on the user's `Remotable` instance. A user
+/// destructor that initiates an outgoing synchronous IPC ends up in
+/// `wait_for_response` → `talk_with_driver` → `execute_command`,
+/// whose BR_RELEASE / BR_DECREFS arms try to push back into
+/// `BINDER_DEREFS` via a fresh `borrow_mut()`.
+///
+/// To make that re-entrancy safe, this function never holds the
+/// `BINDER_DEREFS` `RefCell` borrow across a `deref_native_kernel`
+/// call. It alternates between:
+///
+///   1. Acquire the borrow, take the entire weak queue (or pop one
+///      strong id), release the borrow.
+///   2. Dispatch outside the borrow.
+///
+/// Pushes from re-entrant BR handlers go into a fresh `borrow_mut`,
+/// and the outer loop picks them up on the next iteration.
+///
+/// Order matches Android's libbinder: drain ALL weak derefs before
+/// dispatching the next strong, so a strong-deref destructor that
+/// queues a weak-deref gets drained ahead of the next pending
+/// strong. FIFO within each queue (`VecDeque::pop_front` /
+/// `mem::take` preserves insertion order).
+fn process_pending_derefs() -> Result<()> {
+    loop {
+        // Inner loop: drain weak fully. Re-take after each batch
+        // because dispatch may push more weak entries (from
+        // `Inner<T>::drop` running user destructor code that
+        // synchronously triggers another BR_DECREFS).
+        loop {
+            let batch: VecDeque<u64> = BINDER_DEREFS.with(|d| {
+                std::mem::take(&mut d.borrow_mut().pending_weak_derefs)
+            });
+            if batch.is_empty() {
+                break;
+            }
+            for id in batch {
                 if ProcessState::as_self().deref_native_kernel(id).is_none() {
                     log::trace!("BR_DECREFS for unknown native id {id}");
                 }
             }
+        }
 
-            // FIFO front-pop on strong derefs (`pop_front`). Process
-            // exactly one before re-checking the outer loop so a
-            // destructor-queued weak-deref is drained ahead of the
-            // next pending strong — same pattern as Android's
-            // libbinder.
-            if let Some(id) = self.pending_strong_derefs.pop_front() {
+        // Pop exactly one strong id under a fresh borrow, then
+        // dispatch outside the borrow. If none, both queues are
+        // empty (the inner loop just confirmed weak is empty), so
+        // we're done. Re-checking weak after dispatch is handled by
+        // looping back to the inner loop above.
+        let id = BINDER_DEREFS.with(|d| d.borrow_mut().pending_strong_derefs.pop_front());
+        match id {
+            Some(id) => {
                 if ProcessState::as_self().deref_native_kernel(id).is_none() {
                     log::trace!("BR_RELEASE for unknown native id {id}");
                 }
             }
+            None => return Ok(()),
         }
-        Ok(())
     }
 }
 
@@ -1319,9 +1326,7 @@ pub(crate) fn join_thread_pool(is_main: bool) -> Result<()> {
 
         loop {
             if thread_state.borrow_mut().is_process_pending_derefs() {
-                BINDER_DEREFS.with(|binder_derefs| -> Result<()> {
-                    binder_derefs.borrow_mut().process_pending_derefs()
-                })?;
+                process_pending_derefs()?;
             }
             if let Err(e) = get_and_execute_command() {
                 match e {

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -2391,3 +2391,52 @@ fn test_dump_fast_fails_on_dead_proxy_closes_fd() {
 
     drop(recipient);
 }
+
+/// Soak the publish-native → drop → kernel-deref cycle that the new
+/// id-encoded `flat_binder_object` lifecycle replaces. Under the prior
+/// fat-pointer encoding, this loop could trigger UAF when `Inner<T>`
+/// was dropped between `BR_RELEASE` and `BR_DECREFS` (the deferred
+/// `BR_DECREFS` arm reconstructed an SIBinder via `from_raw` and
+/// dispatched `dec_weak` on a freed allocation).
+///
+/// Each iteration:
+///   1. Constructs a fresh native binder (`BnNamedCallback::new_binder`
+///      over a local `ExtNamedCallback` impl).
+///   2. Publishes it across the kernel via `service.TakesAnIBinder` —
+///      our process emits `flat_binder_object { binder = id, cookie =
+///      0 }` for `BINDER_TYPE_BINDER`; the remote receives it as a
+///      handle, holds it for the call duration, then drops it. The
+///      kernel then schedules `BR_RELEASE` / `BR_DECREFS` back to us.
+///   3. Drops every user-side strong reference to the local binder.
+///      Under the new model the sidecar `published_natives` table
+///      keeps the canonical `Arc<dyn IBinder>` strong while
+///      `kernel_refs > 0`; entry removal — and therefore
+///      `Inner<T>::drop` — only happens once both `publish_count` and
+///      `kernel_refs` reach zero.
+///
+/// 100 iterations is the same soak depth used by
+/// `integration-test.yml`. A regression here surfaces either as a
+/// segfault (UAF) or as kernel-driver `EINVAL` on `BC_FREE_BUFFER`
+/// (table entry torn down before the kernel finished its
+/// dereferences).
+#[test]
+fn test_native_publish_drop_release_cycle() {
+    let service = get_test_service();
+
+    for i in 0..100 {
+        let local =
+            INamedCallback::BnNamedCallback::new_binder(ExtNamedCallback(format!("uaf_soak_{i}")));
+        let binder = local.as_binder();
+        // Fire-and-forget: the remote receives, holds briefly, then
+        // releases. We only care that the round-trip completes
+        // without crashing or returning an error.
+        service
+            .TakesAnIBinder(&binder)
+            .unwrap_or_else(|err| panic!("TakesAnIBinder iter {i} failed: {err:?}"));
+
+        // Drop both strong handles. The table's `binder_pin` keeps
+        // the inner Arc alive while the kernel still has refs.
+        drop(binder);
+        drop(local);
+    }
+}


### PR DESCRIPTION
## Summary

The previous `flat_binder_object` encoding for published native binders stored both halves of a `*const dyn IBinder` fat pointer (`binder` = data ptr, `cookie` = vtable ptr) into the same `Arc<Inner<T>>` allocation. When the final `BR_RELEASE` triggered `Inner<T>::drop` via `decrease_drop`, a still-pending `BR_DECREFS` would reconstruct an `SIBinder` from the dangling pointer and dispatch `dec_weak` on freed memory.

This PR replaces that encoding with a process-monotonic u64 id keyed into a sidecar `ProcessState::published_natives` table. The table holds the canonical `Arc<dyn IBinder>` while either an outgoing parcel (`publish_count`) or any kernel ref (`kernel_refs`) references the binder; entry removal — and therefore `Inner<T>::drop` — happens only when both reach zero, after the kernel has guaranteed no further `BR_*` will arrive.

Same shape as Android's two-allocation (`weakref_type*` + `BBinder*`) design, reached via id-indirection instead.

## Changes

- `process_state.rs`: `PublishedNative` struct, helper methods, two-phase removal pattern.
- `binder_object.rs`: `From<&SIBinder>` BINDER_TYPE_BINDER arm encodes the id; `acquire`/`release` drive `publish_count`.
- `thread_state.rs`: BR_INCREFS / BR_ACQUIRE / BR_RELEASE / BR_DECREFS / BR_ATTEMPT_ACQUIRE become pure id-bookkeeping; `BinderDerefs` queues are `VecDeque<u64>`. `process_pending_derefs` is a free function that drops the `BINDER_DEREFS` borrow before each dispatch (prevents re-entrancy panic when user destructors initiate sync IPC).
- `parcelable.rs`: BINDER_TYPE_BINDER receive path looks up the id in the table.
- `native.rs`, `binder.rs`: removed `into_raw`/`from_raw`/`split_fat_pointer`/`make_fat_pointer`/`raw_pointer_to_strong_binder`/`decrease_drop`; rewrote `TryFrom<SIBinder> for Binder<B>` to use the new `as_arc` accessor.

Plan: [PLAN_NATIVE_BINDER_UAF_FIX.md](PLAN_NATIVE_BINDER_UAF_FIX.md).

## Test plan

- [ ] `cargo build --workspace` clean — confirmed locally.
- [ ] `cargo clippy --workspace --all-targets` zero warnings — confirmed locally.
- [ ] `cargo test --workspace --no-run` builds — confirmed locally.
- [ ] Linux unit tests in `process_state.rs::tests`: `test_native_uaf_window_closed`, `test_native_dedup_same_arc`, `test_native_distinct_arcs_get_distinct_ids`, `test_native_lookup_does_not_change_counts` — require `/dev/binderfs/binder`, run in CI.
- [ ] Integration test `test_native_publish_drop_release_cycle` (100 sync-IPC iterations against real binderfs) — run via `gh workflow run integration-test.yml --ref fix/native-binder-uaf -f iterations=100`.
- [ ] Existing destructive tests (`test_death_recipient`, `test_wibinder_upgrade_after_obituary`) unaffected.

## Known limitation

Cross-thread `BR_INCREFS` / `BR_DECREFS` race through `proc->todo` can leave `kernel_refs` over-counted by 1 per race occurrence (entry stranded with `kernel_refs >= 1`). `saturating_sub` clamps; no panic. Bound is "one entry per id that ever raced." OLD encoding hit the same race silently via `RefCounter`'s `INITIAL_STRONG_VALUE` self-correction. Documented inline; follow-up could move to a signed counter with dual-direction trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)