### PR TITLE
docs(book): sync API tables with source

### DIFF
--- a/book/src/aidl-annotations.md
+++ b/book/src/aidl-annotations.md
@@ -133,7 +133,9 @@ When `None` is passed over a Binder transaction, a null marker is written to the
 
 ### Heap-Allocated Nullable: @nullable(heap=true)
 
-For recursive or self-referential types, use `@nullable(heap=true)` to wrap the field in a `Box<T>`:
+AOSP AIDL uses `@nullable(heap=true)` to mark fields of recursive or
+self-referential parcelables, so that the C++ and Java backends know to
+allocate the inner value on the heap:
 
 ```aidl
 parcelable RecursiveList {
@@ -142,7 +144,7 @@ parcelable RecursiveList {
 }
 ```
 
-This generates:
+The Rust backend generates:
 
 ```rust
 pub struct RecursiveList {
@@ -151,9 +153,17 @@ pub struct RecursiveList {
 }
 ```
 
-The `Box` indirection is necessary because without it, `RecursiveList` would contain itself directly, making the type infinitely large. The `heap=true` parameter places the inner value on the heap, giving the struct a finite, known size at compile time.
+The `Box` indirection is necessary because without it, `RecursiveList` would contain itself directly, making the type infinitely large.
 
-Use `@nullable(heap=true)` only when you need recursive structures. For non-recursive optional fields, plain `@nullable` is sufficient and avoids the extra heap allocation.
+In rsbinder, the `Box<T>` wrapping is driven by **self-reference detection in
+the code generator**, not by the `heap=true` parameter — the parameter is
+accepted for AOSP-faithful AIDL syntax compatibility but does not itself
+control the wrapping. Whenever a parcelable field references the enclosing
+parcelable's own type, the generator emits `Box<...>` around it to give the
+struct a known size. Keep the `heap=true` form when writing AIDL that must
+also compile under the AOSP toolchain.
+
+For non-recursive optional fields, plain `@nullable` is sufficient and avoids the extra heap allocation.
 
 ## @utf8InCpp
 
@@ -287,7 +297,7 @@ The following table provides a quick reference for all annotations covered in th
 | `@RustDerive` | parcelable, union | Adds `derive` attributes (`Clone`, `Copy`, `PartialEq`) |
 | `@Backing` | enum | Sets the backing integer type (`i8`, `i32`, `i64`) |
 | `@nullable` | field, param, return | Maps to `Option<T>` |
-| `@nullable(heap=true)` | field | Maps to `Option<Box<T>>` for recursive types |
+| `@nullable(heap=true)` | field | AOSP-faithful syntax for recursive fields; rsbinder boxes self-referential fields automatically (parameter accepted but not required) |
 | `@utf8InCpp` | String | No effect in Rust (strings are always UTF-8) |
 | `@Descriptor` | interface | Overrides the wire descriptor string |
 | `@VintfStability` | parcelable, interface | Enforces VINTF stability rules |

--- a/book/src/aidl-parcelable.md
+++ b/book/src/aidl-parcelable.md
@@ -137,7 +137,7 @@ When the client passes `None`, the service receives `None` and can return `None`
 
 ## Recursive Structures
 
-AIDL supports self-referential parcelable types using the `@nullable(heap=true)` annotation. This is necessary because a struct that directly contains itself would have infinite size. The `heap=true` attribute causes the field to be wrapped in `Box<T>` in the generated Rust code, which places the recursive field on the heap and gives the type a known size at compile time.
+AIDL supports self-referential parcelable types. In AOSP-faithful AIDL the recursive field is marked `@nullable(heap=true)`, signalling to the C++ and Java backends that the inner value lives on the heap so the struct has a finite, known size at compile time. rsbinder accepts the same syntax for source compatibility, but the actual `Box<T>` wrapping is emitted by the code generator whenever a field references the enclosing parcelable's own type — the `heap=true` parameter is not what triggers it.
 
 AIDL definition (from `RecursiveList.aidl` in the test suite):
 
@@ -148,7 +148,7 @@ parcelable RecursiveList {
 }
 ```
 
-This generates a Rust struct where `next` has the type `Option<Box<RecursiveList>>`. The `@nullable` part makes it `Option`, and `heap=true` makes it `Box`-wrapped. Together they enable a linked-list pattern.
+This generates a Rust struct where `next` has the type `Option<Box<RecursiveList>>`. The `@nullable` part makes it `Option`, and the self-reference detection adds the `Box` wrapper that gives the type a known size. Together they enable a linked-list pattern.
 
 Rust usage (based on the `test_reverse_recursive_list` test):
 
@@ -175,7 +175,7 @@ for n in 0..10 {
 assert!(current.is_none());
 ```
 
