### PR TITLE
feat(rsbinder-aidl): generate getInterfaceVersion/Hash meta methods (#10)

### DIFF
--- a/rsbinder-aidl/src/generator.rs
+++ b/rsbinder-aidl/src/generator.rs
@@ -160,11 +160,35 @@ pub mod {{mod}} {
     {%- for member in const_members %}
     pub const r#{{ member.0 }}: {{ member.1 }} = {{ member.2 }};
     {%- endfor %}
+    {%- if version %}
+    /// Stable-AIDL interface version. Echoed verbatim through
+    /// `getInterfaceVersion()`. Matches AOSP `aidl --version N`.
+    pub const VERSION: i32 = {{ version }};
+    {%- endif %}
+    {%- if hash %}
+    /// Stable-AIDL frozen-API hash. Echoed verbatim through
+    /// `getInterfaceHash()`. Matches AOSP `aidl --hash <s>`; the generator
+    /// does not validate it against the AIDL contents (freeze workflow's
+    /// responsibility).
+    pub const HASH: &str = "{{ hash }}";
+    {%- endif %}
     pub trait {{name}}: {{crate}}::Interface + Send {
         fn descriptor() -> &'static str where Self: Sized { "{{ namespace }}" }
         {%- for member in fn_members %}
         fn r#{{ member.identifier }}({{ member.args }}) -> {{crate}}::status::Result<{{ member.return_type }}>;
         {%- endfor %}
+        {%- if version %}
+        // Server-side default returns the module's VERSION constant.
+        // `Bp{{name}}` overrides this with a cache+transact pattern.
+        fn r#getInterfaceVersion(&self) -> {{crate}}::status::Result<i32> {
+            Ok(VERSION)
+        }
+        {%- endif %}
+        {%- if hash %}
+        fn r#getInterfaceHash(&self) -> {{crate}}::status::Result<String> {
+            Ok(HASH.into())
+        }
+        {%- endif %}
         fn getDefaultImpl() -> Option<{{ name }}DefaultRef> where Self: Sized {
             DEFAULT_IMPL.get().cloned()
         }
@@ -251,6 +275,15 @@ pub mod {{mod}} {
         {%- set_global counter = counter + 1 %}
         {%- endif %}
         {%- endfor %}
+        {%- if version %}
+        // AOSP stable-AIDL meta transactions; offsets match
+        // `system/tools/aidl/include/aidl/transaction_ids.h`:
+        // kLastCallTransaction (0x00ffffff) - kFirstCallTransaction (1).
+        pub(crate) const r#getInterfaceVersion: {{crate}}::TransactionCode = {{crate}}::FIRST_CALL_TRANSACTION + 16777214;
+        {%- endif %}
+        {%- if hash %}
+        pub(crate) const r#getInterfaceHash: {{crate}}::TransactionCode = {{crate}}::FIRST_CALL_TRANSACTION + 16777213;
+        {%- endif %}
     }
     pub type {{ name }}DefaultRef = std::sync::Arc<dyn {{ name }}Default>;
     static DEFAULT_IMPL: std::sync::OnceLock<{{ name }}DefaultRef> = std::sync::OnceLock::new();
@@ -263,7 +296,18 @@ pub mod {{mod}} {
                 r#async: {{ name }}AsyncService,
                 {%- endif %}
             },
+            {%- if version or hash %}
+            proxy: {{ bp_name }} {
+                {%- if version %}
+                cached_version: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(-1){% if hash %},{% endif %}
+                {%- endif %}
+                {%- if hash %}
+                cached_hash: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None)
+                {%- endif %}
+            },
+            {%- else %}
             proxy: {{ bp_name }},
+            {%- endif %}
             {%- if enabled_async %}
             r#async: {{ name }}Async,
             {%- endif %}
@@ -308,6 +352,34 @@ pub mod {{mod}} {
             {%- endif %}
         }
         {%- endfor %}
