### PR TITLE
fix(rsbinder)!: src review hardening — soundness, panic→Result, untrusted-input (12 commits)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -112,8 +112,20 @@ jobs:
           # deadlock guards (PR #118, `481b8c9`). This binder-enabled job
           # is the only place they can actually run, so gate them here.
           # rsb_hub is already up (handle 0); test_service is up so the
-          # cache has real entries to resurrect across the parallel tests.
-          RUST_BACKTRACE=1 cargo test --package rsbinder || {
+          # cache has real entries to resurrect.
+          #
+          # --test-threads=1 is required: these tests share the
+          # process-wide `ProcessState` singleton and a single binder fd.
+          # The slow-path concurrency / re-entrant-obituary guards
+          # deliberately drop and obituary the handle-0 (service manager)
+          # cache entry; running them concurrently with siblings that
+          # assert `strong_proxy_for_handle(0).is_ok()` or read the
+          # process-global thread-pool counter is inherently racy. Each
+          # guard spawns its own internal threads, so serializing test
+          # *functions* does not weaken them — it also makes the
+          # same-thread deadlock test reliably non-vacuous (no sibling
+          # keeps the handle-0 Weak upgradeable).
+          RUST_BACKTRACE=1 cargo test --package rsbinder -- --test-threads=1 || {
             echo "::error::rsbinder unit tests failed — capturing dmesg"
             sudo dmesg | tail -200
             cat rsb_hub.log

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -102,6 +102,24 @@ jobs:
           sleep 2
           kill -0 "$(cat test_service.pid)" || { echo "::error::test_service failed to start"; cat test_service.log; exit 1; }
 
+      - name: Run rsbinder unit tests (slow-path / hardening regression gate)
+        run: |
+          # The `rsbinder` crate's own unit tests are NOT exercised by the
+          # `cargo test --package tests` loop below, and build.yml only
+          # compiles them (`--no-run`). Several of them need a live binder
+          # device + service manager (handle 0) — e.g. the P1/P2/P3
+          # slow-path concurrency / same-thread re-entrant obituary
+          # deadlock guards (PR #118, `481b8c9`). This binder-enabled job
+          # is the only place they can actually run, so gate them here.
+          # rsb_hub is already up (handle 0); test_service is up so the
+          # cache has real entries to resurrect across the parallel tests.
+          RUST_BACKTRACE=1 cargo test --package rsbinder || {
+            echo "::error::rsbinder unit tests failed — capturing dmesg"
+            sudo dmesg | tail -200
+            cat rsb_hub.log
+            exit 1
+          }
+
       - name: Run cargo test (sync) — ${{ env.TEST_ITERATIONS }} iteration(s)
         run: |
           # Issue #97 manifests as kernel-log warnings rather than test

--- a/example-hello/src/bin/hello_client.rs
+++ b/example-hello/src/bin/hello_client.rs
@@ -31,7 +31,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
 
     // Initialize ProcessState with the default binder path and the default max threads.
-    ProcessState::init_default();
+    ProcessState::init_default()?;
 
     println!("list services:");
     // This is an example of how to use service manager.

--- a/example-hello/src/bin/hello_service.rs
+++ b/example-hello/src/bin/hello_service.rs
@@ -31,7 +31,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     // Initialize ProcessState with the default binder path and the default max threads.
     println!("Initializing ProcessState...");
-    ProcessState::init_default();
+    ProcessState::init_default()?;
 
     // Start the thread pool.
     // This is optional. If you don't call this, only one thread will be created to handle the binder transactions.

--- a/rsbinder-tools/src/bin/rsb_hub.rs
+++ b/rsbinder-tools/src/bin/rsb_hub.rs
@@ -691,7 +691,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     log::info!("Starting rsb_hub with binder device: {}", binder_path);
 
-    ProcessState::init(&binder_path, 0);
+    ProcessState::init(&binder_path, 0)?;
 
     // Create a binder service.
     let service = BnServiceManager::new_binder(ServiceManager::new());

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -92,6 +92,13 @@ pub const INTERFACE_HEADER: u32 = b_pack_chars('S', 'Y', 'S', 'T');
 /// Equivalent to `IInterface` in Android's C++ binder implementation.
 pub trait Interface: Send + Sync {
     /// Convert this binder object into a generic [`SIBinder`] reference.
+    ///
+    /// Has a default because AIDL interface traits have `Interface` as a
+    /// supertrait, so every service impl must write `impl Interface for
+    /// MyService {}`; the inner service value is never itself a binder
+    /// (it is wrapped by a generated `Bn*`), so calling `as_binder` on it
+    /// is a programmer error. Real binder types (native `Binder<T>`,
+    /// generated `Bp*` proxies, async wrappers) all override this.
     fn as_binder(&self) -> SIBinder {
         log::error!(
             "as_binder() called on non-Binder object of type {}. \

--- a/rsbinder/src/binder_object.rs
+++ b/rsbinder/src/binder_object.rs
@@ -32,8 +32,12 @@ impl flat_binder_object {
             hdr: binder_object_header {
                 type_: BINDER_TYPE_FD,
             },
-            flags: 0x7F & FLAT_BINDER_FLAG_ACCEPTS_FDS,
-            __bindgen_anon_1: flat_binder_object__bindgen_ty_1 { handle: fd as _ },
+            flags: 0x7F | FLAT_BINDER_FLAG_ACCEPTS_FDS,
+            // Init via the 8-byte `binder` field (not the u32 `handle`) so the upper bytes are zeroed:
+            // mirrors AOSP Parcel.cpp `obj.binder = 0; obj.handle = fd;`, avoids leaking uninit stack to the remote.
+            __bindgen_anon_1: flat_binder_object__bindgen_ty_1 {
+                binder: (fd as u32) as u64,
+            },
             cookie: if take_ownership { 1 } else { 0 },
         }
     }

--- a/rsbinder/src/binder_object.rs
+++ b/rsbinder/src/binder_object.rs
@@ -60,14 +60,25 @@ impl flat_binder_object {
     }
 
     pub(crate) fn handle(&self) -> u32 {
+        // SAFETY: `__bindgen_anon_1` is an integer union (`binder: u64` |
+        // `handle: u32`); every bit pattern is a valid value for both
+        // variants, so the read itself is never UB. Reading `.handle` is
+        // meaningful only for handle/FD-typed objects — that selection is
+        // the caller's contract per `hdr.type`.
         unsafe { self.__bindgen_anon_1.handle }
     }
 
     pub(crate) fn borrowed_fd(&self) -> BorrowedFd<'_> {
+        // SAFETY: caller invariant — only called on a BINDER_TYPE_FD object
+        // whose fd is kept alive by the owning parcel for the returned
+        // borrow's lifetime (tied to `&self`).
         unsafe { BorrowedFd::borrow_raw(self.handle() as _) }
     }
 
     pub(crate) fn owned_fd(&self) -> OwnedFd {
+        // SAFETY: caller invariant — only called on a BINDER_TYPE_FD object
+        // that owns its fd, and at most once, so the resulting OwnedFd has
+        // exclusive ownership and will not double-close.
         unsafe { OwnedFd::from_raw_fd(self.handle() as _) }
     }
 
@@ -76,6 +87,8 @@ impl flat_binder_object {
     }
 
     pub(crate) fn pointer(&self) -> binder_uintptr_t {
+        // SAFETY: integer union read (see `handle`); never UB. Meaningful
+        // only for BINDER_TYPE_(WEAK_)BINDER objects — caller's contract.
         unsafe { self.__bindgen_anon_1.binder }
     }
 
@@ -234,6 +247,11 @@ pub(crate) fn read_flat_binder(data: &[u8], offset: usize) -> Result<flat_binder
     let bytes = data
         .get(offset..offset + size)
         .ok_or(StatusCode::NotEnoughData)?;
+    // SAFETY: `get(offset..offset + size)` guarantees `bytes` is exactly
+    // `size_of::<flat_binder_object>()` readable bytes. `flat_binder_object`
+    // is a bindgen `#[repr(C)]` POD (no invalid bit patterns), so any byte
+    // pattern is a valid value; `read_unaligned` covers the unknown
+    // alignment of the parcel offset and returns an owned stack copy.
     Ok(unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const flat_binder_object) })
 }
 
@@ -247,6 +265,10 @@ pub(crate) fn write_flat_binder(
     let bytes = data
         .get_mut(offset..offset + size)
         .ok_or(StatusCode::NotEnoughData)?;
+    // SAFETY: `get_mut(offset..offset + size)` guarantees `bytes` is exactly
+    // `size_of::<flat_binder_object>()` writable bytes. `*obj` is a valid
+    // `flat_binder_object`; `write_unaligned` covers the unknown alignment
+    // of the parcel offset.
     unsafe { std::ptr::write_unaligned(bytes.as_mut_ptr() as *mut flat_binder_object, *obj) };
     Ok(())
 }

--- a/rsbinder/src/binder_object.rs
+++ b/rsbinder/src/binder_object.rs
@@ -272,3 +272,65 @@ pub(crate) fn write_flat_binder(
     unsafe { std::ptr::write_unaligned(bytes.as_mut_ptr() as *mut flat_binder_object, *obj) };
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression guard for the `new_with_fd` construction fix.
+    ///
+    /// Two distinct defects were present before the fix:
+    ///
+    ///  1. `flags: 0x7F & FLAT_BINDER_FLAG_ACCEPTS_FDS` — a bitwise AND
+    ///     between disjoint bit ranges (`0x7F` vs `0x100`) is always 0,
+    ///     so every FD object went on the wire with `flags == 0`. The
+    ///     fix is `0x7F | FLAT_BINDER_FLAG_ACCEPTS_FDS`, byte-identical
+    ///     to AOSP `Parcel::writeFileDescriptor`.
+    ///  2. The union was initialized via the u32 `handle` variant, so
+    ///     the upper 4 bytes of the 8-byte `binder` field were left
+    ///     uninitialized and leaked uninitialized stack to the remote
+    ///     (Rust UB). The fix initializes the full-width `binder` field
+    ///     so the upper bytes are guaranteed zero.
+    #[test]
+    fn new_with_fd_flags_and_full_width_init() {
+        let fd: i32 = 7;
+        let obj = flat_binder_object::new_with_fd(fd, false);
+
+        assert_eq!(obj.header_type(), BINDER_TYPE_FD, "must be a FD object");
+
+        // Defect 1: flags must be the OR (0x7F | 0x100 == 0x17F), never 0.
+        assert_eq!(
+            obj.flags,
+            0x7F | FLAT_BINDER_FLAG_ACCEPTS_FDS,
+            "flags must be 0x7F | FLAT_BINDER_FLAG_ACCEPTS_FDS (regression: was 0x7F & ... == 0)"
+        );
+        assert_ne!(
+            obj.flags, 0,
+            "AND-instead-of-OR regression: flags collapsed to 0"
+        );
+        assert_eq!(
+            obj.flags & FLAT_BINDER_FLAG_ACCEPTS_FDS,
+            FLAT_BINDER_FLAG_ACCEPTS_FDS,
+            "ACCEPTS_FDS bit must be set"
+        );
+
+        // Defect 2: the full 8-byte union must equal exactly `fd` with a
+        // zeroed upper half — no uninitialized stack bytes leaked.
+        assert_eq!(
+            obj.pointer(),
+            fd as u32 as u64,
+            "upper 32 bits of the union must be zero (uninit-leak UB regression)"
+        );
+        assert_eq!(
+            obj.handle(),
+            fd as u32,
+            "handle variant must round-trip the fd"
+        );
+    }
+
+    #[test]
+    fn new_with_fd_cookie_tracks_take_ownership() {
+        assert_eq!(flat_binder_object::new_with_fd(3, true).cookie, 1);
+        assert_eq!(flat_binder_object::new_with_fd(3, false).cookie, 0);
+    }
+}

--- a/rsbinder/src/error.rs
+++ b/rsbinder/src/error.rs
@@ -164,8 +164,15 @@ impl From<std::array::TryFromSliceError> for StatusCode {
 }
 
 impl From<std::io::Error> for StatusCode {
-    fn from(_: std::io::Error) -> Self {
-        StatusCode::BadFd
+    fn from(err: std::io::Error) -> Self {
+        // Preserve the underlying errno instead of flattening every I/O
+        // failure to BadFd. OS-backed errors route through the errno
+        // mapping (BADF still yields BadFd); non-OS errors have no errno
+        // to map, so they surface as Unknown.
+        match err.raw_os_error() {
+            Some(raw) => StatusCode::from(rustix::io::Errno::from_raw_os_error(raw)),
+            None => StatusCode::Unknown,
+        }
     }
 }
 

--- a/rsbinder/src/error.rs
+++ b/rsbinder/src/error.rs
@@ -442,4 +442,26 @@ mod tests {
         let code = StatusCode::from(rustix::io::Errno::from_raw_os_error(64));
         assert_eq!(code, StatusCode::Errno(-64));
     }
+
+    // Regression: `From<std::io::Error>` must preserve the underlying
+    // errno through the Errno mapping instead of flattening every I/O
+    // failure to `BadFd`. Non-OS errors (no errno) surface as `Unknown`.
+    #[test]
+    fn status_code_from_io_error_preserves_errno() {
+        let enoent = std::io::Error::from_raw_os_error(rustix::io::Errno::NOENT.raw_os_error());
+        assert_eq!(
+            StatusCode::from(enoent),
+            StatusCode::NameNotFound,
+            "ENOENT must map to NameNotFound, not be flattened to BadFd"
+        );
+
+        // BADF still resolves to BadFd — via the errno mapping, not a blanket default.
+        let ebadf = std::io::Error::from_raw_os_error(rustix::io::Errno::BADF.raw_os_error());
+        assert_eq!(StatusCode::from(ebadf), StatusCode::BadFd);
+
+        // A non-OS error has no errno to map → Unknown.
+        let non_os = std::io::Error::other("no errno");
+        assert_eq!(non_os.raw_os_error(), None);
+        assert_eq!(StatusCode::from(non_os), StatusCode::Unknown);
+    }
 }

--- a/rsbinder/src/hub/mod.rs
+++ b/rsbinder/src/hub/mod.rs
@@ -204,6 +204,26 @@ pub fn default() -> Result<Arc<ServiceManager>> {
     Ok(GLOBAL_SM.get_or_init(|| Arc::new(service_manager)).clone())
 }
 