-Without `heap=true`, the compiler would reject the type definition because `RecursiveList` would need to contain itself directly, leading to an infinite-size type. The `Box` indirection solves this by storing the nested value behind a pointer.
+Without the `Box` indirection the Rust compiler would reject the type definition because `RecursiveList` would need to contain itself directly, leading to an infinite-size type. The code generator inserts that indirection automatically whenever it sees a field whose type matches the enclosing parcelable.
 
 ## ExtendableParcelable and ParcelableHolder
 

--- a/book/src/error-handling.md
+++ b/book/src/error-handling.md
@@ -85,17 +85,21 @@ status.is_ok()               // -> bool
 
 `ExceptionCode` classifies the kind of error:
 
-| Variant                | Meaning                                    |
-|------------------------|--------------------------------------------|
-| `None`                 | No error                                   |
-| `Security`             | Security / permission violation            |
-| `BadParcelable`        | Malformed parcelable data                  |
-| `IllegalArgument`      | Invalid argument provided                  |
-| `NullPointer`          | Unexpected null value                      |
-| `IllegalState`         | Operation invalid for current state        |
-| `UnsupportedOperation` | Requested operation is not supported       |
-| `ServiceSpecific`      | Application-defined error with custom code |
-| `TransactionFailed`    | Low-level transaction failure              |
+| Variant                | Wire value | Meaning                                                        |
+|------------------------|-----------:|----------------------------------------------------------------|
+| `None`                 |          0 | No error                                                       |
+| `Security`             |         -1 | Security / permission violation                                |
+| `BadParcelable`        |         -2 | Malformed parcelable data                                      |
+| `IllegalArgument`      |         -3 | Invalid argument provided                                      |
+| `NullPointer`          |         -4 | Unexpected null value                                          |
+| `IllegalState`         |         -5 | Operation invalid for current state                            |
+| `NetworkMainThread`    |         -6 | Network operation on main thread (Java compatibility)          |
+| `UnsupportedOperation` |         -7 | Requested operation is not supported                           |
+| `ServiceSpecific`      |         -8 | Application-defined error with custom code                     |
+| `Parcelable`           |         -9 | Embedded user parcelable exception (Java compatibility)        |
+| `HasReplyHeader`       |       -128 | Internal: reply parcel carries a header (Java-specific marker) |
+| `TransactionFailed`    |       -129 | Low-level transaction failure                                  |
+| `JustError`            |       -256 | Generic error fallback used internally by the library          |
 
 ## Returning Errors from a Service
 


### PR DESCRIPTION
## Summary

Audit of the mdBook docs against current source surfaced three places where the book overstated or misdescribed actual behavior. All three are now corrected.

- **`book/src/error-handling.md`** — `ExceptionCode` table only listed 9 of the 13 variants defined in [`rsbinder/src/status.rs`](../blob/master/rsbinder/src/status.rs). Added the four missing entries (`NetworkMainThread`, `Parcelable`, `HasReplyHeader`, `JustError`) and a wire-value column so the table matches the enum 1:1.
- **`book/src/aidl-annotations.md`** and **`book/src/aidl-parcelable.md`** — Both files described `@nullable(heap=true)` as the trigger that produces `Option<Box<T>>` for recursive parcelables. The rsbinder AIDL parser/generator does not look at `heap` at all (the keyword does not appear anywhere under `rsbinder-aidl/src/`); the `Box` wrap is emitted by self-reference detection in [`rsbinder-aidl/src/type_generator.rs`](../blob/master/rsbinder-aidl/src/type_generator.rs) (`curr_ns.ns.last() == name` → `Box<{name}>`). The `heap=true` parameter is accepted for AOSP-faithful AIDL syntax compatibility, but it is not what controls the wrapping. The text now reflects this while still recommending the AOSP-compatible form.

Source-of-truth check passed for the other docs reviewed (service-development, service-manager, service-patterns, callbacks-and-interfaces, hello-world, rpc-transport, parcel-file-descriptor, async-service, stability-tiers, architecture, overview, SUMMARY).

## Test plan

- [x] `mdbook build` succeeds in `book/` (mermaid preprocessor warning is unrelated, pre-existing).
- [ ] Render the three modified pages locally and visually confirm tables/paragraphs read well.
- [ ] Diff-review the wire values in the `ExceptionCode` table against `rsbinder/src/status.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)