### PR TITLE
fix(rsbinder): integration-test races — wibinder upgrade poll + start_thread_pool counter split

### DIFF
--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -307,7 +307,23 @@ pub struct ProcessState {
     call_restriction: RwLock<CallRestriction>,
     thread_pool_started: AtomicBool,
     thread_pool_seq: AtomicUsize,
+    /// Counts pooled-thread spawns driven by kernel `BR_SPAWN_LOOPER`
+    /// commands — i.e. `spawn_pooled_thread(is_main = false)` from
+    /// [`thread_state::join_thread_pool`]. Incremented asynchronously
+    /// by binder worker threads at any time after they start running,
+    /// so it is **not** a deterministic indicator of any particular
+    /// caller's effect. Use [`Self::main_thread_spawned`] when you
+    /// need to observe the spawn driven by `start_thread_pool` itself.
     kernel_started_threads: AtomicUsize,
+    /// Counts pooled-thread spawns driven by [`Self::start_thread_pool`]
+    /// — i.e. `spawn_pooled_thread(is_main = true)`. The
+    /// `thread_pool_started` CAS in `start_thread_pool` admits at most
+    /// one successful spawn for the process lifetime, so this counter
+    /// is monotonic `0 → 1`. Split from `kernel_started_threads` so
+    /// tests can verify the `start_thread_pool` spawn contract without
+    /// racing kernel-driven `BR_SPAWN_LOOPER` spawns from prior
+    /// serial-test workers that stay alive in the process.
+    main_thread_spawned: AtomicUsize,
     pub(crate) current_threads: AtomicUsize,
 }
 
@@ -411,6 +427,7 @@ impl ProcessState {
             thread_pool_started: AtomicBool::new(false),
             thread_pool_seq: AtomicUsize::new(1),
             kernel_started_threads: AtomicUsize::new(0),
+            main_thread_spawned: AtomicUsize::new(0),
             current_threads: AtomicUsize::new(0),
         })
     }
@@ -1198,7 +1215,15 @@ impl ProcessState {
                 .name(name)
                 .spawn(move || thread_state::join_thread_pool(is_main));
 
-            self.kernel_started_threads.fetch_add(1, Ordering::SeqCst);
+            // Account into the per-origin counter so tests can verify
+            // the `start_thread_pool` spawn contract without racing
+            // kernel-driven `BR_SPAWN_LOOPER` spawns. See the field
+            // docs on `main_thread_spawned` / `kernel_started_threads`.
+            if is_main {
+                self.main_thread_spawned.fetch_add(1, Ordering::SeqCst);
+            } else {
+                self.kernel_started_threads.fetch_add(1, Ordering::SeqCst);
+            }
         }
         // TODO: if startThreadPool is called on another thread after the process
         // starts up, the kernel might think that it already requested those
