### PR TITLE
feat(rsbinder): add configurable binder feature flags

### DIFF
--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -259,9 +259,11 @@ pub trait IBinder: Any + Send + Sync {
         Err(StatusCode::InvalidOperation)
     }
 
-    /// Return the local binder flags exported to the binder driver.
+    /// Local binder flags exported to the binder driver via
+    /// `flat_binder_object.flags`. Only native binders return a meaningful
+    /// value; proxies and test mocks inherit the `0` default.
     fn local_binder_flags(&self) -> u32 {
-        sys::FLAT_BINDER_FLAG_ACCEPTS_FDS
+        0
     }
 
     fn inc_strong(&self, strong: &SIBinder) -> Result<()>;

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -259,6 +259,11 @@ pub trait IBinder: Any + Send + Sync {
         Err(StatusCode::InvalidOperation)
     }
 
+    /// Return the local binder flags exported to the binder driver.
+    fn local_binder_flags(&self) -> u32 {
+        sys::FLAT_BINDER_FLAG_ACCEPTS_FDS
+    }
+
     fn inc_strong(&self, strong: &SIBinder) -> Result<()>;
     fn attempt_inc_strong(&self) -> bool;
     fn dec_strong(&self, strong: Option<ManuallyDrop<SIBinder>>) -> Result<()>;

--- a/rsbinder/src/binder_object.rs
+++ b/rsbinder/src/binder_object.rs
@@ -212,7 +212,7 @@ impl From<&SIBinder> for flat_binder_object {
                 hdr: binder_object_header {
                     type_: BINDER_TYPE_BINDER,
                 },
-                flags: FLAT_BINDER_FLAG_ACCEPTS_FDS | sched_bits,
+                flags: binder.local_binder_flags() | sched_bits,
                 __bindgen_anon_1: flat_binder_object__bindgen_ty_1 { binder: id },
                 cookie: 0,
             }

--- a/rsbinder/src/macros.rs
+++ b/rsbinder/src/macros.rs
@@ -46,6 +46,14 @@ macro_rules! __declare_binder_interface {
             impl $native {
                 /// Create a new binder service.
                 pub fn new_binder<T: $interface + Sync + Send + 'static>(inner: T) -> $crate::Strong<dyn $interface> {
+                    Self::new_binder_with_features(inner, $crate::BinderFeatures::default())
+                }
+
+                /// Create a new binder service with explicit binder features.
+                pub fn new_binder_with_features<T: $interface + Sync + Send + 'static>(
+                    inner: T,
+                    features: $crate::BinderFeatures,
+                ) -> $crate::Strong<dyn $interface> {
                     struct Wrapper<T> {
                         _inner: T,
                     }
@@ -58,7 +66,11 @@ macro_rules! __declare_binder_interface {
                             unreachable!("{} doesn't support async interface.", stringify!($interface))
                         }
                     }
-                    let binder = $crate::native::Binder::new_with_stability($native(Box::new(Wrapper {_inner: inner})), $stability);
+                    let binder = $crate::native::Binder::new_with_stability_and_features(
+                        $native(Box::new(Wrapper {_inner: inner})),
+                        $stability,
+                        features,
+                    );
                     $crate::Strong::new(Box::new(binder))
                 }
             }
@@ -157,7 +169,19 @@ macro_rules! __declare_binder_interface {
         impl $native {
             /// Create a new binder service.
             pub fn new_binder<T: $interface + Sync + Send + 'static>(inner: T) -> $crate::Strong<dyn $interface> {
-                let binder = $crate::native::Binder::new_with_stability($native(Box::new(inner)), $stability);
+                Self::new_binder_with_features(inner, $crate::BinderFeatures::default())
+            }
+
+            /// Create a new binder service with explicit binder features.
+            pub fn new_binder_with_features<T: $interface + Sync + Send + 'static>(
+                inner: T,
+                features: $crate::BinderFeatures,
+            ) -> $crate::Strong<dyn $interface> {
+                let binder = $crate::native::Binder::new_with_stability_and_features(
+                    $native(Box::new(inner)),
+                    $stability,
+                    features,
+                );
                 $crate::Strong::new(Box::new(binder))
             }
         }

--- a/rsbinder/src/native.rs
+++ b/rsbinder/src/native.rs
@@ -36,9 +36,15 @@ use crate::{
     thread_state,
 };
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BinderFeatures {
+    pub set_requesting_sid: bool,
+}
+
 struct Inner<T: Remotable + Send + Sync> {
     remotable: T,
     stability: Stability,
+    binder_flags: u32,
     strong: RefCounter,
     weak: RefCounter,
     extension: RwLock<Option<SIBinder>>,
@@ -126,6 +132,10 @@ impl<T: 'static + Remotable> IBinder for Inner<T> {
 
     fn stability(&self) -> Stability {
         self.stability
+    }
+
+    fn local_binder_flags(&self) -> u32 {
+        self.binder_flags
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -238,15 +248,35 @@ pub struct Binder<T: 'static + Remotable + Send + Sync> {
 impl<T: 'static + Remotable> Binder<T> {
     /// Create a new Binder object with default stability.
     pub fn new(remotable: T) -> Self {
-        Self::new_with_stability(remotable, Default::default())
+        Self::new_with_stability_and_features(remotable, Default::default(), Default::default())
+    }
+
+    /// Create a new Binder object with default stability and custom features.
+    pub fn new_with_features(remotable: T, features: BinderFeatures) -> Self {
+        Self::new_with_stability_and_features(remotable, Default::default(), features)
     }
 
     /// Create a new Binder object with the specified stability level.
     pub fn new_with_stability(remotable: T, stability: Stability) -> Self {
+        Self::new_with_stability_and_features(remotable, stability, Default::default())
+    }
+
+    /// Create a new Binder object with the specified stability level and features.
+    pub fn new_with_stability_and_features(
+        remotable: T,
+        stability: Stability,
+        features: BinderFeatures,
+    ) -> Self {
         Binder::<T> {
             inner: Arc::new(Inner {
                 remotable,
                 stability,
+                binder_flags: if features.set_requesting_sid {
+                    crate::sys::FLAT_BINDER_FLAG_ACCEPTS_FDS
+                        | crate::sys::FLAT_BINDER_FLAG_TXN_SECURITY_CTX
+                } else {
+                    crate::sys::FLAT_BINDER_FLAG_ACCEPTS_FDS
+                },
                 strong: Default::default(),
                 weak: Default::default(),
                 extension: RwLock::new(None),


### PR DESCRIPTION
Introduce `BinderFeatures` to allow callers to set binder flags at service creation time. Specifically, the `set_requesting_sid` flag enables `FLAT_BINDER_FLAG_TXN_SECURITY_CTX`, so that a service can request the sender's security context during transactions.

Add `local_binder_flags()` to the `IBinder` trait and use it when building `flat_binder_object` instead of hardcoding the flags. Extend the binder construction API with `new_binder_with_features` and `Binder::new_with_stability_and_features` to propagate the feature selection down to the native binder structure.

This keeps the default behaviour unchanged (only `FLAT_BINDER_FLAG_ACCEPTS_FDS` is set) while giving interface authors a straightforward way to opt into TXN_SECURITY_CTX.