+        {%- if version %}
+        fn build_parcel_getInterfaceVersion(&self) -> {{crate}}::Result<{{crate}}::Parcel> {
+            let data = self.binder.as_remote().ok_or({{crate}}::StatusCode::BadType)?.prepare_transact(true)?;
+            Ok(data)
+        }
+        fn read_response_getInterfaceVersion(&self, _aidl_reply: {{crate}}::Result<Option<{{crate}}::Parcel>>) -> {{crate}}::status::Result<i32> {
+            let mut _aidl_reply = _aidl_reply?.ok_or({{crate}}::StatusCode::UnexpectedNull)?;
+            let _status = _aidl_reply.read::<{{crate}}::Status>()?;
+            if !_status.is_ok() { return Err(_status); }
+            let _aidl_return: i32 = _aidl_reply.read()?;
+            self.cached_version.store(_aidl_return, std::sync::atomic::Ordering::Relaxed);
+            Ok(_aidl_return)
+        }
+        {%- endif %}
+        {%- if hash %}
+        fn build_parcel_getInterfaceHash(&self) -> {{crate}}::Result<{{crate}}::Parcel> {
+            let data = self.binder.as_remote().ok_or({{crate}}::StatusCode::BadType)?.prepare_transact(true)?;
+            Ok(data)
+        }
+        fn read_response_getInterfaceHash(&self, _aidl_reply: {{crate}}::Result<Option<{{crate}}::Parcel>>) -> {{crate}}::status::Result<String> {
+            let mut _aidl_reply = _aidl_reply?.ok_or({{crate}}::StatusCode::UnexpectedNull)?;
+            let _status = _aidl_reply.read::<{{crate}}::Status>()?;
+            if !_status.is_ok() { return Err(_status); }
+            let _aidl_return: String = _aidl_reply.read()?;
+            *self.cached_hash.lock().unwrap() = Some(_aidl_return.clone());
+            Ok(_aidl_return)
+        }
+        {%- endif %}
     }
     impl {{ name }} for {{ bp_name }} {
         {%- for member in fn_members %}
@@ -321,6 +393,28 @@ pub mod {{mod}} {
             {%- endif %}
         }
         {%- endfor %}
+        {%- if version %}
+        fn r#getInterfaceVersion(&self) -> {{crate}}::status::Result<i32> {
+            let _aidl_version = self.cached_version.load(std::sync::atomic::Ordering::Relaxed);
+            if _aidl_version != -1 { return Ok(_aidl_version); }
+            let _aidl_data = self.build_parcel_getInterfaceVersion()?;
+            let _aidl_reply = self.binder.as_remote().ok_or({{crate}}::StatusCode::BadType)?.submit_transact(transactions::r#getInterfaceVersion, &_aidl_data, {{crate}}::FLAG_PRIVATE_LOCAL | {{crate}}::FLAG_CLEAR_BUF);
+            self.read_response_getInterfaceVersion(_aidl_reply)
+        }
+        {%- endif %}
+        {%- if hash %}
+        fn r#getInterfaceHash(&self) -> {{crate}}::status::Result<String> {
+            {
+                let _aidl_hash_lock = self.cached_hash.lock().unwrap();
+                if let Some(ref _aidl_hash) = *_aidl_hash_lock {
+                    return Ok(_aidl_hash.clone());
+                }
+            }
+            let _aidl_data = self.build_parcel_getInterfaceHash()?;
+            let _aidl_reply = self.binder.as_remote().ok_or({{crate}}::StatusCode::BadType)?.submit_transact(transactions::r#getInterfaceHash, &_aidl_data, {{crate}}::FLAG_PRIVATE_LOCAL | {{crate}}::FLAG_CLEAR_BUF);
+            self.read_response_getInterfaceHash(_aidl_reply)
+        }
+        {%- endif %}
     }
     {%- if enabled_async %}
     impl<P: {{crate}}::BinderAsyncPool> {{name}}Async<P> for {{ bp_name }} {
@@ -392,6 +486,36 @@ pub mod {{mod}} {
                 Ok(())
             }
         {%- endfor %}
+        {%- if version %}
+            transactions::r#getInterfaceVersion => {
+                let _aidl_return = _service.r#getInterfaceVersion();
+                match &_aidl_return {
+                    Ok(_aidl_return) => {
+                        _reply.write(&{{crate}}::Status::from({{crate}}::StatusCode::Ok))?;
+                        _reply.write(_aidl_return)?;
+                    }
+                    Err(_aidl_status) => {
+                        _reply.write(_aidl_status)?;
+                    }
+                }
+                Ok(())
+            }
+        {%- endif %}
+        {%- if hash %}
+            transactions::r#getInterfaceHash => {
+                let _aidl_return = _service.r#getInterfaceHash();
+                match &_aidl_return {
+                    Ok(_aidl_return) => {
+                        _reply.write(&{{crate}}::Status::from({{crate}}::StatusCode::Ok))?;
+                        _reply.write(_aidl_return)?;
+                    }
+                    Err(_aidl_status) => {
+                        _reply.write(_aidl_status)?;
+                    }
+                }
+                Ok(())
+            }
+        {%- endif %}
             _ => Err({{crate}}::StatusCode::UnknownTransaction),
         }
     }
