### PR TITLE
chore: drop four redundant clones in parser and rsb_hub

### DIFF
--- a/rsbinder-aidl/src/parser.rs
+++ b/rsbinder-aidl/src/parser.rs
@@ -1183,7 +1183,7 @@ fn parse_value(pair: pest::iterators::Pair<Rule>) -> Result<ConstExpr, AidlError
 fn parse_factor(pair: pest::iterators::Pair<Rule>) -> Result<ConstExpr, AidlError> {
     // println!("parse_factor {:?}", pair);
     match pair.as_rule() {
-        Rule::expression => parse_expression(pair.clone().into_inner()),
+        Rule::expression => parse_expression(pair.into_inner()),
         Rule::unary => parse_unary(pair.into_inner()),
         Rule::value => parse_value(pair.into_inner().next().unwrap()),
         _ => unreachable!("Unexpected rule in parse_factor(): {}", pair),
@@ -1200,7 +1200,7 @@ fn parse_expression_term(pair: pest::iterators::Pair<Rule>) -> Result<ConstExpr,
         | Rule::shift
         | Rule::arith
         | Rule::logical_or
-        | Rule::logical_and => parse_expression(pair.clone().into_inner()),
+        | Rule::logical_and => parse_expression(pair.into_inner()),
         Rule::factor => parse_factor(pair.into_inner().next().unwrap()),
         _ => unreachable!("Unexpected rule in Rule::parse_expression_into: {}", pair),
     }
@@ -1301,7 +1301,7 @@ fn parse_const_expr(pair: pest::iterators::Pair<Rule>) -> Result<ConstExpr, Aidl
             Ok(ConstExpr::new(ValueType::Char(ch)))
         }
 
-        Rule::expression => parse_expression(pair.clone().into_inner()),
+        Rule::expression => parse_expression(pair.into_inner()),
 
         Rule::string_expr => parse_string_expr(pair.into_inner()),
 

--- a/rsbinder-tools/src/bin/rsb_hub.rs
+++ b/rsbinder-tools/src/bin/rsb_hub.rs
@@ -761,7 +761,7 @@ impl IServiceManager for ServiceManager {
             return Err((ExceptionCode::Security, msg.as_str()).into());
         }
 
-        if arg_service.clone() != service.binder.clone() {
+        if service.binder != *arg_service {
             let msg = format!("{context:?} Tried to unregister {name}, but a different service is registered under this name.");
             log::warn!("{}", &msg);
             return Err((ExceptionCode::IllegalArgument, msg.as_str()).into());


### PR DESCRIPTION
## Summary

Audited every `.clone()` call in non-test code across the workspace
(`rsbinder`, `rsbinder-aidl`, `rsbinder-tools`, `example-hello`).
The vast majority are required `Arc`/`Weak` handoffs, `MutexGuard` →
owned-value escapes, `HashMap::get` lookups, `RefCell::borrow` escapes,
and FFI/thread boundary handoffs — those stay.

Four production clones are reducible to plain moves/borrows without
any behavior change:

- **`rsbinder-aidl/src/parser.rs`** (3 sites): `parse_factor`,
  `parse_expression_term`, and `parse_const_expr` each had a
  `Rule::expression => parse_expression(pair.clone().into_inner())`
  arm, while sibling arms in the same `match` already move `pair`
  via `pair.into_inner()`. The `_` unreachable arm uses `pair` in
  its `{}` format, but it never runs when an earlier arm matched,
  so the clone served no purpose. Aligned all three arms with the
  surrounding pattern.

- **`rsbinder-tools/src/bin/rsb_hub.rs:764`**: the
  `unregisterForNotifications` mismatch check was
  `if arg_service.clone() != service.binder.clone()`. The
  neighbouring `addService`-side check on
  [line 708](https://github.com/hiking90/rsbinder/blob/master/rsbinder-tools/src/bin/rsb_hub.rs#L708)
  already does `service.binder != *arg_service` (no clones — `&SIBinder`
  deref + `PartialEq`). Aligned this site with the same pattern.

## Test plan

- [x] `cargo build --all-targets`
- [x] `cargo build --all-targets --features rpc`
- [x] `cargo test -p rsbinder-aidl` (all 17 binaries green)
- [x] `cargo clippy --all-targets -- -D warnings`

No wire format / public API / behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)