### PR TITLE
test(rsbinder-aidl): lock PR #121 interface-field and enum-mismatch behavior

### DIFF
--- a/rsbinder-aidl/tests/test_enum_references.rs
+++ b/rsbinder-aidl/tests/test_enum_references.rs
@@ -714,3 +714,123 @@ fn test_cross_package_enum_default_value() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+// PR #121 — parcelable with a non-null interface field.
+//
+// Pre-#121 generated `pub r#op: rsbinder::Strong<dyn IFoo>` for this field,
+// which fails to compile because `Strong<_>` has no `Default` impl (verified
+// against master prior to PR #121 — produced exactly that non-compiling
+// output). PR #121 now wraps interface fields in `Option<>`, matching AOSP
+// `aidl_to_rust.cpp` `TypeNeedsOption` for PARCELABLE_FIELD storage.
+//
+// Note: the AIDL non-null contract is NOT enforced at the Rust type level
+// — a caller can send `None` and the peer will reject at unmarshal time.
+// This mirrors AOSP's Rust backend behavior.
+#[test]
+fn test_pr121_parcelable_non_null_interface_field_is_option() -> Result<(), Box<dyn Error>> {
+    let gen = rsbinder_aidl::Generator::new(false, false);
+
+    let doc = rsbinder_aidl::parse_document(&rsbinder_aidl::SourceContext::new(
+        "Holder.aidl",
+        r#"
+        package test.iface;
+
+        interface IFoo {
+            void noop();
+        }
+
+        parcelable Holder {
+            IFoo op;
+        }
+    "#,
+    ))?;
+
+    let res = gen.document(&doc)?;
+    let output = &res.1;
+
+    let holder_field = output.lines().find(|l| l.contains("r#op:")).unwrap_or("");
+    assert!(
+        holder_field.contains("Option<rsbinder::Strong<dyn super::IFoo::IFoo>>"),
+        "non-null interface field must be Option<Strong<dyn _>>, got: {}",
+        holder_field
+    );
+
+    // And the default impl must compile (Option's Default is None).
+    assert!(
+        output.contains("r#op: Default::default()"),
+        "Default impl must use Default::default() for the Option field, got:\n{}",
+        output
+    );
+
+    Ok(())
+}
+
+// PR #121 — cross-enum mismatch is rejected.
+//
+// Pre-#121, a parcelable `HardwareAuthenticatorType` field defaulting to
+// `Digest.NONE` silently generated `super::Digest::Digest::NONE` — a wrong-
+// type initializer that would only be caught by rustc compiling the
+// generated code (or might compile accidentally if both enums share the
+// same backing and the value coerces). PR #121's `validate_enum_value`
+// now rejects this at AIDL-parse time with a clear diagnostic.
+//
+// AOSP `aidl_to_rust.cpp:89-93` silently re-targets `Bar.X` for a `Foo`
+// field to `Foo::X` (using only the suffix). rsbinder is intentionally
+// stricter; real AIDL never writes this pattern, so this test also
+// documents the divergence rather than guarding a common case.
+#[test]
+fn test_pr121_cross_enum_mismatch_is_rejected() -> Result<(), Box<dyn Error>> {
+    let gen = rsbinder_aidl::Generator::new(false, false);
+
+    let digest_doc = rsbinder_aidl::parse_document(&rsbinder_aidl::SourceContext::new(
+        "Digest.aidl",
+        r#"
+        package keymint;
+
+        @Backing(type="int")
+        enum Digest {
+            NONE = 7,
+        }
+    "#,
+    ))?;
+
+    let auth_type_doc = rsbinder_aidl::parse_document(&rsbinder_aidl::SourceContext::new(
+        "HardwareAuthenticatorType.aidl",
+        r#"
+        package keymint;
+
+        @Backing(type="int")
+        enum HardwareAuthenticatorType {
+            NONE = 0,
+        }
+    "#,
+    ))?;
+
+    let parcelable_doc = rsbinder_aidl::parse_document(&rsbinder_aidl::SourceContext::new(
+        "BadSpec.aidl",
+        r#"
+        package keymint;
+
+        import keymint.Digest;
+        import keymint.HardwareAuthenticatorType;
+
+        parcelable BadSpec {
+            HardwareAuthenticatorType authenticatorType = Digest.NONE;
+        }
+    "#,
+    ))?;
+
+    let _ = gen.document(&digest_doc)?;
+    let _ = gen.document(&auth_type_doc)?;
+    let result = gen.document(&parcelable_doc);
+
+    let err = result.expect_err("cross-enum mismatch must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("does not match target enum") || msg.contains("HardwareAuthenticatorType"),
+        "error must mention the target-enum mismatch, got: {}",
+        msg
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Tests-only follow-up to #121. Adds two unit tests that lock the behavior #121 fixed, both mutation-verified against the pre-#121 master tip (`7442e1b`) to confirm they fail without #121 and pass with it.

- `test_pr121_parcelable_non_null_interface_field_is_option` — locks `Option<Strong<dyn IFoo>>` for non-`@nullable` interface fields in a parcelable. Pre-#121 emitted bare `Strong<dyn IFoo>`, which does not compile because `Strong<_>` has no `Default` impl. Matches AOSP `system/tools/aidl/aidl_to_rust.cpp` `TypeNeedsOption` for `PARCELABLE_FIELD` storage.
- `test_pr121_cross_enum_mismatch_is_rejected` — locks the new `validate_enum_value` rejection when a parcelable field defaults to a member of a different enum (e.g. `HardwareAuthenticatorType x = Digest.NONE`). Pre-#121 silently produced a wrong-type initializer (`super::Digest::Digest::NONE` for a `HardwareAuthenticatorType` field). AOSP's Rust codegen also silently re-targets in `aidl_to_rust.cpp:89-93`; rsbinder is intentionally stricter and this test documents the divergence.

## Scope notes
- No production code changes — tests only.
- A third candidate test (cross-enum `NONE` collision happy-path with `pre_register_enums` omitted) was prototyped but dropped: every AIDL pattern I tried for it resolved correctly on pre-#121 master too, so it would not have caught a real regression. The existing `test_multiple_enums_with_same_member_name` continues to cover the issue #71 scenario.
- During mutation testing I noticed `pre_register_enums()` may not actually be required for `test_multiple_enums_with_same_member_name` to pass on pre-#121 master. Worth a separate look — left out of this PR to keep it tests-only.

## Test plan
- [x] `cargo test --package rsbinder-aidl --test test_enum_references` — 13/13 passing (11 pre-existing + 2 new)
- [x] `cargo test --package rsbinder-aidl` — full suite green
- [x] `cargo fmt --package rsbinder-aidl --check` — clean
- [x] `cargo clippy --package rsbinder-aidl --tests --all-features` — clean
- [x] Mutation check against `7442e1b` (pre-#121 master): both new tests fail as expected, confirming regression-catch value

🤖 Generated with [Claude Code](https://claude.com/claude-code)