+/// Re-wraps a version-agnostic `IServiceCallback` as the version-specific
+/// `Strong<dyn android_N::IServiceCallback>` expected by a per-version
+/// service-manager shim.
+///
+/// Each `android_N::IServiceCallback` is generated from its own AIDL unit,
+/// so they are distinct trait types with independently-built vtables.
+/// Reinterpreting the `Strong` (a `Box<dyn _>` fat pointer) across them
+/// would dispatch through a foreign vtable — a layout Rust does not
+/// guarantee. Instead we extract the underlying `SIBinder` (via the real
+/// type's correct vtable) and rebuild the target `Strong` through the safe
+/// `FromIBinder` path. All `IServiceCallback` variants share the AIDL
+/// descriptor `"android.os.IServiceCallback"`, so this round-trip always
+/// succeeds and serializes to the identical wire bytes.
+#[cfg(target_os = "android")]
+fn rewrap_callback<T: crate::FromIBinder + ?Sized>(
+    callback: &crate::Strong<dyn IServiceCallback>,
+) -> Result<crate::Strong<T>> {
+    <T as crate::FromIBinder>::try_from(callback.as_binder())
+}
+
 impl ServiceManager {
     /// Retrieves a service by name.
     ///
@@ -405,39 +425,23 @@ impl ServiceManager {
             }
             #[cfg(all(target_os = "android", feature = "android_11"))]
             ServiceManager::Android11(sm) => {
-                // SAFETY: This transmutation is safe because both types represent the same AIDL interface
-                let callback = unsafe {
-                    &*(callback as *const _
-                        as *const crate::Strong<dyn android_11::IServiceCallback>)
-                };
-                android_11::register_for_notifications(sm, name, callback)
+                let callback = rewrap_callback::<dyn android_11::IServiceCallback>(callback)?;
+                android_11::register_for_notifications(sm, name, &callback)
             }
             #[cfg(all(target_os = "android", feature = "android_12"))]
             ServiceManager::Android12(sm) => {
-                // SAFETY: This transmutation is safe because both types represent the same AIDL interface
-                let callback = unsafe {
-                    &*(callback as *const _
-                        as *const crate::Strong<dyn android_12::IServiceCallback>)
-                };
-                android_12::register_for_notifications(sm, name, callback)
+                let callback = rewrap_callback::<dyn android_12::IServiceCallback>(callback)?;
+                android_12::register_for_notifications(sm, name, &callback)
             }
             #[cfg(all(target_os = "android", feature = "android_13"))]
             ServiceManager::Android13(sm) => {
-                // SAFETY: This transmutation is safe because both types represent the same AIDL interface
-                let callback = unsafe {
-                    &*(callback as *const _
-                        as *const crate::Strong<dyn android_13::IServiceCallback>)
-                };
-                android_13::register_for_notifications(sm, name, callback)
+                let callback = rewrap_callback::<dyn android_13::IServiceCallback>(callback)?;
+                android_13::register_for_notifications(sm, name, &callback)
             }
             #[cfg(all(target_os = "android", feature = "android_14"))]
             ServiceManager::Android14(sm) => {
-                // SAFETY: This transmutation is safe because both types represent the same AIDL interface
-                let callback = unsafe {
-                    &*(callback as *const _
-                        as *const crate::Strong<dyn android_14::IServiceCallback>)
-                };
-                android_14::register_for_notifications(sm, name, callback)
+                let callback = rewrap_callback::<dyn android_14::IServiceCallback>(callback)?;
+                android_14::register_for_notifications(sm, name, &callback)
             }
             ServiceManager::Android16(sm) => {
                 android_16::register_for_notifications(sm, name, callback)
@@ -461,39 +465,23 @@ impl ServiceManager {
             }
             #[cfg(all(target_os = "android", feature = "android_11"))]
             ServiceManager::Android11(sm) => {
-                // SAFETY: This transmutation is safe because both types represent the same AIDL interface
-                let callback = unsafe {
-                    &*(callback as *const _
-                        as *const crate::Strong<dyn android_11::IServiceCallback>)
-                };
-                android_11::unregister_for_notifications(sm, name, callback)
+                let callback = rewrap_callback::<dyn android_11::IServiceCallback>(callback)?;
+                android_11::unregister_for_notifications(sm, name, &callback)
             }
             #[cfg(all(target_os = "android", feature = "android_12"))]
             ServiceManager::Android12(sm) => {
-                // SAFETY: This transmutation is safe because both types represent the same AIDL interface
-                let callback = unsafe {
-                    &*(callback as *const _
-                        as *const crate::Strong<dyn android_12::IServiceCallback>)
-                };
-                android_12::unregister_for_notifications(sm, name, callback)
+                let callback = rewrap_callback::<dyn android_12::IServiceCallback>(callback)?;
+                android_12::unregister_for_notifications(sm, name, &callback)
             }
             #[cfg(all(target_os = "android", feature = "android_13"))]
             ServiceManager::Android13(sm) => {
-                // SAFETY: This transmutation is safe because both types represent the same AIDL interface
-                let callback = unsafe {
-                    &*(callback as *const _
-                        as *const crate::Strong<dyn android_13::IServiceCallback>)
-                };
-                android_13::unregister_for_notifications(sm, name, callback)
+                let callback = rewrap_callback::<dyn android_13::IServiceCallback>(callback)?;
+                android_13::unregister_for_notifications(sm, name, &callback)
             }
             #[cfg(all(target_os = "android", feature = "android_14"))]
             ServiceManager::Android14(sm) => {
-                // SAFETY: This transmutation is safe because both types represent the same AIDL interface
-                let callback = unsafe {
-                    &*(callback as *const _
-                        as *const crate::Strong<dyn android_14::IServiceCallback>)
-                };
-                android_14::unregister_for_notifications(sm, name, callback)
+                let callback = rewrap_callback::<dyn android_14::IServiceCallback>(callback)?;
+                android_14::unregister_for_notifications(sm, name, &callback)
             }
             ServiceManager::Android16(sm) => {
                 android_16::unregister_for_notifications(sm, name, callback)

--- a/rsbinder/src/hub/mod.rs
+++ b/rsbinder/src/hub/mod.rs
@@ -204,25 +204,76 @@ pub fn default() -> Result<Arc<ServiceManager>> {
     Ok(GLOBAL_SM.get_or_init(|| Arc::new(service_manager)).clone())
 }
 
-/// Re-wraps a version-agnostic `IServiceCallback` as the version-specific
-/// `Strong<dyn android_N::IServiceCallback>` expected by a per-version
-/// service-manager shim.
+/// Forwards an existing `IServiceCallback` to a per-version
+/// service-manager shim without reconstructing a typed `Strong`.
 ///
 /// Each `android_N::IServiceCallback` is generated from its own AIDL unit,
-/// so they are distinct trait types with independently-built vtables.
-/// Reinterpreting the `Strong` (a `Box<dyn _>` fat pointer) across them
-/// would dispatch through a foreign vtable — a layout Rust does not
-/// guarantee. Instead we extract the underlying `SIBinder` (via the real
-/// type's correct vtable) and rebuild the target `Strong` through the safe
-/// `FromIBinder` path. All `IServiceCallback` variants share the AIDL
-/// descriptor `"android.os.IServiceCallback"`, so this round-trip always
-/// succeeds and serializes to the identical wire bytes.
-#[cfg(target_os = "android")]
-fn rewrap_callback<T: crate::FromIBinder + ?Sized>(
-    callback: &crate::Strong<dyn IServiceCallback>,
-) -> Result<crate::Strong<T>> {
-    <T as crate::FromIBinder>::try_from(callback.as_binder())
+/// so they are distinct trait types with independently-built vtables;
+/// transmuting a `Strong<dyn _>` (a `Box<dyn _>` fat pointer) across them
+/// would dispatch through a foreign vtable, a layout Rust does not
+/// guarantee. A `FromIBinder::try_from` round-trip is also wrong: it
+/// rejects a *local* callback whose concrete native type differs from the
+/// target version's (descriptor matches but the `Inner<B>` downcast
+/// fails), which is the normal case for this API.
+///
+/// `register/unregister_for_notifications` only ever serialize the
+/// callback as its underlying `SIBinder` (`Serialize for dyn _` calls
+/// `as_binder()` and nothing else), so a thin wrapper that returns the
+/// original `SIBinder` is wire-identical and behavior-identical for both
+/// local and proxy callbacks, with no `unsafe`. `onRegistration` is
+/// unreachable here: the wrapper is only serialized and sent; inbound
+/// notifications are delivered by the kernel to the original binder node,
+/// never to this transient local forwarder.
+#[cfg(all(
+    target_os = "android",
+    any(
+        feature = "android_11",
+        feature = "android_12",
+        feature = "android_13",
+        feature = "android_14"
+    )
+))]
+struct ForwardServiceCallback(crate::SIBinder);
+
+#[cfg(all(
+    target_os = "android",
+    any(
+        feature = "android_11",
+        feature = "android_12",
+        feature = "android_13",
+        feature = "android_14"
+    )
+))]
+impl crate::Interface for ForwardServiceCallback {
+    fn as_binder(&self) -> crate::SIBinder {
+        self.0.clone()
+    }
 }
