### PR TITLE
test(rsbinder): make test_process_state_start_thread_pool order-independent

### DIFF
--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -1510,14 +1510,25 @@ mod tests {
     #[test]
     #[serial_test::serial(binder)]
     fn test_process_state_start_thread_pool() {
+        // `kernel_started_threads` is a process-wide `AtomicUsize` that
+        // also tracks kernel-driven `BR_SPAWN_LOOPER` events from prior
+        // tests in the same process, so we can't assert an absolute
+        // value of 1. Instead we capture the pre-state and assert the
+        // contract `start_thread_pool` actually promises: on the first
+        // call it flips `thread_pool_started` and spawns exactly one
+        // pooled thread; subsequent calls are no-ops.
         assert_process_state_initialized();
+        let process = ProcessState::as_self();
+        let was_started = process.thread_pool_started.load(Ordering::SeqCst);
+        let before = process.kernel_started_threads.load(Ordering::SeqCst);
         ProcessState::start_thread_pool();
-        assert_eq!(
-            ProcessState::as_self()
-                .kernel_started_threads
-                .load(Ordering::SeqCst),
-            1
-        );
+        assert!(process.thread_pool_started.load(Ordering::SeqCst));
+        let after = process.kernel_started_threads.load(Ordering::SeqCst);
+        if was_started {
+            assert_eq!(after, before);
+        } else {
+            assert_eq!(after, before + 1);
+        }
     }
 
     /// Minimal `IBinder` impl for the `published_natives` bookkeeping


### PR DESCRIPTION
## Summary
- Fixes the `Linux Binder Integration Test` failure in [run 26327950895](https://github.com/hiking90/rsbinder/actions/runs/26327950895/job/77508953127): `test_process_state_start_thread_pool` panicked with `left: 3, right: 1`.
- `kernel_started_threads` is a process-wide `AtomicUsize` that is also incremented by kernel-driven `BR_SPAWN_LOOPER` events in `thread_state::join_thread_pool` ([thread_state.rs#L975](https://github.com/hiking90/rsbinder/blob/master/rsbinder/src/thread_state.rs#L975)) — not just by `ProcessState::start_thread_pool`. With the unit-test suite now serializing 126 tests through the `serial(binder)` lock, prior tests that drive real binder traffic (P1/P2/P3 slow-path concurrency / obituary tests via `strong_proxy_for_handle(0)`) had already pushed the counter to 3 before this test ran.
- Snapshot `thread_pool_started` and `kernel_started_threads` first, then assert the contract `start_thread_pool` actually promises: first call flips the bool and spawns exactly one pooled thread (delta = +1); subsequent calls are no-ops (delta = 0). Test-only change — no production code touched.

## Test plan
- [ ] `cargo test -p rsbinder --lib` on macOS (hermetic) — still green.
- [ ] Re-run the `Linux Binder Integration Test` workflow on this branch (with `rsb_hub` + `test_service` up) — `test_process_state_start_thread_pool` passes regardless of where it sorts within the 126-test suite.
- [ ] Verify other `process_state::tests::*` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)