@@ -1510,20 +1535,25 @@ mod tests {
     #[test]
     #[serial_test::serial(binder)]
     fn test_process_state_start_thread_pool() {
-        // `kernel_started_threads` is a process-wide `AtomicUsize` that
-        // also tracks kernel-driven `BR_SPAWN_LOOPER` events from prior
-        // tests in the same process, so we can't assert an absolute
-        // value of 1. Instead we capture the pre-state and assert the
-        // contract `start_thread_pool` actually promises: on the first
-        // call it flips `thread_pool_started` and spawns exactly one
-        // pooled thread; subsequent calls are no-ops.
+        // Observe `main_thread_spawned` — incremented **only** by
+        // `spawn_pooled_thread(is_main = true)`, whose sole caller is
+        // `start_thread_pool`. Kernel-driven `BR_SPAWN_LOOPER` spawns
+        // go to `kernel_started_threads` and never touch this counter,
+        // so the assertion is race-free against leftover worker
+        // threads from prior `serial(binder)` tests that stay alive in
+        // the process and may receive `BR_SPAWN_LOOPER` at any time.
+        //
+        // The contract: the first `start_thread_pool` call flips
+        // `thread_pool_started` and increments `main_thread_spawned`
+        // exactly once; subsequent calls are no-ops (CAS rejects
+        // re-entry).
         assert_process_state_initialized();
         let process = ProcessState::as_self();
         let was_started = process.thread_pool_started.load(Ordering::SeqCst);
-        let before = process.kernel_started_threads.load(Ordering::SeqCst);
+        let before = process.main_thread_spawned.load(Ordering::SeqCst);
         ProcessState::start_thread_pool();
         assert!(process.thread_pool_started.load(Ordering::SeqCst));
-        let after = process.kernel_started_threads.load(Ordering::SeqCst);
+        let after = process.main_thread_spawned.load(Ordering::SeqCst);
         if was_started {
             assert_eq!(after, before);
         } else {

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -2123,8 +2123,7 @@ fn test_wibinder_upgrade_after_obituary() {
     // poll preserves that regression-detection intent while matching
     // the real semantic: *eventually after obituary + last user Strong
     // drop*, upgrade reports DeadObject.
-    let deadline =
-        std::time::Instant::now() + std::time::Duration::from_secs(2);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
     loop {
         match weak.upgrade() {
             Err(rsbinder::StatusCode::DeadObject) => break,

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -2103,19 +2103,41 @@ fn test_wibinder_upgrade_after_obituary() {
     // not strictly required for the assertion below, but cleaner.
     drop(recipient);
 
-    // Drop our last Strong<dyn ITestService>; the obituary already
-    // removed the cache entry, so the underlying `Arc<ProxyHandle>`
-    // is now the only thing keeping the inner Arc alive. After this
-    // drop it goes to 0.
+    // Drop our last user-held Strong<dyn ITestService>; the obituary
+    // already removed the cache entry, so once the binder worker
+    // thread retires its `send_obituary_for_handle` dispatch frame
+    // (which holds two stack-local strong refs on the inner
+    // `Arc<ProxyHandle>` — see process_state.rs:`send_obituary_for_handle`
+    // — for the duration of `arc.send_obituary(&who)`), the strong
+    // count goes to 0 and `weak.upgrade()` is required to return
+    // `Err(DeadObject)`.
     drop(test_service);
 
-    // `upgrade()` MUST return Err(DeadObject) now. Pre-PR this
-    // assertion would not have been reachable (upgrade always Ok).
-    match weak.upgrade() {
-        Err(rsbinder::StatusCode::DeadObject) => {}
-        Err(other) => panic!("expected DeadObject, got {other:?}"),
-        Ok(_) => {
-            panic!("regression: WIBinder::upgrade() succeeded after obituary + last Strong drop")
+    // `upgrade()` must eventually return `Err(DeadObject)`. We poll
+    // with a deadline rather than asserting on the first call because
+    // reading "died\n" only proves the worker has entered the dispatch
+    // loop — at that instant the worker still holds `arc` + `sibinder`
+    // on its stack, so `sync::Weak::upgrade` (the fast path in
+    // `WIBinder::upgrade`) can still observe a positive strong count.
+    // Pre-PR this branch was unreachable (upgrade always Ok); the
+    // poll preserves that regression-detection intent while matching
+    // the real semantic: *eventually after obituary + last user Strong
+    // drop*, upgrade reports DeadObject.
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        match weak.upgrade() {
+            Err(rsbinder::StatusCode::DeadObject) => break,
+            Err(other) => panic!("expected DeadObject, got {other:?}"),
+            Ok(_) => {
+                if std::time::Instant::now() >= deadline {
+                    panic!(
+                        "regression: WIBinder::upgrade() still succeeded 2s after \
+                         obituary + last Strong drop"
+                    );
+                }
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
         }
     }
 }


### PR DESCRIPTION
Two test-race fixes that surfaced on consecutive `Integration Test` workflow runs against master / this PR. Both are pre-existing races; one is test-only, the other is a small crate-internal production split that root-causes the race that 99be9f8 (PR #127) only partially fixed.

## Fix 1 — `test_wibinder_upgrade_after_obituary` (test-only)

Triggered on master [run 26328409557](https://github.com/hiking90/rsbinder/actions/runs/26328409557/job/77510162580).

**Race.** When the death-recipient writes `\"died\\n\"` to the pipe, the binder worker thread is still inside `send_obituary_for_handle` ([process_state.rs:863-887](rsbinder/src/process_state.rs#L863-L887)):

```rust
if let Some(arc) = entry.weak.upgrade() {              // stack ref +1
    let sibinder = SIBinder::from_arc(arc.clone() ...);// stack ref +1
    let who = SIBinder::downgrade(&sibinder);
    arc.send_obituary(&who)?;                          // ← binder_died runs here
}
```

So the worker holds **two** stack-local strong refs on the inner `Arc<ProxyHandle>` for the duration of `arc.send_obituary(&who)`. The test's `drop(test_service)` releases only the user-held +1, leaving the worker's two refs alive — `WIBinder::upgrade`'s fast path (`sync::Weak::upgrade`) returns `Some` and the test panics with `regression: WIBinder::upgrade() succeeded after obituary + last Strong drop`.

C++ libbinder's `BpBinder::sendObituary` has the same property (it's a member call; recipients' `wp.promote()` would also see a positive strong count during dispatch), so this is not a divergence from the Android contract.

**Fix.** Replace the one-shot match in `test_wibinder_upgrade_after_obituary` with a bounded poll (2s deadline, 5ms between attempts). The test's true semantic is *\"eventually after obituary + last user Strong drop, upgrade returns DeadObject\"* — which the worker dispatch frame retiring + the test-thread drop combine to satisfy. The panic message still distinguishes a true regression (upgrade *never* reports DeadObject) from the formerly-tolerated transient `Ok`.

## Fix 2 — `test_process_state_start_thread_pool` (production counter split)

Triggered on this PR's [run 26328948156](https://github.com/hiking90/rsbinder/actions/runs/26328948156/job/77511563842) with `left: 2, right: 1`. PR #127 / 99be9f8 had switched this test to delta-based (`assert_eq!(after, before + 1)`) but only addressed the cumulative facet of the race.

**Root cause.** `kernel_started_threads` was incremented from two semantically distinct spawn paths funneled through the same counter:

1. `spawn_pooled_thread(is_main = true)` — sole caller `ProcessState::start_thread_pool` (the test asserts on this).
2. `spawn_pooled_thread(is_main = false)` — sole caller the `BR_SPAWN_LOOPER` arm in [thread_state.rs:974-976](rsbinder/src/thread_state.rs#L974-L976), fired **asynchronously** by the kernel against any live worker thread.

`#[serial_test::serial(binder)]` only serializes tests in the `binder` group; it does not stop prior-test worker threads that stay alive in the process and can receive `BR_SPAWN_LOOPER` from the kernel at any moment. Between the test's `load(before)` and `load(after)`, both `+1` from `start_thread_pool` **and** `+1` from a concurrent kernel command can land — producing `delta = 2` and breaking the `before + 1` assertion.

99be9f8 fixed the **cumulative** facet (prior tests had pushed the counter to 3 before `load(before)`); the **concurrent** facet (kernel `BR_SPAWN_LOOPER` firing between the two loads) was the latent defect that surfaced next.

**Fix.** Split `kernel_started_threads` into two per-origin counters at the production level:

- `kernel_started_threads` — now only counts `is_main = false` spawns (BR_SPAWN_LOOPER). Same name, semantic narrowed.
- `main_thread_spawned` — new counter, only touched by `spawn_pooled_thread(is_main = true)`. Monotonic `0 → 1` because the `thread_pool_started` CAS in `start_thread_pool` admits at most one successful spawn per process.

`spawn_pooled_thread` routes its `fetch_add` to the right counter based on `is_main`. The test then asserts on `main_thread_spawned`, which is by construction untouched by the kernel-driven path — race-free regardless of leftover worker threads.

Neither field is in the public API surface (crate-private struct fields). The split is the root-cause fix the partial 99be9f8 patch was reaching for: the two spawn origins were always semantically distinct (`is_main` is the explicit discriminator at the call site); merging them into one counter was the latent defect.

## Test plan
- [ ] Manual: `cargo test --package tests -- --ignored test_client::test_wibinder_upgrade_after_obituary` on a kernel-binder host in a loop (e.g. ×20) passes every iteration.
- [ ] Manual: `cargo test --package rsbinder` (full 126-test serial(binder) suite) passes including `test_process_state_start_thread_pool`.
- [ ] `Integration Test` workflow (workflow_dispatch) green end-to-end, including the other `#[ignore]`'d destructive tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)