### PR TITLE
chore(deps): bump rand 0.8.5 → 0.8.6 for RUSTSEC-2026-0097

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,9 +983,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",


### PR DESCRIPTION
## Summary
- Bumps transitive `rand` dependency from 0.8.5 → 0.8.6 to address [RUSTSEC-2026-0097](https://github.com/advisories/GHSA-cq8v-f236-94qc) (unsoundness when a custom `log` logger calls `rand::rng()` and triggers a reseed).
- Lockfile-only change; reached via `tera` (and `tera → chrono-tz → chrono-tz-build → phf_codegen → phf_generator`).
- MSRV (1.85) and direct dependency declarations are unaffected — `tera` already accepts `rand = \"0.8\"`, so `cargo update -p rand` was sufficient.

Refs: #93

## Test plan
- [x] `cargo update -p rand` produces a single-line change (`rand v0.8.5 -> v0.8.6`)
- [x] `cargo build --workspace` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)