### PR TITLE
docs: announce Android 10 support and refresh book version pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Both rsbinder and Android Binder utilize the same core protocol, enabling seamle
 - **Memory Management**: Compatible parcel serialization and shared memory handling
 
 ### Android Version Support:
-**rsbinder** supports Android versions 11 through 16.
+**rsbinder** supports Android versions 10 through 16 (API levels 29–36). Android 10 uses the legacy C service manager protocol; APIs not implemented there (`is_declared`, `register_for_notifications`, `unregister_for_notifications`, `get_service_debug_info`) return an error or `false` so callers can detect the gap. CI exercises emulator API levels 29, 30, 32, 34, and 36.
 
 ### AIDL Compatibility:
 The **rsbinder-aidl** compiler generates Rust code that maintains compatibility with Android's AIDL:

--- a/book/src/android.md
+++ b/book/src/android.md
@@ -12,6 +12,7 @@ See: [Android Build Environment Setup](./android-build.md)
 
 ### Supported Android Versions
 
+- **Android 10 (API 29)**: `android_10` feature
 - **Android 11 (API 30)**: `android_11` feature
 - **Android 12 (API 31) / 12L (API 32)**: `android_12` feature
 - **Android 13 (API 33)**: `android_13` feature
@@ -20,16 +21,19 @@ See: [Android Build Environment Setup](./android-build.md)
 
 > **Note**: Android 12L (API 32) uses the same Binder protocol as Android 12, so both are covered by the `android_12` feature flag. Similarly, Android 15 (API 35) uses the same Binder protocol as Android 14, so it is covered by the `android_14` or `android_14_plus` feature flag. No separate `android_12l` or `android_15` feature is needed.
 
+> **Android 10 caveat**: Android 10 uses the legacy C `IServiceManager` (the AIDL-based interface only landed in Android 11). The `android_10` dispatch supports `get_service`, `check_service`, `add_service`, and `list_services`. APIs introduced later — `is_declared`, `register_for_notifications`, `unregister_for_notifications`, and `get_service_debug_info` — return `false` or `StatusCode::UnknownTransaction` so callers can detect the gap rather than silently misbehave.
+
 ### Feature Flag Configuration
 
 In your `Cargo.toml`, specify the Android versions you want to support:
 
 ```toml
 [dependencies]
-rsbinder = { version = "0.5", features = ["android_14_plus"] }
+rsbinder = { version = "0.7", features = ["android_14_plus"] }
 ```
 
 Available feature combinations:
+- `android_10_plus`: Supports Android 10 through 16
 - `android_11_plus`: Supports Android 11 through 16
 - `android_12_plus`: Supports Android 12 through 16
 - `android_13_plus`: Supports Android 13 through 16

--- a/book/src/hello-world.md
+++ b/book/src/hello-world.md
@@ -18,12 +18,12 @@ publish = false
 edition = "2021"
 
 [dependencies]
-rsbinder = "0.5"
+rsbinder = "0.7"
 async-trait = "0.1"
 env_logger = "0.11"
 
 [build-dependencies]
-rsbinder-aidl = "0.5"
+rsbinder-aidl = "0.7"
 ```
 Add rsbinder and async-trait to [dependencies], and add rsbinder-aidl to [build-dependencies].
 

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -81,12 +81,12 @@ Add the following configuration to your Cargo.toml file:
 
 ```toml
 [dependencies]
-rsbinder = "0.5"
+rsbinder = "0.7"
 async-trait = "0.1"
 env_logger = "0.11"  # Optional: for logging
 
 [build-dependencies]
-rsbinder-aidl = "0.5"
+rsbinder-aidl = "0.7"
 ```
 
 ### Feature Flags
@@ -94,11 +94,11 @@ rsbinder-aidl = "0.5"
 
 ```toml
 [dependencies]
-rsbinder = "0.5"  # Default: includes tokio async runtime
+rsbinder = "0.7"  # Default: includes tokio async runtime
 # or
-rsbinder = { version = "0.5", features = ["async"] }  # Async trait support without tokio — use your own async runtime
+rsbinder = { version = "0.7", features = ["async"] }  # Async trait support without tokio — use your own async runtime
 # or
-rsbinder = { version = "0.5", default-features = false }  # Synchronous only (no async support)
+rsbinder = { version = "0.7", default-features = false }  # Synchronous only (no async support)
 ```
 
 Available features:

--- a/book/src/service-manager.md
+++ b/book/src/service-manager.md
@@ -226,8 +226,8 @@ The returned `ServiceDebugInfo` struct has two fields:
 - `name` (`String`) -- the registered service name.
 - `debugPid` (`i32`) -- the PID of the process that registered the service.
 
-This feature is available on Android 12 and above. On Android 11, calling
-`get_service_debug_info` returns an error.
+This feature is available on Android 12 and above. On Android 10 and Android 11,
+calling `get_service_debug_info` returns an error.
 
 ## Linux vs. Android Differences
 
@@ -240,14 +240,18 @@ Android's native `servicemanager`:
 | **Process**             | User-space `rsb_hub` binary             | System `servicemanager` daemon          |
 | **Access control**      | No SELinux enforcement                  | Full SELinux MAC policy enforcement     |
 | **VINTF manifests**     | Not supported (`is_declared` is false)  | Supported and enforced                  |
-| **Service debug info**  | Supported                               | Supported (Android 12+)                 |
+| **Service debug info**  | Supported                               | Supported (Android 12+; not on 10/11)   |
 | **Binder device**       | Must be created with `rsb_device`       | Managed by Android init                 |
 | **Version selection**   | Always uses Android 16 protocol         | Auto-detected from SDK version          |
 | **Death notifications** | Supported                               | Supported                               |
 
 On Android, rsbinder automatically detects the SDK version and uses the
-appropriate service manager protocol (Android 11 through 16). On Linux, it
-always uses the Android 16 protocol, which is what `rsb_hub` implements.
+appropriate service manager protocol (Android 10 through 16). Android 10
+falls back to the legacy C `IServiceManager` and therefore lacks
+`is_declared`, service notification callbacks, and `get_service_debug_info`
+— those entry points return `false` or `StatusCode::UnknownTransaction`.
+On Linux, rsbinder always uses the Android 16 protocol, which is what
+`rsb_hub` implements.
 
 ## Using the ServiceManager Object Directly
 


### PR DESCRIPTION
## Summary
- Announce Android 10 (API 29) support across the README and book, following the workspace's bump to 0.7.0 and the `android_10_plus` integration test coverage in PR #113.
- Document the limits of Android 10's legacy C `IServiceManager`: `is_declared`, `register/unregister_for_notifications`, and `get_service_debug_info` are not implemented and surface as `false` / `StatusCode::UnknownTransaction` so callers can detect the gap.
- Refresh stale `version = "0.5"` snippets in `book/installation.md`, `book/hello-world.md`, and `book/android.md` to `"0.7"` to match the current release.

## Test plan
- [ ] Visual review of `book/src/android.md` and `book/src/service-manager.md` after `mdbook build` (or via the deploy-book workflow once merged).
- [ ] Confirm the Cargo.toml snippets are unambiguous against current crates.io.
- [ ] No code changes — sanity check that `cargo check --workspace` still passes locally (it does on this branch's tip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)