### PR TITLE
chore(rsbinder): replace unmaintained rustls-pemfile with rustls-pki-types PemObject

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,6 @@ dependencies = [
  "rsproperties",
  "rustix",
  "rustls",
- "rustls-pemfile",
  "serial_test",
  "sha2",
  "tokio",
@@ -1211,15 +1210,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/rsbinder/Cargo.toml
+++ b/rsbinder/Cargo.toml
@@ -93,9 +93,6 @@ rsbinder-aidl = { workspace = true, features = ["async"] }
 [dev-dependencies]
 env_logger = { workspace = true }
 serial_test = { workspace = true }
-# PEM parsing for the `rpc-tls` e2e test only (tiny, no crypto). The
-# test itself is `#![cfg(feature = "rpc-tls")]`.
-rustls-pemfile = "2"
 
 # loom is only used by tests gated on `--cfg loom`. Run with:
 #   RUSTFLAGS="--cfg loom" cargo test --test loom_cache_pin --release

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -737,9 +737,9 @@ fn android13plus_profile_e2e() {
 #[cfg(feature = "rpc-tls")]
 #[test]
 fn tls_android13plus_nested_callback_e2e() {
-    use std::io::BufReader;
     use std::net::TcpListener;
 
+    use rsbinder::rpc::rustls::pki_types::pem::PemObject;
     use rsbinder::rpc::rustls::pki_types::{CertificateDer, PrivateKeyDer};
     use rsbinder::rpc::rustls::{ClientConfig, RootCertStore, ServerConfig};
     use rsbinder::rpc::transport::TlsTransport;
@@ -749,14 +749,12 @@ fn tls_android13plus_nested_callback_e2e() {
     const SRV_KEY: &str = include_str!("tls_fixtures/srv.key");
 
     fn certs(pem: &str) -> Vec<CertificateDer<'static>> {
-        rustls_pemfile::certs(&mut BufReader::new(pem.as_bytes()))
+        CertificateDer::pem_slice_iter(pem.as_bytes())
             .collect::<std::result::Result<_, _>>()
             .expect("parse certs")
     }
     fn key(pem: &str) -> PrivateKeyDer<'static> {
-        rustls_pemfile::private_key(&mut BufReader::new(pem.as_bytes()))
-            .expect("parse key")
-            .expect("a key")
+        PrivateKeyDer::from_pem_slice(pem.as_bytes()).expect("parse key")
     }
     let srv_cfg = Arc::new(
         ServerConfig::builder()

--- a/rsbinder/tests/rpc_tls.rs
+++ b/rsbinder/tests/rpc_tls.rs
@@ -13,12 +13,12 @@
 
 #![cfg(feature = "rpc-tls")]
 
-use std::io::BufReader;
 use std::net::{TcpListener, TcpStream};
 use std::os::unix::net::UnixStream;
 use std::sync::Arc;
 use std::thread;
 
+use rsbinder::rpc::rustls::pki_types::pem::PemObject;
 use rsbinder::rpc::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rsbinder::rpc::rustls::{ClientConfig, RootCertStore, ServerConfig};
 use rsbinder::rpc::transport::TlsTransport;
@@ -38,14 +38,12 @@ const ROGUE_CRT: &str = include_str!("tls_fixtures/rogue.crt");
 const ROGUE_KEY: &str = include_str!("tls_fixtures/rogue.key");
 
 fn certs(pem: &str) -> Vec<CertificateDer<'static>> {
-    rustls_pemfile::certs(&mut BufReader::new(pem.as_bytes()))
+    CertificateDer::pem_slice_iter(pem.as_bytes())
         .collect::<std::result::Result<_, _>>()
         .expect("parse certs")
 }
 fn key(pem: &str) -> PrivateKeyDer<'static> {
-    rustls_pemfile::private_key(&mut BufReader::new(pem.as_bytes()))
-        .expect("parse key")
-        .expect("a key")
+    PrivateKeyDer::from_pem_slice(pem.as_bytes()).expect("parse key")
 }
 
 fn server_config(cert_pem: &str, key_pem: &str) -> Arc<ServerConfig> {


### PR DESCRIPTION
## Summary
- `rustls-pemfile` is unmaintained (RUSTSEC-2025-0134, archived since Aug 2025). Upstream recommends migrating to the `PemObject` trait in `rustls-pki-types`, which ships the same PEM parser and is already in the dep tree via `rustls`.
- Switch the two `rpc-tls` test helpers — [rsbinder/tests/rpc_tls.rs](../blob/chore/rustsec-2025-0134-rustls-pemfile/rsbinder/tests/rpc_tls.rs) and the nested-callback fn in [rsbinder/tests/rpc_server.rs](../blob/chore/rustsec-2025-0134-rustls-pemfile/rsbinder/tests/rpc_server.rs) — to `CertificateDer::pem_slice_iter` / `PrivateKeyDer::from_pem_slice`, and drop the dev-dep from [rsbinder/Cargo.toml](../blob/chore/rustsec-2025-0134-rustls-pemfile/rsbinder/Cargo.toml). The slice-based API also removes the `BufReader` wrapping.
- No new dependency is added; `Cargo.lock` loses the `rustls-pemfile` entry.

Closes #124

## Test plan
- [x] `cargo check --package rsbinder --features rpc-tls --tests` — clean
- [x] `cargo test --package rsbinder --features rpc-tls --test rpc_tls` — 7/0 PASS
- [x] `cargo test --package rsbinder --features rpc-tls --test rpc_server tls_android13plus_nested_callback_e2e` — 1/0 PASS
- [ ] CI green on the `rpc-suite` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)