### PR TITLE
test(rsbinder): scope unit-test parallel-safety via serial_test (replace --test-threads=1)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -114,18 +114,22 @@ jobs:
           # rsb_hub is already up (handle 0); test_service is up so the
           # cache has real entries to resurrect.
           #
-          # --test-threads=1 is required: these tests share the
-          # process-wide `ProcessState` singleton and a single binder fd.
-          # The slow-path concurrency / re-entrant-obituary guards
-          # deliberately drop and obituary the handle-0 (service manager)
-          # cache entry; running them concurrently with siblings that
-          # assert `strong_proxy_for_handle(0).is_ok()` or read the
-          # process-global thread-pool counter is inherently racy. Each
-          # guard spawns its own internal threads, so serializing test
-          # *functions* does not weaken them — it also makes the
-          # same-thread deadlock test reliably non-vacuous (no sibling
-          # keeps the handle-0 Weak upgradeable).
-          RUST_BACKTRACE=1 cargo test --package rsbinder -- --test-threads=1 || {
+          # No `--test-threads=1`: only the ~14 tests that share the
+          # process-wide `ProcessState` singleton + single binder fd carry
+          # `#[serial_test::serial(binder)]` (group key `binder`), so they
+          # are mutually exclusive while the ~100 pure unit tests still run
+          # in parallel. The slow-path concurrency / re-entrant-obituary
+          # guards deliberately drop and obituary the handle-0 (service
+          # manager) cache entry; the `binder` group lock keeps them from
+          # overlapping a sibling that asserts
+          # `strong_proxy_for_handle(0).is_ok()` or reads the
+          # process-global thread-pool counter. Each guard spawns its own
+          # internal threads, so the group lock does not weaken them — and
+          # pure tests never touch handle 0, so the same-thread deadlock
+          # test stays reliably non-vacuous (no sibling keeps the handle-0
+          # Weak upgradeable). If this step flakes, the bug is a missing
+          # `#[serial(binder)]`, not a reason to re-add `--test-threads=1`.
+          RUST_BACKTRACE=1 cargo test --package rsbinder || {
             echo "::error::rsbinder unit tests failed — capturing dmesg"
             sudo dmesg | tail -200
             cat rsb_hub.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,9 +177,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -591,7 +591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1088,6 +1088,7 @@ dependencies = [
  "rsbinder-aidl",
  "rsproperties",
  "rustix",
+ "serial_test",
  "tokio",
 ]
 
@@ -1166,6 +1167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1186,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -1227,6 +1243,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1446,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -1623,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1636,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1646,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1659,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,11 @@ clap = "4.6"
 rsproperties = "0.3"
 miette = { version = "7.6", features = ["fancy"] }
 thiserror = "2"
+# dev-only: serializes the handful of rsbinder unit tests that share the
+# process-wide `ProcessState` singleton + single binder fd (group key
+# `binder`). default-features = false drops the `logging`/`async` features
+# (and the `futures` dep) — every gated test is a sync `#[test]`.
+serial_test = { version = "3", default-features = false }
 
 [patch.crates-io]
 chrono = { git = "https://github.com/chronotope/chrono", tag = "v0.4.41" }

--- a/rsbinder/Cargo.toml
+++ b/rsbinder/Cargo.toml
@@ -46,6 +46,7 @@ rsbinder-aidl = { workspace = true, features = ["async"] }
 
 [dev-dependencies]
 env_logger = { workspace = true }
+serial_test = { workspace = true }
 
 # loom is only used by tests gated on `--cfg loom`. Run with:
 #   RUSTFLAGS="--cfg loom" cargo test --test loom_cache_pin --release

--- a/rsbinder/src/lib.rs
+++ b/rsbinder/src/lib.rs
@@ -223,6 +223,7 @@ mod tests {
     use crate::*;
     #[test]
     #[cfg(target_os = "linux")]
+    #[serial_test::serial(binder)]
     fn process_state() {
         ProcessState::init("/dev/binderfs/binder", 0).expect("init");
     }

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -1268,8 +1268,12 @@ impl Drop for ProcessState {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_process_state() {
+    /// Shared init + invariant checks for the two tests that assert a
+    /// freshly-initialized `ProcessState`. Deliberately NOT `#[serial]`:
+    /// both callers already run inside the `binder` serial section, so
+    /// keeping this a plain fn avoids depending on serial_test's lock
+    /// being reentrant for a same-thread nested `#[serial]` call.
+    fn assert_process_state_initialized() {
         let process = ProcessState::init_default().expect("init_default");
         assert_eq!(process.max_threads, DEFAULT_MAX_BINDER_THREADS);
         assert_eq!(
@@ -1279,12 +1283,20 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(binder)]
+    fn test_process_state() {
+        assert_process_state_initialized();
+    }
+
+    #[test]
+    #[serial_test::serial(binder)]
     fn test_process_state_context_object() {
         let process = ProcessState::init_default().expect("init_default");
         assert!(process.context_object().is_ok());
     }
 
     #[test]
+    #[serial_test::serial(binder)]
     fn test_process_state_strong_proxy_for_handle() {
         let process = ProcessState::init_default().expect("init_default");
         assert!(process.strong_proxy_for_handle(0).is_ok());
@@ -1298,6 +1310,7 @@ mod tests {
     /// (c) re-check, P3's case (c) re-check, or P3's
     /// `(CaseA, Some(_))` cross-thread arm.
     #[test]
+    #[serial_test::serial(binder)]
     fn test_concurrent_strong_proxy_same_handle_returns_same_arc() {
         let _ = ProcessState::init_default();
         let handles: Vec<_> = (0..8)
@@ -1337,6 +1350,7 @@ mod tests {
     /// the winner's Arc. Verifies the case (b) generation-preservation
     /// invariant survives concurrent resurrection.
     #[test]
+    #[serial_test::serial(binder)]
     fn test_concurrent_strong_proxy_case_b_resurrection() {
         let _ = ProcessState::init_default();
         // Force a cache entry to exist for handle 0.
@@ -1410,6 +1424,7 @@ mod tests {
     /// to short-circuit at case (c) and the hook to never fire
     /// (vacuous pass).
     #[test]
+    #[serial_test::serial(binder)]
     fn test_strong_proxy_under_same_thread_dead_binder_no_deadlock() {
         let process = ProcessState::init_default().expect("init_default");
 
@@ -1469,6 +1484,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(binder)]
     fn test_process_state_disable_background_scheduling() {
         let process = ProcessState::init_default().expect("init_default");
         process.disable_background_scheduling(true);
@@ -1476,8 +1492,9 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(binder)]
     fn test_process_state_start_thread_pool() {
-        test_process_state();
+        assert_process_state_initialized();
         ProcessState::start_thread_pool();
         assert_eq!(
             ProcessState::as_self()
@@ -1550,6 +1567,7 @@ mod tests {
     ///      are zero and the entry is removed → `lookup_native` returns
     ///      `None`.
     #[test]
+    #[serial_test::serial(binder)]
     fn test_native_uaf_window_closed() {
         let process = ProcessState::init_default().expect("init_default");
         let arc: Arc<dyn IBinder> = Arc::new(MockNative);
@@ -1602,6 +1620,7 @@ mod tests {
     /// `acquire`/`release` independently keeps the entry alive until
     /// the last `release` fires.
     #[test]
+    #[serial_test::serial(binder)]
     fn test_native_dedup_same_arc() {
         let process = ProcessState::init_default().expect("init_default");
         let arc: Arc<dyn IBinder> = Arc::new(MockNative);
@@ -1634,6 +1653,7 @@ mod tests {
     /// e.g. `MockNative` being a unit struct — `Arc::ptr_eq` keys on
     /// allocation, not type).
     #[test]
+    #[serial_test::serial(binder)]
     fn test_native_distinct_arcs_get_distinct_ids() {
         let process = ProcessState::init_default().expect("init_default");
         let arc_a: Arc<dyn IBinder> = Arc::new(MockNative);
@@ -1657,6 +1677,7 @@ mod tests {
     /// `deserialize_option` round-trip path where the kernel routes a
     /// previously-published binder back to its publisher.
     #[test]
+    #[serial_test::serial(binder)]
     fn test_native_lookup_does_not_change_counts() {
         let process = ProcessState::init_default().expect("init_default");
         let arc: Arc<dyn IBinder> = Arc::new(MockNative);

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -1882,6 +1882,7 @@ mod tests {
     /// `process_state` M4 tests; surfaces under
     /// `.github/workflows/integration-test.yml`.
     #[test]
+    #[serial_test::serial(binder)]
     fn test_process_pending_derefs_handles_reentrant_push_from_drop() {
         use std::sync::atomic::AtomicU64;
         use std::sync::{self, Mutex};


### PR DESCRIPTION
## Summary

The `rsbinder` crate's unit tests were serialized wholesale via
`cargo test --package rsbinder -- --test-threads=1` (added in `1b1dcb9` on
the base branch) because ~14 of them share the process-wide `ProcessState`
singleton and the single binder fd. That blunt flag also throttled the
~100 pure unit tests that never touch binder.

This scopes the constraint precisely: only the singleton/binder-fd tests
carry `#[serial_test::serial(binder)]` (group key `binder`) and are
mutually exclusive; the pure tests run in parallel unannotated.

## Stacked PR

Base is **`chore/pr115-followup-pr-a-non-exhaustive-features`**, not
`master`: this work directly supersedes `1b1dcb9` and edits the
`integration-test.yml` rsbinder-test gate that only exists on that branch.
A `master`-based PR would bundle ~16 unrelated hardening commits.

## Changes

- `#[serial_test::serial(binder)]` on the 14 tests that init `ProcessState`
  / touch handle-0 cache / read process-global thread-pool counters
  (12 in `process_state.rs`, 1 Linux-only in `lib.rs`, 1 in `thread_state.rs`).
- Extract shared `ProcessState` init + invariant checks into a plain
  `assert_process_state_initialized()` helper so `test_process_state` and
  `test_process_state_start_thread_pool` no longer nest one `#[serial]`
  test inside another (removes the implicit reliance on serial_test's
  lock being reentrant).
- `integration-test.yml`: drop `-- --test-threads=1`, rewrite the
  rationale comment.
- `serial_test = { version = "3", default-features = false }` — no
  async/logging features, no `futures` dep; every gated test is sync.

## Why the singleton stays

`OnceLock<ProcessState>` mirrors the kernel binder ABI / Android libbinder
and is correct for production — only test parallelism needed fixing. The
`binder` group lock preserves the exact mutual-exclusion guarantee the old
flag gave (incl. the non-vacuous same-thread deadlock test: pure tests
never hold a handle-0 `Weak`).

## Verification

Built for `aarch64-linux-android` and run on an Android 15 emulator
(arm64, servicemanager up = handle 0 resolves):

- Full suite **116/116 green** under default parallelism, 20 iterations.
- `process_state` subset under `--test-threads=12`, **30/30 green** — directly
  exercises the `1b1dcb9` race window (handle-0 drop/obituary vs
  `strong_proxy_for_handle(0)`, thread-pool counter) with no transient
  `DeadObject` / counter race.
- Host `cargo build -p rsbinder --tests` + `cargo fmt --check` clean.

Note: these rsbinder *unit* tests run in CI only on the Linux binderfs job
(the one whose flag this PR changes); the Linux job remains the canonical
gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)