### PR TITLE
fix(rsbinder-aidl): resolve enum defaults by target type

### DIFF
--- a/rsbinder-aidl/src/const_expr.rs
+++ b/rsbinder-aidl/src/const_expr.rs
@@ -156,6 +156,8 @@ pub enum ValueType {
     Holder,
     UserDefined(String),
     Reference {
+        // Full AIDL enum type. Short enum names can collide across packages.
+        enum_type: String,
         enum_name: String,
         member_name: String,
         value: i64,
@@ -413,6 +415,7 @@ impl ValueType {
             ValueType::Char(_) => format!("'{}' as u16", self.to_value_string()),
             ValueType::Name(_) => self.to_value_string(),
             ValueType::Reference {
+                enum_type,
                 enum_name,
                 member_name,
                 value,
@@ -422,7 +425,7 @@ impl ValueType {
                     format!("{}", value)
                 } else {
                     // Use proper namespace resolution for cross-package enum references
-                    match parser::lookup_decl_from_name(enum_name, crate::Namespace::AIDL) {
+                    match parser::lookup_decl_from_name(enum_type, crate::Namespace::AIDL) {
                         Some(lookup_decl) => {
                             let curr_ns = parser::current_namespace();
                             let ns = curr_ns.relative_mod(&lookup_decl.ns);

--- a/rsbinder-aidl/src/generator.rs
+++ b/rsbinder-aidl/src/generator.rs
@@ -715,7 +715,7 @@ impl Generator {
                     generator.init_value(
                         constant.const_expr.as_ref(),
                         InitParam::builder().with_const(true),
-                    ),
+                    )?,
                 ));
             }
 
@@ -898,7 +898,7 @@ pub mod {mod} {{
                             generator.init_value(
                                 var.const_expr.as_ref(),
                                 InitParam::builder().with_const(true),
-                            ),
+                            )?,
                         ));
                     } else {
                         let init_value = match generator.value_type {
@@ -915,7 +915,7 @@ pub mod {mod} {{
                                     .with_const(false)
                                     .with_vintf(is_vintf)
                                     .with_crate_name(self.get_crate_name()),
-                            ),
+                            )?,
                         ))
                     }
                 } else {
@@ -959,50 +959,25 @@ pub mod {mod} {{
             return;
         }
 
-        let mut enum_val: i64 = 0;
+        let enum_type = decl.namespace.to_string(Namespace::AIDL);
+        let lookup_decl = parser::LookupDecl {
+            decl: parser::Declaration::Enum(decl.clone()),
+            ns: decl.namespace.clone(),
+            name: Namespace::new(&enum_type, Namespace::AIDL),
+        };
 
         for enumerator in &decl.enumerator_list {
             let member_name = &enumerator.identifier;
-
-            if let Some(const_expr) = &enumerator.const_expr {
-                // Try to compute the value, but handle cases where it might reference other enum members
-                let computed_val = match const_expr.calculate() {
-                    Ok(calculated) => match calculated.value {
-                        crate::const_expr::ValueType::Name(_) => {
-                            // This is an unresolved reference, use current enum_val as fallback
-                            enum_val
-                        }
-                        _ => calculated.to_i64().unwrap_or(enum_val),
-                    },
-                    Err(_) => enum_val,
-                };
-
+            if let Some(expr) =
+                parser::enum_member_const_expr_from_lookup(&lookup_decl, member_name)
+            {
                 parser::register_symbol(
                     member_name,
-                    crate::const_expr::ConstExpr::new(crate::const_expr::ValueType::Reference {
-                        enum_name: decl.name.clone(),
-                        member_name: member_name.to_string(),
-                        value: computed_val,
-                    }),
+                    expr,
                     parser::SymbolType::EnumMember,
-                    Some(&decl.name),
-                );
-
-                enum_val = computed_val;
-            } else {
-                parser::register_symbol(
-                    member_name,
-                    crate::const_expr::ConstExpr::new(crate::const_expr::ValueType::Reference {
-                        enum_name: decl.name.clone(),
-                        member_name: member_name.to_string(),
-                        value: enum_val,
-                    }),
-                    parser::SymbolType::EnumMember,
-                    Some(&decl.name),
+                    Some(&enum_type),
                 );
             }
-
-            enum_val += 1;
         }
     }
 
@@ -1019,16 +994,19 @@ pub mod {mod} {{
         // First pass: register all enum members with their names for resolution
         Self::register_enum_members(decl);
 
-        // Second pass: resolve all values now that all members are registered
-        let mut enum_val: i64 = 0;
+        let lookup_decl = parser::LookupDecl {
+            decl: parser::Declaration::Enum(decl.clone()),
+            ns: decl.namespace.clone(),
+            name: Namespace::new(&decl.namespace.to_string(Namespace::AIDL), Namespace::AIDL),
+        };
+
+        // Second pass: render the values resolved by the shared enum member path.
         for enumerator in &decl.enumerator_list {
-            if let Some(const_expr) = &enumerator.const_expr {
-                if let Some(val) = const_expr.calculate().ok().and_then(|c| c.to_i64().ok()) {
-                    enum_val = val;
-                }
+            if let Some(expr) =
+                parser::enum_member_const_expr_from_lookup(&lookup_decl, &enumerator.identifier)
+            {
+                members.push((enumerator.identifier.to_owned(), expr.to_i64().unwrap_or(0)));
             }
-            members.push((enumerator.identifier.to_owned(), enum_val));
-            enum_val += 1;
         }
 
         let mut context = self.new_context();
@@ -1078,7 +1056,7 @@ pub mod {mod} {{
                         generator.init_value(
                             var.const_expr.as_ref(),
                             InitParam::builder().with_const(true),
-                        ),
+                        )?,
                     ));
                 } else {
                     members.push((

--- a/rsbinder-aidl/src/parser.rs
+++ b/rsbinder-aidl/src/parser.rs
@@ -4,7 +4,7 @@
 // #![allow(clippy::missing_const_for_fn)]
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::error::{pest_error_to_diagnostic, AidlError, ParseError};
 
@@ -45,6 +45,8 @@ thread_local! {
 
     // Universal Symbol Table - supports all types of named constants
     static SYMBOL_TABLE: RefCell<HashMap<String, Symbol>> = RefCell::new(HashMap::new());
+    static ENUM_VALUE_CACHE: RefCell<HashMap<String, ConstExpr>> = RefCell::new(HashMap::new());
+    static ENUM_RESOLUTION_STACK: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
 
     // Filename and source text of the source currently being parsed (used for error message generation)
     #[allow(clippy::missing_const_for_thread_local)]
@@ -134,6 +136,15 @@ pub fn current_namespace() -> Namespace {
     NAMESPACE_STACK.with(|stack| stack.borrow().last().cloned().unwrap_or_default())
 }
 
+fn reset_enum_resolution_state() {
+    ENUM_VALUE_CACHE.with(|cache| {
+        cache.borrow_mut().clear();
+    });
+    ENUM_RESOLUTION_STACK.with(|stack| {
+        stack.borrow_mut().clear();
+    });
+}
+
 pub fn set_current_document(document: &Document) {
     DOCUMENT.with(|doc| {
         let mut doc = doc.borrow_mut();
@@ -192,6 +203,11 @@ pub fn lookup_decl_from_name(name: &str, style: &str) -> Option<LookupDecl> {
             ns_vec.push(new_ns);
         }
     });
+
+    // 3. check fully-qualified names as written.
+    if namespace.ns.len() > 1 {
+        ns_vec.append(&mut make_ns_candidate(&Namespace::default(), &namespace));
+    }
 
     let (decl, ns) = DECLARATION_MAP.with(|hashmap| {
         for ns in &ns_vec {
@@ -264,7 +280,7 @@ fn lookup_name_from_decl(decl: &Declaration, lookup_decl: &LookupDecl) -> Option
         Declaration::Enum(ref decl) => {
             for enumerator in &decl.enumerator_list {
                 if enumerator.identifier == lookup_ident {
-                    return Some(make_const_expr(None, lookup_decl));
+                    return enum_member_const_expr_from_lookup(lookup_decl, &lookup_ident);
                 }
             }
             lookup_name_members(&decl.members, lookup_decl)
@@ -281,6 +297,119 @@ fn lookup_name_members(members: &Vec<Declaration>, lookup_decl: &LookupDecl) -> 
         }
     }
     None
+}
+
+pub(crate) fn enum_member_const_expr_from_lookup(
+    lookup_decl: &LookupDecl,
+    member_name: &str,
+) -> Option<ConstExpr> {
+    let Declaration::Enum(enum_decl) = &lookup_decl.decl else {
+        return None;
+    };
+
+    let mut enum_val: i64 = 0;
+    let enum_type = lookup_decl.ns.to_string(Namespace::AIDL);
+    let resolution_key = format!("{enum_type}.{member_name}");
+
+    if let Some(cached) =
+        ENUM_VALUE_CACHE.with(|cache| cache.borrow().get(&resolution_key).cloned())
+    {
+        return Some(cached);
+    }
+
+    let is_circular = ENUM_RESOLUTION_STACK.with(|stack| {
+        let mut stack = stack.borrow_mut();
+        if stack.contains(&resolution_key) {
+            true
+        } else {
+            stack.insert(resolution_key.clone());
+            false
+        }
+    });
+    if is_circular {
+        return None;
+    }
+
+    let _guard = NamespaceGuard::new(&lookup_decl.ns);
+    let mut result = None;
+
+    // Resolve inside the enum declaration, not through a global member name.
+    for enumerator in &enum_decl.enumerator_list {
+        if let Some(const_expr) = &enumerator.const_expr {
+            if let Ok(calculated) = const_expr.calculate() {
+                if !matches!(calculated.value, ValueType::Name(_)) {
+                    enum_val = calculated.to_i64().unwrap_or(enum_val);
+                }
+            }
+        }
+
+        if enumerator.identifier == member_name {
+            result = Some(ConstExpr::new(ValueType::Reference {
+                enum_type: enum_type.clone(),
+                enum_name: enum_decl.name.clone(),
+                member_name: member_name.to_string(),
+                value: enum_val,
+            }));
+            break;
+        }
+
+        enum_val += 1;
+    }
+
+    ENUM_RESOLUTION_STACK.with(|stack| {
+        stack.borrow_mut().remove(&resolution_key);
+    });
+
+    if let Some(expr) = &result {
+        ENUM_VALUE_CACHE.with(|cache| {
+            cache.borrow_mut().insert(resolution_key, expr.clone());
+        });
+    }
+
+    result
+}
+
+pub fn name_to_enum_member_const_expr(name: &str, target_enum: Option<&str>) -> Option<ConstExpr> {
+    // A field default has a target type. Use it to resolve unqualified
+    // members and reject defaults from a different enum family.
+    if let Some((enum_name, member_name)) = name.rsplit_once('.') {
+        let lookup_decl = lookup_decl_from_name(enum_name, Namespace::AIDL)?;
+        if !matches!(lookup_decl.decl, Declaration::Enum(_)) {
+            return None;
+        }
+
+        if let Some(target_enum) = target_enum {
+            let target_lookup = lookup_decl_from_name(target_enum, Namespace::AIDL)?;
+            if lookup_decl.ns != target_lookup.ns {
+                return None;
+            }
+        }
+
+        return enum_member_const_expr_from_lookup(&lookup_decl, member_name);
+    }
+
+    if let Some(target_enum) = target_enum {
+        let lookup_decl = lookup_decl_from_name(target_enum, Namespace::AIDL)?;
+        if matches!(lookup_decl.decl, Declaration::Enum(_)) {
+            return enum_member_const_expr_from_lookup(&lookup_decl, name);
+        }
+        return None;
+    }
+
+    let curr_ns = current_namespace();
+    DECLARATION_MAP.with(|hashmap| {
+        let lookup_decl = hashmap
+            .borrow()
+            .get(&curr_ns)
+            .filter(|decl| matches!(decl, Declaration::Enum(_)))
+            .cloned()
+            .map(|decl| LookupDecl {
+                decl,
+                ns: curr_ns.clone(),
+                name: Namespace::new(name, Namespace::AIDL),
+            })?;
+        enum_member_const_expr_from_lookup(&lookup_decl, name)
+    })
 }
 
 // Universal symbol registration - supports all types of named constants
@@ -300,13 +429,25 @@ pub fn register_symbol(
     SYMBOL_TABLE.with(|table| {
         let mut table = table.borrow_mut();
 
-        // Register with simple name
-        table.insert(name.to_string(), symbol.clone());
+        match &symbol.symbol_type {
+            SymbolType::EnumMember => {
+                // Enum members are only registered under their enum type.
+                // Simple enum member names are not globally unique.
+                if let Some(ns) = namespace {
+                    let qualified_name = format!("{}.{}", ns, name);
+                    table.insert(qualified_name, symbol);
+                }
+            }
+            _ => {
+                // Register with simple name
+                table.insert(name.to_string(), symbol.clone());
 
-        // Also register with qualified name if namespace is provided
-        if let Some(ns) = namespace {
-            let qualified_name = format!("{}.{}", ns, name);
-            table.insert(qualified_name, symbol);
+                // Also register with qualified name if namespace is provided
+                if let Some(ns) = namespace {
+                    let qualified_name = format!("{}.{}", ns, name);
+                    table.insert(qualified_name, symbol);
+                }
+            }
         }
     });
 }
@@ -316,6 +457,10 @@ pub fn register_symbol(
 
 // Enhanced name resolution with universal symbol table
 pub fn name_to_const_expr(name: &str) -> Option<ConstExpr> {
+    if let Some(expr) = name_to_enum_member_const_expr(name, None) {
+        return Some(expr);
+    }
+
     // First, try to resolve from universal symbol table (exact match)
     let symbol_result =
         SYMBOL_TABLE.with(|table| table.borrow().get(name).map(|symbol| symbol.value.clone()));
@@ -1635,6 +1780,7 @@ pub fn calculate_namespace(decl: &mut Declaration, mut namespace: Namespace) {
 
 pub fn parse_document(ctx: &SourceContext) -> Result<Document, AidlError> {
     let _guard = SourceGuard::new(&ctx.filename, &ctx.source);
+    reset_enum_resolution_state();
     let mut document = Document::new();
 
     match AIDLParser::parse(Rule::document, &ctx.source) {
@@ -1701,6 +1847,7 @@ pub fn reset() {
     SYMBOL_TABLE.with(|table| {
         table.borrow_mut().clear();
     });
+    reset_enum_resolution_state();
 }
 
 #[cfg(test)]

--- a/rsbinder-aidl/src/parser.rs
+++ b/rsbinder-aidl/src/parser.rs
@@ -39,6 +39,7 @@ pub struct Symbol {
 
 thread_local! {
     static DECLARATION_MAP: RefCell<HashMap<Namespace, Declaration>> = RefCell::new(HashMap::new());
+    static DECLARATION_DOCUMENT_MAP: RefCell<HashMap<Namespace, DocumentContext>> = RefCell::new(HashMap::new());
     #[allow(clippy::missing_const_for_thread_local)]
     static NAMESPACE_STACK: RefCell<Vec<Namespace>> = RefCell::new(Vec::new());
     static DOCUMENT: RefCell<Document> = RefCell::new(Document::new());
@@ -146,12 +147,44 @@ fn reset_enum_resolution_state() {
 }
 
 pub fn set_current_document(document: &Document) {
+    let context = DocumentContext::from_document(document);
+    set_current_document_context(&context);
+}
+
+fn set_current_document_context(context: &DocumentContext) {
     DOCUMENT.with(|doc| {
         let mut doc = doc.borrow_mut();
 
-        doc.package = document.package.clone();
-        doc.imports = document.imports.clone();
+        doc.package = context.package.clone();
+        doc.imports = context.imports.clone();
     })
+}
+
+fn current_document_context() -> DocumentContext {
+    DOCUMENT.with(|doc| {
+        let doc = doc.borrow();
+        DocumentContext::from_document(&doc)
+    })
+}
+
+struct DocumentGuard(DocumentContext);
+
+impl DocumentGuard {
+    fn new(context: &DocumentContext) -> Self {
+        let previous = current_document_context();
+        set_current_document_context(context);
+        Self(previous)
+    }
+}
+
+impl Drop for DocumentGuard {
+    fn drop(&mut self) {
+        set_current_document_context(&self.0);
+    }
+}
+
+fn declaration_document_context(ns: &Namespace) -> Option<DocumentContext> {
+    DECLARATION_DOCUMENT_MAP.with(|hashmap| hashmap.borrow().get(ns).cloned())
 }
 
 fn make_ns_candidate(ns: &Namespace, name: &Namespace) -> Vec<Namespace> {
@@ -330,6 +363,8 @@ pub(crate) fn enum_member_const_expr_from_lookup(
         return None;
     }
 
+    let document_context = declaration_document_context(&lookup_decl.ns);
+    let _document_guard = document_context.as_ref().map(DocumentGuard::new);
     let _guard = NamespaceGuard::new(&lookup_decl.ns);
     let mut result = None;
 
@@ -540,6 +575,21 @@ impl Document {
             package: None,
             imports: HashMap::new(),
             decls: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct DocumentContext {
+    package: Option<String>,
+    imports: HashMap<String, String>,
+}
+
+impl DocumentContext {
+    fn from_document(document: &Document) -> Self {
+        Self {
+            package: document.package.clone(),
+            imports: document.imports.clone(),
         }
     }
 }
@@ -1760,7 +1810,11 @@ fn parse_decl(pairs: pest::iterators::Pairs<Rule>) -> Result<Vec<Declaration>, A
     Ok(declarations)
 }
 
-pub fn calculate_namespace(decl: &mut Declaration, mut namespace: Namespace) {
+fn calculate_namespace(
+    decl: &mut Declaration,
+    mut namespace: Namespace,
+    document_context: &DocumentContext,
+) {
     if decl.is_variable().is_some() {
         return;
     }
@@ -1772,9 +1826,14 @@ pub fn calculate_namespace(decl: &mut Declaration, mut namespace: Namespace) {
     DECLARATION_MAP.with(|hashmap| {
         hashmap.borrow_mut().insert(namespace.clone(), decl.clone());
     });
+    DECLARATION_DOCUMENT_MAP.with(|hashmap| {
+        hashmap
+            .borrow_mut()
+            .insert(namespace.clone(), document_context.clone());
+    });
 
     for decl in decl.members_mut() {
-        calculate_namespace(decl, namespace.clone());
+        calculate_namespace(decl, namespace.clone(), document_context);
     }
 }
 
@@ -1827,8 +1886,9 @@ pub fn parse_document(ctx: &SourceContext) -> Result<Document, AidlError> {
         Namespace::default()
     };
 
+    let document_context = DocumentContext::from_document(&document);
     for decl in &mut document.decls {
-        calculate_namespace(decl, namespace.clone());
+        calculate_namespace(decl, namespace.clone(), &document_context);
     }
 
     Ok(document)
@@ -1836,6 +1896,9 @@ pub fn parse_document(ctx: &SourceContext) -> Result<Document, AidlError> {
 
 pub fn reset() {
     DECLARATION_MAP.with(|hashmap| {
+        hashmap.borrow_mut().clear();
+    });
+    DECLARATION_DOCUMENT_MAP.with(|hashmap| {
         hashmap.borrow_mut().clear();
     });
     NAMESPACE_STACK.with(|stack| {

--- a/rsbinder-aidl/src/type_generator.rs
+++ b/rsbinder-aidl/src/type_generator.rs
@@ -221,6 +221,18 @@ impl TypeGenerator {
         }
     }
 
+    fn is_interface(value_type: &ValueType) -> bool {
+        match value_type {
+            ValueType::UserDefined(name) => {
+                matches!(
+                    lookup_decl_from_name(name, crate::Namespace::AIDL),
+                    Some(lookup_decl) if matches!(lookup_decl.decl, Declaration::Interface(_))
+                )
+            }
+            _ => false,
+        }
+    }
+
     pub fn is_variable_array(&self) -> bool {
         if matches!(self.value_type, ValueType::Array(_)) {
             let sub_type = self.array_types.first().expect("array_types is empty.");
@@ -235,14 +247,23 @@ impl TypeGenerator {
     pub fn can_be_defaulted(value_type: &ValueType, is_struct: bool) -> bool {
         if is_struct {
             Self::is_primitive(value_type)
-                || matches!(
-                    value_type,
+                || match value_type {
                     ValueType::String(_)
-                        | ValueType::Array(_)
-                        | ValueType::Map(_, _)
-                        | ValueType::Holder
-                        | ValueType::UserDefined(_)
-                )
+                    | ValueType::Array(_)
+                    | ValueType::Map(_, _)
+                    | ValueType::Holder => true,
+                    ValueType::UserDefined(name) => {
+                        match lookup_decl_from_name(name, crate::Namespace::AIDL) {
+                            // Strong<dyn IFoo> has no sensible Default, so struct
+                            // interface fields must be represented as Option<Strong<_>>.
+                            Some(lookup_decl) => {
+                                !matches!(lookup_decl.decl, Declaration::Interface(_))
+                            }
+                            None => true,
+                        }
+                    }
+                    _ => false,
+                }
         } else {
             Self::is_primitive(value_type)
                 || match value_type {
@@ -344,6 +365,8 @@ impl TypeGenerator {
         let value_str = if is_struct {
             if self.is_nullable && Self::is_aidl_nullable(&array_info.value_type) {
                 format!("Option<{type_name}>")
+            } else if !Self::can_be_defaulted(&array_info.value_type, is_struct) {
+                format!("Option<{type_name}>")
             } else {
                 type_name
             }
@@ -416,7 +439,9 @@ impl TypeGenerator {
             Direction::Inout => {
                 if self.is_nullable {
                     format!("Vec<Option<{type_name}>>")
-                } else if Self::can_be_defaulted(&sub_type.value_type, true) {
+                } else if Self::can_be_defaulted(&sub_type.value_type, true)
+                    || Self::is_interface(&sub_type.value_type)
+                {
                     format!("Vec<{type_name}>")
                 } else {
                     format!("Vec<Option<{type_name}>>")
@@ -682,26 +707,202 @@ impl TypeGenerator {
         }
     }
 
-    pub(crate) fn init_value(&self, const_expr: Option<&ConstExpr>, param: InitParam) -> String {
-        match const_expr {
+    fn enum_lookup(&self) -> Option<LookupDecl> {
+        let ValueType::UserDefined(name) = &self.value_type else {
+            return None;
+        };
+
+        let lookup_decl = lookup_decl_from_name(name, crate::Namespace::AIDL)?;
+        if matches!(&lookup_decl.decl, Declaration::Enum(_)) {
+            Some(lookup_decl)
+        } else {
+            None
+        }
+    }
+
+    fn resolve_enum_reference_for_target(expr: &ConstExpr, target_enum: &str) -> ConstExpr {
+        match &expr.value {
+            ValueType::Name(name) => {
+                parser::name_to_enum_member_const_expr(name, Some(target_enum))
+                    .unwrap_or_else(|| expr.clone())
+            }
+            ValueType::Array(values) => ConstExpr::new(ValueType::Array(
+                values
+                    .iter()
+                    .map(|value| Self::resolve_enum_reference_for_target(value, target_enum))
+                    .collect(),
+            )),
+            ValueType::Expr { lhs, operator, rhs } => ConstExpr::new(ValueType::Expr {
+                lhs: Box::new(Self::resolve_enum_reference_for_target(lhs, target_enum)),
+                operator: operator.clone(),
+                rhs: Box::new(Self::resolve_enum_reference_for_target(rhs, target_enum)),
+            }),
+            ValueType::Unary { operator, expr } => ConstExpr::new(ValueType::Unary {
+                operator: operator.clone(),
+                expr: Box::new(Self::resolve_enum_reference_for_target(expr, target_enum)),
+            }),
+            _ => expr.clone(),
+        }
+    }
+
+    fn validate_enum_value(
+        &self,
+        expr: &ConstExpr,
+        target_lookup: &LookupDecl,
+    ) -> Result<ConstExpr, AidlError> {
+        let target_enum = target_lookup.ns.to_string(crate::Namespace::AIDL);
+        let resolved = Self::resolve_enum_reference_for_target(expr, &target_enum);
+        let calculated = resolved
+            .calculate()
+            .map_err(|e| make_type_error(e.message, self.type_span))?;
+
+        match &calculated.value {
+            ValueType::Reference { enum_type, .. } => {
+                // Same member names are common across enums; ensure a default
+                // belongs to the field's enum family before rendering Rust.
+                if enum_type != &target_enum {
+                    return Err(make_type_error(
+                        format!(
+                            "enum default value {} does not match target enum {}",
+                            calculated.to_value_string(),
+                            target_enum
+                        ),
+                        self.type_span,
+                    ));
+                }
+
+                Ok(calculated)
+            }
+            ValueType::Name(name) => Err(make_type_error(
+                format!(
+                    "unresolved enum default value {} for target enum {}",
+                    name, target_enum
+                ),
+                self.type_span,
+            )),
+            _ => Err(make_type_error(
+                format!(
+                    "enum default value {} is not a member of target enum {}",
+                    calculated.to_value_string(),
+                    target_enum
+                ),
+                self.type_span,
+            )),
+        }
+    }
+
+    fn init_enum_value(
+        &self,
+        expr: &ConstExpr,
+        target_lookup: &LookupDecl,
+        param: InitParam,
+    ) -> Result<String, AidlError> {
+        let calculated = self.validate_enum_value(expr, target_lookup)?;
+        Ok(calculated
+            .value
+            .to_init(param.with_fixed_array(false).with_nullable(false)))
+    }
+
+    fn init_enum_array_value(
+        &self,
+        expr: &ConstExpr,
+        target_lookup: &LookupDecl,
+        param: InitParam,
+        is_fixed_array: bool,
+        is_nullable: bool,
+    ) -> Result<String, AidlError> {
+        let target_enum = target_lookup.ns.to_string(crate::Namespace::AIDL);
+        let resolved = Self::resolve_enum_reference_for_target(expr, &target_enum);
+        let calculated = resolved
+            .calculate()
+            .map_err(|e| make_type_error(e.message, self.type_span))?;
+
+        let ValueType::Array(values) = calculated.value else {
+            return Err(make_type_error(
+                format!(
+                    "enum array default value {} is not an array",
+                    calculated.to_value_string()
+                ),
+                self.type_span,
+            ));
+        };
+
+        let mut enum_values = Vec::new();
+        for value in values {
+            enum_values.push(self.validate_enum_value(&value, target_lookup)?);
+        }
+
+        Ok(ValueType::Array(enum_values).to_init(
+            param
+                .with_fixed_array(is_fixed_array)
+                .with_nullable(is_nullable),
+        ))
+    }
+
+    fn init_array_value(
+        expr: &ConstExpr,
+        array_info: &ArrayInfo,
+        param: InitParam,
+        is_nullable: bool,
+    ) -> String {
+        match expr
+            .calculate()
+            .and_then(|c| c.convert_to(&array_info.value_type))
+        {
+            Ok(converted) => converted.value.to_init(
+                param
+                    .with_fixed_array(array_info.is_fixed())
+                    .with_nullable(is_nullable),
+            ),
+            Err(_) => ValueType::Void.to_init(param.with_fixed_array(false).with_nullable(false)),
+        }
+    }
+
+    pub(crate) fn init_value(
+        &self,
+        const_expr: Option<&ConstExpr>,
+        param: InitParam,
+    ) -> Result<String, AidlError> {
+        let init_value = match const_expr {
             Some(expr) => {
                 let init_str = if let ValueType::Array(_) = self.value_type {
                     let array_info = self.array_types.first().unwrap();
                     let is_nullable =
                         self.is_nullable && Self::is_aidl_nullable(&array_info.value_type);
-                    match expr
-                        .calculate()
-                        .and_then(|c| c.convert_to(&array_info.value_type))
-                    {
-                        Ok(converted) => converted.value.to_init(
-                            param
-                                .with_fixed_array(array_info.is_fixed())
-                                .with_nullable(is_nullable),
-                        ),
-                        Err(_) => ValueType::Void
-                            .to_init(param.with_fixed_array(false).with_nullable(false)),
+                    if let ValueType::UserDefined(name) = &array_info.value_type {
+                        if let Some(lookup_decl) =
+                            lookup_decl_from_name(name, crate::Namespace::AIDL)
+                        {
+                            if matches!(&lookup_decl.decl, Declaration::Enum(_)) {
+                                self.init_enum_array_value(
+                                    expr,
+                                    &lookup_decl,
+                                    param,
+                                    array_info.is_fixed(),
+                                    is_nullable,
+                                )?
+                            } else {
+                                Self::init_array_value(expr, array_info, param, is_nullable)
+                            }
+                        } else {
+                            Self::init_array_value(expr, array_info, param, is_nullable)
+                        }
+                    } else {
+                        Self::init_array_value(expr, array_info, param, is_nullable)
                     }
                 } else {
+                    if let Some(enum_lookup) = self.enum_lookup() {
+                        return self
+                            .init_enum_value(expr, &enum_lookup, param)
+                            .map(|init_str| {
+                                if self.is_nullable {
+                                    format!("Some({init_str})")
+                                } else {
+                                    init_str
+                                }
+                            });
+                    }
+
                     match expr.calculate() {
                         Ok(calculated) => {
                             // Check if we have an enum reference and target is a primitive type
@@ -739,7 +940,9 @@ impl TypeGenerator {
                 }
             }
             None => ValueType::Void.to_init(param.with_fixed_array(false).with_nullable(false)),
-        }
+        };
+
+        Ok(init_value)
     }
 }
 

--- a/rsbinder-aidl/src/type_generator.rs
+++ b/rsbinder-aidl/src/type_generator.rs
@@ -363,9 +363,9 @@ impl TypeGenerator {
         let type_name = self.array_type_name(&array_info.value_type);
 
         let value_str = if is_struct {
-            if self.is_nullable && Self::is_aidl_nullable(&array_info.value_type) {
-                format!("Option<{type_name}>")
-            } else if !Self::can_be_defaulted(&array_info.value_type, is_struct) {
+            if (self.is_nullable && Self::is_aidl_nullable(&array_info.value_type))
+                || !Self::can_be_defaulted(&array_info.value_type, is_struct)
+            {
                 format!("Option<{type_name}>")
             } else {
                 type_name


### PR DESCRIPTION
```aidl
enum Digest {
    NONE = 7,
}

enum HardwareAuthenticatorType {
    NONE = 0, // same name with Digest.NONE
}

parcelable AuthenticatorSpec {
    HardwareAuthenticatorType authenticatorType = HardwareAuthenticatorType.NONE;
}
```

this aidl will generate code like:
```rust
r#authenticatorType: super::Digest::Digest::NONE,
```
which is wrong.
correct one:
```rust
r#authenticatorType: super::HardwareAuthenticatorType::HardwareAuthenticatorType::NONE,
```

---

this commit also makes interfaces with non-Null values ​​in parcelable fields, but without initial values, become `Option`. (Dirty fix, but I don't have a better idea.)

```aidl
parcelable BeginResult {
    IKeyMintOperation operation; // this is a non-null interface
}
```

generated code:
```rust
r#operation: rsbinder::Strong<dyn super::IKeyMintOperation::IKeyMintOperation>, // compile failed cuz you can't generate default interface for it.
```
"correct" one:
```rust
pub r#operation: Option<rsbinder::Strong<dyn super::IKeyMintOperation::IKeyMintOperation>>,
```