+
+/// Emits the per-version `IServiceCallback` impl for [`ForwardServiceCallback`]
+/// (one per supported pre-16 version; collapses what was 4× duplicated).
+macro_rules! forward_service_callback_impl {
+    ($modu:ident, $feat:literal) => {
+        #[cfg(all(target_os = "android", feature = $feat))]
+        impl $modu::IServiceCallback for ForwardServiceCallback {
+            fn r#onRegistration(
+                &self,
+                _name: &str,
+                _binder: &crate::SIBinder,
+            ) -> crate::status::Result<()> {
+                // Unreachable on the serialize-only path; see the
+                // ForwardServiceCallback doc. Return an error rather than
+                // panic in library code if it is ever reached.
+                Err(crate::StatusCode::UnknownTransaction.into())
+            }
+        }
+    };
+}
+
+forward_service_callback_impl!(android_11, "android_11");
+forward_service_callback_impl!(android_12, "android_12");
+forward_service_callback_impl!(android_13, "android_13");
+forward_service_callback_impl!(android_14, "android_14");
 
 impl ServiceManager {
     /// Retrieves a service by name.
@@ -425,22 +476,26 @@ impl ServiceManager {
             }
             #[cfg(all(target_os = "android", feature = "android_11"))]
             ServiceManager::Android11(sm) => {
-                let callback = rewrap_callback::<dyn android_11::IServiceCallback>(callback)?;
+                let callback: crate::Strong<dyn android_11::IServiceCallback> =
+                    crate::Strong::new(Box::new(ForwardServiceCallback(callback.as_binder())));
                 android_11::register_for_notifications(sm, name, &callback)
             }
             #[cfg(all(target_os = "android", feature = "android_12"))]
             ServiceManager::Android12(sm) => {
-                let callback = rewrap_callback::<dyn android_12::IServiceCallback>(callback)?;
+                let callback: crate::Strong<dyn android_12::IServiceCallback> =
+                    crate::Strong::new(Box::new(ForwardServiceCallback(callback.as_binder())));
                 android_12::register_for_notifications(sm, name, &callback)
             }
             #[cfg(all(target_os = "android", feature = "android_13"))]
             ServiceManager::Android13(sm) => {
-                let callback = rewrap_callback::<dyn android_13::IServiceCallback>(callback)?;
+                let callback: crate::Strong<dyn android_13::IServiceCallback> =
+                    crate::Strong::new(Box::new(ForwardServiceCallback(callback.as_binder())));
                 android_13::register_for_notifications(sm, name, &callback)
             }
             #[cfg(all(target_os = "android", feature = "android_14"))]
             ServiceManager::Android14(sm) => {
-                let callback = rewrap_callback::<dyn android_14::IServiceCallback>(callback)?;
+                let callback: crate::Strong<dyn android_14::IServiceCallback> =
+                    crate::Strong::new(Box::new(ForwardServiceCallback(callback.as_binder())));
                 android_14::register_for_notifications(sm, name, &callback)
             }
             ServiceManager::Android16(sm) => {
@@ -465,22 +520,26 @@ impl ServiceManager {
             }
             #[cfg(all(target_os = "android", feature = "android_11"))]
             ServiceManager::Android11(sm) => {
-                let callback = rewrap_callback::<dyn android_11::IServiceCallback>(callback)?;
+                let callback: crate::Strong<dyn android_11::IServiceCallback> =
+                    crate::Strong::new(Box::new(ForwardServiceCallback(callback.as_binder())));
                 android_11::unregister_for_notifications(sm, name, &callback)
             }
             #[cfg(all(target_os = "android", feature = "android_12"))]
             ServiceManager::Android12(sm) => {
-                let callback = rewrap_callback::<dyn android_12::IServiceCallback>(callback)?;
+                let callback: crate::Strong<dyn android_12::IServiceCallback> =
+                    crate::Strong::new(Box::new(ForwardServiceCallback(callback.as_binder())));
                 android_12::unregister_for_notifications(sm, name, &callback)
             }
             #[cfg(all(target_os = "android", feature = "android_13"))]
             ServiceManager::Android13(sm) => {
-                let callback = rewrap_callback::<dyn android_13::IServiceCallback>(callback)?;
+                let callback: crate::Strong<dyn android_13::IServiceCallback> =
+                    crate::Strong::new(Box::new(ForwardServiceCallback(callback.as_binder())));
                 android_13::unregister_for_notifications(sm, name, &callback)
             }
             #[cfg(all(target_os = "android", feature = "android_14"))]
             ServiceManager::Android14(sm) => {
-                let callback = rewrap_callback::<dyn android_14::IServiceCallback>(callback)?;
+                let callback: crate::Strong<dyn android_14::IServiceCallback> =
+                    crate::Strong::new(Box::new(ForwardServiceCallback(callback.as_binder())));
                 android_14::unregister_for_notifications(sm, name, &callback)
             }
             ServiceManager::Android16(sm) => {

--- a/rsbinder/src/hub/mod.rs
+++ b/rsbinder/src/hub/mod.rs
@@ -171,8 +171,7 @@ pub fn default() -> Result<Arc<ServiceManager>> {
         macro_rules! create_service_manager {
             ($variant:ident, $module:ident) => {
                 ServiceManager::$variant(
-                    $module::BpServiceManager::from_binder(context)
-                        .ok_or(StatusCode::BadType)?,
+                    $module::BpServiceManager::from_binder(context).ok_or(StatusCode::BadType)?,
                 )
             };
         }
@@ -180,11 +179,15 @@ pub fn default() -> Result<Arc<ServiceManager>> {
         match sdk_version {
             sdk_versions::ANDROID_16 => create_service_manager!(Android16, android_16),
             #[cfg(feature = "android_14")]
-            sdk_versions::ANDROID_14 | sdk_versions::ANDROID_15 => create_service_manager!(Android14, android_14),
+            sdk_versions::ANDROID_14 | sdk_versions::ANDROID_15 => {
+                create_service_manager!(Android14, android_14)
+            }
             #[cfg(feature = "android_13")]
             sdk_versions::ANDROID_13 => create_service_manager!(Android13, android_13),
             #[cfg(feature = "android_12")]
-            sdk_versions::ANDROID_12 | sdk_versions::ANDROID_12L => create_service_manager!(Android12, android_12),
+            sdk_versions::ANDROID_12 | sdk_versions::ANDROID_12L => {
+                create_service_manager!(Android12, android_12)
+            }
             #[cfg(feature = "android_11")]
             sdk_versions::ANDROID_11 => create_service_manager!(Android11, android_11),
             #[cfg(feature = "android_10")]

--- a/rsbinder/src/hub/mod.rs
+++ b/rsbinder/src/hub/mod.rs
@@ -147,51 +147,61 @@ pub enum ServiceManager {
 
 /// Returns the global ServiceManager instance appropriate for the current Android version.
 ///
-/// This function creates a singleton ServiceManager instance on first call and returns it
-/// for subsequent calls. The correct version-specific implementation is automatically
-/// selected based on the detected Android SDK version.
-pub fn default() -> Arc<ServiceManager> {
+/// The singleton is created on first call and reused afterwards. The correct
+/// version-specific implementation is selected from the detected Android SDK
+/// version.
+///
+/// Returns an error instead of panicking when the context object cannot be
+/// obtained, the proxy cannot be created, or the SDK version is unsupported.
+/// A failed initialization is not cached, so a later call may retry.
+pub fn default() -> Result<Arc<ServiceManager>> {
     static GLOBAL_SM: OnceLock<Arc<ServiceManager>> = OnceLock::new();
 
-    GLOBAL_SM.get_or_init(|| {
-        let process = ProcessState::as_self();
-        let context = process.context_object()
-            .expect("Failed to get context_object during ServiceManager initialization");
-        #[cfg(target_os = "android")]
-        let sdk_version = crate::get_android_sdk_version();
+    if let Some(sm) = GLOBAL_SM.get() {
+        return Ok(sm.clone());
+    }
 
-        const ERROR_MSG: &str = "Failed to create BpServiceManager from binder during ServiceManager initialization";
+    let process = ProcessState::as_self();
+    let context = process.context_object()?;
+    #[cfg(target_os = "android")]
+    let sdk_version = crate::get_android_sdk_version();
 
-        #[cfg(target_os = "android")]
-        let service_manager = {
-            macro_rules! create_service_manager {
-                ($variant:ident, $module:ident) => {
-                    ServiceManager::$variant($module::BpServiceManager::from_binder(context).expect(ERROR_MSG))
-                };
-            }
+    #[cfg(target_os = "android")]
+    let service_manager = {
+        macro_rules! create_service_manager {
+            ($variant:ident, $module:ident) => {
+                ServiceManager::$variant(
+                    $module::BpServiceManager::from_binder(context)
+                        .ok_or(StatusCode::BadType)?,
+                )
+            };
+        }
 
-            match sdk_version {
-                sdk_versions::ANDROID_16 => create_service_manager!(Android16, android_16),
-                #[cfg(feature = "android_14")]
-                sdk_versions::ANDROID_14 | sdk_versions::ANDROID_15 => create_service_manager!(Android14, android_14),
-                #[cfg(feature = "android_13")]
-                sdk_versions::ANDROID_13 => create_service_manager!(Android13, android_13),
-                #[cfg(feature = "android_12")]
-                sdk_versions::ANDROID_12 | sdk_versions::ANDROID_12L => create_service_manager!(Android12, android_12),
-                #[cfg(feature = "android_11")]
-                sdk_versions::ANDROID_11 => create_service_manager!(Android11, android_11),
-                #[cfg(feature = "android_10")]
-                sdk_versions::ANDROID_10 => create_service_manager!(Android10, android_10),
-                _ => panic!("default: Unsupported Android SDK version: {}", sdk_version),
-            }
-        };
+        match sdk_version {
+            sdk_versions::ANDROID_16 => create_service_manager!(Android16, android_16),
+            #[cfg(feature = "android_14")]
+            sdk_versions::ANDROID_14 | sdk_versions::ANDROID_15 => create_service_manager!(Android14, android_14),
+            #[cfg(feature = "android_13")]
+            sdk_versions::ANDROID_13 => create_service_manager!(Android13, android_13),
+            #[cfg(feature = "android_12")]
+            sdk_versions::ANDROID_12 | sdk_versions::ANDROID_12L => create_service_manager!(Android12, android_12),
+            #[cfg(feature = "android_11")]
+            sdk_versions::ANDROID_11 => create_service_manager!(Android11, android_11),
+            #[cfg(feature = "android_10")]
+            sdk_versions::ANDROID_10 => create_service_manager!(Android10, android_10),
+            _ => return Err(StatusCode::InvalidOperation),
+        }
+    };
 
-        #[cfg(not(target_os = "android"))]
-        let service_manager = ServiceManager::Android16(android_16::BpServiceManager::from_binder(context)
-            .expect(ERROR_MSG));
+    #[cfg(not(target_os = "android"))]
+    let service_manager = ServiceManager::Android16(
+        android_16::BpServiceManager::from_binder(context).ok_or(StatusCode::BadType)?,
+    );
 
-        Arc::new(service_manager)
-    }).clone()
+    // Cache only on success; a failed init returned above is not stored,
+    // so a later call may retry. If two threads race here, get_or_init
+    // keeps the first stored instance and the extra one is dropped.
+    Ok(GLOBAL_SM.get_or_init(|| Arc::new(service_manager)).clone())
 }
 
 impl ServiceManager {
@@ -502,7 +512,7 @@ impl ServiceManager {
 /// This is equivalent to `default().get_interface(name)`.
 #[inline]
 pub fn get_interface<T: FromIBinder + ?Sized>(name: &str) -> Result<Strong<T>> {
-    default().get_interface(name)
+    default()?.get_interface(name)
 }
 
 /// Convenience function to list services from the default ServiceManager.
@@ -510,7 +520,11 @@ pub fn get_interface<T: FromIBinder + ?Sized>(name: &str) -> Result<Strong<T>> {
 /// This is equivalent to `default().list_services(dump_priority)`.
 #[inline]
 pub fn list_services(dump_priority: i32) -> Vec<String> {
-    default().list_services(dump_priority)
+    // Consistent with this wrapper's existing error-swallowing contract:
+    // an unavailable ServiceManager yields an empty list rather than a panic.
+    default()
+        .map(|sm| sm.list_services(dump_priority))
+        .unwrap_or_default()
 }
 
 /// Convenience function to register for notifications from the default ServiceManager.
@@ -521,7 +535,7 @@ pub fn register_for_notifications(
     name: &str,
     callback: &crate::Strong<dyn IServiceCallback>,
 ) -> Result<()> {
-    default().register_for_notifications(name, callback)
+    default()?.register_for_notifications(name, callback)
 }
 
 /// Convenience function to unregister from notifications from the default ServiceManager.
@@ -532,7 +546,7 @@ pub fn unregister_for_notifications(
     name: &str,
     callback: &crate::Strong<dyn IServiceCallback>,
 ) -> Result<()> {
-    default().unregister_for_notifications(name, callback)
+    default()?.unregister_for_notifications(name, callback)
 }
 
 /// Convenience function to add a service to the default ServiceManager.
@@ -540,7 +554,8 @@ pub fn unregister_for_notifications(
 /// This is equivalent to `default().add_service(identifier, binder)`.
 #[inline]
 pub fn add_service(identifier: &str, binder: SIBinder) -> std::result::Result<(), Status> {
-    default().add_service(identifier, binder)
+    // `?` converts a StatusCode init failure into Status via From<StatusCode>.
+    default()?.add_service(identifier, binder)
 }
 
 /// Convenience function to get a service from the default ServiceManager.
@@ -548,7 +563,7 @@ pub fn add_service(identifier: &str, binder: SIBinder) -> std::result::Result<()
 /// This is equivalent to `default().get_service(name)`.
 #[inline]
 pub fn get_service(name: &str) -> Option<SIBinder> {
-    default().get_service(name)
+    default().ok()?.get_service(name)
 }
 
 /// Convenience function to check if a service is available from the default ServiceManager.
@@ -556,7 +571,7 @@ pub fn get_service(name: &str) -> Option<SIBinder> {
 /// This is equivalent to `default().check_service(name)`.
 #[inline]
 pub fn check_service(name: &str) -> Option<SIBinder> {
-    default().check_service(name)
+    default().ok()?.check_service(name)
 }
 
 /// Convenience function to check if a service is declared from the default ServiceManager.
@@ -564,7 +579,7 @@ pub fn check_service(name: &str) -> Option<SIBinder> {
 /// This is equivalent to `default().is_declared(name)`.
 #[inline]
 pub fn is_declared(name: &str) -> bool {
-    default().is_declared(name)
+    default().map(|sm| sm.is_declared(name)).unwrap_or(false)
 }
 
 /// Convenience function to get debug information about all services from the default ServiceManager.
@@ -573,5 +588,5 @@ pub fn is_declared(name: &str) -> bool {
 /// Note that this feature may not be available on all Android versions.
 #[inline]
 pub fn get_service_debug_info() -> Result<Vec<ServiceDebugInfo>> {
-    default().get_service_debug_info()
+    default()?.get_service_debug_info()
 }

--- a/rsbinder/src/lib.rs
+++ b/rsbinder/src/lib.rs
@@ -73,7 +73,7 @@
 //!
 //! # fn main() -> Result<()> {
 //! // Initialize the process state
-//! ProcessState::init_default();
+//! ProcessState::init_default()?;
 //!
 //! // Start the thread pool
 //! ProcessState::start_thread_pool();
@@ -101,7 +101,7 @@
 //!
 //! # fn main() -> Result<()> {
 //! // Initialize the process state
-//! ProcessState::init_default();
+//! ProcessState::init_default()?;
 //!
 //! // Get service from service manager
 //! let service = hub::get_service("hello_service")?;
@@ -224,6 +224,6 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn process_state() {
-        ProcessState::init("/dev/binderfs/binder", 0);
+        ProcessState::init("/dev/binderfs/binder", 0).expect("init");
     }
 }

--- a/rsbinder/src/macros.rs
+++ b/rsbinder/src/macros.rs
@@ -311,13 +311,13 @@ macro_rules! declare_binder_interface {
     } => {
         $crate::declare_binder_interface! {
             $interface[$descriptor] {
-                @doc[concat!("A binder [`Remotable`]($crate::binder_impl::Remotable) that holds an [`", stringify!($interface), "`] object.")]
+                @doc[concat!("A binder `Remotable` that holds an [`", stringify!($interface), "`] object.")]
                 native: {
                     $native($on_transact),
                     $(adapter: $native_adapter,)?
                     $(r#async: $native_async,)?
                 },
-                @doc[concat!("A binder [`Proxy`]($crate::binder_impl::Proxy) that holds an [`", stringify!($interface), "`] remote interface.")]
+                @doc[concat!("A binder `Proxy` that holds an [`", stringify!($interface), "`] remote interface.")]
                 proxy: $proxy {
                     $($fname: $fty = $finit),*
                 },
@@ -405,7 +405,7 @@ macro_rules! declare_binder_interface {
             }
         }
 
-        impl $crate::parcelable::Serialize for dyn $interface
+        impl $crate::parcelable::Serialize for dyn $interface + '_
         where
             dyn $interface: $crate::Interface
         {
@@ -416,7 +416,7 @@ macro_rules! declare_binder_interface {
             }
         }
 
-        impl $crate::parcelable::SerializeOption for dyn $interface {
+        impl $crate::parcelable::SerializeOption for dyn $interface + '_ {
             fn serialize_option(this: Option<&Self>, parcel: &mut $crate::Parcel) -> $crate::Result<()> {
                 parcel.write(&this.map($crate::Interface::as_binder))
             }

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -145,6 +145,11 @@ impl<T: Clone + Default> ParcelData<T> {
 
     fn set_len(&mut self, len: usize) {
         match self {
+            // SAFETY: Vec::set_len requires `len <= capacity` and that the
+            // first `len` bytes are initialized. Element type is `u8`, so any
+            // byte pattern is a valid value; every caller reserves capacity
+            // and writes the bytes (copy_nonoverlapping) before calling this,
+            // so the caller must uphold `len <= capacity`.
             ParcelData::Vec(v) => unsafe { v.set_len(len) },
             _ => panic!("&[u8] can't support set_len()."),
         }
@@ -587,6 +592,11 @@ impl Parcel {
         let pos = self.pos;
 
         self.data.reserve(pos + padded);
+        // SAFETY: `reserve(pos + padded)` above guarantees the destination
+        // has at least `pos + padded` bytes of capacity, so `add(pos)` and
+        // the `size`-byte copy (size <= padded) stay in-bounds and the
+        // ranges do not overlap (distinct allocations). `set_len` only grows
+        // up to the just-reserved capacity over now-initialized `u8` bytes.
         unsafe {
             std::ptr::copy_nonoverlapping::<u8>(
                 parcelable.as_ptr() as _,
@@ -633,6 +643,9 @@ impl Parcel {
 
     pub(crate) fn write_aligned<T>(&mut self, val: &T) {
         let unaligned = std::mem::size_of::<T>();
+        // SAFETY: `val` is a live `&T`, so its `size_of::<T>()` bytes are
+        // valid to read as `u8` for the borrow's duration. The resulting
+        // slice does not outlive `val` (consumed synchronously below).
         let val_bytes: &[u8] =
             unsafe { std::slice::from_raw_parts(val as *const T as *const u8, unaligned) };
 
@@ -645,6 +658,11 @@ impl Parcel {
         let pos = self.pos;
 
         self.data.reserve(pos + aligned);
+        // SAFETY: `reserve(pos + aligned)` guarantees capacity for `add(pos)`
+        // and the `unaligned`-byte copy (unaligned <= aligned). Source `data`
+        // and the parcel buffer are distinct allocations (non-overlapping).
+        // `set_len` only grows up to the reserved capacity over `u8` bytes
+        // just initialized by the copy.
         unsafe {
             std::ptr::copy_nonoverlapping::<u8>(
                 data.as_ptr(),
@@ -775,6 +793,12 @@ impl Parcel {
         let num_objects = last_idx - first_idx + 1;
 
         self.data.reserve(self.pos + size);
+        // SAFETY: the source range `other.data[offset..offset + size]` is
+        // bounds-checked by the slice index above (panics if out of range),
+        // and `reserve(self.pos + size)` guarantees the destination has
+        // capacity for `add(self.pos)` plus `size` bytes. `other` and `self`
+        // are distinct parcels (non-overlapping). `set_len` only grows up to
+        // the reserved capacity over the `u8` bytes just copied.
         unsafe {
             std::ptr::copy_nonoverlapping::<u8>(
                 other.data.as_slice()[offset..offset + size].as_ptr(),
@@ -854,6 +878,10 @@ impl std::fmt::Debug for Parcel {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         writeln!(f, "Parcel: pos {}, len {}", self.pos, self.data.len())?;
         if self.objects.len() > 0 {
+            // SAFETY: `self.objects` is a live `Vec<binder_size_t>`, so its
+            // `len * size_of::<binder_size_t>()` bytes are a valid contiguous
+            // region readable as `u8`. The slice is consumed synchronously by
+            // `pretty_hex` and does not outlive the borrow of `self.objects`.
             let bytes: &[u8] = unsafe {
                 std::slice::from_raw_parts(
                     self.objects.as_ptr() as *const u8,

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -879,9 +879,7 @@ impl Drop for Parcel {
                     self.objects.as_ptr() as _,
                     self.objects.len(),
                 ) {
-                    log::error!(
-                        "Failed to free parcel buffer ({e}); leaking the kernel buffer"
-                    );
+                    log::error!("Failed to free parcel buffer ({e}); leaking the kernel buffer");
                 }
             }
             None => {

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -1126,4 +1126,43 @@ mod tests {
         assert_eq!(parcel.data_size(), 0);
         drop(parcel);
     }
+
+    // Hardening regression: `set_data_size` must reject a length larger
+    // than the backing buffer's capacity instead of entering the
+    // `Vec::set_len` UB of claiming uninitialized capacity. A broken
+    // driver/buffer contract is the untrusted-input source here.
+    #[test]
+    fn set_data_size_rejects_over_capacity() {
+        let mut parcel = Parcel::new();
+        let cap = parcel.capacity();
+
+        // Exactly at capacity is the boundary and must succeed.
+        assert!(parcel.set_data_size(cap).is_ok());
+        // One past capacity must be refused with BadValue, not panic/UB.
+        assert_eq!(parcel.set_data_size(cap + 1), Err(StatusCode::BadValue));
+        // Zero is always valid.
+        assert!(parcel.set_data_size(0).is_ok());
+    }
+
+    // Hardening regression: `data_avail` must saturate when the cursor
+    // has been moved past the end (`set_data_position` is unbounded).
+    // The pre-fix `len - pos` underflowed and panicked in debug builds
+    // on attacker-influenced positions.
+    #[test]
+    fn data_avail_saturates_when_pos_past_end() {
+        let mut parcel = Parcel::new();
+        parcel.write(&0u64).expect("write u64");
+        assert_eq!(parcel.data_avail(), 0, "cursor at end → nothing available");
+
+        parcel.set_data_position(0);
+        assert_eq!(parcel.data_avail(), 8, "8 bytes available from start");
+
+        // Cursor far past the end must not underflow-panic.
+        parcel.set_data_position(9999);
+        assert_eq!(
+            parcel.data_avail(),
+            0,
+            "saturating_sub, not underflow panic"
+        );
+    }
 }

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -286,11 +286,22 @@ impl Parcel {
         self.pos >= self.data.len()
     }
 
-    pub fn set_data_size(&mut self, new_len: usize) {
+    pub fn set_data_size(&mut self, new_len: usize) -> Result<()> {
+        if new_len > self.data.capacity() {
+            // The backing buffer cannot hold `new_len` bytes — a broken
+            // driver/buffer contract. Refuse rather than enter the
+            // `Vec::set_len` UB of claiming uninitialized capacity.
+            log::error!(
+                "set_data_size({new_len}) exceeds capacity {}",
+                self.data.capacity()
+            );
+            return Err(StatusCode::BadValue);
+        }
         self.data.set_len(new_len);
         if new_len < self.pos {
             self.pos = new_len;
         }
+        Ok(())
     }
 
     pub fn close_file_descriptors(&self) {
@@ -335,7 +346,10 @@ impl Parcel {
     }
 
     pub fn data_avail(&self) -> usize {
-        let result = self.data.len() - self.pos;
+        // `pos` can legitimately be moved past `len` (set_data_position is
+        // unbounded), so saturate instead of underflow-panicking: nothing
+        // is available once the cursor is at/after the end.
+        let result = self.data.len().saturating_sub(self.pos);
         assert!(result < i32::MAX as _, "data too big: {result}");
 
         result
@@ -855,17 +869,20 @@ impl Drop for Parcel {
     fn drop(&mut self) {
         match self.free_buffer {
             Some(free_buffer) => {
-                // Free buffer must succeed - if it fails, we have a critical system issue
-                // that will lead to resource leaks. Better to abort than continue in
-                // an inconsistent state.
-                free_buffer(
+                // Never panic in Drop: a failure here may run during unwind,
+                // and a double-panic aborts the whole process — strictly
+                // worse than logging and leaking the kernel buffer.
+                if let Err(e) = free_buffer(
                     Some(self),
                     self.data.as_ptr() as _,
                     self.data.len(),
                     self.objects.as_ptr() as _,
                     self.objects.len(),
-                )
-                .expect("Failed to free parcel buffer: critical system resource leak");
+                ) {
+                    log::error!(
+                        "Failed to free parcel buffer ({e}); leaking the kernel buffer"
+                    );
+                }
             }
             None => {
                 self.release_objects();

--- a/rsbinder/src/parcelable.rs
+++ b/rsbinder/src/parcelable.rs
@@ -373,6 +373,13 @@ macro_rules! impl_parcelable_struct {
         impl Deserialize for $ty {
             fn deserialize(parcel: &mut Parcel) -> Result<Self> {
                 const SIZE: usize = std::mem::size_of::<$ty>();
+                // SAFETY: this macro arm is only instantiated for the
+                // bindgen `#[repr(C)]` binder-ABI structs listed in the
+                // `parcelable_struct!` invocations below — plain-old-data
+                // (integers / unions / fixed arrays) with no invalid bit
+                // patterns, so every `[u8; SIZE]` is a valid `$ty`.
+                // `parcel.try_into()?` yields exactly `SIZE` initialized
+                // bytes (length-checked; returns Err otherwise).
                 Ok(unsafe { std::mem::transmute::<[u8; SIZE], $ty>(parcel.try_into()?) })
             }
         }

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -1378,26 +1378,14 @@ mod tests {
     /// released the lock by the time the obituary fires, so the
     /// re-acquisition succeeds.
     ///
-    /// The simulation injects the obituary call via the
-    /// `slow_path_p2_test_hook` cfg(test) entry hook (fired the
+    /// The simulation drives the slow path on a worker thread that
+    /// installs a `slow_path_p2` cfg(test) hook calling
+    /// `send_obituary_for_handle` from the same thread (fired the
     /// instant P1 releases the lock and before P2 enters IPC).
     /// Driving the obituary from the actual binder driver would
     /// require crashing a service mid-transact — too brittle for a
     /// unit test, and the lock semantics being tested are
     /// driver-independent.
-    ///
-    /// Wallclock-bounded so a regression manifests as a CI timeout
-    /// failure rather than an indefinite hang.
-    /// Plan §5.2 — same-thread re-entrant obituary regression guard.
-    ///
-    /// Drives the slow path on a worker thread that has installed a
-    /// `slow_path_p2` hook calling `send_obituary_for_handle` from
-    /// the same thread. Under non-reentrant `std::sync::RwLock`
-    /// write semantics, the hook's `handle_to_proxy.write()` call
-    /// would deadlock if the slow path were still holding the write
-    /// lock at the P2 entry point. The current three-phase split
-    /// releases the lock between P1 and P2, so the obituary
-    /// re-acquisition succeeds.
     ///
     /// Wallclock-bounded so a regression manifests as a CI timeout
     /// failure rather than an indefinite hang. The `fired` flag

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -36,6 +36,136 @@ fn undo_case_a_pin(handle: u32) {
     }
 }
 
+/// Plan computed under P1's write lock and consumed by P2/P3.
+///
+/// Drives the lock-decoupled three-phase slow path: the case decision
+/// is made under one short write-lock window, IPC runs with the lock
+/// released, and a second short write-lock window commits the cache
+/// entry while re-checking cross-thread races.
+enum SlowPathPlan {
+    /// Sub-case (a): entry absent at P1 time. P1 issued `BC_INCREFS`
+    /// then flushed, so this thread now owns the cache pin. P3 either
+    /// transfers ownership to the cache entry on insert, or undoes the
+    /// pin via [`undo_case_a_pin`] on failure / cross-thread race.
+    CaseA,
+    /// Sub-case (b): entry present at P1 time but its `weak` is
+    /// dangling. The cache pin remains owned by the existing entry —
+    /// this thread does not issue or own a pin. P1 snapshotted the
+    /// entry's descriptor and generation; P2 skips
+    /// `query_interface` (descriptor immutable for the binder_ref
+    /// slot's lifetime) and P3 resurrects under the same generation
+    /// when the snapshot still matches.
+    CaseB { descriptor: String, generation: u64 },
+}
+
+/// Outcome of P1: either we observed a live entry and the slow path
+/// is done, or we have a [`SlowPathPlan`] to drive P2/P3.
+enum SlowPathDecision {
+    /// Sub-case (c): another thread inserted/upgraded between the
+    /// read-fast-path miss and the P1 write-lock acquisition.
+    Cached(SIBinder),
+    /// Sub-cases (a)/(b) — proceed to P2 (IPC) and P3 (commit).
+    NeedIpc(SlowPathPlan),
+}
+
+/// Output of P2 — carries the descriptor each branch needs into P3,
+/// so the (CaseA, _) commit arms can consume the freshly-queried
+/// descriptor without going through an `Option<String>` that P3
+/// would otherwise have to runtime-`expect` for `(CaseA, None)`.
+enum SlowPathReady {
+    /// Sub-case (a) ready for commit: P2 issued `query_interface`
+    /// and obtained a fresh descriptor.
+    CaseA { descriptor: String },
+    /// Sub-case (b) ready for commit: descriptor and generation
+    /// snapshotted by P1, no IPC required in P2.
+    CaseB { descriptor: String, generation: u64 },
+}
+
+/// RAII guard that restores this thread's [`CallRestriction`] to its
+/// pre-call value when dropped. Applied around `ping_binder(0)` in
+/// P2 so an early-`Err` return or panic cannot leak
+/// [`CallRestriction::None`] into subsequent calls on this thread.
+struct RestoreCallRestriction(CallRestriction);
+
+impl Drop for RestoreCallRestriction {
+    fn drop(&mut self) {
+        thread_state::set_call_restriction(self.0);
+    }
+}
+
+// Test-only hook fired at the entry of `ProcessState::slow_path_p2`
+// (immediately after P1 releases the `handle_to_proxy` write lock
+// and before P2 issues any IPC). Used by the same-thread deadlock
+// regression test to invoke `send_obituary_for_handle` on the same
+// thread that is currently in the slow path — the pre-fix code held
+// the write lock across this point and would deadlock on the
+// obituary's `handle_to_proxy.write()` re-entry; the post-fix split
+// releases the lock during P2 so the obituary acquires it cleanly.
+// Empty-by-default; tests install a closure via
+// `set_slow_path_p2_test_hook`.
+#[cfg(test)]
+type SlowPathP2TestHook = Box<dyn FnMut(u32)>;
+
+#[cfg(test)]
+thread_local! {
+    static SLOW_PATH_P2_TEST_HOOK: std::cell::RefCell<Option<SlowPathP2TestHook>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn set_slow_path_p2_test_hook(hook: Option<SlowPathP2TestHook>) {
+    SLOW_PATH_P2_TEST_HOOK.with(|h| *h.borrow_mut() = hook);
+}
+
+#[cfg(test)]
+fn slow_path_p2_test_hook(handle: u32) {
+    // Take the closure out before invoking so the hook body can
+    // re-enter `strong_proxy_for_handle` (and thus this function)
+    // without a nested-borrow panic on the RefCell.
+    let hook = SLOW_PATH_P2_TEST_HOOK.with(|h| h.borrow_mut().take());
+    if let Some(mut hook) = hook {
+        hook(handle);
+        SLOW_PATH_P2_TEST_HOOK.with(|h| *h.borrow_mut() = Some(hook));
+    }
+}
+
+/// P3 commit primitive: acquire one kernel strong ref
+/// (`BC_ACQUIRE`) and insert (or replace) the cache entry. Caller
+/// holds the `handle_to_proxy` write lock.
+///
+/// `owns_case_a_pin` records whether *this thread* issued the
+/// case (a) `BC_INCREFS` pin during P1; on `new_acquired` failure it
+/// gates whether to undo our own pin. Case (b) and the cross-thread
+/// `(CaseA, Some(_))` race both pass `false` because the existing
+/// cache entry's pin is owned by the entry, not by us.
+fn commit_new_acquired(
+    handle_to_proxy: &mut HashMap<u32, CacheEntry>,
+    handle: u32,
+    descriptor: String,
+    generation: u64,
+    stability: Stability,
+    owns_case_a_pin: bool,
+) -> Result<SIBinder> {
+    let arc = match ProxyHandle::new_acquired(handle, descriptor.clone(), stability) {
+        Ok(arc) => arc,
+        Err(err) => {
+            if owns_case_a_pin {
+                undo_case_a_pin(handle);
+            }
+            return Err(err);
+        }
+    };
+    handle_to_proxy.insert(
+        handle,
+        CacheEntry {
+            weak: Arc::downgrade(&arc),
+            descriptor,
+            generation,
+        },
+    );
+    Ok(SIBinder::from_arc(arc as Arc<dyn IBinder>))
+}
+
 /// Per-handle cache entry under the cache-pin model.
 ///
 /// `weak` lets the process resurrect a fresh `Arc<ProxyHandle>` after the
@@ -48,6 +178,28 @@ fn undo_case_a_pin(handle: u32) {
 /// `handle_to_proxy`. The pin is acquired exactly once on first
 /// insertion (slow-path case (a)) and released exactly once on obituary
 /// teardown.
+///
+/// **Slow-path lock discipline.** The slow path is split into three
+/// phases (P1/P2/P3) so that the descriptor query (and the
+/// `ping_binder(0)` issued for service manager on Android sdk>=30)
+/// runs with `handle_to_proxy` *unlocked*. This is required for
+/// re-entrancy: the catch-all arm of `wait_for_response` dispatches
+/// `BR_DEAD_BINDER` to `execute_command`, which calls
+/// [`ProcessState::send_obituary_for_handle`] and re-acquires the
+/// same write lock. Holding the lock across IPC would deadlock under
+/// `std::sync::RwLock`'s non-reentrant write semantics.
+///
+/// To preserve the cache pin invariant under that split, P3 covers a
+/// race where another thread (T2) ran a complete case (a) during our
+/// P2 IPC and then dropped its `Arc`: when our P3 plan was CaseA but
+/// the cache slot is again "present + dangling weak", we have one
+/// spare BC_INCREFS pin (ours) on top of T2's cache-owned pin. P3
+/// undoes our pin and adopts T2's descriptor/generation, restoring
+/// "entry-1 ↔ pin-1". The companion `(CaseB, None)` arm — cache
+/// entry vanished mid-flight via obituary — returns `DeadObject`
+/// rather than racing BC_ACQUIRE against a freed binder_ref slot;
+/// this is the one window where the "BC_ACQUIRE precondition = pin
+/// alive" invariant could otherwise break.
 ///
 /// `generation` is a process-wide monotonic counter snapshotted at
 /// case-(a) insertion. It enables `WIBinder::upgrade()` to detect when
@@ -334,122 +486,240 @@ impl ProcessState {
             return Ok(SIBinder::from_arc(arc));
         }
 
-        // Write-lock slow path. Three sub-cases distinguished after taking
-        // the lock:
-        //   (a) entry absent          → BC_INCREFS pin + flush + query +
-        //                                 BC_ACQUIRE + insert
-        //   (b) entry present, dead   → reuse cached descriptor + BC_ACQUIRE
-        //                                 (cache pin still active)
-        //   (c) entry present, alive  → another thread won the race;
-        //                                 return its Arc
+        // Slow path: lock-decoupled three phases.
+        //
+        //   P1: short write-lock window. Decide the sub-case and, for
+        //        case (a), issue BC_INCREFS + flush so the cache pin
+        //        is live in the kernel before any IPC enters.
+        //        flush_commands is a write-only ioctl (read_size = 0),
+        //        so no BR_* — including BR_DEAD_BINDER — can be
+        //        dispatched while the lock is held; reentrant
+        //        send_obituary_for_handle paths only originate from
+        //        BR_DEAD_BINDER.
+        //   P2: lock released. IPC (ping_binder for handle 0 sdk>=30
+        //        and query_interface for case (a)) runs without the
+        //        handle_to_proxy lock held, so a re-entrant
+        //        BR_DEAD_BINDER → send_obituary_for_handle path can
+        //        take the lock without deadlocking against us.
+        //   P3: re-acquire write lock. Re-check case (c) and the
+        //        case (a)→(b) cross-thread race, undo any spare pin,
+        //        and commit the cache entry.
+        let plan = match self.slow_path_p1(handle)? {
+            SlowPathDecision::Cached(arc) => return Ok(arc),
+            SlowPathDecision::NeedIpc(plan) => plan,
+        };
+        let ready = self.slow_path_p2(handle, plan)?;
+        self.slow_path_p3(handle, stability, ready)
+    }
+
+    /// Slow-path phase 1: short write-lock window that decides the
+    /// sub-case and, for case (a), issues the kernel cache pin
+    /// (`BC_INCREFS` + `flush_commands`) before releasing the lock.
+    fn slow_path_p1(&self, handle: u32) -> Result<SlowPathDecision> {
+        // Write lock — even though P1 only reads, holding the write
+        // lock here prevents two concurrent slow paths from both
+        // observing "absent" and producing two case-(a) commits with
+        // distinct generations. The write lock serializes the
+        // BC_INCREFS issue point.
+        let handle_to_proxy = self
+            .handle_to_proxy
+            .write()
+            .expect("Handle to proxy lock poisoned");
+
+        // Sub-case (c): another thread inserted/upgraded between the
+        // read-fast-path miss and this write-lock acquisition.
+        if let Some(arc) = handle_to_proxy.get(&handle).and_then(|e| e.weak.upgrade()) {
+            return Ok(SlowPathDecision::Cached(SIBinder::from_arc(arc)));
+        }
+
+        // Sub-case (b): entry present with dangling weak. Snapshot the
+        // descriptor/generation; the cache pin (BC_INCREFS issued at
+        // first insertion) is still active so P3's BC_ACQUIRE will
+        // succeed without needing a new pin.
+        if let Some(entry) = handle_to_proxy.get(&handle) {
+            return Ok(SlowPathDecision::NeedIpc(SlowPathPlan::CaseB {
+                descriptor: entry.descriptor.clone(),
+                generation: entry.generation,
+            }));
+        }
+
+        // Sub-case (a): entry absent. Pin the kernel binder_ref slot
+        // here, under the lock, so that:
+        //   - the pin is observable in the kernel before P2 runs any
+        //     transaction on this handle (BC_ACQUIRE in P3 cannot
+        //     race against a freed binder_ref slot);
+        //   - concurrent slow paths cannot both observe "absent" and
+        //     thus collapse onto the (CaseA, Some(_)) race in P3
+        //     instead of producing two true case-(a) commits.
+        //
+        // BC_INCREFS + flush_commands inside the lock is safe —
+        // talk_with_driver(false) sets read_size = 0 so no BR_* are
+        // dispatched, including BR_DEAD_BINDER.
+        thread_state::inc_weak_handle(handle)?;
+        if let Err(err) = thread_state::flush_commands() {
+            log::warn!(
+                "BC_INCREFS for handle {handle} failed at flush: {err:?}; \
+                 handle is no longer valid in the kernel"
+            );
+            return Err(StatusCode::DeadObject);
+        }
+        Ok(SlowPathDecision::NeedIpc(SlowPathPlan::CaseA))
+    }
+
+    /// Slow-path phase 2: lock-released IPC.
+    ///
+    /// Performs `ping_binder(0)` for `handle == 0 && sdk_at_least(30)`
+    /// and, for [`SlowPathPlan::CaseA`], `query_interface(handle)`.
+    /// On any IPC failure, undoes our case (a) pin (if owned) before
+    /// propagating the error.
+    fn slow_path_p2(&self, handle: u32, plan: SlowPathPlan) -> Result<SlowPathReady> {
+        // P2 entry hook (test-only). Used by the same-thread deadlock
+        // regression test to fire `send_obituary_for_handle(handle)`
+        // from inside the slow path while the `handle_to_proxy` lock
+        // is released — the exact scenario that used to deadlock under
+        // the monolithic pre-fix slow path.
+        #[cfg(test)]
+        slow_path_p2_test_hook(handle);
+
+        if handle == 0 && crate::sdk_at_least(30) {
+            // RAII restore so a ping failure can't leak
+            // CallRestriction::None into later calls on this thread.
+            let _restore = RestoreCallRestriction(thread_state::call_restriction());
+            thread_state::set_call_restriction(CallRestriction::None);
+            if let Err(err) = thread_state::ping_binder(handle) {
+                if matches!(plan, SlowPathPlan::CaseA) {
+                    undo_case_a_pin(handle);
+                }
+                return Err(err);
+            }
+        }
+        match plan {
+            SlowPathPlan::CaseA => match thread_state::query_interface(handle) {
+                Ok(descriptor) => Ok(SlowPathReady::CaseA { descriptor }),
+                Err(err) => {
+                    undo_case_a_pin(handle);
+                    Err(err)
+                }
+            },
+            SlowPathPlan::CaseB {
+                descriptor,
+                generation,
+            } => Ok(SlowPathReady::CaseB {
+                descriptor,
+                generation,
+            }),
+        }
+    }
+
+    /// Slow-path phase 3: short write-lock window that re-checks
+    /// races spawned during P2 and commits the cache entry.
+    ///
+    /// Race resolution table (P2 ready × cache state at P3):
+    ///
+    /// | ready  | cached at P3 | action                                              |
+    /// |--------|--------------|-----------------------------------------------------|
+    /// | (any)  | live entry   | drop our work; if CaseA, undo our pin               |
+    /// | CaseA  | None         | standard commit; new generation                     |
+    /// | CaseA  | Some(_)      | undo our pin; commit using cached desc/gen          |
+    /// | CaseB  | None         | DeadObject (cache pin gone — BC_ACQUIRE unsafe)     |
+    /// | CaseB  | Some, gen=   | resurrect under same generation                     |
+    /// | CaseB  | Some, gen≠   | adopt new entry's desc/gen                          |
+    fn slow_path_p3(
+        &self,
+        handle: u32,
+        stability: Stability,
+        ready: SlowPathReady,
+    ) -> Result<SIBinder> {
         let mut handle_to_proxy = self
             .handle_to_proxy
             .write()
             .expect("Handle to proxy lock poisoned");
 
-        // Sub-case (c): another thread inserted/upgraded between our
-        // read-fast-path miss and write-lock acquisition.
+        // Re-check (c): a concurrent slow path completed during our
+        // P2 IPC. Our work is redundant.
         if let Some(arc) = handle_to_proxy.get(&handle).and_then(|e| e.weak.upgrade()) {
+            if matches!(ready, SlowPathReady::CaseA { .. }) {
+                undo_case_a_pin(handle);
+            }
             return Ok(SIBinder::from_arc(arc));
         }
 
-        // Distinguish (a) vs (b). On (b) the entry is present (with a
-        // dangling weak) and we reuse the cached descriptor; the cache
-        // pin (BC_INCREFS) issued at first insertion is still active so
-        // BC_ACQUIRE below will succeed. On (a) the entry is absent — we
-        // pin first, then query, then insert.
-        //
-        // Generation handling:
-        //   - Case (a): allocate a fresh generation (new BC_INCREFS pin
-        //     means a fresh kernel binder_ref slot from the user's POV;
-        //     even if the handle id is being recycled in the kernel,
-        //     the generation snapshot held by any old WIBinder will not
-        //     match, correctly returning DeadObject on resurrection).
-        //   - Case (b): preserve the existing entry's generation —
-        //     same kernel slot (cache pin held), same binder_node,
-        //     same descriptor; this is just user-space resurrection.
         let cached = handle_to_proxy
             .get(&handle)
             .map(|e| (e.descriptor.clone(), e.generation));
 
-        if handle == 0 && crate::sdk_at_least(30) {
-            let original_call_restriction = thread_state::call_restriction();
-            thread_state::set_call_restriction(CallRestriction::None);
-            thread_state::ping_binder(handle)?;
-            thread_state::set_call_restriction(original_call_restriction);
+        match (ready, cached) {
+            (SlowPathReady::CaseA { descriptor }, None) => {
+                // Standard case (a): fresh entry, fresh generation.
+                let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+                commit_new_acquired(
+                    &mut handle_to_proxy,
+                    handle,
+                    descriptor,
+                    generation,
+                    stability,
+                    true,
+                )
+            }
+            (SlowPathReady::CaseA { .. }, Some((cached_desc, cached_gen))) => {
+                // Cross-thread race: while P2 ran, another thread
+                // (T2) completed a case (a) for this handle and then
+                // dropped its Arc, leaving the entry present + weak
+                // dead. T2's BC_INCREFS pin is owned by the cache
+                // entry; ours is spare. Undo ours so the
+                // "entry-1 ↔ pin-1" invariant holds, then resurrect
+                // under T2's descriptor/generation.
+                undo_case_a_pin(handle);
+                commit_new_acquired(
+                    &mut handle_to_proxy,
+                    handle,
+                    cached_desc,
+                    cached_gen,
+                    stability,
+                    false,
+                )
+            }
+            (
+                SlowPathReady::CaseB {
+                    descriptor,
+                    generation,
+                },
+                Some((_, cached_gen)),
+            ) if cached_gen == generation => {
+                // CaseB confirmed: same entry, same generation. The
+                // cache pin from first insertion is still active.
+                commit_new_acquired(
+                    &mut handle_to_proxy,
+                    handle,
+                    descriptor,
+                    generation,
+                    stability,
+                    false,
+                )
+            }
+            (SlowPathReady::CaseB { .. }, Some((cached_desc, cached_gen))) => {
+                // Generation differs: original entry was obituary'd
+                // and a new case (a) installed a fresh slot during
+                // P2. Drop our CaseB plan and follow the new entry.
+                commit_new_acquired(
+                    &mut handle_to_proxy,
+                    handle,
+                    cached_desc,
+                    cached_gen,
+                    stability,
+                    false,
+                )
+            }
+            (SlowPathReady::CaseB { .. }, None) => {
+                // Cache entry vanished mid-flight (obituary). The
+                // pin we relied on for BC_ACQUIRE may be gone.
+                // Surfacing DeadObject is safer than racing
+                // BC_ACQUIRE against a freed binder_ref slot — the
+                // user's contract is to re-resolve through service
+                // manager, identical to BR_DEAD_BINDER recovery.
+                Err(StatusCode::DeadObject)
+            }
         }
-
-        let (descriptor, generation) = match cached {
-            Some((desc, gen)) => {
-                // Sub-case (b): entry present, dead Arc. Skip BC_INCREFS
-                // (would double-pin) and skip INTERFACE_TRANSACTION
-                // (descriptor immutable for the binder_ref slot's
-                // lifetime). Preserve the existing generation.
-                (desc, gen)
-            }
-            None => {
-                // Sub-case (a): entry absent. Pin the kernel binder_ref
-                // slot before the (potentially failing) descriptor query.
-                //
-                // Step 1: queue BC_INCREFS on this thread's out-parcel.
-                thread_state::inc_weak_handle(handle)?;
-                // Step 2: flush so the kernel observes BC_INCREFS now.
-                // If the kernel has already freed binder_ref(handle) —
-                // recycled handle id, never-valid id, etc. — the ioctl
-                // returns -EINVAL and we propagate `DeadObject` without
-                // touching the cache. Subsequent re-resolution through
-                // service manager is the user's contract (same as after
-                // BR_DEAD_BINDER).
-                if let Err(err) = thread_state::flush_commands() {
-                    log::warn!(
-                        "BC_INCREFS for handle {handle} failed at flush: {err:?}; \
-                         handle is no longer valid in the kernel"
-                    );
-                    return Err(StatusCode::DeadObject);
-                }
-                // Step 3: pin is live in the kernel. Query the interface
-                // descriptor. On failure we MUST undo the pin so the
-                // kernel does not leak a binder_ref slot.
-                let desc = match thread_state::query_interface(handle) {
-                    Ok(s) => s,
-                    Err(err) => {
-                        undo_case_a_pin(handle);
-                        return Err(err);
-                    }
-                };
-                let gen = self.next_generation.fetch_add(1, Ordering::Relaxed);
-                (desc, gen)
-            }
-        };
-
-        // Allocate ProxyHandle + acquire kernel strong ref. The cache pin
-        // (already held for case (b), or freshly issued+flushed above for
-        // case (a)) guarantees binder_ref(handle) is alive at this moment,
-        // so BC_ACQUIRE succeeds.
-        //
-        // If `new_acquired` fails we MUST undo the case (a) pin (case (b)'s
-        // pin was issued at first insertion and is still owned by the
-        // existing cache entry, which we leave intact). Distinguishing the
-        // two cases is exactly `!handle_to_proxy.contains_key(&handle)` —
-        // case (a) entered with no entry, case (b) entered with one.
-        let arc = match ProxyHandle::new_acquired(handle, descriptor.clone(), stability) {
-            Ok(arc) => arc,
-            Err(err) => {
-                if !handle_to_proxy.contains_key(&handle) {
-                    undo_case_a_pin(handle);
-                }
-                return Err(err);
-            }
-        };
-        handle_to_proxy.insert(
-            handle,
-            CacheEntry {
-                weak: Arc::downgrade(&arc),
-                descriptor,
-                generation,
-            },
-        );
-        Ok(SIBinder::from_arc(arc as Arc<dyn IBinder>))
     }
 
     /// Snapshot the cache entry's generation for `handle`, if present.
@@ -544,6 +814,19 @@ impl ProcessState {
     /// cache pin) is performed by `release_obituary_pin`, called from
     /// `thread_state::execute_command`'s BR_DEAD_BINDER arm AFTER
     /// BC_DEAD_BINDER_DONE has been queued.
+    ///
+    /// # Reentrancy with the slow path
+    ///
+    /// `wait_for_response`'s catch-all arm dispatches
+    /// `BR_DEAD_BINDER` to `execute_command`, which calls this
+    /// method on the same thread that issued the originating
+    /// transaction — including a thread currently inside
+    /// [`Self::strong_proxy_for_handle_stability`]. Under
+    /// `std::sync::RwLock`'s non-reentrant write semantics, the
+    /// `handle_to_proxy.write()` taken here would deadlock if the
+    /// slow path were holding that lock across IPC; the slow path's
+    /// P1/P2/P3 split keeps the lock released during all IPC for
+    /// exactly this reason.
     ///
     /// # Borrow discipline (R1)
     ///
@@ -991,6 +1274,196 @@ mod tests {
     fn test_process_state_strong_proxy_for_handle() {
         let process = ProcessState::init_default();
         assert!(process.strong_proxy_for_handle(0).is_ok());
+    }
+
+    /// N threads racing on the same uncached handle (service manager =
+    /// 0) must converge on a single cache entry and a single `Arc`
+    /// identity. Exercises the lock-decoupled three-phase slow path's
+    /// race-resolution table — at most one P3 winner installs the
+    /// entry, every other thread either short-circuits in P1's case
+    /// (c) re-check, P3's case (c) re-check, or P3's
+    /// `(CaseA, Some(_))` cross-thread arm.
+    #[test]
+    fn test_concurrent_strong_proxy_same_handle_returns_same_arc() {
+        let _ = ProcessState::init_default();
+        let handles: Vec<_> = (0..8)
+            .map(|_| std::thread::spawn(|| ProcessState::as_self().strong_proxy_for_handle(0)))
+            .collect();
+        let arcs: Vec<SIBinder> = handles
+            .into_iter()
+            .map(|h| {
+                h.join()
+                    .expect("thread panic")
+                    .expect("strong_proxy failed")
+            })
+            .collect();
+        let first = &arcs[0];
+        for a in &arcs[1..] {
+            assert_eq!(
+                first, a,
+                "concurrent slow-path winners must share a single Arc"
+            );
+        }
+        // Exactly one cache entry for this handle.
+        let map = ProcessState::as_self()
+            .handle_to_proxy
+            .read()
+            .expect("Handle to proxy lock poisoned");
+        assert!(
+            map.contains_key(&0),
+            "case (a) winner must have installed an entry for handle 0"
+        );
+    }
+
+    /// Drop all live `Arc<ProxyHandle>` for handle 0 so the cache
+    /// entry's `weak` is dangling, then race N threads through the
+    /// resurrection path. Each thread observes case (b) in P1 (entry
+    /// present, weak dead) and races to commit in P3 — only one
+    /// winner; the rest fall through P3's case (c) re-check and reuse
+    /// the winner's Arc. Verifies the case (b) generation-preservation
+    /// invariant survives concurrent resurrection.
+    #[test]
+    fn test_concurrent_strong_proxy_case_b_resurrection() {
+        let _ = ProcessState::init_default();
+        // Force a cache entry to exist for handle 0.
+        let initial = ProcessState::as_self()
+            .strong_proxy_for_handle(0)
+            .expect("initial strong_proxy failed");
+        let initial_gen = ProcessState::as_self()
+            .cache_generation_for(0)
+            .expect("entry must exist for handle 0");
+        // Drop all strong refs to make `weak` dangling.
+        drop(initial);
+        // Yield so any other Arc borrowers (e.g. `context_manager`
+        // cache) settle. In a clean test process there are no other
+        // strong refs to handle 0 by this point.
+        std::thread::yield_now();
+
+        let handles: Vec<_> = (0..8)
+            .map(|_| std::thread::spawn(|| ProcessState::as_self().strong_proxy_for_handle(0)))
+            .collect();
+        let arcs: Vec<SIBinder> = handles
+            .into_iter()
+            .map(|h| {
+                h.join()
+                    .expect("thread panic")
+                    .expect("strong_proxy failed")
+            })
+            .collect();
+        let first = &arcs[0];
+        for a in &arcs[1..] {
+            assert_eq!(
+                first, a,
+                "concurrent case (b) resurrection must produce a single Arc"
+            );
+        }
+        // Generation preserved (case (b) reuses the existing entry's
+        // generation; a fresh case (a) would have allocated a new one).
+        assert_eq!(
+            ProcessState::as_self().cache_generation_for(0),
+            Some(initial_gen),
+            "case (b) resurrection must preserve the entry's generation"
+        );
+    }
+
+    /// Plan §5.2 — same-thread re-entrant obituary regression guard.
+    ///
+    /// Reproduces the exact deadlock the P1/P2/P3 split closes:
+    /// while the slow path is mid-flight, a `BR_DEAD_BINDER` for the
+    /// same handle dispatches `send_obituary_for_handle` on the
+    /// *same* thread, which re-acquires `handle_to_proxy.write()`.
+    /// Under the pre-fix monolithic slow path that lock was already
+    /// held by this thread → `std::sync::RwLock`'s non-reentrant
+    /// write semantics → hang. Under the post-fix split P1 has
+    /// released the lock by the time the obituary fires, so the
+    /// re-acquisition succeeds.
+    ///
+    /// The simulation injects the obituary call via the
+    /// `slow_path_p2_test_hook` cfg(test) entry hook (fired the
+    /// instant P1 releases the lock and before P2 enters IPC).
+    /// Driving the obituary from the actual binder driver would
+    /// require crashing a service mid-transact — too brittle for a
+    /// unit test, and the lock semantics being tested are
+    /// driver-independent.
+    ///
+    /// Wallclock-bounded so a regression manifests as a CI timeout
+    /// failure rather than an indefinite hang.
+    /// Plan §5.2 — same-thread re-entrant obituary regression guard.
+    ///
+    /// Drives the slow path on a worker thread that has installed a
+    /// `slow_path_p2` hook calling `send_obituary_for_handle` from
+    /// the same thread. Under non-reentrant `std::sync::RwLock`
+    /// write semantics, the hook's `handle_to_proxy.write()` call
+    /// would deadlock if the slow path were still holding the write
+    /// lock at the P2 entry point. The current three-phase split
+    /// releases the lock between P1 and P2, so the obituary
+    /// re-acquisition succeeds.
+    ///
+    /// Wallclock-bounded so a regression manifests as a CI timeout
+    /// failure rather than an indefinite hang. The `fired` flag
+    /// asserts the hook actually ran — required because the
+    /// process-wide singleton `ProcessState` is shared with other
+    /// parallel tests, and a sibling test holding an `Arc` for
+    /// handle 0 could keep the cache `Weak` upgradeable, causing P1
+    /// to short-circuit at case (c) and the hook to never fire
+    /// (vacuous pass).
+    #[test]
+    fn test_strong_proxy_under_same_thread_dead_binder_no_deadlock() {
+        let process = ProcessState::init_default();
+
+        // Seed handle 0 (service manager) into the cache, then drop
+        // so the next lookup hits case (b) — entry present, weak
+        // dead. Case (b) lets us exercise the lock pattern without
+        // having to issue a fresh BC_INCREFS that the kernel might
+        // reject mid-test.
+        let seed = process
+            .strong_proxy_for_handle(0)
+            .expect("seed strong_proxy_for_handle(0) must succeed");
+        drop(seed);
+
+        let fired = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let fired_w = std::sync::Arc::clone(&fired);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let join = std::thread::spawn(move || {
+            // Hook is thread-local: install on the worker so the
+            // injected obituary fires on the same thread that is
+            // running strong_proxy_for_handle.
+            super::set_slow_path_p2_test_hook(Some(Box::new(move |handle| {
+                fired_w.store(true, std::sync::atomic::Ordering::SeqCst);
+                ProcessState::as_self()
+                    .send_obituary_for_handle(handle)
+                    .expect("send_obituary_for_handle from P2 hook must not fail");
+            })));
+            let r = ProcessState::as_self().strong_proxy_for_handle(0);
+            super::set_slow_path_p2_test_hook(None);
+            tx.send(r).expect("result channel must not drop");
+        });
+
+        // Wallclock bound: regression in the lock structure manifests
+        // as an indefinite hang here.
+        let result = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("strong_proxy_for_handle must complete within 5s — deadlock regression");
+        join.join().expect("worker thread must not panic");
+
+        assert!(
+            fired.load(std::sync::atomic::Ordering::SeqCst),
+            "P2 hook never fired — P1 short-circuited at case (c), most likely \
+             because a parallel test held an Arc for handle 0 and kept the \
+             cache Weak upgradeable. Test passed vacuously."
+        );
+
+        // Either outcome is acceptable — what we are guarding
+        // against is the deadlock, not the resolution. After the
+        // obituary, P3's (CaseB, None) arm normally returns
+        // DeadObject; a parallel resurrection might also produce a
+        // live Arc.
+        match result {
+            Ok(_arc) => {}
+            Err(StatusCode::DeadObject) => {}
+            Err(other) => panic!("unexpected slow-path result: {other:?}"),
+        }
     }
 
     #[test]

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -272,6 +272,11 @@ struct MemoryMap {
     ptr: *mut c_void,
     size: usize,
 }
+// SAFETY: `ptr` is a PROT_READ binder mapping owned for the whole
+// ProcessState lifetime. It is never written through and never read as
+// Rust data (the binder driver manages the pages); the only use is the
+// single `munmap(ptr, size)` in ProcessState::drop. No data race is
+// possible, so the handle is safe to send and share across threads.
 unsafe impl Sync for MemoryMap {}
 unsafe impl Send for MemoryMap {}
 
@@ -353,14 +358,13 @@ impl ProcessState {
         let vm_size = (1024 * 1024) - rustix::param::page_size() * 2;
         // let vm_size = std::num::NonZeroUsize::new(vm_size).ok_or("vm_size is zero!")?;
 
+        // SAFETY: `mmap` is unsafe because it creates a new mapping. `driver`
+        // is a live, open binder device fd; `vm_size > 0`; addr is null so
+        // the kernel chooses the address; PROT_READ + MAP_PRIVATE means the
+        // region is never written through this pointer; offset 0 is the
+        // binder ABI contract. The result is `?`-checked, and the mapping is
+        // unmapped exactly once in ProcessState::drop.
         let mmap = unsafe {
-            // let vm_start = nix::sys::mman::mmap(None,
-            //     vm_size,
-            //     nix::sys::mman::ProtFlags::PROT_READ,
-            //     nix::sys::mman::MapFlags::MAP_PRIVATE | nix::sys::mman::MapFlags::MAP_NORESERVE,
-            //     &driver,
-            //     0)?;
-
             let vm_start = rustix::mm::mmap(
                 std::ptr::null_mut(),
                 vm_size,
@@ -1244,6 +1248,10 @@ fn open_driver(
 impl Drop for ProcessState {
     fn drop(self: &mut ProcessState) {
         let mmap = self.mmap.read().expect("Mmap lock poisoned");
+        // SAFETY: `mmap.ptr`/`mmap.size` are exactly the address and length
+        // returned by the `mmap` call in `ProcessState::new`. This runs only
+        // in `Drop`, so the mapping is still live and is unmapped exactly
+        // once; no references into the region outlive `ProcessState`.
         unsafe {
             rustix::mm::munmap(mmap.ptr, mmap.size).expect("Failed to unmap memory");
         }

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -421,8 +421,8 @@ impl ProcessState {
     /// Initialize ProcessState with default binder path and max threads.
     /// The meaning of zero max threads is to use the default value. It is dependent on the kernel.
     /// DEFAULT_BINDER_PATH is "/dev/binderfs/binder".
-    pub fn init_default(
-    ) -> std::result::Result<&'static ProcessState, Box<dyn std::error::Error>> {
+    pub fn init_default() -> std::result::Result<&'static ProcessState, Box<dyn std::error::Error>>
+    {
         let path = if Path::new(crate::DEFAULT_BINDER_PATH).exists() {
             crate::DEFAULT_BINDER_PATH
         } else {

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -402,21 +402,27 @@ impl ProcessState {
     /// Initialize ProcessState with binder path and max threads.
     /// The meaning of zero max threads is to use the default value. It is dependent on the kernel.
     /// If you want to use the default binder path, use init_default().
-    pub fn init(driver_name: &str, max_threads: u32) -> &'static ProcessState {
-        // TODO: panic! is not good. It should return Result.
-        // But, get_or_try_init is not stable yet.
-        Self::instance().get_or_init(|| match Self::inner_init(driver_name, max_threads) {
-            Ok(instance) => instance,
-            Err(e) => {
-                panic!("Error in init(): {e}");
-            }
-        })
+    pub fn init(
+        driver_name: &str,
+        max_threads: u32,
+    ) -> std::result::Result<&'static ProcessState, Box<dyn std::error::Error>> {
+        let cell = Self::instance();
+        if let Some(existing) = cell.get() {
+            return Ok(existing);
+        }
+        // Build outside the cell so a failed init is NOT cached: a later
+        // call can retry (this is why `get_or_try_init`, still unstable,
+        // is avoided). If two threads race here, `get_or_init` keeps the
+        // first stored instance and the extra one is dropped.
+        let instance = Self::inner_init(driver_name, max_threads)?;
+        Ok(cell.get_or_init(|| instance))
     }
 
     /// Initialize ProcessState with default binder path and max threads.
     /// The meaning of zero max threads is to use the default value. It is dependent on the kernel.
     /// DEFAULT_BINDER_PATH is "/dev/binderfs/binder".
-    pub fn init_default() -> &'static ProcessState {
+    pub fn init_default(
+    ) -> std::result::Result<&'static ProcessState, Box<dyn std::error::Error>> {
         let path = if Path::new(crate::DEFAULT_BINDER_PATH).exists() {
             crate::DEFAULT_BINDER_PATH
         } else {
@@ -1264,7 +1270,7 @@ mod tests {
 
     #[test]
     fn test_process_state() {
-        let process = ProcessState::init_default();
+        let process = ProcessState::init_default().expect("init_default");
         assert_eq!(process.max_threads, DEFAULT_MAX_BINDER_THREADS);
         assert_eq!(
             process.driver_name,
@@ -1274,13 +1280,13 @@ mod tests {
 
     #[test]
     fn test_process_state_context_object() {
-        let process = ProcessState::init_default();
+        let process = ProcessState::init_default().expect("init_default");
         assert!(process.context_object().is_ok());
     }
 
     #[test]
     fn test_process_state_strong_proxy_for_handle() {
-        let process = ProcessState::init_default();
+        let process = ProcessState::init_default().expect("init_default");
         assert!(process.strong_proxy_for_handle(0).is_ok());
     }
 
@@ -1405,7 +1411,7 @@ mod tests {
     /// (vacuous pass).
     #[test]
     fn test_strong_proxy_under_same_thread_dead_binder_no_deadlock() {
-        let process = ProcessState::init_default();
+        let process = ProcessState::init_default().expect("init_default");
 
         // Seed handle 0 (service manager) into the cache, then drop
         // so the next lookup hits case (b) — entry present, weak
@@ -1464,7 +1470,7 @@ mod tests {
 
     #[test]
     fn test_process_state_disable_background_scheduling() {
-        let process = ProcessState::init_default();
+        let process = ProcessState::init_default().expect("init_default");
         process.disable_background_scheduling(true);
         assert!(process.background_scheduling_disabled());
     }
@@ -1545,7 +1551,7 @@ mod tests {
     ///      `None`.
     #[test]
     fn test_native_uaf_window_closed() {
-        let process = ProcessState::init_default();
+        let process = ProcessState::init_default().expect("init_default");
         let arc: Arc<dyn IBinder> = Arc::new(MockNative);
 
         let id = process.publish_native(Arc::clone(&arc));
@@ -1597,7 +1603,7 @@ mod tests {
     /// the last `release` fires.
     #[test]
     fn test_native_dedup_same_arc() {
-        let process = ProcessState::init_default();
+        let process = ProcessState::init_default().expect("init_default");
         let arc: Arc<dyn IBinder> = Arc::new(MockNative);
 
         let id1 = process.publish_native(Arc::clone(&arc));
@@ -1629,7 +1635,7 @@ mod tests {
     /// allocation, not type).
     #[test]
     fn test_native_distinct_arcs_get_distinct_ids() {
-        let process = ProcessState::init_default();
+        let process = ProcessState::init_default().expect("init_default");
         let arc_a: Arc<dyn IBinder> = Arc::new(MockNative);
         let arc_b: Arc<dyn IBinder> = Arc::new(MockNative);
         assert!(!Arc::ptr_eq(&arc_a, &arc_b));
@@ -1652,7 +1658,7 @@ mod tests {
     /// previously-published binder back to its publisher.
     #[test]
     fn test_native_lookup_does_not_change_counts() {
-        let process = ProcessState::init_default();
+        let process = ProcessState::init_default().expect("init_default");
         let arc: Arc<dyn IBinder> = Arc::new(MockNative);
         let id = process.publish_native(Arc::clone(&arc));
 

--- a/rsbinder/src/status.rs
+++ b/rsbinder/src/status.rs
@@ -216,7 +216,19 @@ impl From<ExceptionCode> for StatusCode {
 
 impl From<Status> for StatusCode {
     fn from(status: Status) -> Self {
-        status.code
+        // A Status that carries an exception must never collapse to `Ok`.
+        // An application-level exception (e.g. IllegalArgument) with an
+        // `Ok` status code means "no transaction error, but the call did
+        // not succeed" — surface it as FailedTransaction so callers that
+        // map this into a `Result` cannot end up with `Err(StatusCode::Ok)`.
+        // The success path (exception None) and real error codes
+        // (TransactionFailed / ServiceSpecific) are preserved unchanged.
+        match status.code {
+            StatusCode::Ok if status.exception != ExceptionCode::None => {
+                StatusCode::FailedTransaction
+            }
+            code => code,
+        }
     }
 }
 
@@ -251,6 +263,12 @@ impl From<StatusCode> for Status {
 
 impl Serialize for Status {
     fn serialize(&self, parcel: &mut Parcel) -> error::Result<()> {
+        // Mirrors AOSP `Status::writeToParcel`: on EX_TRANSACTION_FAILED
+        // the binder layer already failed, so nothing is written and the
+        // status code is returned via the error channel rather than as
+        // wire data. This is intentionally indistinguishable from a real
+        // parcel-write failure — same as libbinder ("not going to even
+        // try returning rich error data").
         if self.exception == ExceptionCode::TransactionFailed {
             return Err(self.code);
         }

--- a/rsbinder/src/status.rs
+++ b/rsbinder/src/status.rs
@@ -451,4 +451,52 @@ mod tests {
 
         Ok(())
     }
+
+    // Regression: a Status that carries an application-level exception
+    // but an `Ok` status code must never collapse to `StatusCode::Ok`.
+    // Callers map this into a `Result`, so an `Err(StatusCode::Ok)`
+    // would be a silent success that wasn't one.
+    #[test]
+    fn status_with_exception_never_maps_to_ok() {
+        let status = Status::new(ExceptionCode::IllegalArgument, StatusCode::Ok, None);
+        assert_eq!(
+            StatusCode::from(status),
+            StatusCode::FailedTransaction,
+            "exception + Ok code must surface as FailedTransaction, not Ok"
+        );
+
+        // Success path: no exception, Ok code → preserved as Ok.
+        let ok = Status::new(ExceptionCode::None, StatusCode::Ok, None);
+        assert_eq!(StatusCode::from(ok), StatusCode::Ok);
+
+        // Real error codes are preserved unchanged.
+        let svc = Status::from(StatusCode::ServiceSpecific(7));
+        assert_eq!(StatusCode::from(svc), StatusCode::ServiceSpecific(7));
+        let txn = Status::new(
+            ExceptionCode::TransactionFailed,
+            StatusCode::DeadObject,
+            None,
+        );
+        assert_eq!(StatusCode::from(txn), StatusCode::DeadObject);
+    }
+
+    // Regression: `Serialize for Status` mirrors AOSP
+    // `Status::writeToParcel` — on EX_TRANSACTION_FAILED nothing is
+    // written and the code is returned via the error channel instead
+    // of as wire data.
+    #[test]
+    fn serialize_transaction_failed_returns_err_without_writing() {
+        let status = Status::new(
+            ExceptionCode::TransactionFailed,
+            StatusCode::DeadObject,
+            None,
+        );
+        let mut parcel = Parcel::new();
+        assert_eq!(status.serialize(&mut parcel), Err(StatusCode::DeadObject));
+        assert_eq!(
+            parcel.data_size(),
+            0,
+            "nothing must be written on the failed path"
+        );
+    }
 }

--- a/rsbinder/src/sys/mod.rs
+++ b/rsbinder/src/sys/mod.rs
@@ -8,6 +8,11 @@
     non_snake_case,
     unused_qualifications
 )]
+// `missing_safety_doc` is allowed for the bindgen-generated `sys.rs`
+// below: it emits many `pub unsafe fn` FFI bindings without `# Safety`
+// rustdoc and is not hand-editable. The hand-written ioctl wrappers in
+// this module are safe `pub(crate) fn`, so the lint does not apply to
+// them; their inner `unsafe` blocks carry explicit SAFETY comments.
 #![allow(clippy::unreadable_literal, clippy::missing_safety_doc)]
 
 include!("sys.rs");
@@ -91,13 +96,24 @@ pub mod binder {
     use rustix::{io, ioctl};
     use std::os::fd::AsFd;
 
+    // Shared SAFETY rationale for every `ioctl::ioctl(fd, ctl)` below:
+    // `rustix::ioctl::ioctl` is unsafe because it cannot verify that the
+    // opcode matches the argument type or that the request is valid for
+    // the fd. In each wrapper the opcode is built at compile time from
+    // the binder UAPI request number (`b'b'`, N) and the exact argument
+    // type via `ioctl::opcode::{read_write,write}::<T>`, the typed
+    // `Setter`/`Updater` holds a value/buffer of precisely that `T`, and
+    // the `Fd: AsFd` bound guarantees a valid borrowed fd for the call's
+    // duration. So the opcode <-> arg-type <-> fd precondition holds and
+    // no memory unsafety is possible. Each block notes only its request.
+
     // nix::ioctl_readwrite!(write_read, b'b', 1, binder_write_read);
     pub(crate) fn write_read<Fd: AsFd>(
         fd: Fd,
         write_read: &mut binder_write_read,
     ) -> std::result::Result<(), io::Errno> {
         unsafe {
-            // BINDER_WRITE_READ
+            // SAFETY: see shared rationale above. Request: BINDER_WRITE_READ.
             let ctl = ioctl::Updater::<
                 { ioctl::opcode::read_write::<binder_write_read>(b'b', 1) },
                 _,
@@ -112,7 +128,7 @@ pub mod binder {
         max_threads: u32,
     ) -> std::result::Result<(), io::Errno> {
         unsafe {
-            // BINDER_SET_MAX_THREADS
+            // SAFETY: see shared rationale above. Request: BINDER_SET_MAX_THREADS.
             let ctl =
                 ioctl::Setter::<{ ioctl::opcode::write::<__u32>(b'b', 5) }, _>::new(max_threads);
             ioctl::ioctl(fd, ctl)
@@ -125,7 +141,7 @@ pub mod binder {
         pid: i32,
     ) -> std::result::Result<(), io::Errno> {
         unsafe {
-            // BINDER_SET_CONTEXT_MGR
+            // SAFETY: see shared rationale above. Request: BINDER_SET_CONTEXT_MGR.
             let ctl = ioctl::Setter::<{ ioctl::opcode::write::<__s32>(b'b', 7) }, _>::new(pid);
             ioctl::ioctl(fd, ctl)
         }
@@ -137,7 +153,7 @@ pub mod binder {
         ver: &mut binder_version,
     ) -> std::result::Result<(), io::Errno> {
         unsafe {
-            // BINDER_VERSION
+            // SAFETY: see shared rationale above. Request: BINDER_VERSION.
             let ctl =
                 ioctl::Updater::<{ ioctl::opcode::read_write::<binder_version>(b'b', 9) }, _>::new(
                     ver,
@@ -152,7 +168,7 @@ pub mod binder {
         obj: flat_binder_object,
     ) -> std::result::Result<(), io::Errno> {
         unsafe {
-            // BINDER_SET_CONTEXT_MGR_EXT
+            // SAFETY: see shared rationale above. Request: BINDER_SET_CONTEXT_MGR_EXT.
             let ctl =
                 ioctl::Setter::<{ ioctl::opcode::write::<flat_binder_object>(b'b', 13) }, _>::new(
                     obj,
@@ -167,7 +183,7 @@ pub mod binder {
         enable: __u32,
     ) -> std::result::Result<(), io::Errno> {
         unsafe {
-            // BINDER_ENABLE_ONEWAY_SPAM_DETECTION
+            // SAFETY: see shared rationale above. Request: BINDER_ENABLE_ONEWAY_SPAM_DETECTION.
             let ctl = ioctl::Setter::<{ ioctl::opcode::write::<__u32>(b'b', 16) }, _>::new(enable);
             ioctl::ioctl(fd, ctl)
         }
@@ -179,7 +195,7 @@ pub mod binder {
         device: &mut binderfs_device,
     ) -> std::result::Result<(), io::Errno> {
         unsafe {
-            // BINDER_CTL_ADD
+            // SAFETY: see shared rationale above. Request: BINDER_CTL_ADD.
             let ctl =
                 ioctl::Updater::<{ ioctl::opcode::read_write::<binderfs_device>(b'b', 1) }, _>::new(
                     device,
@@ -194,7 +210,7 @@ pub mod binder {
         timeout: i64,
     ) -> std::result::Result<(), io::Errno> {
         unsafe {
-            // BINDER_SET_IDLE_TIMEOUT
+            // SAFETY: see shared rationale above. Request: BINDER_SET_IDLE_TIMEOUT.
             let ctl = ioctl::Setter::<{ ioctl::opcode::write::<__s64>(b'b', 3) }, _>::new(timeout);
             ioctl::ioctl(fd, ctl)
         }
@@ -206,7 +222,7 @@ pub mod binder {
         priority: i32,
     ) -> std::result::Result<(), io::Errno> {
         unsafe {
-            // BINDER_SET_IDLE_PRIORITY
+            // SAFETY: see shared rationale above. Request: BINDER_SET_IDLE_PRIORITY.
             let ctl = ioctl::Setter::<{ ioctl::opcode::write::<__s32>(b'b', 6) }, _>::new(priority);
             ioctl::ioctl(fd, ctl)
         }
@@ -215,7 +231,7 @@ pub mod binder {
     // nix::ioctl_write_ptr!(thread_exit, b'b', 8, __s32);
     pub(crate) fn thread_exit<Fd: AsFd>(fd: Fd, pid: i32) -> std::result::Result<(), io::Errno> {
         unsafe {
-            // BINDER_THREAD_EXIT
+            // SAFETY: see shared rationale above. Request: BINDER_THREAD_EXIT.
             let ctl = ioctl::Setter::<{ ioctl::opcode::write::<__s32>(b'b', 8) }, _>::new(pid);
             ioctl::ioctl(fd, ctl)
         }
@@ -227,7 +243,7 @@ pub mod binder {
         node_debug_info: &mut binder_node_debug_info,
     ) -> std::result::Result<(), rustix::io::Errno> {
         unsafe {
-            // BINDER_GET_NODE_DEBUG_INFO
+            // SAFETY: see shared rationale above. Request: BINDER_GET_NODE_DEBUG_INFO.
             let ctl = ioctl::Updater::<
                 { ioctl::opcode::read_write::<binder_node_debug_info>(b'b', 11) },
                 _,
@@ -242,7 +258,7 @@ pub mod binder {
         node_info: &mut binder_node_info_for_ref,
     ) -> std::result::Result<(), rustix::io::Errno> {
         unsafe {
-            // BINDER_GET_NODE_INFO_FOR_REF
+            // SAFETY: see shared rationale above. Request: BINDER_GET_NODE_INFO_FOR_REF.
             let ctl = ioctl::Updater::<
                 { ioctl::opcode::read_write::<binder_node_info_for_ref>(b'b', 12) },
                 _,
@@ -257,7 +273,7 @@ pub mod binder {
         info: binder_freeze_info,
     ) -> std::result::Result<(), io::Errno> {
         unsafe {
-            // BINDER_FREEZE
+            // SAFETY: see shared rationale above. Request: BINDER_FREEZE.
             let ctl =
                 ioctl::Setter::<{ ioctl::opcode::write::<binder_freeze_info>(b'b', 14) }, _>::new(
                     info,
@@ -272,7 +288,7 @@ pub mod binder {
         frozen_info: &mut binder_frozen_status_info,
     ) -> std::result::Result<(), io::Errno> {
         unsafe {
-            // BINDER_GET_FROZEN_INFO
+            // SAFETY: see shared rationale above. Request: BINDER_GET_FROZEN_INFO.
             let ctl = ioctl::Updater::<
                 { ioctl::opcode::read_write::<binder_frozen_status_info>(b'b', 15) },
                 _,

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -1229,9 +1229,20 @@ pub(crate) fn flash_if_needed() -> Result<bool> {
             }
         }
 
+        // Reset is_flushing on every exit (Ok / Err / panic) so a failed
+        // flush_commands() cannot leave the flag stuck true and wedge all
+        // future flushes. Must NOT hold a THREAD_STATE borrow across
+        // flush_commands() — it re-borrows internally (R1).
+        struct FlushGuard;
+        impl Drop for FlushGuard {
+            fn drop(&mut self) {
+                THREAD_STATE.with(|ts| ts.borrow_mut().is_flushing = false);
+            }
+        }
+
         thread_state.borrow_mut().is_flushing = true;
+        let _guard = FlushGuard;
         flush_commands()?;
-        thread_state.borrow_mut().is_flushing = false;
 
         Ok(true)
     })

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -750,6 +750,13 @@ fn execute_command(cmd: i32) -> Result<()> {
                     }
                 };
 
+                // SAFETY: `tr_secctx` was just filled by the kernel on the
+                // BR_TRANSACTION(_SEC_CTX) path, so `transaction_data` is
+                // fully initialized and the `data.ptr` union variant (buffer
+                // + offsets, not `data.buf`) is the active one for a
+                // kernel-delivered transaction. `from_ipc_parts` adopts the
+                // driver-owned buffer/offsets with sizes taken from the same
+                // struct and the matching `free_buffer` reclaimer.
                 let mut reader = unsafe {
                     let tr = &tr_secctx.transaction_data;
 
@@ -782,6 +789,9 @@ fn execute_command(cmd: i32) -> Result<()> {
                 let mut reply = Parcel::new();
 
                 let result = {
+                    // SAFETY: kernel-delivered transaction (see above); for a
+                    // transaction targeting a local binder the `target` union's
+                    // `ptr` variant is the active one. Read-only.
                     let target_ptr = unsafe { tr_secctx.transaction_data.target.ptr };
                     if target_ptr != 0 {
                         // `target_ptr` is now the process-monotonic id
@@ -852,6 +862,8 @@ fn execute_command(cmd: i32) -> Result<()> {
                     let mut log = format!(
                         "oneway function results for code {} on binder at {:X}",
                         tr_secctx.transaction_data.code,
+                        // SAFETY: kernel-delivered transaction; `target.ptr`
+                        // is the active union variant. Read-only (logging).
                         unsafe { tr_secctx.transaction_data.target.ptr }
                     );
                     log += &format!(" will be dropped but finished with status {err}");

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -1437,7 +1437,16 @@ pub(crate) fn join_thread_pool(is_main: bool) -> Result<()> {
                         break;
                     }
                     _ => {
-                        panic!("get_and_execute_command() returned unexpected error {e}, aborting");
+                        // A non-EINTR ioctl error (EAGAIN/EBUSY/ENOMEM/…)
+                        // must not abort the process. Leave the thread pool
+                        // gracefully like the TimedOut/CONNREFUSED arms so
+                        // the pool can spawn a replacement looper.
+                        log::error!(
+                            "get_and_execute_command() returned unexpected error {e}; \
+                             leaving the thread pool"
+                        );
+                        result = e;
+                        break;
                     }
                 }
             }
@@ -1874,7 +1883,7 @@ mod tests {
     fn test_process_pending_derefs_handles_reentrant_push_from_drop() {
         use std::sync::atomic::AtomicU64;
         use std::sync::{self, Mutex};
-        let process = ProcessState::init_default();
+        let process = ProcessState::init_default().expect("init_default");
 
         let drop_log: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
         let pusher_target: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -1127,7 +1127,9 @@ fn talk_with_driver(do_receive: bool) -> Result<()> {
             }
 
             if bwr.read_consumed > 0 {
-                thread_state.in_parcel.set_data_size(bwr.read_consumed as _)?;
+                thread_state
+                    .in_parcel
+                    .set_data_size(bwr.read_consumed as _)?;
                 thread_state.in_parcel.set_data_position(0);
 
                 log::trace!(

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -1123,11 +1123,11 @@ fn talk_with_driver(do_receive: bool) -> Result<()> {
                         thread_state.out_parcel.data_size()
                     );
                 }
-                thread_state.out_parcel.set_data_size(0);
+                thread_state.out_parcel.set_data_size(0)?;
             }
 
             if bwr.read_consumed > 0 {
-                thread_state.in_parcel.set_data_size(bwr.read_consumed as _);
+                thread_state.in_parcel.set_data_size(bwr.read_consumed as _)?;
                 thread_state.in_parcel.set_data_position(0);
 
                 log::trace!(

--- a/tests/src/bin/test_service.rs
+++ b/tests/src/bin/test_service.rs
@@ -687,7 +687,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     // Initialize ProcessState with binder path and max threads.
     // The meaning of zero max threads is to use the default value. It is dependent on the kernel.
-    ProcessState::init_default();
+    ProcessState::init_default()?;
     ProcessState::start_thread_pool();
 
     let service_name = <BpTestService as ITestService::ITestService>::descriptor();

--- a/tests/src/bin/test_service_async.rs
+++ b/tests/src/bin/test_service_async.rs
@@ -734,7 +734,7 @@ fn rt() -> TokioRuntime<tokio::runtime::Handle> {
 fn main() {
     env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
 
-    ProcessState::init_default();
+    ProcessState::init_default().expect("init_default");
     ProcessState::start_thread_pool();
 
     let runtime = tokio::runtime::Builder::new_current_thread()

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -1455,7 +1455,7 @@ fn test_hub() {
 /// resolutions:
 ///
 /// ```ignore
-/// let service_manager = rsbinder::hub::default();
+/// let service_manager = rsbinder::hub::default()?;
 /// let all_services = service_manager.list_services(0xf);
 /// for service_name in &all_services {
 ///     let service = service_manager.get_service(service_name).unwrap();

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -54,7 +54,7 @@ fn init_logger() {
 
 fn init_test() {
     init_logger();
-    ProcessState::init_default();
+    ProcessState::init_default().expect("init_default");
     ProcessState::start_thread_pool();
 }
 

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -1446,6 +1446,67 @@ fn test_hub() {
         .any(|s| s.name == ITestService::BpTestService::descriptor()));
 }
 
+/// Real-binder regression for the lock-decoupled slow path
+/// (PR #118, `481b8c9`). N threads concurrently resolve the same
+/// service, racing through `strong_proxy_for_handle`'s P1/P2/P3 slow
+/// path while it performs IPC (descriptor query / service-manager
+/// ping) with the `handle_to_proxy` lock released.
+///
+/// Guards two properties the P1/P2/P3 split must preserve under real
+/// binder traffic:
+///
+///  1. **No deadlock.** The pre-fix monolithic slow path held the
+///     `handle_to_proxy` write lock across IPC; the re-entrant
+///     `BR_DEAD_BINDER → send_obituary_for_handle` path then wedged
+///     on the non-reentrant write lock. A regression manifests here
+///     as the `recv_timeout` firing — a bounded test failure, not an
+///     indefinite hang.
+///  2. **Single-Arc convergence.** Every concurrent slow-path
+///     winner/loser must end up sharing one cached proxy identity
+///     (the race-resolution table's whole purpose).
+///
+/// The rsbinder-crate unit tests cover the same logic with a
+/// `cfg(test)` hook; this one adds coverage over a real kernel binder
+/// path and runs inside the integration-test.yml 100-iteration loop,
+/// so it also accumulates cross-iteration cache state (case (b)
+/// resurrection).
+#[test]
+fn test_concurrent_service_resolution_slow_path_no_deadlock() {
+    init_test();
+    let name = ITestService::BpTestService::descriptor();
+
+    const N: usize = 8;
+    let (tx, rx) = std::sync::mpsc::channel();
+    let mut joins = Vec::with_capacity(N);
+    for _ in 0..N {
+        let tx = tx.clone();
+        joins.push(std::thread::spawn(move || {
+            tx.send(hub::get_service(name))
+                .expect("result channel must not drop");
+        }));
+    }
+    drop(tx);
+
+    let mut binders = Vec::with_capacity(N);
+    for _ in 0..N {
+        let r = rx.recv_timeout(std::time::Duration::from_secs(10)).expect(
+            "concurrent get_service must complete within 10s — slow-path deadlock regression",
+        );
+        binders.push(r.expect("test_service must be registered"));
+    }
+    for j in joins {
+        j.join().expect("worker thread must not panic");
+    }
+
+    let first = &binders[0];
+    for b in &binders[1..] {
+        assert_eq!(
+            first, b,
+            "concurrent slow-path resolutions must share one proxy identity"
+        );
+    }
+}
+
 /// Test for issue #47: cached interface string bug
 ///
 /// Originally reproduced the case where `handle_to_proxy` returned a


### PR DESCRIPTION
Implements the confirmed findings of the `rsbinder/src` review
(`/review-rust`, 12 sub-agents → main-agent 2차 검증 → AOSP cross-check).
Every commit was verified with host `cargo check/clippy --workspace
--tests` and `--target aarch64-linux-android --features
android_10_plus`. PR #116 (`30de3ca`) is already merged and is not part
of this delta.

## Critical

- **FD `flat_binder_object` construction** (`0f5e0d9`): `flags` used
  `0x7F & FLAT_BINDER_FLAG_ACCEPTS_FDS` (always 0); fixed to `|`,
  byte-identical to AOSP `Parcel::writeFileDescriptor`. A field-by-field
  AOSP cross-check then found a second defect — the bindgen union was
  initialized via the u32 `handle` only, leaking 4 uninitialized bytes
  to the wire (Rust UB) — fixed by full-width `binder` init.
- **handle_to_proxy lock across IPC** (`481b8c9`): the slow path held
  the `handle_to_proxy` write lock across `ping_binder`/`query_interface`,
  deadlocking on the re-entrant `BR_DEAD_BINDER → send_obituary_for_handle`
  path. Split into a lock-decoupled P1/P2/P3 design with 3 regression
  tests.

## Major

- `is_flushing` stuck-true on flush failure → RAII guard (`2a06b75`).
- SAFETY-comment sweep over ~30 `unsafe` sites (`dc5052e`).
- Error-handling conversions no longer mask failures (`70191a2`).
- Removed all 8 `IServiceCallback` vtable transmutes (`00a6d1c`), then
  replaced the `FromIBinder` round-trip with an SIBinder-forwarding
  wrapper that also works for local callbacks (`51aa7a9`).
- `join_thread_pool` no longer aborts on a transient ioctl errno
  (`169cd71`).
- Parcel hardened against untrusted input: Drop never panics,
  `data_avail` saturates, `set_data_size` rejects over-capacity
  (`d659ae3`).
- sync `Serialize for dyn $interface` lifetime parity + broken
  generated rustdoc links (`34831f0`).

## ⚠️ Breaking changes

- `hub::default()` → `Result` (`8963ec5`)
- `ProcessState::init` / `init_default` → `Result` (`169cd71`)
- `Parcel::set_data_size` → `Result` (`d659ae3`)

All are niche/low-level surfaces; rationale is soundness-over-compat,
consistent across the set. In-tree call sites (bins via `?`, tests via
`.expect`, doc examples) are updated.

## Test coverage (`b365673`, `1b1dcb9`)

Regression coverage for the behavior-changing fixes that previously
had none, plus closing the CI gap where rsbinder-crate unit tests ran
nowhere (`build.yml` only `--no-run`; the integration loop only
`--package tests`). Each unit test is written to fail against the
pre-fix code.

Pure unit tests (no binder device):
- binder_object: `new_with_fd` flags (`&`→`|`, was always 0) +
  full-width union init (uninit-leak UB) (`0f5e0d9`)
- parcel: `set_data_size` over-capacity → `Err`; `data_avail`
  saturates instead of underflow-panic (`d659ae3`)
- status: exception + `Ok` code never collapses to `StatusCode::Ok`;
  `Serialize` TransactionFailed early-errs (`70191a2`)
- error: `From<io::Error>` preserves errno vs flattening to `BadFd`
  (`70191a2`)

Real-binder: `tests/test_client` — N threads concurrently resolve the
same service, racing the lock-decoupled slow path; `recv_timeout`
turns a deadlock regression into a bounded failure (`481b8c9`). Runs
in the integration-test 100-iteration loop.

CI: the `integration-test.yml` Linux binder job now runs `cargo test
--package rsbinder -- --test-threads=1` (serial — these tests share
the process-wide `ProcessState` singleton + one binder fd), so the
P1/P2/P3 slow-path and same-thread re-entrant-obituary deadlock guards
execute in CI for the first time.

## Reviewed, intentionally unchanged (evidence in plan doc)

- **proxy.rs Drop/RAII** (dec_strong_handle / request_death_notification
  / send_obituary): already resolved by the 2026-04 hardening series
  (`b2f5931`/`3024279`/`619327c`); the review flagged the *prior* state.
- **SM10 `add_service` Status fidelity**: AOSP cross-check shows
  Android 10's legacy C servicemanager only writes a single `int32`;
  the lossy round-trip is unreachable on that protocol.
- **`Interface::as_binder` `unreachable!()` default**: every AIDL
  service relies on this default (`impl Interface for S {}`); making it
  required would break all services. AOSP `libbinder_rs` has the
  identical design. The real fix is a `Strong`/`as_binder` redesign
  (tracked as refactor). Rationale documented in `binder.rs`.

## Out of scope

32-bit-only arithmetic items (gated on a "do we support 32-bit"
decision); `ref_counter` loom scenarios; the `Strong`/`as_binder`
refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