@@ -641,6 +765,17 @@ fn validate_transaction_codes(decl: &parser::InterfaceDecl) -> Result<(), AidlEr
 pub struct Generator {
     enabled_async: bool,
     is_crate: bool,
+    /// Stable-AIDL `--version N` equivalent. When `Some`, the interface
+    /// template emits `pub const VERSION`, the two synthetic meta
+    /// transactions (`getInterfaceVersion` / `getInterfaceHash`), and the
+    /// proxy-side cache plumbing. `None` ⇒ wire-byte-identical to the
+    /// pre-versioning generator output.
+    version: Option<i32>,
+    /// Stable-AIDL `--hash <s>` equivalent. Echoed verbatim through the
+    /// generated `getInterfaceHash()` method; generator does not compute
+    /// or validate it. Independent of `version` — set either, both, or
+    /// neither (matches AOSP's per-flag conditional).
+    hash: Option<String>,
 }
 
 impl Generator {
@@ -648,7 +783,21 @@ impl Generator {
         Self {
             enabled_async,
             is_crate,
+            version: None,
+            hash: None,
         }
+    }
+
+    /// Per-source version/hash metadata, mirroring AOSP `aidl --version N
+    /// --hash <s>` flags. Pass `None` for either to suppress the
+    /// corresponding emission (matches AOSP's per-flag conditional).
+    ///
+    /// Crate-internal: the public entry points are [`crate::Builder::version`]
+    /// and [`crate::Builder::hash`], which route through this method.
+    pub(crate) fn with_version_meta(mut self, version: Option<i32>, hash: Option<String>) -> Self {
+        self.version = version;
+        self.hash = hash;
+        self
     }
 
     fn get_crate_name(&self) -> &str {
@@ -811,6 +960,12 @@ impl Generator {
         context.insert("nested", &nested.trim());
         context.insert("enabled_async", &enabled_async);
         context.insert("is_vintf", &is_vintf);
+        // Stable-AIDL `getInterfaceVersion`/`getInterfaceHash` plumbing.
+        // `version` and `hash` are independent — INTERFACE_TEMPLATE emits
+        // each only if its key is set, matching AOSP's per-flag conditional.
+        // Both missing ⇒ wire byte-identical to the pre-versioning generator.
+        context.insert("version", &self.version);
+        context.insert("hash", &self.hash);
 
         let rendered =
             template()

--- a/rsbinder-aidl/src/lib.rs
+++ b/rsbinder-aidl/src/lib.rs
@@ -4,7 +4,7 @@
 // extern crate lazy_static;
 
 use miette::{NamedSource, SourceSpan};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::mem::take;
 use std::path::{Path, PathBuf};
@@ -106,6 +106,18 @@ pub fn add_indent(step: usize, source: &str) -> String {
     content
 }
 
+/// Per-source frozen-API metadata, populated by [`Builder::version`] /
+/// [`Builder::hash`]. Mirrors AOSP `aidl --version N --hash <s>` semantics:
+/// the version int and hash string are echoed verbatim through the
+/// generated `getInterfaceVersion()` / `getInterfaceHash()` meta methods —
+/// the generator does not compute or validate either value (AIDL API
+/// snapshot freeze is a separate workflow).
+#[derive(Default, Clone, Debug)]
+struct VersionMeta {
+    version: Option<i32>,
+    hash: Option<String>,
+}
+
 pub struct Builder {
     sources: Vec<PathBuf>,
     includes: Vec<PathBuf>,
@@ -113,6 +125,10 @@ pub struct Builder {
     output: PathBuf,
     enabled_async: bool,
     is_crate: bool,
+    /// Per-source version/hash overrides. Keyed by the source path passed
+    /// to [`Builder::source`]. [`Builder::version`] and [`Builder::hash`]
+    /// apply to the most recently added source.
+    version_meta: HashMap<PathBuf, VersionMeta>,
 }
 
 impl Default for Builder {
@@ -131,11 +147,54 @@ impl Builder {
             output: "rsbinder_generated_aidl.rs".into(),
             enabled_async: cfg!(feature = "async"),
             is_crate: false,
+            version_meta: HashMap::new(),
         }
     }
 
     pub fn source(mut self, source: impl AsRef<Path>) -> Self {
         self.sources.push(source.as_ref().into());
+        self
+    }
+
+    /// Stamp the **most recently added** source with an interface version,
+    /// equivalent to AOSP `aidl --version N`. Causes the generator to emit
+    /// `pub const VERSION: i32 = N;` plus a synthetic `getInterfaceVersion()`
+    /// meta method (transaction code `FIRST_CALL_TRANSACTION + 0xFFFFFE`)
+    /// for every interface declared in that source. Pair with
+    /// [`Builder::hash`] to also emit `getInterfaceHash()`.
+    ///
+    /// Panics if no source has been added yet or if `v <= 0` (matches
+    /// AOSP `aidl.cpp:615` which silently ignores non-positive versions —
+    /// surfacing it here as an explicit failure avoids the silent-no-op
+    /// trap that Tera's falsy-`0` semantics would otherwise create).
+    pub fn version(mut self, v: i32) -> Self {
+        assert!(
+            v > 0,
+            "Builder::version: N must be > 0; omit the call for unversioned interfaces"
+        );
+        let last = self
+            .sources
+            .last()
+            .cloned()
+            .expect("Builder::version() called before any source()");
+        self.version_meta.entry(last).or_default().version = Some(v);
+        self
+    }
+
+    /// Stamp the **most recently added** source with an interface hash,
+    /// equivalent to AOSP `aidl --hash <s>`. The string is echoed verbatim
+    /// through the generated `getInterfaceHash()` meta method — generator
+    /// does not validate it against the AIDL contents (AIDL API snapshot
+    /// freeze is a separate workflow).
+    ///
+    /// Panics if no source has been added yet.
+    pub fn hash(mut self, h: impl Into<String>) -> Self {
+        let last = self
+            .sources
+            .last()
+            .cloned()
+            .expect("Builder::hash() called before any source()");
+        self.version_meta.entry(last).or_default().hash = Some(h.into());
         self
     }
 
@@ -385,7 +444,17 @@ impl Builder {
             // Re-establish the source context so that semantic errors generated
             // during code generation can reference the correct file name and source text.
             let _guard = parser::SourceGuard::new(&document.2.filename, &document.2.source);
-            let gen = generator::Generator::new(self.enabled_async, self.is_crate);
+            // Look up per-source version/hash. Document filename matches
+            // the path passed to `.source()` (see `parse_file`), so a
+            // PathBuf key roundtrips. Imported sources picked up during
+            // resolution have no entry and fall through to `None`.
+            let meta = self
+                .version_meta
+                .get(&PathBuf::from(&document.2.filename))
+                .cloned()
+                .unwrap_or_default();
+            let gen = generator::Generator::new(self.enabled_async, self.is_crate)
+                .with_version_meta(meta.version, meta.hash);
             match gen.document(&document.1) {
                 Ok(package) => {
                     package_list.push((package.0, package.1, document.0.clone()));

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -74,6 +74,12 @@ fn main() {
         .source(PathBuf::from(
             "aidl/android/aidl/versioned/tests/IFooInterface.aidl",
         ))
+        // Stable-AIDL meta methods: version + frozen-API hash.
+        // The hash literal matches AOSP's `aidl_api/aidl-test-versioned-interface/1/.hash`
+        // (second/legacy line). Generator echoes both values verbatim — see
+        // `getInterfaceVersion()`/`getInterfaceHash()` in the generated `BpFooInterface`.
+        .version(1)
+        .hash("9e7be1859820c59d9d55dd133e71a3687b5d2e5b")
         .source(PathBuf::from("aidl/android/aidl/tests/sm/IFoo.aidl"))
         .output(PathBuf::from("test_aidl.rs"))
         .generate()

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -961,10 +961,9 @@ fn test_default_impl() {
     assert_eq!(result, Ok(EXPECTED_RETURN_VALUE));
 }
 
-// Not supported version and hash yet.
-/*
 #[test]
 fn test_versioned_interface_version() {
+    init_test();
     let service: rsbinder::Strong<dyn IFooInterface::IFooInterface> =
         hub::get_interface(<BpFooInterface as IFooInterface::IFooInterface>::descriptor())
             .expect("did not get binder service");
@@ -975,14 +974,17 @@ fn test_versioned_interface_version() {
 
 #[test]
 fn test_versioned_interface_hash() {
+    init_test();
     let service: rsbinder::Strong<dyn IFooInterface::IFooInterface> =
         hub::get_interface(<BpFooInterface as IFooInterface::IFooInterface>::descriptor())
             .expect("did not get binder service");
 
     let hash = service.getInterfaceHash();
-    assert_eq!(hash.as_ref().map(String::as_str), Ok("9e7be1859820c59d9d55dd133e71a3687b5d2e5b"));
+    assert_eq!(
+        hash.as_ref().map(String::as_str),
+        Ok("9e7be1859820c59d9d55dd133e71a3687b5d2e5b")
+    );
 }
-*/
 
 #[test]
 fn test_versioned_known_union_field_is_ok() {


### PR DESCRIPTION
Closes #10.

## Summary

- `Builder::version(N)` / `Builder::hash(s)` per-source stamps trigger emission of AOSP-faithful synthetic `getInterfaceVersion()` / `getInterfaceHash()` meta methods on every interface in the stamped source. Transaction codes match AOSP `transaction_ids.h`: `FIRST_CALL_TRANSACTION + 0xFFFFFE` (version) and `+ 0xFFFFFD` (hash).
- Server side returns module-level `VERSION` / `HASH` constants via the trait's default impl; proxy side uses an `AtomicI32` / `Mutex<Option<String>>` cache + transact pattern (lock released before transact, identical to AOSP's Rust backend).
- The two flags are independent — sources without a stamp are wire byte-identical to the pre-versioning generator output (no regression risk for existing AIDL).
- Resurrects the previously disabled `test_versioned_interface_version` / `_hash` in `tests/src/test_client.rs` and stamps the versioned-test AIDL fixture with `version=1` + the AOSP V1 legacy hash.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (default / `--features rpc` / `--all-features` / `--no-default-features --features tokio` all green)
- [x] `cargo test -p rsbinder-aidl` — 19/0 unit + 13 integration test binaries all green
- [x] hermetic RPC integration: `rpc_e2e` 4/0, `rpc_fd` 4/0, `rpc_server` 22/0
- [x] **Live kernel binder e2e on REMOTE_LINUX (Rust kernel binder driver)**: `cargo test -p tests` = **120 passed / 0 failed / 5 ignored** (baseline 118/0 + the 2 newly resurrected `test_versioned_interface_*` tests)