### PR TITLE
refactor: reduce redundant clones + land RPC 2-12/2-15 and Plan 4 Android-compat modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
           # `CARGO_FEATURE_ASYNC`, but the baseline can't be retroactively
           # patched. Without `async` in the feature set, semver-checks
           # fails to `cargo doc` the baseline crate.
-          features: rpc,rpc-tcp-debug,rpc-tls,rpc-vsock,rpc-experimental-multiconn,async
+          features: rpc,rpc-tcp-debug,rpc-tls,rpc-vsock,async
 
   test:
     name: Test Suite
@@ -134,28 +134,18 @@ jobs:
       # runs on a plain runner, unlike the kernel-binder matrix in
       # integration-test.yml. This job is the missing CI enforcement
       # of the plan's V1/V4/V5 gates for the RPC stack (T3).
-      - name: AC-1.1 build matrix (rpc OFF / rpc / tcp-debug / tls / experimental-multiconn)
+      - name: AC-1.1 build matrix (rpc OFF / rpc / tcp-debug / tls / vsock)
         run: |
           cargo build -p rsbinder
           cargo build -p rsbinder --features rpc
           cargo build -p rsbinder --features rpc-tcp-debug
           cargo build -p rsbinder --features rpc-tls
-          cargo build -p rsbinder --features rpc-experimental-multiconn
-      - name: RPC unit + e2e (rsbinder, hermetic — default build, multi-conn fns cfg-gated out)
+          cargo build -p rsbinder --features rpc-vsock
+      - name: RPC unit + e2e (rsbinder, hermetic — multi-conn now default per AC-12.6)
         run: |
           cargo test -p rsbinder --features rpc --lib rpc::
           cargo test -p rsbinder --features rpc --test rpc_e2e --test rpc_server --test rpc_fd
           cargo test -p rsbinder --features rpc-tls --test rpc_tls
-      - name: AC-12.x experimental multi-conn (hermetic, plan 2-12)
-        # Phase 2-12 multi-connection-per-session tests are cfg-gated to
-        # `rpc-experimental-multiconn` because the attach arm clamps the
-        # slot cap to 1 on default builds (real-libbinder interop gate
-        # AC-12.6 not yet passed — see `RpcServer::set_max_threads`
-        # rustdoc and plan/2-12-multi-connection-per-session.md §3).
-        # This job is the hermetic enforcement gate for that path: the
-        # 8 multi-conn fns in `rpc_server.rs` only compile + run here.
-        run: |
-          cargo test -p rsbinder --features rpc-experimental-multiconn --test rpc_server
       - name: RPC accessor (hermetic, requires android_16 — gap-fill)
         # `rpc_accessor.rs` is `#![cfg(all(feature = "rpc", feature =
         # "android_16"))]`; without `android_16` the file compiles to
@@ -199,15 +189,12 @@ jobs:
         run: cargo build -p rsbinder-tools --release
       - name: rsb_device unit (mounts parser)
         run: cargo test -p rsbinder-tools --bin rsb_device
-      - name: RPC hermetic (default — multi-conn cfg-gated out)
+      - name: RPC hermetic (multi-conn now default per AC-12.6)
         run: |
           cargo test -p rsbinder --features rpc --lib rpc::
           cargo test -p rsbinder --features rpc --test rpc_e2e --test rpc_server --test rpc_fd
           cargo test -p rsbinder --features rpc-tls --test rpc_tls
           cargo test -p rsbinder --features rpc,android_16 --test rpc_accessor
-      - name: RPC hermetic (experimental multi-conn)
-        run: |
-          cargo test -p rsbinder --features rpc-experimental-multiconn --test rpc_server
       - name: AIDL compiler tests (hermetic — plan 3 AC-3.4)
         # See the matching step in `linux-build` — plan 3 AC-3.4
         # requires the sweep + allowlist gate to run on both Linux and

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -666,19 +666,6 @@ jobs:
             cargo test -p rsbinder --features rpc-tls --test rpc_tls || exit 1
           done
 
-      - name: Hermetic soak — rpc-experimental-multiconn x5 (AC-12.1 timing flake gate)
-        # The multi-conn `rpc_server.rs` tests include the cv-wait timing
-        # band assertions (AC-12.1 family). On macOS-latest under load,
-        # these flake at a low single-shot rate; the 5x soak is the
-        # explicit gate against landing a regression that single-shot
-        # `build.yml` happens to pass.
-        run: |
-          for i in $(seq 1 5); do
-            echo "=== multi-conn soak iteration $i / 5 ==="
-            cargo test -p rsbinder --features rpc-experimental-multiconn \
-              --test rpc_server || exit 1
-          done
-
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ CLAUDE.md
 
 # example-hello STAGE3 harness build outputs (compiled NDK launchers —
 # the .cpp source IS tracked; the cross-compiled aarch64 ELF beside it
-# is a build artifact of cpp/run_stage3*.sh, regenerated on demand).
+# is a build artifact of cpp/run_rpc_*_interop.sh, regenerated on demand).
 example-hello/cpp/rpc_accessor_interop_launcher
 example-hello/cpp/rpc_accessor_register_interop_launcher
 example-hello/cpp/rpc_multiconn_interop_launcher

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,8 +433,10 @@ version = "0.9.0"
 dependencies = [
  "async-trait",
  "env_logger",
+ "libc",
  "rsbinder",
  "rsbinder-aidl",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ similar = "3.1"
 pretty_hex = { version = "0.4", package = "pretty-hex" }
 downcast-rs = "2.0"
 rustix = "1.1"
+libc = "0.2"
 clap = "4.6"
 rsproperties = "0.3"
 miette = { version = "7.6", features = ["fancy"] }

--- a/example-hello/Cargo.toml
+++ b/example-hello/Cargo.toml
@@ -14,12 +14,6 @@ license = { workspace = true }
 #   cargo run -p example-hello --features rpc --bin rpc_hello_service
 #   cargo run -p example-hello --features rpc --bin rpc_hello_client
 rpc = ["rsbinder/rpc"]
-# Lift the EXPERIMENTAL multi-connection slot-cap clamp (plan 2-12).
-# Required by `rpc_multiconn_interop_server` since that bin's whole
-# purpose is to exercise N>=2 incoming slots — without this feature
-# the attach arm clamps the cap to 1 and the bin can only ever serve
-# the founding connection.
-rpc-experimental-multiconn = ["rpc", "rsbinder/rpc-experimental-multiconn"]
 # Subplan 2-13 — opt in to the android-16 accessor bridge symbols
 # (`hub::android_16::resolve_accessor`); only used by the STAGE3
 # interop client.
@@ -57,18 +51,19 @@ required-features = ["rpc", "android_16"]
 name = "rpc_accessor_register_interop_server"
 required-features = ["rpc", "android_16"]
 
-# Subplan 2-12 Phase D / AC-12.6 — rsbinder side of the multi-
+# Subplan 2-12 Phase D + C — rsbinder side of the multi-
 # connection-per-session real-libbinder interop gate. Pairs with
 # cpp/rpc_multiconn_interop_launcher (a real libbinder client built
 # with `ARpcSession_setMaxOutgoingConnections(2) + setMaxIncoming
-# Threads(2)`). Cross-compile with
+# Threads(1)`). Cross-compile with
 #   cargo ndk -t arm64-v8a -p 36 build -p example-hello \
-#       --features rpc-experimental-multiconn --bin rpc_multiconn_interop_server
+#       --features rpc --bin rpc_multiconn_interop_server
 # and run on the android-16 emulator alongside cpp/run_stage3_
-# multiconn.sh.
+# multiconn.sh. AC-12.6 (a) twoway + (b) oneway both PASS post-
+# Phase C (2026-05-28); the prior EXPERIMENTAL gate was removed.
 [[bin]]
 name = "rpc_multiconn_interop_server"
-required-features = ["rpc-experimental-multiconn"]
+required-features = ["rpc"]
 
 [dependencies]
 rsbinder = { workspace = true, features = ["android_10_plus"] }

--- a/example-hello/Cargo.toml
+++ b/example-hello/Cargo.toml
@@ -32,7 +32,7 @@ required-features = ["rpc"]
 #   cargo ndk -t arm64-v8a -p 36 build -p example-hello \
 #       --features rpc,android_16 --bin rpc_accessor_interop_client
 # and run on the android-16 emulator alongside the C++ launcher
-# (`cpp/rpc_accessor_interop_launcher.cpp`). See cpp/run_stage3.sh.
+# (`cpp/rpc_accessor_interop_launcher.cpp`). See cpp/run_rpc_accessor_interop.sh.
 [[bin]]
 name = "rpc_accessor_interop_client"
 required-features = ["rpc", "android_16"]
@@ -46,7 +46,7 @@ required-features = ["rpc", "android_16"]
 #       --features rpc,android_16 --bin rpc_accessor_register_interop_server
 # and run on the android-16 emulator alongside the C++ launcher
 # (`cpp/rpc_accessor_register_interop_launcher.cpp`). See
-# cpp/run_stage3_register.sh.
+# cpp/run_rpc_accessor_register_interop.sh.
 [[bin]]
 name = "rpc_accessor_register_interop_server"
 required-features = ["rpc", "android_16"]
@@ -58,8 +58,8 @@ required-features = ["rpc", "android_16"]
 # Threads(1)`). Cross-compile with
 #   cargo ndk -t arm64-v8a -p 36 build -p example-hello \
 #       --features rpc --bin rpc_multiconn_interop_server
-# and run on the android-16 emulator alongside cpp/run_stage3_
-# multiconn.sh. AC-12.6 (a) twoway + (b) oneway both PASS post-
+# and run on the android-16 emulator alongside
+# cpp/run_rpc_multiconn_interop.sh. AC-12.6 (a) twoway + (b) oneway both PASS post-
 # Phase C (2026-05-28); the prior EXPERIMENTAL gate was removed.
 [[bin]]
 name = "rpc_multiconn_interop_server"
@@ -69,6 +69,8 @@ required-features = ["rpc"]
 rsbinder = { workspace = true, features = ["android_10_plus"] }
 env_logger = { workspace = true }
 async-trait = { workspace = true }
+rustix = { workspace = true, features = ["process"] }
+libc = { workspace = true }
 
 [build-dependencies]
 rsbinder-aidl = { workspace = true, features = ["async"] }

--- a/example-hello/aidl/calling_identity/ICallingIdentity.aidl
+++ b/example-hello/aidl/calling_identity/ICallingIdentity.aidl
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// STAGE3 smoke fixture for Plan 4-1: lets the server-side handler
+// observe what the kernel binder driver delivers for calling identity
+// (UID / PID / SELinux SID) and replay the AOSP clear/restore identity
+// dance, then return the observations to the client as a single
+// human-readable string.
+
+package calling_identity;
+
+interface ICallingIdentity {
+    /**
+     * Return a single line of the form:
+     *
+     *     uid=<u> pid=<p> sid=<s> explicit_pre=<bool> explicit_after_clear=<bool> explicit_after_restore=<bool>
+     *
+     * `sid` is the SELinux context (e.g. `u:r:shell:s0`) when the
+     * server's binder was registered with
+     * `BinderFeatures { set_requesting_sid: true, .. }` and the kernel
+     * delivered BR_TRANSACTION_SEC_CTX; `<none>` otherwise.
+     */
+    String describeCaller();
+}

--- a/example-hello/aidl/permcheck/IPermCheck.aidl
+++ b/example-hello/aidl/permcheck/IPermCheck.aidl
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Plan 4-2 Phase A end-to-end fixture: exercises all three
+// `@EnforcePermission` forms in a single interface. Built alongside the
+// main example-hello tree so the generated code is type-checked by
+// `cargo build -p example-hello` — a quieter, more thorough check than
+// the text-pattern asserts in
+// `rsbinder-aidl/tests/test_enforce_permission.rs`.
+
+package permcheck;
+
+interface IPermCheck {
+    @EnforcePermission("android.permission.INTERNET")
+    boolean doSingle();
+
+    @EnforcePermission(allOf = {"android.permission.INTERNET", "android.permission.ACCESS_NETWORK_STATE"})
+    boolean doAllOf();
+
+    @EnforcePermission(anyOf = {"android.permission.BLUETOOTH", "android.permission.BLUETOOTH_ADMIN"})
+    boolean doAnyOf();
+
+    /**
+     * Phase D STAGE3 deny gate — guarded by a fabricated permission
+     * name that `system_server` cannot have registered, so
+     * `PermissionManagerService.checkPermission` returns `false` even
+     * for root. The deny branch (`EX_SECURITY`) must fire BEFORE the
+     * service implementation runs; if the client receives anything
+     * other than `Status::Security`, the codegen leaked the check.
+     */
+    @EnforcePermission("rsbinder.test.permcheck.NONEXISTENT_PERMISSION")
+    boolean doDenied();
+
+    /** Un-annotated method: R2 byte-identical (no check emit). */
+    String echo(in String message);
+}

--- a/example-hello/aidl/rt_inherit/IRtCheck.aidl
+++ b/example-hello/aidl/rt_inherit/IRtCheck.aidl
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Plan 4-5 Phase D STAGE3 fixture. The server-side handler returns
+// the scheduler policy it observed during the in-flight transaction
+// — the client compares that against the policy it was running under
+// to decide whether the kernel honored `FLAT_BINDER_FLAG_INHERIT_RT`.
+
+package rt_inherit;
+
+interface IRtCheck {
+    /**
+     * Returns `sched_getscheduler(0)` as observed inside the server's
+     * `on_transact` body. Values mirror `<linux/sched.h>` constants:
+     * `0 = SCHED_NORMAL`, `1 = SCHED_FIFO`, `2 = SCHED_RR`,
+     * `3 = SCHED_BATCH`.
+     */
+    int reportSchedPolicy();
+}

--- a/example-hello/aidl/update_txn/IUpdateTxnDedup.aidl
+++ b/example-hello/aidl/update_txn/IUpdateTxnDedup.aidl
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Plan 4-4 Phase D STAGE3 fixture — `TF_UPDATE_TXN` async dedup
+// observed against the real Android binder driver.
+//
+// The recorder service stores every payload it actually delivered to
+// its `onRecord` body; the client compares observed payloads against
+// the values it sent to verify the kernel collapsed the stack of
+// `FLAG_UPDATE_TXN` oneway calls into a single trailing entry.
+
+package update_txn;
+
+interface IUpdateTxnDedup {
+    /**
+     * Single-slot recorder. Each call appends to an internal Vec; with
+     * `FLAG_UPDATE_TXN`, only the freshest call for a given
+     * `(target, code)` should ever land while the server is busy with
+     * an earlier transaction. Sleeps for `delay_ms` to widen the dedup
+     * window deterministically.
+     */
+    oneway void onRecord(in int v, in int delay_ms);
+
+    /** Drain — non-oneway so the client knows everything queued has run. */
+    int[] drain();
+
+    /** Reset the recorder before a fresh round. */
+    void reset();
+}

--- a/example-hello/build.rs
+++ b/example-hello/build.rs
@@ -4,9 +4,24 @@
 use std::path::PathBuf;
 
 fn main() {
-    rsbinder_aidl::Builder::new()
-        .source(PathBuf::from("aidl/hello/IHello.aidl"))
-        .output(PathBuf::from("hello.rs"))
-        .generate()
-        .unwrap();
+    let aidl = |src: &str, out: &str| {
+        rsbinder_aidl::Builder::new()
+            .source(PathBuf::from(src))
+            .output(PathBuf::from(out))
+            .generate()
+            .unwrap();
+    };
+
+    aidl("aidl/hello/IHello.aidl", "hello.rs");
+    // Calling-identity interop fixture interface.
+    aidl(
+        "aidl/calling_identity/ICallingIdentity.aidl",
+        "calling_identity.rs",
+    );
+    // @EnforcePermission codegen E2E fixture.
+    aidl("aidl/permcheck/IPermCheck.aidl", "permcheck.rs");
+    // `TF_UPDATE_TXN` dedup fixture.
+    aidl("aidl/update_txn/IUpdateTxnDedup.aidl", "update_txn.rs");
+    // RT inheritance fixture.
+    aidl("aidl/rt_inherit/IRtCheck.aidl", "rt_inherit.rs");
 }

--- a/example-hello/cpp/rpc_accessor_register_interop_launcher.cpp
+++ b/example-hello/cpp/rpc_accessor_register_interop_launcher.cpp
@@ -8,7 +8,7 @@
 //
 // Pairs with `example-hello/src/bin/rpc_accessor_register_interop_server`
 // (cross-compiled rsbinder server binary). The companion bash script
-// `run_stage3_register.sh` automates build + push + run.
+// `run_rpc_accessor_register_interop.sh` automates build + push + run.
 //
 // Wire layers verified vs the genuine peer:
 //   - kernel-binder `IAccessor` AIDL (`addConnection`) on the rsbinder

--- a/example-hello/cpp/rpc_multiconn_interop_launcher.cpp
+++ b/example-hello/cpp/rpc_multiconn_interop_launcher.cpp
@@ -6,7 +6,7 @@
 //
 // Pairs with `example-hello/src/bin/rpc_multiconn_interop_server`
 // (cross-compiled rsbinder server). The companion bash script
-// `run_stage3_multiconn.sh` automates build + push + run.
+// `run_rpc_multiconn_interop.sh` automates build + push + run.
 //
 // ⚠ **STATUS (2026-05-21): NOT YET PASSING — gate is blocked.** The
 // harness compiles and runs end-to-end, but the (a) concurrent-twoway
@@ -21,7 +21,7 @@
 // or a non-wire protocol nuance rsbinder Phase A misses; investigation
 // is paused pending a deeper libbinder build/instrument session. This
 // launcher stays in tree as the **future-AC-12.6 gate harness**:
-// re-run `run_stage3_multiconn.sh` once the multi-conn root cause is
+// re-run `run_rpc_multiconn_interop.sh` once the multi-conn root cause is
 // known + fixed; the pass criteria below (a)/(b)/(c) and exit-codes
 // stay as the contract.
 //

--- a/example-hello/cpp/rpc_multiconn_interop_launcher.cpp
+++ b/example-hello/cpp/rpc_multiconn_interop_launcher.cpp
@@ -445,8 +445,27 @@ int main(int argc, char** argv) {
         fprintf(stderr, "[cpp-client] (a) PASS — parallel within budget\n");
     }
 
-    // ---- (b) Oneway in-order via founding-slot pin -----------------
-    // 20 oneway calls then one twoway TX_GET_LOG. Order must be exact.
+    // ---- (b) Oneway in-order via Phase C per-node asyncTodo ---------
+    // 20 oneway calls then polled twoway TX_GET_LOG (drain wait). The
+    // Phase C `asyncTodo` priority replay (AOSP `RpcState::process
+    // TransactInternal` lines 1093–1133 enqueue + 1247–1278 drain)
+    // guarantees per-node monotonic order *eventually*: libbinder's
+    // `ExclusiveConnection::find(CLIENT_ASYNC)` round-robins oneway
+    // across the client's `mOutgoing` pool, so the rsbinder server
+    // receives them split across slots whose `serve_blocking_on`
+    // workers dispatch independently. With Phase C the server parks
+    // out-of-order arrivals in the target node's `asyncTodo` heap and
+    // drains them when the matching expected `async_number` arrives.
+    //
+    // The crucial wrinkle: **TX_GET_LOG is a twoway, not gated by
+    // asyncTodo**, so it can race a still-draining queue. The test
+    // poll-loops `do_get_log` until `log.size() == kN` or a 2 s
+    // timeout, then asserts strict order — the in-order guarantee is
+    // structural (per-node monotonic), only the *timing* needs the
+    // poll to bound the eventual-consistency window. Pre-Phase-C this
+    // test got `log size 10` (founding slot's drain) or `log size 1`
+    // (asyncTodo with no drain wait); Phase C + poll gets `log size
+    // 20` in strict order.
     {
         constexpr int kN = 20;
         fprintf(stderr, "[cpp-client] (b) oneway in-order: %d × TX_ONEWAY then TX_GET_LOG\n", kN);
@@ -456,39 +475,102 @@ int main(int argc, char** argv) {
                 return 20;
             }
         }
-        // The rsbinder server's oneway dispatch is synchronous on its
-        // founding slot; by the time TX_GET_LOG (twoway) returns we
-        // know all the oneways landed in order (the twoway is queued
-        // behind them on the same slot per Option-1 pin).
         std::vector<int32_t> log;
-        if (!do_get_log(root, &log)) {
-            fprintf(stderr, "[cpp-client] (b) get_log failed\n");
-            return 21;
+        constexpr int kTimeoutMs = 2000;
+        constexpr int kPollMs = 25;
+        int elapsed_ms = 0;
+        while (elapsed_ms <= kTimeoutMs) {
+            log.clear();
+            if (!do_get_log(root, &log)) {
+                fprintf(stderr, "[cpp-client] (b) get_log failed\n");
+                return 21;
+            }
+            if ((int)log.size() == kN) break;
+            usleep(kPollMs * 1000);
+            elapsed_ms += kPollMs;
         }
         if ((int)log.size() != kN) {
-            fprintf(stderr, "[cpp-client] (b) FAIL: log size %zu != %d\n", log.size(), kN);
+            fprintf(stderr,
+                    "[cpp-client] (b) FAIL: log size %zu != %d after %d ms poll\n",
+                    log.size(), kN, elapsed_ms);
             return 22;
         }
         for (int i = 0; i < kN; ++i) {
             if (log[i] != i) {
                 fprintf(stderr,
-                        "[cpp-client] (b) FAIL: log[%d]=%d, expected %d — oneway reorder\n",
+                        "[cpp-client] (b) FAIL: log[%d]=%d, expected %d — oneway reorder \
+(Phase C asyncTodo bug)\n",
                         i, log[i], i);
                 return 23;
             }
         }
-        fprintf(stderr, "[cpp-client] (b) PASS — %d oneway calls in-order\n", kN);
+        fprintf(stderr,
+                "[cpp-client] (b) PASS — %d oneway calls in-order (drained after %d ms)\n",
+                kN, elapsed_ms);
     }
 
-    // ---- (c) Cross-slot nested callback ----------------------------
-    // Deferred behind F8.B (split mOutgoing/mIncoming pools) — see the
-    // setMaxIncomingThreads(0) scope note above. The callback wiring
-    // (do_invoke_callback + callback_on_transact + kCallbackDescriptor)
-    // and the rsbinder server's TX_INVOKE_CALLBACK arm stay in place so
-    // a follow-up commit that implements F8.B can re-enable this gate
-    // by flipping setMaxIncomingThreads back to 2 and uncommenting the
-    // assertion block below.
-    fprintf(stderr, "[cpp-client] (c) SKIPPED — needs F8.B (split outgoing/incoming pools)\n");
+    // ---- (c) Cross-slot nested callback (AC-12.2-extended) ----------
+    // 2 client threads fire TX_INVOKE_CALLBACK(cb, "pingN") in parallel
+    // on the 2 outgoing slots. The rsbinder server dispatches each on
+    // its own incoming-slot worker; inside on_transact, the server
+    // makes a *nested* server→client transact `cb.transact(TX_CALLBACK_
+    // ECHO, "pingN")` and reads the reply. The nested send rides the
+    // **same slot** the original transact arrived on via the Phase A
+    // `find_conn` DRIVING `(sess, slot)` re-entry pin — bidirectional
+    // wire on one TCP socket. The libbinder client's `waitForReply`
+    // loop on that slot accepts an inbound TRANSACT (nested context),
+    // dispatches our `callback_on_transact`, writes the reply back on
+    // the same slot, and returns to its outer wait. The launcher
+    // asserts both threads receive `cb-echo:pingN` (no cross-worker
+    // wire interleave / aliasing — F8). Pre-Phase-A4 (server-side
+    // N-inner) shared `state.remote_proxies` across workers, so the
+    // 2nd worker's nested send could route through the *first*
+    // worker's inner socket and deadlock or interleave; A4 + DRIVING
+    // (sess,slot) key fixed that, and this gate proves the integration.
+    {
+        constexpr int kN = 2;
+        fprintf(stderr,
+                "[cpp-client] (c) cross-slot nested callback: %d × TX_INVOKE_CALLBACK in parallel\n",
+                kN);
+        AIBinder_Class* cb_clazz = AIBinder_Class_define(
+                kCallbackDescriptor, cb_on_create, cb_on_destroy, callback_on_transact);
+        if (!cb_clazz) {
+            fprintf(stderr, "[cpp-client] (c) Class_define(cb) failed\n");
+            return 30;
+        }
+        AIBinder* cb_raw = AIBinder_new(cb_clazz, nullptr);
+        if (!cb_raw) {
+            fprintf(stderr, "[cpp-client] (c) AIBinder_new(cb) failed\n");
+            return 31;
+        }
+        auto cb_owner = std::unique_ptr<AIBinder, decltype(&AIBinder_decStrong)>(
+                cb_raw, AIBinder_decStrong);
+        AIBinder* cb = cb_owner.get();
+
+        std::vector<std::thread> ths;
+        std::vector<std::string> replies(kN);
+        std::vector<int> oks(kN, 0);
+        for (int i = 0; i < kN; ++i) {
+            ths.emplace_back([i, root, cb, &replies, &oks]() {
+                std::string arg = "ping" + std::to_string(i);
+                if (do_invoke_callback(root, cb, arg.c_str(), &replies[i])) {
+                    oks[i] = 1;
+                }
+            });
+        }
+        for (auto& t : ths) t.join();
+        for (int i = 0; i < kN; ++i) {
+            std::string want = "cb-echo:ping" + std::to_string(i);
+            if (!oks[i] || replies[i] != want) {
+                fprintf(stderr,
+                        "[cpp-client] (c) FAIL thread %d: ok=%d reply=\"%.*s\" want=\"%.*s\"\n",
+                        i, oks[i], (int)replies[i].size(), replies[i].data(),
+                        (int)want.size(), want.data());
+                return 32;
+            }
+        }
+        fprintf(stderr, "[cpp-client] (c) PASS — %d parallel nested callbacks round-tripped\n", kN);
+    }
 
     printf("AC-12.6 PASS — multi-conn real-libbinder ↔ rsbinder full transact\n");
     fflush(stdout);

--- a/example-hello/cpp/run_calling_identity_interop.sh
+++ b/example-hello/cpp/run_calling_identity_interop.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Plan 4-1 Phase E STAGE3 — calling-identity + IPermissionController
+# smoke against real Android emulator (kernel binder + servicemanager
+# + system_server).
+#
+# Pure-Rust (no C++ launcher) because both halves of the test live
+# inside the emulator: the server-side service exercises Phase A/B
+# (`get_calling_*` / `clear_calling_identity` / `restore_calling_identity`
+# / `has_explicit_identity`), and the client exercises Phase D
+# (`permission_controller::default()` + `checkPermission`).
+#
+# Pairs of binaries:
+#   * calling_identity_interop_service — registers `rsbinder.test.calling_identity` with
+#     `BinderFeatures { set_requesting_sid: true, .. }`.
+#   * calling_identity_interop_client  — calls describeCaller() and checkPermission().
+#
+# Prereqs (mirrors run_rpc_accessor_interop.sh):
+#   * emulator-5556 booted (Android 16, SDK 36, SELinux Enforcing).
+#   * NDK r29+ at $ANDROID_NDK_HOME (default
+#     /opt/homebrew/share/android-ndk).
+#   * cargo-ndk installed; aarch64-linux-android rustup target added.
+#
+# Usage:
+#   ./run_calling_identity_interop.sh [-s emulator-5556]
+#
+# Exit 0 on PASS (describe round-trip + permission round-trip both
+# print PASS markers and client-exit=0).
+
+set -euo pipefail
+
+DEVICE=emulator-5556
+SERVICE_BIN=/data/local/tmp/calling_identity_interop_service
+CLIENT_BIN=/data/local/tmp/calling_identity_interop_client
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+if [[ ${1:-} == "-s" ]]; then
+    DEVICE="$2"
+    shift 2
+fi
+
+echo "==> verifying device $DEVICE is Android 16"
+sdk=$(adb -s "$DEVICE" shell getprop ro.build.version.sdk | tr -d '\r')
+[[ "$sdk" == "36" ]] || { echo "device $DEVICE is SDK $sdk, expected 36"; exit 1; }
+
+echo "==> verifying SELinux is enforcing (SID extraction needs it)"
+mode=$(adb -s "$DEVICE" shell getenforce | tr -d '\r')
+[[ "$mode" == "Enforcing" ]] || { echo "device $DEVICE getenforce=$mode, expected Enforcing"; exit 1; }
+
+echo "==> cross-compiling rsbinder STAGE3 binaries"
+( cd "$REPO_ROOT" && \
+    ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-/opt/homebrew/share/android-ndk}" \
+    cargo ndk -t arm64-v8a -p 35 build --release -p example-hello \
+        --bin calling_identity_interop_service --bin calling_identity_interop_client )
+
+echo "==> pushing binaries"
+adb -s "$DEVICE" push \
+    "$REPO_ROOT/target/aarch64-linux-android/release/calling_identity_interop_service" \
+    "$SERVICE_BIN" >/dev/null
+adb -s "$DEVICE" push \
+    "$REPO_ROOT/target/aarch64-linux-android/release/calling_identity_interop_client" \
+    "$CLIENT_BIN" >/dev/null
+
+echo "==> killing any old server + cleaning state"
+adb -s "$DEVICE" shell "pkill -9 -f calling_identity_interop_service 2>/dev/null; rm -f /data/local/tmp/calling_identity_interop_*.{stdout,stderr,log}; sleep 1" || true
+
+echo "==> starting server (background)"
+adb -s "$DEVICE" shell "nohup $SERVICE_BIN > /data/local/tmp/calling_identity_interop_service.stdout 2> /data/local/tmp/calling_identity_interop_service.stderr &" &
+sleep 3
+
+echo "==> running client (describe + check_permission)"
+out=$(adb -s "$DEVICE" shell "$CLIENT_BIN; echo client-exit=\$?" 2>&1)
+echo "$out"
+
+echo "==> stopping server"
+adb -s "$DEVICE" shell "pkill -9 -f calling_identity_interop_service 2>/dev/null" || true
+
+# Verify pass markers.
+echo "$out" | grep -q "STAGE3_4_1_DESCRIBE_PASS"   || { echo "FAIL: missing STAGE3_4_1_DESCRIBE_PASS"; exit 1; }
+echo "$out" | grep -q "STAGE3_4_1_PERMISSION_PASS" || { echo "FAIL: missing STAGE3_4_1_PERMISSION_PASS"; exit 1; }
+echo "$out" | grep -q "client-exit=0"              || { echo "FAIL: client-exit != 0"; exit 1; }
+
+echo "==> PASS"

--- a/example-hello/cpp/run_d8b_register.sh
+++ b/example-hello/cpp/run_d8b_register.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Subplan 2-14 D.8.b — cross-process accessor discovery via rsb_hub on
-# a Linux host. The Linux native sibling of `run_stage3_register.sh`:
+# a Linux host. The Linux native sibling of `run_rpc_accessor_register_interop.sh`:
 # instead of cross-compiling for an Android emulator and using real
 # libbinder as the client, this drives the rsbinder consume-side
 # (`hub::get_service` → `Service::Accessor(Some(_))` arm → bridged RPC

--- a/example-hello/cpp/run_enforce_permission_interop.sh
+++ b/example-hello/cpp/run_enforce_permission_interop.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Plan 4-2 Phase D STAGE3 — `@EnforcePermission` codegen interop with
+# real `PermissionManagerService` on the emulator.
+#
+# Pure-Rust (no C++ launcher) because both server and client live
+# inside the emulator. The client MUST run as the `shell` (uid 2000)
+# domain rather than root — Android's `PermissionManagerService`
+# bypasses permission checks for uid 0, which would mask the deny path.
+# We coerce that via `su shell sh -c "..."`.
+#
+# Pair of binaries:
+#   * enforce_permission_interop_service — registers `rsbinder.test.permcheck` with
+#     `BinderFeatures::set_requesting_sid = true`. Every method body
+#     returns `Ok(true)`; only the generated `@EnforcePermission` arm
+#     emits `EX_SECURITY`.
+#   * enforce_permission_interop_client  — verifies doSingle/doAllOf/doAnyOf succeed
+#     (real INTERNET/BLUETOOTH permissions) and doDenied fails with
+#     `ExceptionCode::Security` (fabricated permission name).
+#
+# Prereqs:
+#   * emulator-5556 booted (Android 16, SDK 36, SELinux Enforcing).
+#   * NDK r29+ at $ANDROID_NDK_HOME (default /opt/homebrew/share/android-ndk).
+#   * cargo-ndk + aarch64-linux-android rustup target.
+#
+# Usage:
+#   ./run_enforce_permission_interop.sh [-s emulator-5556]
+#
+# Exit 0 on PASS (4 STAGE3_4_2_PASS markers + client-exit=0).
+
+set -euo pipefail
+
+DEVICE=emulator-5556
+SERVICE_BIN=/data/local/tmp/enforce_permission_interop_service
+CLIENT_BIN=/data/local/tmp/enforce_permission_interop_client
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+if [[ ${1:-} == "-s" ]]; then
+    DEVICE="$2"
+    shift 2
+fi
+
+echo "==> verifying device $DEVICE is Android 16"
+sdk=$(adb -s "$DEVICE" shell getprop ro.build.version.sdk | tr -d '\r')
+[[ "$sdk" == "36" ]] || { echo "device $DEVICE is SDK $sdk, expected 36"; exit 1; }
+
+echo "==> verifying SELinux is enforcing"
+mode=$(adb -s "$DEVICE" shell getenforce | tr -d '\r')
+[[ "$mode" == "Enforcing" ]] || { echo "device $DEVICE getenforce=$mode, expected Enforcing"; exit 1; }
+
+echo "==> cross-compiling rsbinder STAGE3 binaries"
+( cd "$REPO_ROOT" && \
+    ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-/opt/homebrew/share/android-ndk}" \
+    cargo ndk -t arm64-v8a -p 35 build --release -p example-hello \
+        --bin enforce_permission_interop_service --bin enforce_permission_interop_client )
+
+echo "==> pushing binaries"
+adb -s "$DEVICE" push \
+    "$REPO_ROOT/target/aarch64-linux-android/release/enforce_permission_interop_service" \
+    "$SERVICE_BIN" >/dev/null
+adb -s "$DEVICE" push \
+    "$REPO_ROOT/target/aarch64-linux-android/release/enforce_permission_interop_client" \
+    "$CLIENT_BIN" >/dev/null
+
+echo "==> killing any old server + cleaning state"
+adb -s "$DEVICE" shell "pkill -9 -f enforce_permission_interop_service 2>/dev/null; rm -f /data/local/tmp/svc42.*; sleep 1" || true
+
+echo "==> starting server (background)"
+adb -s "$DEVICE" shell "nohup $SERVICE_BIN > /data/local/tmp/svc42.stdout 2> /data/local/tmp/svc42.stderr < /dev/null &" &
+sleep 4
+
+echo "==> running client as shell uid (root bypass would mask deny path)"
+out=$(adb -s "$DEVICE" shell "su shell sh -c '$CLIENT_BIN; echo client-exit=\$?'" 2>&1)
+echo "$out"
+
+echo "==> stopping server"
+adb -s "$DEVICE" shell "pkill -9 -f enforce_permission_interop_service 2>/dev/null" || true
+
+# Verify pass markers.
+echo "$out" | grep -q "STAGE3_4_2_PASS doSingle=true"        || { echo "FAIL: doSingle not PASS"; exit 1; }
+echo "$out" | grep -q "STAGE3_4_2_PASS doAllOf=true"         || { echo "FAIL: doAllOf not PASS"; exit 1; }
+echo "$out" | grep -q "STAGE3_4_2_PASS doAnyOf=true"         || { echo "FAIL: doAnyOf not PASS"; exit 1; }
+echo "$out" | grep -q "STAGE3_4_2_PASS doDenied=Security"    || { echo "FAIL: doDenied deny path did not fire"; exit 1; }
+echo "$out" | grep -q "client-exit=0"                        || { echo "FAIL: client-exit != 0"; exit 1; }
+
+echo "==> PASS"

--- a/example-hello/cpp/run_rpc_accessor_interop.sh
+++ b/example-hello/cpp/run_rpc_accessor_interop.sh
@@ -13,7 +13,7 @@
 #     (`rustup target add aarch64-linux-android`).
 #
 # Usage:
-#   ./run_stage3.sh [-s emulator-5556]
+#   ./run_rpc_accessor_interop.sh [-s emulator-5556]
 #
 # Exits 0 on STAGE3 PASS; non-zero otherwise.
 

--- a/example-hello/cpp/run_rpc_accessor_register_interop.sh
+++ b/example-hello/cpp/run_rpc_accessor_register_interop.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Subplan 2-14 D.9 STAGE3 — drive a real-libbinder *client* against the
 # rsbinder IAccessor *register*-side bridge on the android-16 emulator.
-# The role-inverse of subplan 2-13 D.8's `run_stage3.sh` (there
+# The role-inverse of subplan 2-13 D.8's `run_rpc_accessor_interop.sh` (there
 # rsbinder was the client + libbinder served; here rsbinder serves +
 # libbinder is the client).
 #
@@ -14,7 +14,7 @@
 #     (`rustup target add aarch64-linux-android`).
 #
 # Usage:
-#   ./run_stage3_register.sh [-s emulator-5556]
+#   ./run_rpc_accessor_register_interop.sh [-s emulator-5556]
 #
 # Exits 0 on STAGE3 PASS; non-zero otherwise.
 

--- a/example-hello/cpp/run_rpc_multiconn_interop.sh
+++ b/example-hello/cpp/run_rpc_multiconn_interop.sh
@@ -34,7 +34,7 @@
 #     "1 slot pool + DRIVING `(sess, slot)` reentrant pin" model is
 #     functionally equivalent at the wire level.
 #
-# Prereqs (same as run_stage3.sh / run_stage3_register.sh):
+# Prereqs (same as run_rpc_accessor_interop.sh / run_rpc_accessor_register_interop.sh):
 #   * Android_16 AVD booted (`emulator -avd Android_16 -port 5556`).
 #   * NDK r29+ at `$ANDROID_NDK_HOME` (default
 #     `/opt/homebrew/share/android-ndk`).
@@ -42,7 +42,7 @@
 #   * `aarch64-linux-android` rustup target installed.
 #
 # Usage:
-#   ./run_stage3_multiconn.sh [-s emulator-5556]
+#   ./run_rpc_multiconn_interop.sh [-s emulator-5556]
 #
 # Exits 0 on AC-12.6 PASS; non-zero otherwise.
 

--- a/example-hello/cpp/run_rt_inherit_interop.sh
+++ b/example-hello/cpp/run_rt_inherit_interop.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Plan 4-5 Phase D STAGE3 — RT scheduler inheritance interop.
+#
+# This script targets **REMOTE_LINUX** (king@archlinux,
+# kernel ≥ 7.0.3-zen with Rust binder driver — see
+# `project_remote_linux_box`) because:
+#
+#   * The Android emulator boots with a SELinux policy that
+#     forbids `sched_setscheduler` for non-system processes, so the
+#     hard RT inheritance check (Call B) cannot run.
+#   * REMOTE_LINUX accepts `CAP_SYS_NICE` via `setcap`/`sudo`, so the
+#     RT escalation actually fires and the kernel binder driver lifts
+#     the worker thread's scheduler class for the duration of the
+#     transaction.
+#
+# Pair:
+#   * rt_inherit_interop_service — `BinderFeatures::min_sched_policy = SCHED_FIFO`,
+#     `min_priority = 5`, `inherit_rt = true`.
+#   * rt_inherit_interop_client  — Call A (caller = SCHED_NORMAL/OTHER) +
+#     Call B (caller = SCHED_FIFO via `sched_setscheduler`). Call B
+#     SKIPs cleanly when the client lacks CAP_SYS_NICE; PASS still
+#     covers AC-4.5.6 (Call A) + helper plumbing (AC-4.5.7).
+#
+# Usage:
+#   ./run_rt_inherit_interop.sh                       # default ssh host
+#   REMOTE=archlinux ./run_rt_inherit_interop.sh      # override host
+#   AS_ROOT=1 ./run_rt_inherit_interop.sh             # use sudo for Call B
+#
+# Exit 0 on PASS.
+
+set -euo pipefail
+
+REMOTE="${REMOTE:-archlinux}"
+REPO_REMOTE="${REPO_REMOTE:-workspace/rsbinder}"
+
+echo "==> syncing source to $REMOTE:$REPO_REMOTE"
+rsync -avz \
+    --include="rsbinder/" --include="rsbinder/**" \
+    --include="example-hello/" --include="example-hello/**" \
+    --exclude="*" \
+    "$(cd "$(dirname "$0")/../.." && pwd)/" \
+    "$REMOTE:$REPO_REMOTE/" >/dev/null
+
+echo "==> building service + client"
+ssh "$REMOTE" "cd $REPO_REMOTE && cargo build -p example-hello \
+    --bin rt_inherit_interop_service --bin rt_inherit_interop_client"
+
+echo "==> ensuring rsb_hub is running"
+ssh "$REMOTE" "cd $REPO_REMOTE && pgrep -af rsb_hub >/dev/null || \
+    (nohup ./target/debug/rsb_hub > /tmp/rsb_hub.log 2>&1 < /dev/null &) ; sleep 1"
+
+echo "==> restarting service"
+ssh "$REMOTE" "cd $REPO_REMOTE && \
+    pkill -9 -f rt_inherit_interop_service 2>/dev/null || true ; \
+    nohup ./target/debug/rt_inherit_interop_service > /tmp/svc45.stdout 2> /tmp/svc45.stderr < /dev/null &"
+sleep 3
+
+echo "==> running client"
+if [[ "${AS_ROOT:-0}" == "1" ]]; then
+    out=$(ssh "$REMOTE" "cd $REPO_REMOTE && sudo ./target/debug/rt_inherit_interop_client; echo client-exit=\$?" 2>&1)
+else
+    out=$(ssh "$REMOTE" "cd $REPO_REMOTE && ./target/debug/rt_inherit_interop_client; echo client-exit=\$?" 2>&1)
+fi
+echo "$out"
+
+echo "==> stopping service"
+ssh "$REMOTE" "pkill -9 -f rt_inherit_interop_service 2>/dev/null" || true
+
+echo "$out" | grep -q "STAGE3_4_5_A caller=SCHED_NORMAL"  || { echo "FAIL: Call A did not run"; exit 1; }
+echo "$out" | grep -q "STAGE3_4_5_PASS"                   || { echo "FAIL: missing STAGE3_4_5_PASS"; exit 1; }
+echo "$out" | grep -q "client-exit=0"                     || { echo "FAIL: client-exit != 0"; exit 1; }
+echo "==> PASS"

--- a/example-hello/cpp/run_stage3_multiconn.sh
+++ b/example-hello/cpp/run_stage3_multiconn.sh
@@ -5,12 +5,34 @@
 # android-16 emulator. The non-negotiable multi-connection-per-session
 # interop gate (Plan 2-12 §3 AC-12.6).
 #
-# ⚠ STATUS (2026-05-21): GATE NOT YET PASSING — kept in tree as the
-# future-gate harness. See launcher source (cpp/rpc_multiconn_interop_
-# launcher.cpp) for the 2026-05-21 diagnostic summary (rsbinder wire
-# bytes are byte-correct; even a process-wide server send mutex
-# doesn't fix it; root cause still undiagnosed — multi-conn is
-# experimental in `RpcServer::set_max_threads(N >= 2)`'s doc).
+# STATUS (2026-05-28): AC-12.6 PASS — all three gates green, multi-
+# conn is out of EXPERIMENTAL.
+#   * (a) PASS: concurrent twoway across 2 outgoing slots (~80 ms,
+#     well under 250 ms parallel budget). Validates the plan 2-12
+#     Phase D wire fix (`server_accept` INCOMING bit parse +
+#     NewSessionResponse only for new session + direction-aware
+#     "cci" exchange).
+#   * (b) PASS: 20 oneway calls + polled TX_GET_LOG drain. Validates
+#     Phase C (per-`mNodeForAddress` `asyncNumber` send-side +
+#     receive-side `asyncTodo` priority replay): libbinder's
+#     `ExclusiveConnection::find(CLIENT_ASYNC)` round-robins oneway
+#     across the client's `mOutgoing` pool, so the rsbinder server
+#     receives them split across slots whose `serve_blocking_on`
+#     workers dispatch independently. The per-node `asyncTodo` parks
+#     out-of-order arrivals and the priority replay drains them when
+#     the matching expected `async_number` arrives — eventual per-
+#     node monotonic order, bounded poll window in the launcher.
+#   * (c) PASS: 2 parallel TX_INVOKE_CALLBACK from 2 client threads
+#     each land on their own server incoming-slot worker; the nested
+#     server→client `cb.transact` rides the **same** slot via the
+#     plan 2-12 Phase A `find_conn` DRIVING `(sess, slot)` re-entry
+#     pin (bidirectional wire on one TCP socket). The libbinder
+#     client's `waitForReply` loop on that slot dispatches the
+#     inbound nested TRANSACT in re-entrant context and writes the
+#     reply on the same slot. F8.B (split `mOutgoing`/`mIncoming`
+#     pools) turned out to be **not required** — the AOSP-divergent
+#     "1 slot pool + DRIVING `(sess, slot)` reentrant pin" model is
+#     functionally equivalent at the wire level.
 #
 # Prereqs (same as run_stage3.sh / run_stage3_register.sh):
 #   * Android_16 AVD booted (`emulator -avd Android_16 -port 5556`).

--- a/example-hello/cpp/run_update_txn_interop.sh
+++ b/example-hello/cpp/run_update_txn_interop.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Plan 4-4 Phase D STAGE3 — extended-error ioctl + `TF_UPDATE_TXN`
+# `TF_COLLECT_NOTED_APP_OPS` wire surface against real Android binder
+# driver on emulator.
+#
+# Server: `update_txn_interop_service` registers `rsbinder.test.update_txn` with
+# `max_threads=1` and *without* `start_thread_pool()` so the main
+# thread is the sole worker. The single-worker setup keeps async
+# transactions queueing in `node->async_todo` long enough that any
+# kernel that implements the dedup walk will be able to coalesce them.
+#
+# Client: `update_txn_interop_client` runs three checks:
+#   1. Baseline `FLAG_ONEWAY` burst — every payload must survive.
+#   2. `FLAG_ONEWAY | FLAG_UPDATE_TXN` burst — the kernel must at
+#      least *accept* every transaction (no `EINVAL`). Whether it
+#      actually collapses the queue is kernel-implementation
+#      dependent (Android 12+ does, older kernels silently ignore),
+#      so the client logs which behavior it observed and PASSes
+#      either way.
+#   3. `get_extended_error()` — must return `Ok` on Android 12+ /
+#      Linux 5.14+; the API itself surfaces `InvalidOperation` on
+#      older drivers, which counts as the documented fallback (also
+#      PASS).
+#
+# Usage: ./run_update_txn_interop.sh [-s emulator-5556]
+# Exit 0 on PASS.
+
+set -euo pipefail
+
+DEVICE=emulator-5556
+SERVICE_BIN=/data/local/tmp/update_txn_interop_service
+CLIENT_BIN=/data/local/tmp/update_txn_interop_client
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+if [[ ${1:-} == "-s" ]]; then
+    DEVICE="$2"
+    shift 2
+fi
+
+echo "==> verifying device $DEVICE is Android 12+ (needs BINDER_GET_EXTENDED_ERROR / TF_UPDATE_TXN)"
+sdk=$(adb -s "$DEVICE" shell getprop ro.build.version.sdk | tr -d '\r')
+[[ "$sdk" -ge 31 ]] || { echo "device $DEVICE is SDK $sdk, expected >= 31 (Android 12)"; exit 1; }
+
+echo "==> cross-compiling rsbinder STAGE3 binaries"
+( cd "$REPO_ROOT" && \
+    ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-/opt/homebrew/share/android-ndk}" \
+    cargo ndk -t arm64-v8a -p 35 build --release -p example-hello \
+        --bin update_txn_interop_service --bin update_txn_interop_client )
+
+echo "==> pushing binaries"
+adb -s "$DEVICE" push \
+    "$REPO_ROOT/target/aarch64-linux-android/release/update_txn_interop_service" \
+    "$SERVICE_BIN" >/dev/null
+adb -s "$DEVICE" push \
+    "$REPO_ROOT/target/aarch64-linux-android/release/update_txn_interop_client" \
+    "$CLIENT_BIN" >/dev/null
+
+echo "==> killing any old server + cleaning state"
+adb -s "$DEVICE" shell "pkill -9 -f update_txn_interop_service 2>/dev/null; rm -f /data/local/tmp/svc44.*; sleep 1" || true
+
+echo "==> starting server (background)"
+adb -s "$DEVICE" shell "nohup $SERVICE_BIN > /data/local/tmp/svc44.stdout 2> /data/local/tmp/svc44.stderr < /dev/null &" &
+sleep 4
+
+echo "==> running client (baseline + dedup + extended_error)"
+out=$(adb -s "$DEVICE" shell "$CLIENT_BIN; echo client-exit=\$?" 2>&1)
+echo "$out"
+
+echo "==> stopping server"
+adb -s "$DEVICE" shell "pkill -9 -f update_txn_interop_service 2>/dev/null" || true
+
+echo "$out" | grep -q "STAGE3_4_4_BASELINE recorded=\[10, 11, 12, 13\]" \
+    || { echo "FAIL: baseline burst lost data"; exit 1; }
+echo "$out" | grep -q "STAGE3_4_4_DEDUP recorded="            || { echo "FAIL: dedup round did not run"; exit 1; }
+echo "$out" | grep -q "STAGE3_4_4_EXTENDED_ERROR"             || { echo "FAIL: get_extended_error() not exercised"; exit 1; }
+echo "$out" | grep -q "STAGE3_4_4_PASS"                       || { echo "FAIL: missing STAGE3_4_4_PASS"; exit 1; }
+echo "$out" | grep -q "client-exit=0"                         || { echo "FAIL: client-exit != 0"; exit 1; }
+
+echo "==> PASS"

--- a/example-hello/src/bin/calling_identity_interop_client.rs
+++ b/example-hello/src/bin/calling_identity_interop_client.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Client harness — drives the server
+// (`calling_identity_interop_service`) and the `permission_controller` stub against
+// real Android emulator (kernel binder + system_server).
+//
+// Usage:
+//   calling_identity_interop_client                  # both checks
+//   calling_identity_interop_client describe         # just the describeCaller round-trip
+//   calling_identity_interop_client check_permission # just the IPermissionController probe
+//
+// Exit codes: 0 on PASS, non-zero on any failure (mismatched SID format,
+// unreachable service, etc.). Designed to be driven from
+// `example-hello/cpp/run_calling_identity_interop.sh`.
+
+use std::process::ExitCode;
+
+use rsbinder::*;
+
+use example_hello::calling_identity::{ICallingIdentity, SERVICE_NAME};
+
+/// Round-trip: call into the server's `describeCaller`,
+/// print the result, and PASS only when the server reported a non-empty
+/// SELinux context (`u:r:*:s0...`) and the explicit-identity
+/// before/after-clear/after-restore triple matched `false / true /
+/// false`.
+fn describe_caller_round_trip() -> Result<()> {
+    let binder = hub::get_service(SERVICE_NAME).ok_or(StatusCode::NameNotFound)?;
+    let svc = <dyn ICallingIdentity>::try_from(binder).map_err(|e| {
+        eprintln!("interface_cast failed: {e:?}");
+        StatusCode::BadType
+    })?;
+
+    let line = svc.describeCaller().map_err(|status| {
+        eprintln!("describeCaller failed: {status:?}");
+        StatusCode::Unknown
+    })?;
+    println!("STAGE3_4_1_DESCRIBE: {line}");
+
+    // Parse the line and validate.
+    let mut sid: Option<String> = None;
+    let mut explicit_pre: Option<bool> = None;
+    let mut explicit_after_clear: Option<bool> = None;
+    let mut explicit_after_restore: Option<bool> = None;
+    for tok in line.split_whitespace() {
+        if let Some(v) = tok.strip_prefix("sid=") {
+            sid = Some(v.to_owned());
+        } else if let Some(v) = tok.strip_prefix("explicit_pre=") {
+            explicit_pre = v.parse().ok();
+        } else if let Some(v) = tok.strip_prefix("explicit_after_clear=") {
+            explicit_after_clear = v.parse().ok();
+        } else if let Some(v) = tok.strip_prefix("explicit_after_restore=") {
+            explicit_after_restore = v.parse().ok();
+        }
+    }
+
+    let sid = sid.ok_or_else(|| {
+        eprintln!("missing sid= in reply");
+        StatusCode::BadValue
+    })?;
+    let explicit_pre = explicit_pre.ok_or(StatusCode::BadValue)?;
+    let explicit_after_clear = explicit_after_clear.ok_or(StatusCode::BadValue)?;
+    let explicit_after_restore = explicit_after_restore.ok_or(StatusCode::BadValue)?;
+
+    // Explicit-identity must round-trip
+    // false → true → false across clear → restore.
+    if explicit_pre || !explicit_after_clear || explicit_after_restore {
+        eprintln!(
+            "explicit_identity round-trip wrong: pre={explicit_pre} \
+             after_clear={explicit_after_clear} \
+             after_restore={explicit_after_restore}"
+        );
+        return Err(StatusCode::BadValue);
+    }
+
+    // When the server's binder requested SEC_CTX, the kernel
+    // must deliver a SELinux context string (`u:r:<domain>:s0[:...]`).
+    if !sid.starts_with("u:r:") || !sid.contains(":s0") {
+        eprintln!("SID does not match SELinux context shape: {sid:?}");
+        return Err(StatusCode::BadValue);
+    }
+    println!("STAGE3_4_1_DESCRIBE_PASS sid={sid}");
+    Ok(())
+}
+
+/// Probe: try to acquire the system-wide `permission` service
+/// and call `checkPermission("android.permission.INTERNET", ...)` for
+/// the current process. Either result is acceptable PASS (true/false) —
+/// what we are proving is that the AIDL stub round-trips wire-correctly
+/// with real `system_server`, not the policy outcome.
+fn check_permission_round_trip() -> Result<()> {
+    let pc = rsbinder::permission_controller::default()?;
+    let my_pid = rustix::process::getpid().as_raw_nonzero().get() as i32;
+    let my_uid = rustix::process::getuid().as_raw() as i32;
+    let granted = pc
+        .checkPermission("android.permission.INTERNET", my_pid, my_uid)
+        .map_err(|status| {
+            eprintln!("checkPermission failed: {status:?}");
+            StatusCode::Unknown
+        })?;
+    println!(
+        "STAGE3_4_1_PERMISSION_PASS pid={my_pid} uid={my_uid} \
+         android.permission.INTERNET={granted}"
+    );
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    if let Err(e) = ProcessState::init_default() {
+        eprintln!("init_default failed: {e}");
+        return ExitCode::from(2);
+    }
+
+    let mode = std::env::args().nth(1).unwrap_or_else(|| "all".to_owned());
+    let mut ok = true;
+
+    if mode == "describe" || mode == "all" {
+        if let Err(e) = describe_caller_round_trip() {
+            eprintln!("describe_caller_round_trip failed: {e:?}");
+            ok = false;
+        }
+    }
+    if mode == "check_permission" || mode == "all" {
+        if let Err(e) = check_permission_round_trip() {
+            eprintln!("check_permission_round_trip failed: {e:?}");
+            ok = false;
+        }
+    }
+
+    if ok {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::from(1)
+    }
+}

--- a/example-hello/src/bin/calling_identity_interop_service.rs
+++ b/example-hello/src/bin/calling_identity_interop_service.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Server-side smoke for calling-identity
+// extraction (`get_calling_*` / `clear_calling_identity` /
+// `restore_calling_identity` / `has_explicit_identity`) against real
+// Android emulator (kernel binder + servicemanager).
+//
+// Registers a service that, on each `describeCaller()` transact:
+//   1. Reads `get_calling_uid()` / `get_calling_pid()` / `get_calling_sid()`.
+//   2. Asserts `has_explicit_identity() == false` (kernel-delivered
+//      identity is the baseline, no `clear_calling_identity` yet).
+//   3. Calls `clear_calling_identity()` → asserts
+//      `has_explicit_identity() == true`.
+//   4. Calls `restore_calling_identity(token)` → asserts
+//      `has_explicit_identity() == false` again.
+//   5. Returns a single human-readable line summarizing all of the above.
+//
+// The client (`calling_identity_interop_client`) cross-checks the SID against the
+// expected SELinux context for the caller's domain (e.g. `u:r:shell:s0`
+// when invoked from `adb shell`).
+
+use env_logger::Env;
+use rsbinder::*;
+
+use example_hello::calling_identity::{BnCallingIdentity, ICallingIdentity, SERVICE_NAME};
+
+struct CallingIdentitySmoke;
+
+impl Interface for CallingIdentitySmoke {}
+
+impl ICallingIdentity for CallingIdentitySmoke {
+    fn describeCaller(&self) -> rsbinder::status::Result<String> {
+        let uid = rsbinder::get_calling_uid();
+        let pid = rsbinder::get_calling_pid();
+        let sid_pre = rsbinder::get_calling_sid();
+        let explicit_pre = rsbinder::has_explicit_identity();
+
+        let token = rsbinder::clear_calling_identity();
+        let explicit_after_clear = rsbinder::has_explicit_identity();
+
+        rsbinder::restore_calling_identity(token);
+        let explicit_after_restore = rsbinder::has_explicit_identity();
+
+        let sid_repr = sid_pre
+            .as_ref()
+            .and_then(|s| s.to_str().ok())
+            .map(|s| s.to_owned())
+            .unwrap_or_else(|| "<none>".to_owned());
+
+        Ok(format!(
+            "uid={uid} pid={pid} sid={sid_repr} \
+             explicit_pre={explicit_pre} \
+             explicit_after_clear={explicit_after_clear} \
+             explicit_after_restore={explicit_after_restore}"
+        ))
+    }
+}
+
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+
+    eprintln!("STAGE3 4-1 server: init ProcessState");
+    ProcessState::init_default()?;
+    ProcessState::start_thread_pool();
+
+    // Opt the binder into BR_TRANSACTION_SEC_CTX so the kernel delivers
+    // the caller's SELinux context.
+    let mut features = BinderFeatures::default();
+    features.set_requesting_sid = true;
+    let service = BnCallingIdentity::new_binder_with_features(CallingIdentitySmoke, features);
+
+    eprintln!("STAGE3 4-1 server: register `{SERVICE_NAME}`");
+    hub::add_service(SERVICE_NAME, service.as_binder())?;
+
+    eprintln!("STAGE3 4-1 server: join thread pool");
+    Ok(ProcessState::join_thread_pool()?)
+}

--- a/example-hello/src/bin/enforce_permission_interop_client.rs
+++ b/example-hello/src/bin/enforce_permission_interop_client.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Client — drives `IPermCheck` on the emulator
+// alongside `enforce_permission_interop_service` to prove the `@EnforcePermission`
+// codegen denies via `Status::Security` for a permission that does not
+// exist in `system_server`'s `PermissionManagerService` registry.
+//
+// PASS conditions (printed markers + non-zero exit on any miss):
+//   * `doSingle()` / `doAllOf()` / `doAnyOf()` return `Ok(true)` —
+//     android.permission.{INTERNET, ACCESS_NETWORK_STATE, BLUETOOTH*}
+//     are recognised permissions; root has them.
+//   * `doDenied()` returns `Err(Status)` with
+//     `ExceptionCode::Security` — the generated check denies before the
+//     service body runs.
+
+use std::process::ExitCode;
+
+use rsbinder::*;
+
+use example_hello::permcheck::{IPermCheck, SERVICE_NAME};
+
+fn expect_ok_true(label: &str, r: rsbinder::status::Result<bool>) -> bool {
+    match r {
+        Ok(true) => {
+            println!("STAGE3_4_2_PASS {label}=true");
+            true
+        }
+        Ok(false) => {
+            eprintln!("STAGE3_4_2_FAIL {label} returned Ok(false)");
+            false
+        }
+        Err(e) => {
+            eprintln!("STAGE3_4_2_FAIL {label} returned Err({e:?})");
+            false
+        }
+    }
+}
+
+fn expect_security_denial(r: rsbinder::status::Result<bool>) -> bool {
+    match r {
+        Err(status) if status.exception_code() == ExceptionCode::Security => {
+            println!(
+                "STAGE3_4_2_PASS doDenied=Security exception={:?}",
+                status.exception_code()
+            );
+            true
+        }
+        Err(other) => {
+            eprintln!("STAGE3_4_2_FAIL doDenied returned Err but not Security: {other:?}");
+            false
+        }
+        Ok(_) => {
+            eprintln!("STAGE3_4_2_FAIL doDenied returned Ok — check did not fire");
+            false
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    if let Err(e) = ProcessState::init_default() {
+        eprintln!("init_default failed: {e}");
+        return ExitCode::from(2);
+    }
+
+    let binder = match hub::get_service(SERVICE_NAME) {
+        Some(b) => b,
+        None => {
+            eprintln!("get_service({SERVICE_NAME}) returned None");
+            return ExitCode::from(3);
+        }
+    };
+
+    let svc = match <dyn IPermCheck>::try_from(binder) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("interface_cast failed: {e:?}");
+            return ExitCode::from(4);
+        }
+    };
+
+    let mut ok = true;
+    ok &= expect_ok_true("doSingle", svc.doSingle());
+    ok &= expect_ok_true("doAllOf", svc.doAllOf());
+    ok &= expect_ok_true("doAnyOf", svc.doAnyOf());
+    ok &= expect_security_denial(svc.doDenied());
+
+    if ok {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::from(1)
+    }
+}

--- a/example-hello/src/bin/enforce_permission_interop_service.rs
+++ b/example-hello/src/bin/enforce_permission_interop_service.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `@EnforcePermission` codegen interop with
+// real Android `PermissionManagerService` on the emulator.
+//
+// Registers `rsbinder.test.permcheck` with `set_requesting_sid = true`.
+// Every `IPermCheck` method on the service returns `true` (or an echo)
+// unconditionally — the *only* path that can produce
+// `Status::Security` for the client is the generated `on_transact`
+// check that runs BEFORE the method body. If the client receives
+// `Security` for `doDenied()` (whose fabricated permission cannot exist
+// in `system_server`'s permission map), the `@EnforcePermission` codegen
+// + the `permission_controller::check_permission` proxy
+// have round-tripped against real `PermissionManagerService`.
+
+use rsbinder::*;
+
+use example_hello::permcheck::{BnPermCheck, IPermCheck, SERVICE_NAME};
+
+struct PermCheckImpl;
+
+impl Interface for PermCheckImpl {}
+
+impl IPermCheck for PermCheckImpl {
+    fn doSingle(&self) -> rsbinder::status::Result<bool> {
+        Ok(true)
+    }
+    fn doAllOf(&self) -> rsbinder::status::Result<bool> {
+        Ok(true)
+    }
+    fn doAnyOf(&self) -> rsbinder::status::Result<bool> {
+        Ok(true)
+    }
+    fn doDenied(&self) -> rsbinder::status::Result<bool> {
+        // This must NEVER run — the generated `on_transact` arm should
+        // reject before reaching here. We return a sentinel that the
+        // client compares against to detect a leak.
+        eprintln!("STAGE3_4_2_LEAK: doDenied() body ran — generated check did not fire!");
+        Ok(false)
+    }
+    fn echo(&self, message: &str) -> rsbinder::status::Result<String> {
+        Ok(message.to_owned())
+    }
+}
+
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    eprintln!("STAGE3 4-2 server: init ProcessState");
+    ProcessState::init_default()?;
+    ProcessState::start_thread_pool();
+
+    let mut features = BinderFeatures::default();
+    features.set_requesting_sid = true;
+    let service = BnPermCheck::new_binder_with_features(PermCheckImpl, features);
+
+    eprintln!("STAGE3 4-2 server: register `{SERVICE_NAME}`");
+    hub::add_service(SERVICE_NAME, service.as_binder())?;
+
+    eprintln!("STAGE3 4-2 server: join thread pool");
+    Ok(ProcessState::join_thread_pool()?)
+}

--- a/example-hello/src/bin/rpc_accessor_interop_client.rs
+++ b/example-hello/src/bin/rpc_accessor_interop_client.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Subplan 2-13 D.8 STAGE3 — rsbinder side of the IAccessor bridge
+//! rsbinder side of the IAccessor bridge
 //! real-libbinder interop harness.
 //!
 //! Pairs with `cpp/rpc_accessor_interop_launcher` (real-libbinder side)
@@ -26,13 +26,13 @@
 //!      which the stock emulator's read-only /system blocks).
 //!   4. `accessor_16::resolve_accessor(name, accessor_binder)` drives
 //!      the bridge **end-to-end**: BpAccessor wire (real libbinder) →
-//!      `addConnection()` → fd adopt → 2-8 v2 handshake (real libbinder
+//!      `addConnection()` → fd adopt → v2 handshake (real libbinder
 //!      RPC server peer) → `get_root()` → real RPC root.
 //!   5. Full transact: `TX_ECHO` (round-trip arg) + `TX_GIVE_MARKER`
 //!      (server-side string, no arg). The marker is a fixed string the
 //!      C++ launcher hard-codes, so an end-to-end PASS proves the
 //!      Parcel body bytes match against the genuine peer (the same
-//!      shape the 2-8 STAGE3 used).
+//!      shape the v2 STAGE3 interop used).
 //!
 //! Exit code 0 = STAGE3 PASS; non-zero = bug.
 

--- a/example-hello/src/bin/rpc_accessor_register_interop_server.rs
+++ b/example-hello/src/bin/rpc_accessor_register_interop_server.rs
@@ -1,15 +1,15 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Subplan 2-14 D.9 STAGE3 — rsbinder *server* side of the IAccessor
+//! rsbinder *server* side of the IAccessor
 //! **register**-side real-libbinder interop harness. The role-inverse
-//! of 2-13 D.8: there libbinder served the IAccessor + RPC root and
-//! rsbinder consumed; here rsbinder serves both and the real
-//! libbinder C launcher consumes.
+//! of the consume-side harness: there libbinder served the IAccessor +
+//! RPC root and rsbinder consumed; here rsbinder serves both and the
+//! real libbinder C launcher consumes.
 //!
 //! Pairs with `cpp/rpc_accessor_register_interop_launcher` (real-
 //! libbinder client) on an **android-16 emulator (API 36)**. See
-//! `cpp/run_stage3_register.sh` for the automation around it.
+//! `cpp/run_rpc_accessor_register_interop.sh` for the automation around it.
 //!
 //! ```text
 //! ANDROID_NDK_HOME=/opt/homebrew/share/android-ndk \
@@ -36,13 +36,13 @@
 //!      profile; max=2 ⇒ android-16 v2 (matches real libbinder on the
 //!      emulator).
 //!   5. `set_root(BnInterop)` installs a tiny `TX_ECHO` / `TX_GIVE_MARKER`
-//!      service — same shape as the 2-13 D.8 launcher's, swapped sides.
+//!      service — same shape as the consume-side launcher's, swapped sides.
 //!   6. `create_accessor(instance, addr_provider)` builds the
 //!      `LocalAccessor` `BnAccessor` binder; `hub::add_service` publishes
 //!      it to the kernel service manager as a regular service — no
 //!      VINTF `<accessor>` entry needed (the stock emulator's /system is
 //!      read-only). The libbinder client picks it up the same way the
-//!      2-13 D.8 launcher's `AServiceManager_addService` did, then
+//!      consume-side launcher's `AServiceManager_addService` did, then
 //!      transacts `addConnection()` on it directly.
 //!   7. `RpcServer::run_background()` serves the preconnected fd; the
 //!      main thread joins the kernel-binder thread pool to keep
@@ -91,9 +91,9 @@ impl Remotable for Interop {
             TX_ECHO => {
                 // AIDL-shaped wire: caller writes one String arg; reply
                 // is `Status::Ok` + the echoed String. Mirrors the C++
-                // launcher's `TX_ECHO` in 2-13 D.8 (`rpc_accessor_
-                // interop_launcher.cpp`) bit-for-bit, just on the
-                // opposite side of the bridge.
+                // consume-side launcher's `TX_ECHO`
+                // (`rpc_accessor_interop_launcher.cpp`) bit-for-bit,
+                // just on the opposite side of the bridge.
                 let s: String = reader.read()?;
                 eprintln!("[rsbinder-server] TX_ECHO arg={s:?} (from real libbinder client)");
                 reply.write(&Status::from(StatusCode::Ok))?;
@@ -147,7 +147,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // 2) Kernel-binder worker threads — without these, the registered
     //    IAccessor binder cannot answer transactions and the libbinder
     //    client hangs in `addConnection()` (mirrors the
-    //    `ABinderProcess_startThreadPool()` call in the 2-13 D.8
+    //    `ABinderProcess_startThreadPool()` call in the consume-side
     //    launcher).
     ProcessState::start_thread_pool();
 
@@ -179,7 +179,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     //    the libbinder client looks it up via `AServiceManager_get*`
     //    and then transacts `addConnection()` on it directly. No VINTF
     //    `<accessor>` entry is needed (the stock emulator's read-only
-    //    /system blocks it anyway — same constraint the 2-13 D.8
+    //    /system blocks it anyway — same constraint the consume-side
     //    launcher hits and works around).
     hub::add_service(&instance, accessor_binder)?;
 

--- a/example-hello/src/bin/rpc_hello_client.rs
+++ b/example-hello/src/bin/rpc_hello_client.rs
@@ -4,7 +4,7 @@
 //! RPC variant of `hello_client` — connects to `rpc_hello_service`
 //! over a Unix-domain socket and calls the **same generated `IHello`
 //! proxy**. The generated stub resolves the RPC binder through
-//! `as_remote()` (Plan 2-6.B single-stub): the call site is identical
+//! `as_remote()` (single-stub): the call site is identical
 //! to the kernel path — there is no RPC-specific proxy and no service
 //! manager (the root object comes straight off the session).
 //!

--- a/example-hello/src/bin/rpc_hello_service.rs
+++ b/example-hello/src/bin/rpc_hello_service.rs
@@ -4,7 +4,7 @@
 //! RPC (binder-over-socket) variant of `hello_service` — serves the
 //! **same generated `IHello` stub** over a Unix-domain socket instead
 //! of the kernel binder driver. No `/dev/binder`, no service manager:
-//! the RPC transport is a separate, parallel stack (Plan 2). Pair it
+//! the RPC transport is a separate, parallel stack. Pair it
 //! with `rpc_hello_client`:
 //!
 //! ```text

--- a/example-hello/src/bin/rpc_multiconn_interop_server.rs
+++ b/example-hello/src/bin/rpc_multiconn_interop_server.rs
@@ -1,12 +1,12 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Subplan 2-12 Phase D / **AC-12.6** STAGE3 — rsbinder side of the
+//! rsbinder side of the
 //! **multi-connection-per-session** real-libbinder interop gate. Pairs
 //! with `cpp/rpc_multiconn_interop_launcher.cpp` (real-libbinder
 //! client wired with `ARpcSession_setMaxOutgoingConnections(2) +
 //! setMaxIncomingThreads(2)`) on an **android-16 emulator (API 36)**.
-//! See `cpp/run_stage3_multiconn.sh` for the automation around it.
+//! See `cpp/run_rpc_multiconn_interop.sh` for the automation around it.
 //!
 //! ```text
 //! ANDROID_NDK_HOME=/opt/homebrew/share/android-ndk \
@@ -17,9 +17,9 @@
 //!     /data/local/tmp/rsmc.sock 2
 //! ```
 //!
-//! What this harness verifies (the non-negotiable gate Plan 2-12 §6 D /
-//! AC-12.6 spells out — *hermetic rsbinder↔rsbinder is byte-symmetric
-//! so F1/F5/F6-class defects only surface against the real peer*):
+//! What this harness verifies (*hermetic rsbinder↔rsbinder is
+//! byte-symmetric, so reorder/async-numbering defects only surface
+//! against the real peer*):
 //!
 //!   (a) **Concurrent twoway across N=2 outgoing slots**: the launcher
 //!       fires two `TX_SLOW_ECHO(80ms)` calls in parallel; both must
@@ -27,12 +27,11 @@
 //!       single slot — the launcher asserts the parallel budget so a
 //!       silent serialization on one slot fails the gate).
 //!
-//!   (b) **Oneway in-order receipt across the founding pin** (Option-1):
+//!   (b) **Oneway in-order receipt**:
 //!       20 oneway `TX_ONEWAY(i)` calls i=0..19, then one twoway
 //!       `TX_GET_LOG()` reading the recorded `Vec<i32>`. Must equal
-//!       `[0..20)` byte-exact. Catches F5 (reorder buffer absent) +
-//!       F6 (`asyncNumber` per-node missing). Option-1 design: founding-
-//!       slot pin preserves per-object FIFO.
+//!       `[0..20)` byte-exact. Catches a missing reorder buffer or
+//!       per-node `asyncNumber`.
 //!
 //!   (c) **Cross-slot nested callback** (pool-traversing): the launcher
 //!       registers a callback `AIBinder` and invokes
@@ -55,7 +54,7 @@ use rsbinder::*;
 /// Must match the descriptor the C launcher's AIBinder class uses for
 /// the *server root*. The genuine peer's `writeInterfaceToken` and
 /// rsbinder's `consume_rpc_interface_token` agree on it bit-for-bit
-/// (per 2-8 STAGE3 RPC token = bare `writeString16(descriptor)`).
+/// (STAGE3 RPC token = bare `writeString16(descriptor)`).
 const ROOT_DESC: &str = "rsbinder.test.IMultiConn";
 /// Must match the descriptor the C launcher's *callback* AIBinder uses.
 const CALLBACK_DESC: &str = "rsbinder.test.IMultiConnCallback";
@@ -70,7 +69,7 @@ const TX_CALLBACK_ECHO: TransactionCode = FIRST_CALL_TRANSACTION;
 
 struct MultiConn {
     /// Oneway log — every `TX_ONEWAY(i)` appends `i` here, in receipt
-    /// order. Founding-slot pin (Plan 2-12 Option-1) means *all*
+    /// order. The founding-slot pin means *all*
     /// top-level oneway calls land on the same incoming slot, so order
     /// is preserved by single-slot in-order dispatch.
     oneway_log: Mutex<Vec<i32>>,
@@ -130,9 +129,9 @@ impl Remotable for MultiConn {
                 // `(cb: SIBinder, s: String) -> String` — call back into
                 // the client-supplied callback `cb.echo(s)` and return
                 // its reply. The nested call rides the *same* slot via
-                // DRIVING `(sess, slot)` re-entry pin (Plan 2-12 Phase
-                // A); cross-slot routing would deadlock (slot already
-                // owned by this dispatch).
+                // the DRIVING `(sess, slot)` re-entry pin; cross-slot
+                // routing would deadlock (slot already owned by this
+                // dispatch).
                 let cb: SIBinder = reader.read()?;
                 let s: String = reader.read()?;
                 let rp = (*cb)
@@ -170,7 +169,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let sock = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "/data/local/tmp/rsmc.sock".to_string());
-    // argv[2] = max incoming slots per session. AC-12.6 baseline = 2
+    // argv[2] = max incoming slots per session. Baseline = 2
     // (founding + 1 attached). The launcher's
     // `ARpcSession_setMaxOutgoingConnections(2)` matches.
     let max_threads: u32 = std::env::args()
@@ -186,8 +185,8 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     server.set_android13plus(2);
     // **The gate**: opt into N=2 incoming slots per session (founding
     // + 1 attached). Default 1 would silently reject the launcher's
-    // second connection (Phase B.1 cap), so this is the load-bearing
-    // setting that wires AC-12.6 to the multi-conn code path.
+    // second connection (the per-session cap), so this is the
+    // load-bearing setting that wires the multi-conn code path.
     server.set_max_threads(max_threads);
     server.set_root(Interface::as_binder(&Binder::new(MultiConn {
         oneway_log: Mutex::new(Vec::new()),

--- a/example-hello/src/bin/rt_inherit_interop_client.rs
+++ b/example-hello/src/bin/rt_inherit_interop_client.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// RT inheritance client.
+//
+// Calls `IRtCheck::reportSchedPolicy()` twice:
+//
+//   * Once from the default SCHED_NORMAL/SCHED_OTHER class — the
+//     server's worker thread should report SCHED_FIFO (the floor the
+//     server advertised via `BinderFeatures::min_sched_policy`).
+//   * Once after raising the *client* to SCHED_FIFO/10 — the server
+//     should still report SCHED_FIFO (inherited from us).
+//
+// Requires CAP_SYS_NICE for the `sched_setscheduler` call; the
+// `run_rt_inherit_interop.sh` wrapper drops into `sudo` on REMOTE_LINUX.
+
+use std::process::ExitCode;
+
+use rsbinder::*;
+
+use example_hello::rt_inherit::{IRtCheck, SERVICE_NAME};
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn try_become_rt(priority: i32) -> bool {
+    // SAFETY: `sched_param` is a POSIX-defined C aggregate of
+    // primitive integers; a zero-initialized instance is a valid
+    // starting point on every libc that exposes it. We immediately
+    // overwrite the only field rsbinder cares about
+    // (`sched_priority`) before passing the pointer to the kernel,
+    // and the struct lives for the duration of the call.
+    let mut param: libc::sched_param = unsafe { std::mem::zeroed() };
+    param.sched_priority = priority;
+    // SAFETY: pid=0 means "the current thread"; libc::sched_setscheduler
+    // has no preconditions beyond a valid `&sched_param`.
+    let r = unsafe { libc::sched_setscheduler(0, libc::SCHED_FIFO, &param) };
+    r == 0
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn try_become_rt(_priority: i32) -> bool {
+    // SCHED_FIFO is Linux/Android-only; the test reports SKIPPED.
+    false
+}
+
+fn main() -> ExitCode {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    if let Err(e) = ProcessState::init_default() {
+        eprintln!("init_default failed: {e}");
+        return ExitCode::from(2);
+    }
+
+    let binder = match hub::get_service(SERVICE_NAME) {
+        Some(b) => b,
+        None => {
+            eprintln!("get_service({SERVICE_NAME}) returned None");
+            return ExitCode::from(3);
+        }
+    };
+    let svc = match <dyn IRtCheck>::try_from(binder) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("interface_cast failed: {e:?}");
+            return ExitCode::from(4);
+        }
+    };
+
+    let mut ok = true;
+
+    // Linux `<linux/sched.h>` constants — duplicated locally so the
+    // STAGE3 client builds on macOS hosts that vendor a different
+    // `libc::sched_param`. Values match the kernel headers verbatim.
+    const SCHED_OTHER_NORMAL: i32 = 0;
+    const SCHED_FIFO: i32 = 1;
+    const SCHED_RR: i32 = 2;
+
+    // Call A — from SCHED_NORMAL: server should report its declared
+    // floor (SCHED_FIFO = 1).
+    let policy_a = match svc.reportSchedPolicy() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("STAGE3_4_5_FAIL reportSchedPolicy (NORMAL caller): {e:?}");
+            return ExitCode::from(1);
+        }
+    };
+    println!("STAGE3_4_5_A caller=SCHED_NORMAL server_policy={policy_a}");
+    if policy_a != SCHED_FIFO && policy_a != SCHED_RR {
+        // Some kernels only lift to SCHED_FIFO once the caller is
+        // already RT, in which case A reports SCHED_OTHER/NORMAL
+        // (=0). We accept either; the hard check is in Call B.
+        if policy_a != SCHED_OTHER_NORMAL {
+            eprintln!("STAGE3_4_5_FAIL A: unexpected policy {policy_a}");
+            ok = false;
+        }
+    }
+
+    // Call B — from SCHED_FIFO: the kernel MUST honor inherit_rt and
+    // surface SCHED_FIFO inside the server. If `sched_setscheduler`
+    // fails we record the cause and skip B (counts as informational).
+    if try_become_rt(10) {
+        let policy_b = match svc.reportSchedPolicy() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("STAGE3_4_5_FAIL reportSchedPolicy (FIFO caller): {e:?}");
+                return ExitCode::from(1);
+            }
+        };
+        println!("STAGE3_4_5_B caller=SCHED_FIFO server_policy={policy_b}");
+        if policy_b != SCHED_FIFO {
+            eprintln!("STAGE3_4_5_FAIL B: expected SCHED_FIFO (=1) got {policy_b}");
+            ok = false;
+        }
+    } else {
+        let errno = std::io::Error::last_os_error();
+        println!("STAGE3_4_5_B_SKIPPED sched_setscheduler failed: {errno}");
+    }
+
+    if ok {
+        println!("STAGE3_4_5_PASS");
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::from(1)
+    }
+}

--- a/example-hello/src/bin/rt_inherit_interop_service.rs
+++ b/example-hello/src/bin/rt_inherit_interop_service.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// RT priority inheritance verification.
+//
+// The server advertises its binder with
+// `BinderFeatures { inherit_rt: true, min_sched_policy: Some(SCHED_FIFO),
+// min_priority: Some(...) }`. When a client running under SCHED_FIFO
+// calls `reportSchedPolicy()`, the kernel's binder driver lifts the
+// worker thread's scheduler class for the duration of the handler.
+// The handler asks the kernel back via `sched_getscheduler(0)` and
+// returns the result; the client checks it matches expectations.
+
+use rsbinder::*;
+
+use example_hello::rt_inherit::{BnRtCheck, IRtCheck, SERVICE_NAME};
+
+struct RtCheck;
+
+impl Interface for RtCheck {}
+
+impl IRtCheck for RtCheck {
+    fn reportSchedPolicy(&self) -> rsbinder::status::Result<i32> {
+        let policy = rsbinder::get_current_scheduler_policy()
+            .map_err(|_| Status::from(ExceptionCode::IllegalState))?;
+        Ok(policy)
+    }
+}
+
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    eprintln!("STAGE3 4-5 server: init ProcessState");
+    ProcessState::init_default()?;
+    ProcessState::start_thread_pool();
+
+    // Advertise SCHED_FIFO floor + inherit_rt so the driver lifts the
+    // binder worker into RT for any incoming transaction.
+    let mut features = BinderFeatures::default();
+    features.min_sched_policy = Some(libc::SCHED_FIFO);
+    features.min_priority = Some(5);
+    features.inherit_rt = true;
+    let service = BnRtCheck::new_binder_with_features(RtCheck, features);
+
+    eprintln!("STAGE3 4-5 server: register `{SERVICE_NAME}` (SCHED_FIFO/5, inherit_rt)");
+    hub::add_service(SERVICE_NAME, service.as_binder())?;
+
+    eprintln!("STAGE3 4-5 server: join thread pool");
+    Ok(ProcessState::join_thread_pool()?)
+}

--- a/example-hello/src/bin/update_txn_interop_client.rs
+++ b/example-hello/src/bin/update_txn_interop_client.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Client — proves the Android 12+ kernel
+// driver's `TF_UPDATE_TXN` async-dedup is wire-correct from rsbinder.
+//
+// Sends a baseline burst with FLAG_ONEWAY only (no dedup), drains the
+// recorder, asserts every value landed. Then sends the same burst with
+// `FLAG_ONEWAY | FLAG_UPDATE_TXN` while the server is held busy by a
+// long-sleep first call, drains, asserts the queued duplicates were
+// collapsed — only the first call and the most recent update survive.
+//
+// Also verifies `get_extended_error()` is callable on this kernel
+// (Android 12+ / Linux 5.14+ surfaces the ioctl; older returns
+// `InvalidOperation` and the test PASSes the absence-marker).
+
+use std::process::ExitCode;
+use std::time::Duration;
+
+use rsbinder::*;
+
+use example_hello::update_txn::{IUpdateTxnDedup, ONRECORD_CODE, SERVICE_NAME};
+
+fn fire_oneway(
+    binder: &SIBinder,
+    code: u32,
+    v: i32,
+    delay_ms: i32,
+    extra_flags: TransactionFlags,
+) -> Result<()> {
+    let remote = binder.as_remote().ok_or(StatusCode::BadType)?;
+    let mut data = remote.prepare_transact(true)?;
+    data.write::<i32>(&v)?;
+    data.write::<i32>(&delay_ms)?;
+    remote.submit_transact(code, &data, FLAG_ONEWAY | FLAG_CLEAR_BUF | extra_flags)?;
+    Ok(())
+}
+
+/// Wait until the server reports an idle queue. Polls `drain()` (read
+/// only — does not clear) until the returned vector stabilizes for two
+/// consecutive checks, or the timeout fires. Hard timeout protects the
+/// CI from a hung server; if we hit it, the assertion in the caller
+/// surfaces the freshest reading anyway.
+fn wait_until_idle(svc: &Strong<dyn IUpdateTxnDedup>, timeout: Duration, poll_ms: u64) -> Vec<i32> {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut last = svc.drain().unwrap_or_default();
+    while std::time::Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(poll_ms));
+        let now = svc.drain().unwrap_or_default();
+        if now == last && !now.is_empty() {
+            return now;
+        }
+        last = now;
+    }
+    last
+}
+
+fn baseline_round(
+    binder: &SIBinder,
+    svc: &Strong<dyn IUpdateTxnDedup>,
+) -> std::result::Result<(), String> {
+    svc.reset().map_err(|e| format!("reset: {e:?}"))?;
+    let code = ONRECORD_CODE;
+    // Plain oneway burst with NO dedup. With max_threads=1 + 100ms
+    // sleep, all four calls land in `async_todo` and run sequentially.
+    for v in [10, 11, 12, 13] {
+        fire_oneway(binder, code, v, 100, 0).map_err(|e| format!("fire {v}: {e:?}"))?;
+    }
+    let recorded = wait_until_idle(svc, Duration::from_secs(3), 150);
+    println!("STAGE3_4_4_BASELINE recorded={recorded:?}");
+    if recorded != vec![10, 11, 12, 13] {
+        return Err(format!("baseline drift: {recorded:?}"));
+    }
+    Ok(())
+}
+
+fn dedup_round(
+    binder: &SIBinder,
+    svc: &Strong<dyn IUpdateTxnDedup>,
+) -> std::result::Result<(), String> {
+    svc.reset().map_err(|e| format!("reset: {e:?}"))?;
+    let code = ONRECORD_CODE;
+
+    // The hard rsbinder gate: the kernel must accept every transaction
+    // when `FLAG_UPDATE_TXN` is set alongside `FLAG_ONEWAY`. If a wire
+    // mismatch had snuck into [`crate::FLAG_UPDATE_TXN`], the driver
+    // would reject with EINVAL and we would see a non-`Ok` return from
+    // `submit_transact` here.
+    //
+    // The collapse to `[first, last]` is an Android 12+ kernel
+    // behavior (`binder_proc_transaction` walks `node->async_todo`).
+    // Observing it confirms the round-trip end-to-end; not observing
+    // it on an older driver still implies the wire is correct, so we
+    // log either outcome and PASS as long as no transaction failed.
+    fire_oneway(binder, code, 50, 1000, FLAG_UPDATE_TXN).map_err(|e| format!("fire 50: {e:?}"))?;
+    std::thread::sleep(Duration::from_millis(100));
+    fire_oneway(binder, code, 51, 0, FLAG_UPDATE_TXN).map_err(|e| format!("fire 51: {e:?}"))?;
+    fire_oneway(binder, code, 52, 0, FLAG_UPDATE_TXN).map_err(|e| format!("fire 52: {e:?}"))?;
+    fire_oneway(binder, code, 53, 0, FLAG_UPDATE_TXN).map_err(|e| format!("fire 53: {e:?}"))?;
+
+    let recorded = wait_until_idle(svc, Duration::from_secs(4), 200);
+    if recorded == vec![50, 53] {
+        println!("STAGE3_4_4_DEDUP recorded={recorded:?} (kernel collapsed queue)");
+    } else if recorded.first() == Some(&50) && recorded.last() == Some(&53) {
+        println!(
+            "STAGE3_4_4_DEDUP recorded={recorded:?} \
+             (driver accepted FLAG_UPDATE_TXN; kernel did not collapse)"
+        );
+    } else {
+        return Err(format!("dedup unexpected: {recorded:?}"));
+    }
+    Ok(())
+}
+
+fn extended_error_round() -> std::result::Result<(), String> {
+    match rsbinder::get_extended_error() {
+        Ok(ee) => {
+            println!(
+                "STAGE3_4_4_EXTENDED_ERROR id={} command={:#x} param={}",
+                ee.id, ee.command, ee.param
+            );
+            Ok(())
+        }
+        Err(StatusCode::InvalidOperation) => {
+            // Pre-Android-12 driver — feature missing, still a clean
+            // surface from rsbinder.
+            println!("STAGE3_4_4_EXTENDED_ERROR unavailable (pre-Android-12 driver)");
+            Ok(())
+        }
+        Err(e) => Err(format!("get_extended_error: {e:?}")),
+    }
+}
+
+fn main() -> ExitCode {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    if let Err(e) = ProcessState::init_default() {
+        eprintln!("init_default failed: {e}");
+        return ExitCode::from(2);
+    }
+
+    let binder = match hub::get_service(SERVICE_NAME) {
+        Some(b) => b,
+        None => {
+            eprintln!("get_service({SERVICE_NAME}) returned None");
+            return ExitCode::from(3);
+        }
+    };
+    let svc = match <dyn IUpdateTxnDedup>::try_from(binder.clone()) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("interface_cast failed: {e:?}");
+            return ExitCode::from(4);
+        }
+    };
+
+    let mut ok = true;
+    if let Err(e) = baseline_round(&binder, &svc) {
+        eprintln!("STAGE3_4_4_FAIL baseline: {e}");
+        ok = false;
+    }
+    if let Err(e) = dedup_round(&binder, &svc) {
+        eprintln!("STAGE3_4_4_FAIL dedup: {e}");
+        ok = false;
+    }
+    if let Err(e) = extended_error_round() {
+        eprintln!("STAGE3_4_4_FAIL extended_error: {e}");
+        ok = false;
+    }
+
+    if ok {
+        println!("STAGE3_4_4_PASS");
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::from(1)
+    }
+}

--- a/example-hello/src/bin/update_txn_interop_service.rs
+++ b/example-hello/src/bin/update_txn_interop_service.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `TF_UPDATE_TXN` dedup recorder.
+//
+// Registers `rsbinder.test.update_txn`. The async `onRecord` handler
+// sleeps for the requested duration before appending the payload to an
+// internal `Mutex<Vec<i32>>`. With only one pooled worker, an inbound
+// async call has to sit in the driver's `async_todo` queue until the
+// current call's handler returns — that's exactly the window in which
+// `FLAG_UPDATE_TXN` (set by the client) makes a newer same-`(target,
+// code)` call *replace* the queued one instead of stacking. The
+// client's later `drain()` exposes the surviving payloads.
+
+use std::sync::Mutex;
+
+use rsbinder::*;
+
+use example_hello::update_txn::{BnUpdateTxnDedup, IUpdateTxnDedup, SERVICE_NAME};
+
+struct Recorder {
+    recorded: Mutex<Vec<i32>>,
+}
+
+impl Interface for Recorder {}
+
+impl IUpdateTxnDedup for Recorder {
+    fn onRecord(&self, v: i32, delay_ms: i32) -> rsbinder::status::Result<()> {
+        if delay_ms > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(delay_ms as u64));
+        }
+        self.recorded.lock().unwrap().push(v);
+        Ok(())
+    }
+
+    fn drain(&self) -> rsbinder::status::Result<Vec<i32>> {
+        Ok(self.recorded.lock().unwrap().clone())
+    }
+
+    fn reset(&self) -> rsbinder::status::Result<()> {
+        self.recorded.lock().unwrap().clear();
+        Ok(())
+    }
+}
+
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    // Force a single worker — the kernel cannot dispatch async
+    // transactions in parallel, which is exactly the window in which
+    // `TF_UPDATE_TXN` collapses queued duplicates. `max_threads=1`
+    // tells `BINDER_SET_MAX_THREADS` the driver may request at most
+    // *one* looper beyond the main thread, and we skip
+    // `start_thread_pool()` so we never pre-spawn one. The main thread
+    // then becomes the sole consumer once it enters
+    // `join_thread_pool()`.
+    eprintln!("STAGE3 4-4 server: init ProcessState (max_threads=1, single worker)");
+    ProcessState::init(rsbinder::DEFAULT_BINDER_PATH, 1)?;
+
+    let service = BnUpdateTxnDedup::new_binder(Recorder {
+        recorded: Mutex::new(Vec::new()),
+    });
+
+    eprintln!("STAGE3 4-4 server: register `{SERVICE_NAME}`");
+    hub::add_service(SERVICE_NAME, service.as_binder())?;
+
+    eprintln!("STAGE3 4-4 server: join thread pool");
+    Ok(ProcessState::join_thread_pool()?)
+}

--- a/example-hello/src/lib.rs
+++ b/example-hello/src/lib.rs
@@ -9,3 +9,42 @@ pub use crate::hello::IHello::*;
 
 // Define the name of the service to be registered in the HUB(service manager).
 pub const SERVICE_NAME: &str = "my.hello";
+
+/// `ICallingIdentity` calling-identity interop fixture.
+pub mod calling_identity {
+    include!(concat!(env!("OUT_DIR"), "/calling_identity.rs"));
+    pub use self::calling_identity::ICallingIdentity::*;
+    pub const SERVICE_NAME: &str = "rsbinder.test.calling_identity";
+}
+
+/// `@EnforcePermission` codegen E2E fixture
+/// (`IPermCheck`). Built solely so the generated `on_transact` arms
+/// type-check against `rsbinder::permission_controller::check_permission`
+/// and against the `Status` / `ExceptionCode::Security` deny path. The
+/// service implementation lives in
+/// [`example-hello/src/bin/enforce_permission_interop_service.rs`](../bin/enforce_permission_interop_service.rs).
+pub mod permcheck {
+    include!(concat!(env!("OUT_DIR"), "/permcheck.rs"));
+    pub use self::permcheck::IPermCheck::*;
+    pub const SERVICE_NAME: &str = "rsbinder.test.permcheck";
+}
+
+/// `TF_UPDATE_TXN` async-dedup fixture.
+pub mod update_txn {
+    include!(concat!(env!("OUT_DIR"), "/update_txn.rs"));
+    pub use self::update_txn::IUpdateTxnDedup::*;
+    pub const SERVICE_NAME: &str = "rsbinder.test.update_txn";
+    /// The dedup interop client builds its own oneway parcel so it can
+    /// OR in `FLAG_UPDATE_TXN` (the AIDL-generated `Bp*` stub does not
+    /// expose a flag override). Re-expose the generated transaction
+    /// code so we keep using the canonical opcode constant.
+    pub const ONRECORD_CODE: rsbinder::TransactionCode =
+        self::update_txn::IUpdateTxnDedup::transactions::r#onRecord;
+}
+
+/// RT inheritance fixture.
+pub mod rt_inherit {
+    include!(concat!(env!("OUT_DIR"), "/rt_inherit.rs"));
+    pub use self::rt_inherit::IRtCheck::*;
+    pub const SERVICE_NAME: &str = "rsbinder.test.rt_inherit";
+}

--- a/fuzz/fuzz_targets/rpc_accessor_error.rs
+++ b/fuzz/fuzz_targets/rpc_accessor_error.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Fuzz target (subplan 2-13 B.6 / V4): arbitrary bytes → AOSP
+//! Fuzz target: arbitrary bytes → AOSP
 //! `IAccessor::ERROR_*` decode. Property: no panic / OOM / hang; any
 //! unknown code falls through to the `"unknown"` log hint, never an
 //! authoritative-looking symbol. The enforceable regression is the

--- a/fuzz/fuzz_targets/rpc_address_decode.rs
+++ b/fuzz/fuzz_targets/rpc_address_decode.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Fuzz target: arbitrary bytes → RpcWireAddress parse path
-//! (`plan/2-2` S-a / V4). Property: no panic/OOM/UB, the 32-byte
+//! Property: no panic/OOM/UB, the 32-byte
 //! address parse is fully bounds-checked even for short input.
 
 #![no_main]

--- a/fuzz/fuzz_targets/rpc_fd_ancillary.rs
+++ b/fuzz/fuzz_targets/rpc_fd_ancillary.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Fuzz target: arbitrary bytes → RPC `Unix`-mode FD-table decode with
-//! no received fds (`plan/2-7` §6.3 / V4 / T7.6). Property: no panic /
+//! no received fds. Property: no panic /
 //! UB / fd leak; an OOB or dangling fd-table index is a clean `Err`.
 
 #![no_main]

--- a/fuzz/fuzz_targets/rpc_fd_v1_body.rs
+++ b/fuzz/fuzz_targets/rpc_fd_v1_body.rs
@@ -4,7 +4,7 @@
 //! Fuzz target: arbitrary bytes + a hostile object-position table
 //! through the **v1+ AOSP-shape** RPC FD decode
 //! (`[not-null|hasComm|TYPE|idx]` + strict `binary_search`), no
-//! received fds (subplan 2-11 Phase B / V4). Property: no panic / UB /
+//! received fds. Property: no panic / UB /
 //! fd leak — a forged/unsorted/absent position, wrong `TYPE`, non-zero
 //! `hasComm`, or dangling index is a clean `Err`.
 

--- a/fuzz/fuzz_targets/rpc_frame_decode.rs
+++ b/fuzz/fuzz_targets/rpc_frame_decode.rs
@@ -6,9 +6,6 @@
 //! backends). Property under test: **no panic, no OOM, no infinite
 //! loop, no UB** on any input — a declared length above
 //! `MAX_FRAME_LEN` must be rejected before allocation.
-//!
-//! Baseline parity: plan 2 §6.3 / branch history `d659ae3`
-//! ("untrusted input UB/abort/underflow 0").
 
 #![no_main]
 

--- a/fuzz/fuzz_targets/rpc_parcel_rpc_mode.rs
+++ b/fuzz/fuzz_targets/rpc_parcel_rpc_mode.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Fuzz target: arbitrary bytes → **RPC-mode** `Parcel` deserialization
-//! (`plan/2-2` §6.3 / V4 — the third 2-2 fuzz target). RPC newly drives
+//! RPC newly drives
 //! the AIDL parcel deserializers with untrusted *socket* bytes (the
 //! kernel path never did — the driver validated senders). Property: no
 //! panic / OOM / UB / unbounded pre-allocation; every length-driven
-//! allocation is bounded by the bytes actually present (T1-3).
+//! allocation is bounded by the bytes actually present.
 
 #![no_main]
 

--- a/fuzz/fuzz_targets/rpc_session_handshake.rs
+++ b/fuzz/fuzz_targets/rpc_session_handshake.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Fuzz target: arbitrary bytes → session preamble + message decode
-//! (`plan/2-3` §6.3 / V4). Property: no panic/OOM/hang; malformed
+//! Property: no panic/OOM/hang; malformed
 //! negotiation/handshake bytes are rejected, never trusted.
 
 #![no_main]

--- a/fuzz/fuzz_targets/rpc_wire_decode.rs
+++ b/fuzz/fuzz_targets/rpc_wire_decode.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Fuzz target: arbitrary bytes → R34 wire message decoder
-//! (`plan/2-2` S-b / 2-2.b4 / V4). Property: no panic, no OOM, no UB;
+//! Property: no panic, no OOM, no UB;
 //! every length/offset bounds-checked; no pre-alloc past MAX_FRAME_LEN.
 
 #![no_main]

--- a/rsbinder-aidl/src/const_expr.rs
+++ b/rsbinder-aidl/src/const_expr.rs
@@ -531,9 +531,16 @@ impl ValueType {
         lhs: &ConstExpr,
         operator: &str,
         rhs: &ConstExpr,
+        visited: &mut std::collections::HashSet<String>,
     ) -> Result<ConstExpr, ConstExprError> {
-        let lhs = lhs.calculate()?;
-        let rhs = rhs.calculate()?;
+        // Thread the cycle-guard `visited` set through operand resolution so
+        // a reference cycle that crosses a binary operator (e.g.
+        // `const int A = B + 1; const int B = A + 1;`) is detected instead
+        // of recursing until the stack overflows. Each operand gets its OWN
+        // clone of the current resolution path so that sibling references to
+        // a common (non-cyclic) constant are not mistaken for a cycle.
+        let lhs = lhs.value.calculate_with_visited(&mut visited.clone())?;
+        let rhs = rhs.value.calculate_with_visited(&mut visited.clone())?;
 
         let promoted = type_conversion(
             integral_promotion(lhs.value.clone()),
@@ -659,7 +666,9 @@ impl ValueType {
                     Ok(expr)
                 }
             }
-            ValueType::Expr { lhs, operator, rhs } => ValueType::calc_expr(lhs, operator, rhs),
+            ValueType::Expr { lhs, operator, rhs } => {
+                ValueType::calc_expr(lhs, operator, rhs, visited)
+            }
             ValueType::Array(v) => {
                 let mut array = Vec::new();
 

--- a/rsbinder-aidl/src/error.rs
+++ b/rsbinder-aidl/src/error.rs
@@ -207,6 +207,30 @@ pub enum SemanticError {
         #[label("'{type_name}' is not a valid enum backing type")]
         span: SourceSpan,
     },
+
+    /// `@EnforcePermission(...)` annotation present but its argument
+    /// matches none of the AOSP-recognized forms (`"X"`, `value="X"`,
+    /// `allOf={...}`, `anyOf={...}`). AOSP `aidl_language.cpp::
+    /// AidlAnnotation::CheckValid` rejects this at build time; rsbinder
+    /// errors here rather than silently dropping the annotation, which
+    /// would generate an unguarded Bn — a secure-by-default regression.
+    #[error("@EnforcePermission on '{method}' has an unrecognized argument form")]
+    #[diagnostic(
+        code(aidl::malformed_enforce_permission),
+        help(
+            "supported forms are @EnforcePermission(\"X\"), \
+             @EnforcePermission(value=\"X\"), \
+             @EnforcePermission(allOf={{\"X\",\"Y\"}}), \
+             @EnforcePermission(anyOf={{\"X\",\"Y\"}})"
+        )
+    )]
+    MalformedEnforcePermission {
+        method: String,
+        #[source_code]
+        src: NamedSource<String>,
+        #[label("malformed @EnforcePermission argument")]
+        span: SourceSpan,
+    },
 }
 
 /// Auxiliary diagnostic for marking the second conflicting location in

--- a/rsbinder-aidl/src/generator.rs
+++ b/rsbinder-aidl/src/generator.rs
@@ -463,6 +463,9 @@ pub mod {{mod}} {
         match _code {
         {%- for member in fn_members %}
             transactions::r#{{ member.identifier }} => {
+            {%- if member.enforce_permission_check %}
+                {{ member.enforce_permission_check }}
+            {%- endif %}
             {%- for decl in member.transaction_decls %}
                 {{ decl }}
             {%- endfor %}
@@ -558,9 +561,14 @@ struct FnMembers {
     read_onto_params: Vec<String>,
     transaction_code: u32,
     has_explicit_code: bool,
+    /// Pre-rendered Rust block that runs at the top of this method's
+    /// `on_transact` arm and replies with `ExceptionCode::Security`
+    /// (AOSP `EX_SECURITY`) on permission denial. `None` when the
+    /// method carries no `@EnforcePermission`.
+    enforce_permission_check: Option<String>,
 }
 
-fn make_fn_member(method: &parser::MethodDecl) -> Result<FnMembers, AidlError> {
+fn make_fn_member(method: &parser::MethodDecl, crate_name: &str) -> Result<FnMembers, AidlError> {
     let mut func_call_params = String::new();
     let mut args = "&self".to_string();
     let mut args_async = "&'a self".to_string();
@@ -659,6 +667,12 @@ fn make_fn_member(method: &parser::MethodDecl) -> Result<FnMembers, AidlError> {
     let return_type = generator.type_declaration(false);
     let transaction_has_return = return_type != "()";
 
+    let enforce_permission_check = parser::enforce_permission_from_annotation_list(
+        &method.annotation_list,
+        &method.identifier,
+    )?
+    .map(|expr| render_enforce_permission_check(&expr, crate_name));
+
     Ok(FnMembers {
         // identifier: method.identifier.to_case(Case::Snake),
         identifier: method.identifier.to_owned(),
@@ -675,7 +689,49 @@ fn make_fn_member(method: &parser::MethodDecl) -> Result<FnMembers, AidlError> {
         read_onto_params,
         transaction_code: method.intvalue.unwrap_or(0) as u32,
         has_explicit_code: method.intvalue.is_some(),
+        enforce_permission_check,
     })
+}
+
+/// Renders `@EnforcePermission(...)` into the `on_transact` arm's
+/// early-deny block; short-circuits per AOSP
+/// `system/tools/aidl/generate_cpp.cpp::WriteEnforcePermissionCheck`.
+fn render_enforce_permission_check(
+    expr: &parser::EnforcePermissionExpr,
+    crate_name: &str,
+) -> String {
+    fn lit(s: &str) -> String {
+        // The AIDL pest grammar already forbids `\` and `"` in
+        // permission strings; the escape stays as defense-in-depth
+        // against future grammar relaxation.
+        debug_assert!(
+            !s.contains('\\') && !s.contains('"'),
+            "AIDL grammar must reject {s:?} before reaching codegen"
+        );
+        s.replace('\\', "\\\\").replace('"', "\\\"")
+    }
+    // Route the crate prefix through the same `{{crate}}` selection used
+    // everywhere else (`crate::` for AIDL compiled inside the rsbinder crate
+    // via `set_crate_support(true)`, `rsbinder::` otherwise) — a hardcoded
+    // `rsbinder::` would not resolve for internally-compiled AIDL.
+    let call = |p: &str| {
+        format!(
+            "{crate_name}::permission_controller::check_permission(\"{}\")",
+            lit(p)
+        )
+    };
+    let join = |ps: &[String], op: &str| ps.iter().map(|p| call(p)).collect::<Vec<_>>().join(op);
+    let condition = match expr {
+        parser::EnforcePermissionExpr::Single(p) => call(p),
+        parser::EnforcePermissionExpr::AllOf(ps) => join(ps, " && "),
+        parser::EnforcePermissionExpr::AnyOf(ps) => join(ps, " || "),
+    };
+    format!(
+        "if !({condition}) {{ \
+             _reply.write(&{crate_name}::Status::from({crate_name}::ExceptionCode::Security))?; \
+             return Ok(()); \
+         }}"
+    )
 }
 
 /// Enforces AOSP's transaction-code rules for an interface's methods, before
@@ -936,7 +992,7 @@ impl Generator {
             validate_transaction_codes(&decl)?;
 
             for method in decl.method_list.iter() {
-                fn_members.push(make_fn_member(method)?);
+                fn_members.push(make_fn_member(method, self.get_crate_name())?);
             }
         }
 

--- a/rsbinder-aidl/src/parser.rs
+++ b/rsbinder-aidl/src/parser.rs
@@ -1,7 +1,13 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-// #![allow(clippy::missing_const_for_fn)]
+// Clippy's `missing_const_for_thread_local` is a false positive for our
+// `HashMap` / `HashSet` / `Document` (transitively HashMap) initializers
+// — they are not `const fn` (need `RandomState` at runtime), so the
+// suggested `const { ... }` wrap fails with E0015. The lint fires against
+// the whole `thread_local!` block, and neither macro-invocation-level nor
+// per-static `#[allow]` reaches that scope, so suppression is file-scope.
+#![allow(clippy::missing_const_for_thread_local)]
 
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
@@ -27,21 +33,15 @@ pub enum SymbolType {
 }
 
 #[derive(Debug, Clone)]
-pub struct Symbol {
-    #[allow(dead_code)]
-    pub name: String,
+pub(crate) struct Symbol {
     pub value: crate::const_expr::ConstExpr,
-    #[allow(dead_code)]
     pub symbol_type: SymbolType,
-    #[allow(dead_code)]
-    pub namespace: Option<String>,
 }
 
 thread_local! {
     static DECLARATION_MAP: RefCell<HashMap<Namespace, Declaration>> = RefCell::new(HashMap::new());
     static DECLARATION_DOCUMENT_MAP: RefCell<HashMap<Namespace, DocumentContext>> = RefCell::new(HashMap::new());
-    #[allow(clippy::missing_const_for_thread_local)]
-    static NAMESPACE_STACK: RefCell<Vec<Namespace>> = RefCell::new(Vec::new());
+    static NAMESPACE_STACK: RefCell<Vec<Namespace>> = const { RefCell::new(Vec::new()) };
     static DOCUMENT: RefCell<Document> = RefCell::new(Document::new());
 
     // Universal Symbol Table - supports all types of named constants
@@ -50,10 +50,8 @@ thread_local! {
     static ENUM_RESOLUTION_STACK: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
 
     // Filename and source text of the source currently being parsed (used for error message generation)
-    #[allow(clippy::missing_const_for_thread_local)]
-    static CURRENT_SOURCE_NAME: RefCell<String> = RefCell::new(String::new());
-    #[allow(clippy::missing_const_for_thread_local)]
-    static CURRENT_SOURCE_TEXT: RefCell<String> = RefCell::new(String::new());
+    static CURRENT_SOURCE_NAME: RefCell<String> = const { RefCell::new(String::new()) };
+    static CURRENT_SOURCE_TEXT: RefCell<String> = const { RefCell::new(String::new()) };
 
     // Non-fatal diagnostics accumulated during the current `parse_document`
     // call. Drained into `Document::warnings` before parse_document returns.
@@ -501,12 +499,7 @@ pub fn register_symbol(
     symbol_type: SymbolType,
     namespace: Option<&str>,
 ) {
-    let symbol = Symbol {
-        name: name.to_string(),
-        value,
-        symbol_type,
-        namespace: namespace.map(|s| s.to_string()),
-    };
+    let symbol = Symbol { value, symbol_type };
 
     SYMBOL_TABLE.with(|table| {
         let mut table = table.borrow_mut();

--- a/rsbinder-aidl/src/parser.rs
+++ b/rsbinder-aidl/src/parser.rs
@@ -433,7 +433,11 @@ pub(crate) fn enum_member_const_expr_from_lookup(
             break;
         }
 
-        enum_val += 1;
+        // `wrapping_add` matches AOSP's C++ wraparound semantics and avoids
+        // a debug-build panic / release silent overflow when an enumerator
+        // carries an explicit `i64::MAX` value followed by an auto-increment
+        // member.
+        enum_val = enum_val.wrapping_add(1);
     }
 
     ENUM_RESOLUTION_STACK.with(|stack| {
@@ -928,6 +932,111 @@ pub fn rust_derive_list(annotation_list: &[Annotation]) -> String {
     String::new()
 }
 
+/// Parsed AOSP `@EnforcePermission` annotation. Mirrors the three forms
+/// `aidl_language.cpp::AidlAnnotation::EnforceExpression()` accepts:
+/// `@EnforcePermission("X")` / `@EnforcePermission(value = "X")` =
+/// [`EnforcePermissionExpr::Single`], `@EnforcePermission(allOf = {...})`
+/// = [`EnforcePermissionExpr::AllOf`], `@EnforcePermission(anyOf = {...})`
+/// = [`EnforcePermissionExpr::AnyOf`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnforcePermissionExpr {
+    Single(String),
+    AllOf(Vec<String>),
+    AnyOf(Vec<String>),
+}
+
+/// Walks an `Annotation::const_expr` (or array element) and returns the
+/// owned string when the value is `ValueType::String(_)`. The pest
+/// grammar already strips the surrounding double quotes, so no
+/// `trim_matches('"')` is required.
+fn const_expr_as_string(expr: &ConstExpr) -> Option<String> {
+    if let crate::const_expr::ValueType::String(ref s) = expr.value {
+        Some(s.clone())
+    } else {
+        None
+    }
+}
+
+/// Walks an `Annotation::const_expr` representing an AIDL string-array
+/// literal (`{"A", "B"}`) and returns the contained strings. Returns
+/// `None` for non-array values or arrays containing non-string elements
+/// — both are AOSP-rejected per
+/// `aidl_language.cpp::AidlAnnotation::CheckValid()`.
+fn const_expr_as_string_array(expr: &ConstExpr) -> Option<Vec<String>> {
+    let crate::const_expr::ValueType::Array(items) = &expr.value else {
+        return None;
+    };
+    let mut out = Vec::with_capacity(items.len());
+    for item in items {
+        out.push(const_expr_as_string(item)?);
+    }
+    Some(out)
+}
+
+/// Extracts a parsed `@EnforcePermission(...)` from a method's annotation
+/// list, or `None` when the annotation is absent or syntactically
+/// malformed (no `value`/`allOf`/`anyOf` recognized — already surfaced by
+/// `parse_annotation_list`'s unknown-annotation warning path).
+///
+/// AOSP schema reference: `aidl_language.cpp:211-214` declares
+/// `EnforcePermission` with `{{"value", kStringType}, {"anyOf",
+/// kStringArrayType}, {"allOf", kStringArrayType}}` — exactly the three
+/// forms decoded here.
+pub fn enforce_permission_from_annotation_list(
+    annotation_list: &[Annotation],
+    method_name: &str,
+) -> Result<Option<EnforcePermissionExpr>, crate::error::AidlError> {
+    for annotation in annotation_list {
+        if annotation.annotation != "@EnforcePermission" {
+            continue;
+        }
+
+        // Shorthand `@EnforcePermission("X")`: AIDL grammar parses the
+        // bare positional argument into `annotation.const_expr` rather
+        // than `parameter_list`.
+        if let Some(c) = &annotation.const_expr {
+            if let Some(s) = const_expr_as_string(c) {
+                return Ok(Some(EnforcePermissionExpr::Single(s)));
+            }
+        }
+
+        // Named-parameter forms — match the AOSP schema's three keys.
+        for param in &annotation.parameter_list {
+            match param.identifier.as_str() {
+                "value" => {
+                    if let Some(s) = const_expr_as_string(&param.const_expr) {
+                        return Ok(Some(EnforcePermissionExpr::Single(s)));
+                    }
+                }
+                "allOf" => {
+                    if let Some(items) = const_expr_as_string_array(&param.const_expr) {
+                        return Ok(Some(EnforcePermissionExpr::AllOf(items)));
+                    }
+                }
+                "anyOf" => {
+                    if let Some(items) = const_expr_as_string_array(&param.const_expr) {
+                        return Ok(Some(EnforcePermissionExpr::AnyOf(items)));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // `@EnforcePermission` annotation present but no recognized
+        // argument form matched. Refuse to emit an unguarded Bn —
+        // AOSP rejects this at build time too.
+        let (start, end) = annotation.annotation_span.unwrap_or((0, 0));
+        return Err(crate::error::AidlError::Semantic(Box::new(
+            crate::error::SemanticError::MalformedEnforcePermission {
+                method: method_name.to_string(),
+                src: miette::NamedSource::new(current_source_name(), current_source_text()),
+                span: (start, end.saturating_sub(start)).into(),
+            },
+        )));
+    }
+    Ok(None)
+}
+
 pub fn get_descriptor_from_annotation_list(annotation_list: &Vec<Annotation>) -> Option<String> {
     for annotation in annotation_list {
         if annotation.annotation == "@Descriptor" {
@@ -1273,8 +1382,7 @@ fn parse_const_expr(pair: pest::iterators::Pair<Rule>) -> Result<ConstExpr, Aidl
                     .next()
                     .ok_or_else(|| make_parse_error("empty char escape", start, end))?;
                 // Map the common C/AIDL escape sequences to their actual code
-                // points; previously the escaped char was returned verbatim
-                // (e.g. `'\n'` yielded 'n' instead of newline).
+                // points (e.g. `'\n'` becomes newline, not the literal 'n').
                 match esc {
                     'n' => '\n',
                     't' => '\t',

--- a/rsbinder-aidl/src/type_generator.rs
+++ b/rsbinder-aidl/src/type_generator.rs
@@ -113,7 +113,20 @@ impl TypeGenerator {
             "IBinder" => ValueType::IBinder,
             "List" => match &aidl_type.generic {
                 Some(gen) => {
-                    array_types.push(ArrayInfo::new_list(&gen.to_value_type()?, &Vec::new()));
+                    // The grammar admits an array-typed generic argument
+                    // (`List<int[]>`), but a list-of-array element would be
+                    // stored as `ValueType::Array` and later hit the
+                    // `panic!` in `type_decl`. Reject it here with a proper
+                    // diagnostic (AOSP `aidl` likewise rejects list-of-array
+                    // semantically) rather than crashing the generator.
+                    let elem = gen.to_value_type()?;
+                    if matches!(elem, ValueType::Array(_)) {
+                        return Err(make_type_error(
+                            "List element type cannot be an array",
+                            aidl_type.name_span,
+                        ));
+                    }
+                    array_types.push(ArrayInfo::new_list(&elem, &Vec::new()));
                     ValueType::Array(Vec::new())
                 }
                 None => {

--- a/rsbinder-aidl/tests/aidl_fixture_sweep.rs
+++ b/rsbinder-aidl/tests/aidl_fixture_sweep.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Plan 3: AOSP `.aidl` fixture sweep.
+//! AOSP `.aidl` fixture sweep.
 //!
 //! Walks `tests/aidl/android/aidl/tests/**/*.aidl` (the vendored AOSP
 //! fixture set) and runs each through `Builder::generate()`. Each
@@ -41,15 +41,13 @@ const EXPECTED_FAILURES: &[ExpectedFailure] = &[
         relative_path: "android/aidl/tests/map/Foo.aidl",
         reason_substr: "unknown type 'Map'",
         rationale: "AOSP Rust/C++/NDK backends reject `Map<K,V>` \
-                    (aidl_language.cpp:1612-1615). Java-only. \
-                    See plans/3-3-map-non-goal.md.",
+                    (aidl_language.cpp:1612-1615). Java-only.",
     },
     ExpectedFailure {
         relative_path: "android/aidl/tests/map/IMapTest.aidl",
         reason_substr: "unknown type 'Map'",
         rationale: "AOSP Rust/C++/NDK backends reject `Map<K,V>` \
-                    (aidl_language.cpp:1612-1615). Java-only. \
-                    See plans/3-3-map-non-goal.md.",
+                    (aidl_language.cpp:1612-1615). Java-only.",
     },
     ExpectedFailure {
         relative_path: "android/aidl/tests/permission/platform/IProtected.aidl",

--- a/rsbinder-aidl/tests/test_annotation_lockins.rs
+++ b/rsbinder-aidl/tests/test_annotation_lockins.rs
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Recognition-only annotation lock-ins.
+//
+// AOSP's Rust AIDL backend (`system/tools/aidl/generate_rust.cpp`)
+// silently ignores three annotations whose effects are either
+// constraint-only, automatically true in rsbinder, or Java-backend
+// specific. rsbinder-aidl matches the Rust backend's silent-ignore
+// behavior. These tests lock that in:
+//
+//   * `@FixedSize` (parcelable / union / type-param) — AOSP linter
+//     constraint; the wire format is the same as without.
+//   * `@SensitiveData` (interface) — AOSP `generate_cpp.cpp:246` /
+//     `generate_rust.cpp:365` add `FLAG_CLEAR_BUF` to every method on
+//     the interface. rsbinder unconditionally emits `FLAG_CLEAR_BUF`
+//     for **every** generated method (see
+//     `rsbinder-aidl/src/generator.rs` `submit_transact` lines), so
+//     the on-the-wire effect AOSP wants is universal in our output.
+//   * `@PropagateAllowBlocking` (method) — emitted *only* by AOSP's
+//     Java backend (`generate_java_binder.cpp:816`); the C++ and Rust
+//     backends do not emit anything for it. rsbinder follows the Rust
+//     backend.
+
+fn generate(input: &str) -> String {
+    let ctx = rsbinder_aidl::SourceContext::new("test.aidl", input);
+    let document = rsbinder_aidl::parse_document(&ctx).expect("parse");
+    let gen = rsbinder_aidl::Generator::new(false, false);
+    gen.document(&document).expect("generate").1
+}
+
+fn warnings_for(input: &str) -> Vec<String> {
+    let ctx = rsbinder_aidl::SourceContext::new("test.aidl", input);
+    let doc = rsbinder_aidl::parse_document(&ctx).expect("parse");
+    doc.warnings.iter().map(|w| w.message.clone()).collect()
+}
+
+// ---------------------------------------------------------------
+// @FixedSize — AOSP `aidl_language.cpp:189-192` — applies to
+// structured parcelable / union / type parameter; no codegen effect.
+// ---------------------------------------------------------------
+
+#[test]
+fn fixed_size_parcelable_byte_identical() {
+    let plain = generate(
+        r#"
+package test;
+parcelable Foo {
+    int x;
+    int y;
+}
+        "#,
+    );
+    let annotated = generate(
+        r#"
+package test;
+@FixedSize
+parcelable Foo {
+    int x;
+    int y;
+}
+        "#,
+    );
+    assert_eq!(
+        plain, annotated,
+        "@FixedSize must not change parcelable codegen"
+    );
+}
+
+#[test]
+fn fixed_size_union_byte_identical() {
+    let plain = generate(
+        r#"
+package test;
+union FooUnion {
+    int x;
+    long y;
+}
+        "#,
+    );
+    let annotated = generate(
+        r#"
+package test;
+@FixedSize
+union FooUnion {
+    int x;
+    long y;
+}
+        "#,
+    );
+    assert_eq!(plain, annotated, "@FixedSize must not change union codegen");
+}
+
+#[test]
+fn fixed_size_is_recognized_no_warning() {
+    let warnings = warnings_for(
+        r#"
+package test;
+@FixedSize
+parcelable Foo {
+    int x;
+}
+        "#,
+    );
+    let fixed_warnings: Vec<_> = warnings
+        .iter()
+        .filter(|w| w.contains("@FixedSize"))
+        .collect();
+    assert!(
+        fixed_warnings.is_empty(),
+        "@FixedSize must be recognized: {fixed_warnings:?}"
+    );
+}
+
+// ---------------------------------------------------------------
+// @SensitiveData — AOSP `aidl_language.cpp:140`:
+// `CONTEXT_TYPE_INTERFACE`, no parameters. AOSP `generate_cpp.cpp:246`
+// and `generate_rust.cpp:365` add `FLAG_CLEAR_BUF` to every method.
+// rsbinder unconditionally emits `FLAG_CLEAR_BUF` for every generated
+// method (see `generator.rs` `submit_transact` calls), so the wire
+// effect is identical with or without the annotation.
+// ---------------------------------------------------------------
+
+#[test]
+fn sensitive_data_interface_byte_identical() {
+    let plain = generate(
+        r#"
+package test;
+interface IFoo {
+    String getSecret();
+    void setSecret(in String secret);
+}
+        "#,
+    );
+    let annotated = generate(
+        r#"
+package test;
+@SensitiveData
+interface IFoo {
+    String getSecret();
+    void setSecret(in String secret);
+}
+        "#,
+    );
+    assert_eq!(
+        plain, annotated,
+        "@SensitiveData must not change codegen — rsbinder already \
+         emits FLAG_CLEAR_BUF for every method"
+    );
+}
+
+#[test]
+fn sensitive_data_already_universal_clear_buf() {
+    // Defensive regression: confirm rsbinder's *un-annotated* interface
+    // still emits `FLAG_CLEAR_BUF` for every transaction. If this ever
+    // becomes opt-in (so the un-annotated baseline drops the flag), the
+    // `@SensitiveData` lock-in above silently regresses and we need a
+    // real codegen branch.
+    let out = generate(
+        r#"
+package test;
+interface IFoo {
+    String getSecret();
+    void setSecret(in String secret);
+}
+        "#,
+    );
+    let clear_buf_count = out.matches("FLAG_CLEAR_BUF").count();
+    assert!(
+        clear_buf_count >= 2,
+        "rsbinder must keep emitting FLAG_CLEAR_BUF for every method \
+         (else @SensitiveData lock-in regresses). count={clear_buf_count}\n{out}"
+    );
+}
+
+#[test]
+fn sensitive_data_is_recognized_no_warning() {
+    let warnings = warnings_for(
+        r#"
+package test;
+@SensitiveData
+interface IFoo {
+    void run();
+}
+        "#,
+    );
+    let sd_warnings: Vec<_> = warnings
+        .iter()
+        .filter(|w| w.contains("@SensitiveData"))
+        .collect();
+    assert!(
+        sd_warnings.is_empty(),
+        "@SensitiveData must be recognized: {sd_warnings:?}"
+    );
+}
+
+// ---------------------------------------------------------------
+// @PropagateAllowBlocking — AOSP emits codegen for this *only* in the
+// Java backend (`generate_java_binder.cpp:816` calls
+// `_reply.setPropagateAllowBlocking()`); both `generate_cpp.cpp` and
+// `generate_rust.cpp` silently ignore it. rsbinder matches the Rust
+// backend.
+// ---------------------------------------------------------------
+
+#[test]
+fn propagate_allow_blocking_byte_identical() {
+    let plain = generate(
+        r#"
+package test;
+interface IFoo {
+    IBinder getBinder();
+}
+        "#,
+    );
+    let annotated = generate(
+        r#"
+package test;
+interface IFoo {
+    @PropagateAllowBlocking IBinder getBinder();
+}
+        "#,
+    );
+    assert_eq!(
+        plain, annotated,
+        "@PropagateAllowBlocking must not change Rust codegen (Java-only \
+         in AOSP, see generate_java_binder.cpp:816)"
+    );
+}
+
+#[test]
+fn propagate_allow_blocking_is_recognized_no_warning() {
+    let warnings = warnings_for(
+        r#"
+package test;
+interface IFoo {
+    @PropagateAllowBlocking IBinder getBinder();
+}
+        "#,
+    );
+    let pab_warnings: Vec<_> = warnings
+        .iter()
+        .filter(|w| w.contains("@PropagateAllowBlocking"))
+        .collect();
+    assert!(
+        pab_warnings.is_empty(),
+        "@PropagateAllowBlocking must be recognized: {pab_warnings:?}"
+    );
+}

--- a/rsbinder-aidl/tests/test_descriptor_override.rs
+++ b/rsbinder-aidl/tests/test_descriptor_override.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `@Descriptor("X")` interface-descriptor override.
+//
+// The annotation is *already* parsed and consumed by the generator
+// (see `parser::get_descriptor_from_annotation_list` callers in
+// `generator.rs`). These tests are a lock-in: they fail if a future
+// refactor breaks the override for any of the three top-level
+// declarations (interface / parcelable / union) that AOSP allows it on.
+//
+// AOSP reference: `aidl_language.cpp:179` registers `@Descriptor` under
+// `CONTEXT_DECL | CONTEXT_TYPE_INTERFACE | CONTEXT_TYPE_PARCELABLE |
+// CONTEXT_TYPE_UNION` with a single required `value = kStringType`.
+
+fn generate(input: &str) -> String {
+    let ctx = rsbinder_aidl::SourceContext::new("test.aidl", input);
+    let document = rsbinder_aidl::parse_document(&ctx).expect("parse");
+    let gen = rsbinder_aidl::Generator::new(false, false);
+    gen.document(&document).expect("generate").1
+}
+
+#[test]
+fn descriptor_override_replaces_interface_namespace() {
+    let out = generate(
+        r#"
+package test.pkg;
+
+@Descriptor(value = "android.os.IFoo")
+interface IFoo {
+    void run();
+}
+        "#,
+    );
+    // The wire-shipped descriptor must be the override, not the
+    // package-derived `test.pkg.IFoo`.
+    assert!(
+        out.contains("\"android.os.IFoo\""),
+        "override descriptor missing in generated output:\n{out}"
+    );
+    assert!(
+        !out.contains("\"test.pkg.IFoo\""),
+        "package-derived descriptor leaked despite @Descriptor override:\n{out}"
+    );
+}
+
+#[test]
+fn descriptor_override_replaces_parcelable_namespace() {
+    let out = generate(
+        r#"
+package test.pkg;
+
+@Descriptor(value = "android.os.Foo")
+parcelable Foo {
+    int x;
+}
+        "#,
+    );
+    assert!(
+        out.contains("\"android.os.Foo\""),
+        "override descriptor missing in generated parcelable:\n{out}"
+    );
+    assert!(
+        !out.contains("\"test.pkg.Foo\""),
+        "package-derived descriptor leaked despite @Descriptor override:\n{out}"
+    );
+}
+
+#[test]
+fn descriptor_override_replaces_union_namespace() {
+    let out = generate(
+        r#"
+package test.pkg;
+
+@Descriptor(value = "android.os.FooUnion")
+union FooUnion {
+    int x;
+    String y;
+}
+        "#,
+    );
+    assert!(
+        out.contains("\"android.os.FooUnion\""),
+        "override descriptor missing in generated union:\n{out}"
+    );
+    assert!(
+        !out.contains("\"test.pkg.FooUnion\""),
+        "package-derived descriptor leaked despite @Descriptor override:\n{out}"
+    );
+}
+
+#[test]
+fn no_descriptor_annotation_uses_package_path() {
+    // R2 regression: an interface without `@Descriptor` must still wire
+    // up the package-derived descriptor (`test.pkg.IFoo`).
+    let out = generate(
+        r#"
+package test.pkg;
+
+interface IFoo {
+    void run();
+}
+        "#,
+    );
+    assert!(
+        out.contains("\"test.pkg.IFoo\""),
+        "package-derived descriptor missing on un-annotated interface:\n{out}"
+    );
+}

--- a/rsbinder-aidl/tests/test_enforce_permission.rs
+++ b/rsbinder-aidl/tests/test_enforce_permission.rs
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `@EnforcePermission` codegen.
+//
+// Validates that the generated `on_transact` arm:
+//
+//   * Includes a `check_permission` call for each form
+//     (`@EnforcePermission("X")` / `(value = "X")` /
+//     `(allOf = {...})` / `(anyOf = {...})`).
+//   * Uses `&&` for `allOf` and `||` for `anyOf` — short-circuit shape
+//     matches AOSP `generate_cpp.cpp::WriteEnforcePermissionCheck`.
+//   * Emits the deny branch (`Status::from(ExceptionCode::Security)` +
+//     `return Ok(())`) **before** any argument deserialization — the
+//     check appears earlier in the generated arm than the
+//     `let _arg_x: ... = _reader.read()` statements.
+//   * Leaves un-annotated methods byte-identical (R2) — `IPlain` arm
+//     contains no `check_permission` reference.
+
+fn generate(input: &str) -> String {
+    let ctx = rsbinder_aidl::SourceContext::new("test.aidl", input);
+    let document = rsbinder_aidl::parse_document(&ctx).expect("parse");
+    let gen = rsbinder_aidl::Generator::new(false, false);
+    gen.document(&document).expect("generate").1
+}
+
+fn arm_for(method_id: &str, generated: &str) -> String {
+    // Extract from `transactions::r#<method> => {` up to the matching
+    // `}` brace of the arm. The arms are emitted single-level inside a
+    // `match _code { ... }` so a simple brace counter is sufficient.
+    let needle = format!("transactions::r#{method_id} =>");
+    let start = generated
+        .find(&needle)
+        .unwrap_or_else(|| panic!("arm `{method_id}` not found in:\n{generated}"));
+    let after = &generated[start..];
+    let mut depth = 0i32;
+    let mut end = 0;
+    for (i, ch) in after.char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = i + 1;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    after[..end].to_owned()
+}
+
+#[test]
+fn enforce_permission_single_emits_one_check() {
+    let out = generate(
+        r#"
+package test;
+interface IFoo {
+    @EnforcePermission("INTERNET")
+    void doNet();
+}
+        "#,
+    );
+    let arm = arm_for("doNet", &out);
+    let needle = "rsbinder::permission_controller::check_permission(\"INTERNET\")";
+    assert!(
+        arm.contains(needle),
+        "missing single check `{needle}` in arm:\n{arm}"
+    );
+    assert!(
+        arm.contains("rsbinder::ExceptionCode::Security"),
+        "deny branch missing:\n{arm}"
+    );
+}
+
+#[test]
+fn enforce_permission_value_param_form_is_single() {
+    // `@EnforcePermission(value = "X")` is the named-parameter spelling
+    // of the single form — same emit as `@EnforcePermission("X")`.
+    let out = generate(
+        r#"
+package test;
+interface IFoo {
+    @EnforcePermission(value = "INTERNET")
+    void doNet();
+}
+        "#,
+    );
+    let arm = arm_for("doNet", &out);
+    assert!(arm.contains("check_permission(\"INTERNET\")"), "{arm}");
+    // Must NOT contain `&&` or `||` for the single form.
+    assert!(
+        !arm.contains(" && "),
+        "single form must not emit AND:\n{arm}"
+    );
+}
+
+#[test]
+fn enforce_permission_all_of_uses_and_short_circuit() {
+    let out = generate(
+        r#"
+package test;
+interface IFoo {
+    @EnforcePermission(allOf = {"INTERNET", "ACCESS_NETWORK_STATE"})
+    void doNetAndState();
+}
+        "#,
+    );
+    let arm = arm_for("doNetAndState", &out);
+    assert!(arm.contains("check_permission(\"INTERNET\")"), "{arm}");
+    assert!(
+        arm.contains("check_permission(\"ACCESS_NETWORK_STATE\")"),
+        "{arm}"
+    );
+    // The `&&` is the documented AOSP short-circuit shape.
+    assert!(arm.contains(" && "), "AllOf must join with `&&`:\n{arm}");
+    assert!(!arm.contains(" || "), "AllOf must not emit `||`:\n{arm}");
+}
+
+#[test]
+fn enforce_permission_any_of_uses_or_short_circuit() {
+    let out = generate(
+        r#"
+package test;
+interface IFoo {
+    @EnforcePermission(anyOf = {"BLUETOOTH", "BLUETOOTH_ADMIN"})
+    void doBluetooth();
+}
+        "#,
+    );
+    let arm = arm_for("doBluetooth", &out);
+    assert!(arm.contains("check_permission(\"BLUETOOTH\")"), "{arm}");
+    assert!(
+        arm.contains("check_permission(\"BLUETOOTH_ADMIN\")"),
+        "{arm}"
+    );
+    assert!(arm.contains(" || "), "AnyOf must join with `||`:\n{arm}");
+    assert!(!arm.contains(" && "), "AnyOf must not emit `&&`:\n{arm}");
+}
+
+#[test]
+fn enforce_permission_check_runs_before_arg_deserialization() {
+    // AOSP `WriteEnforcePermissionCheck` emits the deny early — before
+    // any `_reader.read()` for arguments. We mirror that so a missing
+    // permission cannot trigger argument deserialization side-effects
+    // (allocations, fd dup, etc.). Regression check: the
+    // `check_permission` call MUST appear before the first
+    // `_reader.read*` for an annotated method.
+    let out = generate(
+        r#"
+package test;
+interface IFoo {
+    @EnforcePermission("INTERNET")
+    void doNet(in String url, in int port);
+}
+        "#,
+    );
+    let arm = arm_for("doNet", &out);
+    let check_pos = arm
+        .find("check_permission(\"INTERNET\")")
+        .expect("check_permission must be emitted");
+    let read_pos = arm.find("_reader.read");
+    if let Some(read_pos) = read_pos {
+        assert!(
+            check_pos < read_pos,
+            "check_permission must precede argument deserialization. \
+             arm:\n{arm}"
+        );
+    }
+}
+
+#[test]
+fn methods_without_enforce_permission_get_no_check() {
+    // R2 regression — un-annotated methods must produce byte-identical
+    // generated code (no permission scaffolding). Confirms the
+    // generator skips the check emit when annotation is absent.
+    let out = generate(
+        r#"
+package test;
+interface IPlain {
+    String echo(in String s);
+}
+        "#,
+    );
+    let arm = arm_for("echo", &out);
+    assert!(
+        !arm.contains("check_permission"),
+        "un-annotated method leaked permission scaffolding:\n{arm}"
+    );
+    assert!(
+        !arm.contains("ExceptionCode::Security"),
+        "un-annotated method leaked deny branch:\n{arm}"
+    );
+}
+
+/// `@PermissionManuallyEnforced` and `@RequiresNoPermission`
+/// are documentation-only annotations in AOSP's AIDL — they exist so
+/// `aidl` can enforce that *every* interface method declares its
+/// permission posture, but neither emits runtime checks. rsbinder-aidl
+/// must (a) recognize them (no `cargo:warning=` for typos) and (b) leave
+/// the generated arm byte-identical to the un-annotated version (R2).
+///
+/// Locking-in test: compare generated output for the same interface
+/// with and without the annotation — they MUST match exactly.
+#[test]
+fn permission_manually_enforced_produces_byte_identical_codegen() {
+    let plain = generate(
+        r#"
+package test;
+interface IFoo {
+    String echo(in String s);
+}
+        "#,
+    );
+    let annotated = generate(
+        r#"
+package test;
+interface IFoo {
+    @PermissionManuallyEnforced
+    String echo(in String s);
+}
+        "#,
+    );
+    assert_eq!(
+        plain, annotated,
+        "@PermissionManuallyEnforced must not change codegen"
+    );
+}
+
+#[test]
+fn requires_no_permission_produces_byte_identical_codegen() {
+    let plain = generate(
+        r#"
+package test;
+interface IFoo {
+    String echo(in String s);
+}
+        "#,
+    );
+    let annotated = generate(
+        r#"
+package test;
+interface IFoo {
+    @RequiresNoPermission
+    String echo(in String s);
+}
+        "#,
+    );
+    assert_eq!(
+        plain, annotated,
+        "@RequiresNoPermission must not change codegen"
+    );
+}
+
+#[test]
+fn permission_manually_enforced_is_recognized_no_warning() {
+    let ctx = rsbinder_aidl::SourceContext::new(
+        "test.aidl",
+        r#"
+package test;
+interface IFoo {
+    @PermissionManuallyEnforced
+    @RequiresNoPermission
+    String echo(in String s);
+}
+        "#,
+    );
+    let doc = rsbinder_aidl::parse_document(&ctx).expect("parse");
+    let manual_or_no_perm_warnings: Vec<_> = doc
+        .warnings
+        .iter()
+        .filter(|w| {
+            w.message.contains("@PermissionManuallyEnforced")
+                || w.message.contains("@RequiresNoPermission")
+        })
+        .collect();
+    assert!(
+        manual_or_no_perm_warnings.is_empty(),
+        "Phase B annotations must be recognized as known: {manual_or_no_perm_warnings:?}"
+    );
+}
+
+#[test]
+fn mixed_methods_only_emit_check_for_annotated_arm() {
+    // An interface with both annotated and un-annotated methods must
+    // emit the check ONLY in the annotated method's arm. Surfaces a
+    // generator regression where the check would leak across arms via
+    // shared template state.
+    let out = generate(
+        r#"
+package test;
+interface IMixed {
+    @EnforcePermission("INTERNET")
+    void doNet();
+
+    String echo(in String s);
+}
+        "#,
+    );
+    let arm_net = arm_for("doNet", &out);
+    let arm_echo = arm_for("echo", &out);
+    assert!(
+        arm_net.contains("check_permission(\"INTERNET\")"),
+        "{arm_net}"
+    );
+    assert!(
+        !arm_echo.contains("check_permission"),
+        "echo arm should not contain check_permission:\n{arm_echo}"
+    );
+}

--- a/rsbinder-aidl/tests/test_oneway_validation.rs
+++ b/rsbinder-aidl/tests/test_oneway_validation.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Plan 3-1 C.1: AOSP `aidl_language.cpp:1211` rejects oneway methods
+//! AOSP `aidl_language.cpp:1211` rejects oneway methods
 //! that return a value or carry `out`/`inout` parameters. Mirror that
 //! at parse time so the diagnostic surfaces before codegen.
 

--- a/rsbinder-aidl/tests/test_rerun_if_changed.rs
+++ b/rsbinder-aidl/tests/test_rerun_if_changed.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Plan 3-2: `Builder::generate()` emits `cargo:rerun-if-changed=<path>`
+//! `Builder::generate()` emits `cargo:rerun-if-changed=<path>`
 //! for every `.aidl` file and directory that contributes to the
 //! generated output, so cargo reruns the build script when the user
 //! edits a source or imported `.aidl`.

--- a/rsbinder-aidl/tests/test_review_regressions.rs
+++ b/rsbinder-aidl/tests/test_review_regressions.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression tests for codegen defects found in the full-source review.
+// Each case used to abort the AIDL compiler (hard `panic!` / stack
+// overflow / debug overflow) on parseable input, violating the project's
+// "no panic on user input" invariant. They must now surface as recoverable
+// errors (or compute without panicking).
+
+/// Returns `true` only when BOTH parsing and code generation succeed.
+fn generate_ok(input: &str) -> bool {
+    let ctx = rsbinder_aidl::SourceContext::new("test.aidl", input);
+    let Ok(document) = rsbinder_aidl::parse_document(&ctx) else {
+        return false;
+    };
+    let gen = rsbinder_aidl::Generator::new(false, false);
+    gen.document(&document).is_ok()
+}
+
+/// M-6: a `List<T[]>` (list-of-array) is grammar-valid but used to hit the
+/// unconditional `panic!("type_decl() can't process Array Type.")`. It must
+/// now be rejected with a diagnostic, while a plain `List<T>` still works.
+#[test]
+fn list_of_array_is_rejected_not_panicked() {
+    for src in [
+        "parcelable P { List<int[]> field; }",
+        "interface I { void m(in List<String[]> a); }",
+        "interface I2 { List<int[]> r(); }",
+    ] {
+        assert!(
+            !generate_ok(src),
+            "expected list-of-array to error: {src:?}"
+        );
+    }
+    assert!(
+        generate_ok("parcelable P { List<int> field; }"),
+        "legitimate List<int> must still generate"
+    );
+}
+
+/// M-7: mutually-referential constants used to recurse until the stack
+/// overflowed (the cycle guard was abandoned when evaluation crossed a
+/// binary operator). Generation must now terminate; non-cyclic chains that
+/// also cross operators must still resolve.
+#[test]
+fn cyclic_constants_do_not_overflow() {
+    // Reaching the end of this call without aborting is the assertion.
+    let _ = generate_ok("interface ICycle { const int A = B + 1; const int B = A + 1; }");
+
+    assert!(
+        generate_ok("interface IOk { const int A = 1; const int B = A + 1; const int C = A + B; }"),
+        "non-cyclic constant chain must still resolve"
+    );
+}
+
+/// L-3: an `i64::MAX` enumerator followed by an auto-increment member used
+/// to panic on debug builds (`enum_val += 1` overflow). It must now wrap
+/// (AOSP C++ semantics) without aborting.
+#[test]
+fn enum_autoincrement_overflow_does_not_panic() {
+    let src = "@Backing(type=\"long\") enum Big { MAXV = 9223372036854775807, NEXT }";
+    // No panic / abort is the assertion.
+    let _ = generate_ok(src);
+}

--- a/rsbinder-aidl/tests/test_unknown_annotation.rs
+++ b/rsbinder-aidl/tests/test_unknown_annotation.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Plan 3-1 A.1/A.2: AOSP `AidlAnnotation::AllSchemas()` defines a
+//! AOSP `AidlAnnotation::AllSchemas()` defines a
 //! closed set of 23 recognised annotations. Anything else used to be
 //! silently dropped — so a typo like `@RustDrive` would compile clean
 //! with no codegen effect and no diagnostic. The parser now records

--- a/rsbinder-tools/src/bin/rsb_hub.rs
+++ b/rsbinder-tools/src/bin/rsb_hub.rs
@@ -17,13 +17,13 @@ struct Service {
     has_clients: bool,
     guarantee_client: bool,
     context: rsbinder::thread_state::CallingContext,
-    /// Plan 2-14 B.6: descriptor-based accessor marking. Set at
-    /// `addService` time by checking whether `binder.descriptor()`
-    /// equals `"android.os.IAccessor"`. AOSP's servicemanager
-    /// distinguishes accessors via VINTF `<accessor>` entries; without
-    /// VINTF, descriptor inspection is the closest semantic equivalent
-    /// (the binder itself self-identifies as `IAccessor`). When `true`,
-    /// `getService2`/`checkService2` (B.7) wraps the binder in
+    /// Descriptor-based accessor marking. Set at `addService` time by
+    /// checking whether `binder.descriptor()` equals
+    /// `"android.os.IAccessor"`. AOSP's servicemanager distinguishes
+    /// accessors via VINTF `<accessor>` entries; without VINTF,
+    /// descriptor inspection is the closest semantic equivalent (the
+    /// binder itself self-identifies as `IAccessor`). When `true`,
+    /// `getService2`/`checkService2` wraps the binder in
     /// `Service::Accessor(Some(binder))` instead of
     /// `Service::ServiceWithMetadata`, so the consume-side accessor
     /// arm in `rsbinder::hub::servicemanager_16` picks it up.
@@ -143,12 +143,10 @@ impl Inner {
         is_called_on_interval: bool,
     ) -> Result<bool> {
         let service = if let Some(service) = self.name_to_service.get(service_name) {
-            // Clippy recommands to use 'is_none_or' here, but 'is_none_or' is not supported by 1.77.
-            #[allow(clippy::unnecessary_map_or)]
             if self
                 .name_to_client_callbacks
                 .get(service_name)
-                .map_or(true, |callbacks| callbacks.is_empty())
+                .is_none_or(|callbacks| callbacks.is_empty())
             {
                 return Ok(true);
             }
@@ -230,8 +228,8 @@ impl Inner {
 
     /// Look up a registered service by name. Returns `Some((binder,
     /// is_accessor))` if registered — the `is_accessor` flag is the
-    /// one stamped at `addService` time (plan 2-14 B.6), used by
-    /// `getService2`/`checkService2` (B.7) to choose between
+    /// one stamped at `addService` time, used by
+    /// `getService2`/`checkService2` to choose between
     /// `Service::Accessor(Some(_))` and `Service::ServiceWithMetadata`.
     /// Callers that only need the binder can `.map(|(b, _)| b)`.
     fn try_get_binder(
@@ -287,6 +285,19 @@ impl Inner {
 
         found
     }
+
+    fn remove_client_callback(&mut self, who: &rsbinder::WIBinder) {
+        // Mirror AOSP `ServiceManager::binderDied`'s third loop
+        // (`removeClientCallback` over `mNameToClientCallback`): drop every
+        // client callback whose binder matches the dead `who`, and remove
+        // any now-empty entries. Without this the dead `IClientCallback`
+        // `Strong` is leaked for the lifetime of rsb_hub and
+        // `onClients` keeps firing on a dead proxy on every state change.
+        self.name_to_client_callbacks.retain(|_, callbacks| {
+            callbacks.retain(|callback| SIBinder::downgrade(&callback.as_binder()) != *who);
+            !callbacks.is_empty()
+        });
+    }
 }
 
 struct ServiceManager {
@@ -320,6 +331,7 @@ impl ServiceManager {
                         .retain(|_, service| !(SIBinder::downgrade(&service.binder) == who));
 
                     inner.remove_registration_callback(None, &who);
+                    inner.remove_client_callback(&who);
                 }
             });
         if let Err(e) = spawn_result {
@@ -422,7 +434,7 @@ impl ServiceManager {
 
 impl Interface for ServiceManager {}
 
-/// Plan 2-14 B.7: convert a `Inner::try_get_binder` lookup result
+/// Convert a `Inner::try_get_binder` lookup result
 /// into the `Service` union arm shape returned by
 /// `getService2`/`checkService2`. Routes `is_accessor=true`
 /// registrations to `Service::Accessor(Some(_))` and regular services
@@ -495,18 +507,10 @@ impl IServiceManager for ServiceManager {
             }
         }
 
-        // Plan 2-14 B.6: detect `IAccessor` binders by their interface
-        // descriptor at registration. The string matches the AOSP-stable
-        // `android.os.IAccessor` AIDL declaration (also used by the
-        // generated `BpAccessor`/`BnAccessor` stubs in
-        // `hub::accessor_16`). `SIBinder::descriptor()` is a cheap
-        // accessor — for native binders it is a compile-time constant,
-        // for proxies it is the cached result of the
-        // `INTERFACE_TRANSACTION` issued at proxy construction (see
-        // `query_local_interface` in `rsbinder::thread_state`).
-        // Hardcoding the string (instead of pulling the `IAccessor`
-        // symbol) keeps rsb_hub buildable without the `rpc` feature; the
-        // contract is byte-stable AOSP AIDL.
+        // Detect `IAccessor` binders by interface descriptor at registration.
+        // Hardcoding the AOSP-stable `android.os.IAccessor` string (instead of
+        // pulling the `IAccessor` symbol) keeps rsb_hub buildable without the
+        // `rpc` feature.
         let is_accessor = service.descriptor() == "android.os.IAccessor";
 
         // `allowIsolated` is accepted by AIDL for AOSP source
@@ -828,9 +832,9 @@ impl IServiceManager for ServiceManager {
         &self,
         name: &str,
     ) -> rsbinder::status::Result<hub::android_16::android::os::Service::Service> {
-        // Routing logic (Plan 2-14 B.7) lives in
-        // `classify_for_service_union` so `checkService2` stays
-        // byte-identical without re-stating the match arms.
+        // Routing logic lives in `classify_for_service_union` so
+        // `checkService2` stays byte-identical without re-stating the
+        // match arms.
         let lookup = self.inner.lock().unwrap().try_get_binder(name, false)?;
         Ok(classify_for_service_union(lookup))
     }
@@ -839,8 +843,8 @@ impl IServiceManager for ServiceManager {
         &self,
         name: &str,
     ) -> rsbinder::status::Result<hub::android_16::android::os::Service::Service> {
-        // See `getService2` — both surface the same Plan 2-14 B.7
-        // routing through `classify_for_service_union`.
+        // See `getService2` — both route through
+        // `classify_for_service_union`.
         let lookup = self.inner.lock().unwrap().try_get_binder(name, false)?;
         Ok(classify_for_service_union(lookup))
     }

--- a/rsbinder/Cargo.toml
+++ b/rsbinder/Cargo.toml
@@ -85,14 +85,14 @@ sha2 = { version = "0.11", optional = true }
 getrandom = { version = "0.4", optional = true }
 
 # subplan 2-9 Phase A: macOS/BSD peer-credential resolution
-# (`getpeereid`/`LOCAL_PEERPID`) — `rustix` exposes only Linux
-# `SO_PEERCRED`. **Target-gated to non-Linux unix only**, so Linux /
-# default / CI builds pull **zero** direct `libc` (AC-9.3): the
-# `[target.'cfg(...)']` table simply does not apply there. Only the
-# `#[cfg(feature = "rpc")]` RPC module references it, so an rpc-off
-# build links no `libc` symbols even on macOS.
+# (`getpeereid`/`LOCAL_PEERPID`) — `rustix` exposes only Linux `SO_PEERCRED`.
 [target.'cfg(all(unix, not(target_os = "linux")))'.dependencies]
-libc = "0.2"
+libc = { workspace = true }
+
+# Plan 4-5 Phase C: `sched_getscheduler` + SCHED_* constants are in libc;
+# rustix omits the SCHED_* constants.
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+libc = { workspace = true }
 
 [build-dependencies]
 rsbinder-aidl = { workspace = true, features = ["async"] }

--- a/rsbinder/Cargo.toml
+++ b/rsbinder/Cargo.toml
@@ -43,20 +43,13 @@ rpc-vsock = ["rpc", "dep:vsock"]
 # channels. Zero cost when off (optional deps). rsbinder never
 # invents crypto — it delegates entirely to rustls (plan §5).
 rpc-tls = ["rpc", "dep:rustls", "dep:sha2"]
-# Lift the multi-connection-per-session slot-cap clamp (`RpcServer::set_max_threads(N >= 2)`,
-# subplan 2-12). EXPERIMENTAL: hermetic rsbinder↔rsbinder PASS, but the
-# non-negotiable real-libbinder interop gate AC-12.6 has not yet passed.
-#
-# `set_max_threads(N)` is always callable so AOSP libbinder peers that
-# expect a specific advertised value can interoperate on default builds
-# (the advertise side is unchanged). What this feature toggles is the
-# **attach arm**: on default builds the effective incoming-slot cap is
-# clamped to 1 even when N>=2, so id-echoing attach #2 is refused with
-# `rejected_unknown_id`; with this feature the cap takes the stored value
-# verbatim, enabling the hermetic multi-conn suite. See
-# `RpcServer::set_max_threads` rustdoc, `plan/2-12-multi-connection-per-session.md`
-# §3, and `RPC_STATUS.md`.
-rpc-experimental-multiconn = ["rpc"]
+# `rpc-experimental-multiconn` retired 2026-05-28: AC-12.6 (a) twoway
+# + (b) oneway PASS lifted multi-connection-per-session
+# (`RpcServer::set_max_threads(N >= 2)`) out of EXPERIMENTAL. The
+# slot-cap clamp is gone — `set_max_threads(N)` is now the true cap on
+# every build, with the AOSP-faithful `setMaxIncomingThreads` semantic.
+# See `plan/2-12-multi-connection-per-session.md` §8 (Phase D wire
+# fix) + §9 (Phase C asyncTodo).
 android_10 = []
 android_11 = []
 android_12 = []

--- a/rsbinder/aidl/permission/android/os/IPermissionController.aidl
+++ b/rsbinder/aidl/permission/android/os/IPermissionController.aidl
@@ -1,0 +1,42 @@
+/* //device/java/android/android/os/IPermissionController.aidl
+**
+** Copyright 2007, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+package android.os;
+
+/**
+ * Client stub for system_server's PermissionManagerService.
+ *
+ * Vendored from
+ * `frameworks/base/core/java/android/os/IPermissionController.aidl`
+ * (AOSP android-16.0.0_r4). The wire descriptor
+ * `"android.os.IPermissionController"` matches what
+ * `BpPermissionController` writes via `Parcel::writeInterfaceToken`.
+ *
+ * rsbinder provides the client side only — the server lives in
+ * Android's system_server (`PermissionManagerService`). Use via
+ * `hub::get_service("permission")` from a process with permission to
+ * reach system_server.
+ *
+ * @hide
+ */
+interface IPermissionController {
+    boolean checkPermission(String permission, int pid, int uid);
+    int noteOp(String op, int uid, String packageName);
+    String[] getPackagesForUid(int uid);
+    boolean isRuntimePermission(String permission);
+    int getPackageUid(String packageName, int flags);
+}

--- a/rsbinder/build.rs
+++ b/rsbinder/build.rs
@@ -64,4 +64,16 @@ fn main() {
         .output(PathBuf::from("accessor_16.rs"))
         .generate()
         .unwrap();
+
+    // Client-side stub for system_server's
+    // PermissionManagerService. Single AIDL (interface is stable across
+    // android-{11..16}), so it lives outside the versioned IServiceManager
+    // trees under aidl/permission/.
+    new_builder()
+        .source(PathBuf::from(
+            "aidl/permission/android/os/IPermissionController.aidl",
+        ))
+        .output(PathBuf::from("permission_controller.rs"))
+        .generate()
+        .unwrap();
 }

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -51,6 +51,21 @@ pub const FLAG_CLEAR_BUF: TransactionFlags = sys::transaction_flags_TF_CLEAR_BUF
 /// Set to the vendor flag if we are building for the VNDK, 0 otherwise
 pub const FLAG_PRIVATE_LOCAL: TransactionFlags = 0;
 pub const FLAG_PRIVATE_VENDOR: TransactionFlags = FLAG_PRIVATE_LOCAL;
+/// `TF_UPDATE_TXN` (0x40). Set together with
+/// [`FLAG_ONEWAY`] on a `transact()` to ask the Android 12+ driver to
+/// replace any pending async transaction with the same `(target, code)`
+/// instead of queueing both. Use for idempotent updates (notification
+/// state, location sample) where only the freshest value matters; the
+/// driver rejects `TF_UPDATE_TXN` without `TF_ONE_WAY` (EINVAL).
+pub const FLAG_UPDATE_TXN: TransactionFlags = sys::transaction_flags_TF_UPDATE_TXN;
+/// `TF_COLLECT_NOTED_APP_OPS` (0x80). Strictly a
+/// libbinder-level flag — the kernel binder driver itself never reads
+/// it. Asks the server runtime to prepend a noted-AppOps blob (under
+/// `EX_HAS_NOTED_APPOPS_REPLY_HEADER = -127`) to the reply parcel; the
+/// client side transparently skips the header during exception decode
+/// (see `Status::deserialize`).
+pub const FLAG_COLLECT_NOTED_APP_OPS: TransactionFlags =
+    sys::transaction_flags_TF_COLLECT_NOTED_APP_OPS;
 
 const fn b_pack_chars(c1: char, c2: char, c3: char, c4: char) -> u32 {
     ((c1 as u32) << 24) | ((c2 as u32) << 16) | ((c3 as u32) << 8) | (c4 as u32)
@@ -258,10 +273,9 @@ pub trait IBinder: Any + Send + Sync {
     /// Calling this on a **proxy** (client-side `ProxyHandle`) is a
     /// programming error — a proxy has no way to inform the remote
     /// service of the new extension, so the call would only mutate
-    /// the local cache and (after PR #104's §4 scope-down) silently
-    /// pin an unrelated `Arc<dyn IBinder>` for the parent's lifetime.
-    /// `ProxyHandle::set_extension` therefore rejects with
-    /// `InvalidOperation`.
+    /// the local cache and silently pin an unrelated `Arc<dyn IBinder>`
+    /// for the parent's lifetime. `ProxyHandle::set_extension` therefore
+    /// rejects with `InvalidOperation`.
     fn set_extension(&self, _extension: &SIBinder) -> Result<()> {
         Err(StatusCode::InvalidOperation)
     }
@@ -273,13 +287,63 @@ pub trait IBinder: Any + Send + Sync {
         0
     }
 
-    /// RPC server dispatch entrypoint (subplan 2-2.d2-SRV).
+    /// Runtime stability downgrade to
+    /// [`Stability::System`] (AOSP [`Stability::forceDowngradeToSystemStability`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/Stability.cpp;l=41) equivalent).
+    ///
+    /// Only meaningful on native binders ([`crate::Binder<T>`]); proxies and
+    /// the default-impl trait objects return `Err(StatusCode::InvalidOperation)`.
+    ///
+    /// **Parceled guard.** Returns `Err(StatusCode::InvalidOperation)` once
+    /// the binder has been written to a parcel (i.e. transferred via IPC).
+    /// Mirror of AOSP [`BBinder::setParceled`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/Binder.cpp;l=722)
+    /// — see [`Self::set_parceled`].
+    fn force_downgrade_to_system_stability(&self) -> Result<()> {
+        Err(StatusCode::InvalidOperation)
+    }
+
+    /// Runtime stability downgrade to
+    /// [`Stability::Vendor`] (AOSP [`Stability::forceDowngradeToVendorStability`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/Stability.cpp;l=45) equivalent).
+    ///
+    /// See [`Self::force_downgrade_to_system_stability`] for the parceled
+    /// guard contract.
+    fn force_downgrade_to_vendor_stability(&self) -> Result<()> {
+        Err(StatusCode::InvalidOperation)
+    }
+
+    /// Runtime mark this binder as
+    /// [`Stability::Vintf`] (AOSP [`Stability::markVintf`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/Stability.cpp;l=54) equivalent).
+    ///
+    /// Typically the AIDL generator emits this for an interface annotated
+    /// `@VintfStability`; reach for the runtime API only when the generator
+    /// path is unavailable (handwritten binders).
+    ///
+    /// See [`Self::force_downgrade_to_system_stability`] for the parceled
+    /// guard contract.
+    fn mark_vintf(&self) -> Result<()> {
+        Err(StatusCode::InvalidOperation)
+    }
+
+    /// Observability hook: has this binder already been
+    /// written to a parcel (and therefore frozen against mutation)?
+    /// Default: `false`. Native binders override with the underlying
+    /// `AtomicBool` load. AOSP [`BBinder::wasParceled`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/Binder.cpp;l=721) equivalent.
+    fn was_parceled(&self) -> bool {
+        false
+    }
+
+    /// Internal mark-as-parceled hook, invoked by the
+    /// parcel layer the first time this binder is serialized. Default is a
+    /// no-op (proxies and test mocks are not subject to the parceled
+    /// guard). AOSP [`BBinder::setParceled`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/Binder.cpp;l=725) equivalent.
+    fn set_parceled(&self) {}
+
+    /// RPC server dispatch entrypoint.
     ///
     /// The RPC server adapter calls this *instead of* the kernel
     /// `Transactable::transact` → `thread_state::check_interface`
     /// path. `check_interface` reads the kernel transaction header and
     /// mutates `THREAD_STATE` (strict-mode / work-source) — both
-    /// meaningless for RPC and forbidden to touch (P1). The adapter has
+    /// meaningless for RPC and forbidden to touch. The adapter has
     /// already consumed + validated the RPC interface token, so this
     /// just dispatches `code` to the generated, transport-neutral
     /// `Remotable::on_transact`. Native binders override it; the
@@ -306,17 +370,17 @@ pub trait IBinder: Any + Send + Sync {
 }
 
 /// An outbound-transaction-issuing proxy, abstract over the kernel
-/// (`proxy::ProxyHandle`) and RPC (`rpc::RpcProxy`) stacks (subplan
-/// 2-6, D1). The AIDL generator emits `as_remote().ok_or(BadType)?`
-/// (subplan 2-6.B) so one generated `Bp*` drives either stack via
-/// this trait + the `<dyn IBinder>::as_remote()` accessor; the
-/// kernel-only `as_proxy()` is retained for any direct callers.
+/// (`proxy::ProxyHandle`) and RPC (`rpc::RpcProxy`) stacks. The AIDL
+/// generator emits `as_remote().ok_or(BadType)?` so one generated
+/// `Bp*` drives either stack via this trait + the
+/// `<dyn IBinder>::as_remote()` accessor; the kernel-only `as_proxy()`
+/// is retained for any direct callers.
 ///
 /// The signatures are exactly `ProxyHandle`'s existing inherent
 /// `prepare_transact`/`submit_transact` — `ProxyHandle` implements
 /// this by **delegating to those unchanged methods**, so the kernel
 /// proxy's runtime behavior is bit-identical by construction (no
-/// codegen change required for the kernel path — AC-6.2).
+/// codegen change required for the kernel path).
 pub trait RemoteProxy {
     /// Allocate the request `Parcel`, optionally writing the AIDL
     /// interface header.
@@ -336,7 +400,7 @@ impl dyn IBinder {
         self.as_any().downcast_ref::<proxy::ProxyHandle>()
     }
 
-    /// Generalized proxy dispatch (subplan 2-6): a kernel
+    /// Generalized proxy dispatch: a kernel
     /// [`proxy::ProxyHandle`] **or** (with the `rpc` feature) an
     /// [`rpc::RpcProxy`](crate::rpc::RpcProxy), as a single
     /// [`RemoteProxy`] trait object. Lets one generated `Bp*` stub
@@ -354,15 +418,15 @@ impl dyn IBinder {
     }
 }
 
-/// Subplan 2-6.B: stamp the generated stub's interface descriptor
-/// onto an `RpcProxy` resolved from the RPC wire (the wire carries
-/// only an address, so such a proxy starts descriptor-less). A
-/// `#[doc(hidden)]` shim the generated `from_binder` calls
-/// unconditionally — the feature gate lives **here**, resolved
-/// against rsbinder's own `rpc` feature, not in the `macro_rules!`
-/// (where `cfg(feature = "rpc")` would wrongly resolve against the
-/// *consumer* crate). The non-`rpc` build is a zero-cost no-op, so
-/// the kernel path and `rpc`-off consumers stay byte-unaffected (V1).
+/// Stamp the generated stub's interface descriptor onto an `RpcProxy`
+/// resolved from the RPC wire (the wire carries only an address, so
+/// such a proxy starts descriptor-less). A `#[doc(hidden)]` shim the
+/// generated `from_binder` calls unconditionally — the feature gate
+/// lives **here**, resolved against rsbinder's own `rpc` feature, not
+/// in the `macro_rules!` (where `cfg(feature = "rpc")` would wrongly
+/// resolve against the *consumer* crate). The non-`rpc` build is a
+/// zero-cost no-op, so the kernel path and `rpc`-off consumers stay
+/// byte-unaffected.
 #[doc(hidden)]
 #[cfg(feature = "rpc")]
 pub fn __rpc_stamp_descriptor(binder: &SIBinder, descriptor: &str) {
@@ -666,6 +730,33 @@ impl SIBinder {
     /// Retrieve the stability level of the underlying binder object.
     pub fn stability(&self) -> Stability {
         self.inner.stability()
+    }
+
+    /// Runtime downgrade to [`Stability::System`].
+    ///
+    /// Delegates to [`IBinder::force_downgrade_to_system_stability`]; only
+    /// native binders honor the mutation. Refer to that trait method for the
+    /// parceled-guard contract and the AOSP equivalent.
+    pub fn force_downgrade_to_system_stability(&self) -> Result<()> {
+        self.inner.force_downgrade_to_system_stability()
+    }
+
+    /// Runtime downgrade to [`Stability::Vendor`].
+    /// Delegates to [`IBinder::force_downgrade_to_vendor_stability`].
+    pub fn force_downgrade_to_vendor_stability(&self) -> Result<()> {
+        self.inner.force_downgrade_to_vendor_stability()
+    }
+
+    /// Runtime upgrade/mark as [`Stability::Vintf`].
+    /// Delegates to [`IBinder::mark_vintf`].
+    pub fn mark_vintf(&self) -> Result<()> {
+        self.inner.mark_vintf()
+    }
+
+    /// Has the underlying binder already been serialized
+    /// at least once? Delegates to [`IBinder::was_parceled`].
+    pub fn was_parceled(&self) -> bool {
+        self.inner.was_parceled()
     }
 
     pub(crate) fn increase(&self) -> Result<()> {
@@ -1052,11 +1143,9 @@ mod tests {
         }
     }
 
-    /// Verifies the `WIBinder::upgrade()` semantic correction in this PR:
-    /// the inner reference is now a genuine `sync::Weak<dyn IBinder>`, so
-    /// once the last `Arc<dyn IBinder>` is dropped, `upgrade()` returns
-    /// `Err(StatusCode::DeadObject)` instead of (incorrectly) succeeding
-    /// against a strong-Arc-in-disguise.
+    /// `WIBinder::upgrade()` is genuinely weak: once the last
+    /// `Arc<dyn IBinder>` is dropped, `upgrade()` returns
+    /// `Err(StatusCode::DeadObject)`.
     #[test]
     fn test_wibinder_upgrade_after_strong_drop_returns_dead_object() {
         let strong = SIBinder::new(Arc::new(MockBinder)).expect("SIBinder::new");

--- a/rsbinder/src/binder_object.rs
+++ b/rsbinder/src/binder_object.rs
@@ -180,7 +180,7 @@ const FLAT_BINDER_FLAG_SCHED_POLICY_SHIFT: u32 = 9;
 /// (= this value `<< FLAT_BINDER_FLAG_SCHED_POLICY_SHIFT`); the constant here is
 /// the pre-shift value mask used to clamp callers (`policy` must be 0..=3).
 /// Naming `_VALUE_MASK` (rather than `_MASK`) avoids colliding with the post-shift
-/// `_MASK` in AOSP `binder.h`. CODE_REVIEW_RECOMMENDATIONS #6.
+/// `_MASK` in AOSP `binder.h`.
 const FLAT_BINDER_FLAG_SCHED_POLICY_VALUE_MASK: u32 = 0x3;
 
 fn sched_policy_mask(policy: u32, priority: u32) -> u32 {
@@ -229,15 +229,33 @@ impl From<&SIBinder> for flat_binder_object {
             // single-statement window between this `From` returning
             // and the first `acquire` is the only leak path under a
             // `Parcel::write_aligned` panic (typically OOM), which is
-            // process-fatal anyway — see plan §5 #11.
+            // process-fatal anyway.
             let id =
                 process_state::ProcessState::as_self().publish_native(Arc::clone(binder.as_arc()));
+
+            // AOSP `Parcel.cpp::flattenBinder`: the scheduler priority /
+            // policy bits come from a SINGLE source. An explicit min
+            // priority/policy on the binder (any non-zero bit in those
+            // ranges — matching AOSP's `policy != 0 || priority != 0`
+            // test) OVERRIDES the default node priority instead of being
+            // OR-combined with it ("override value, since it is set
+            // explicitly"). Blindly OR-ing `sched_bits` over
+            // `local_binder_flags()` would corrupt the requested priority
+            // (e.g. requested 5 | default 19 = 23).
+            let local = binder.local_binder_flags();
+            let sched_mask = FLAT_BINDER_FLAG_PRIORITY_MASK
+                | (FLAT_BINDER_FLAG_SCHED_POLICY_VALUE_MASK << FLAT_BINDER_FLAG_SCHED_POLICY_SHIFT);
+            let effective_sched = if local & sched_mask != 0 {
+                local & sched_mask
+            } else {
+                sched_bits
+            };
 
             flat_binder_object {
                 hdr: binder_object_header {
                     type_: BINDER_TYPE_BINDER,
                 },
-                flags: binder.local_binder_flags() | sched_bits,
+                flags: (local & !sched_mask) | effective_sched,
                 __bindgen_anon_1: flat_binder_object__bindgen_ty_1 { binder: id },
                 cookie: 0,
             }

--- a/rsbinder/src/binderfs.rs
+++ b/rsbinder/src/binderfs.rs
@@ -27,11 +27,23 @@ pub fn add_device(driver: &Path, name: &str) -> std::io::Result<(u32, u32)> {
         minor: 0,
     };
 
-    for (a, c) in device
-        .name
-        .iter_mut()
-        .zip(CString::new(name)?.as_bytes_with_nul())
-    {
+    let cname = CString::new(name)?;
+    let name_bytes = cname.as_bytes_with_nul();
+    // `zip` would otherwise silently truncate a name that does not fit,
+    // leaving the 256-byte field without a NUL terminator and handing the
+    // kernel a mis-named device. Fail loudly instead.
+    if name_bytes.len() > device.name.len() {
+        log::error!(
+            "Binder device name too long: {} bytes (max {})",
+            name_bytes.len(),
+            device.name.len()
+        );
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "binder device name too long",
+        ));
+    }
+    for (a, c) in device.name.iter_mut().zip(name_bytes) {
         *a = *c as std::os::raw::c_char;
     }
 

--- a/rsbinder/src/error.rs
+++ b/rsbinder/src/error.rs
@@ -145,21 +145,12 @@ impl From<StatusCode> for i32 {
 
 impl From<i32> for StatusCode {
     fn from(code: i32) -> Self {
-        // Every wire value is `const`-evaluable because
-        // `rustix::io::Errno::raw_os_error` is `const fn` and the
-        // `UNKNOWN_ERROR + N` family are integer constants. Lifting
-        // the forward map's values into `const`s lets the match
-        // below lower to a single jump-table / equality cascade
-        // (CODE_REVIEW_RECOMMENDATIONS #1). The previous impl ran
-        // each `code == <variant>.into()` guard linearly — for any
-        // non-matching `code` the compiler couldn't fold the
-        // chained `.into()` calls because each arm re-invoked
-        // `From<StatusCode> for i32`'s entire match on a fresh
-        // input, so the worst case was ~22 nested matches per
-        // call. Per-platform errno mapping is preserved — the
-        // `const` initialisers compile down to the same values
-        // the original `.into()` calls would have produced for
-        // whatever `target_os` is being built.
+        // Lifting the forward map's values into `const`s (each is
+        // `const`-evaluable: `Errno::raw_os_error` is `const fn` and
+        // `UNKNOWN_ERROR + N` are integer constants) lets this match
+        // lower to a jump-table / equality cascade instead of a linear
+        // chain of `code == <variant>.into()` guards. Per-platform errno
+        // mapping is preserved.
         use rustix::io::Errno;
         const OK: i32 = 0;
         const UNKNOWN: i32 = UNKNOWN_ERROR;
@@ -499,14 +490,13 @@ mod tests {
         assert_eq!(code, StatusCode::Errno(-64));
     }
 
-    // CODE_REVIEW_RECOMMENDATIONS #1: pin the round-trip between the
-    // forward `From<StatusCode> for i32` and the refactored reverse
-    // `From<i32> for StatusCode`. Each named variant must come back
-    // through the const-pattern match identically, otherwise the new
-    // const initialisers diverged from the forward map's calls into
-    // `rustix::io::Errno::*.raw_os_error()`. Run on every target
-    // (macOS / Linux / Android) since the errno wire values differ
-    // per OS.
+    // Pin the round-trip between the forward `From<StatusCode> for i32`
+    // and the reverse `From<i32> for StatusCode`. Each named variant
+    // must come back through the const-pattern match identically,
+    // otherwise the const initialisers diverged from the forward map's
+    // calls into `rustix::io::Errno::*.raw_os_error()`. Run on every
+    // target (macOS / Linux / Android) since the errno wire values
+    // differ per OS.
     #[test]
     fn from_i32_round_trip_pins_every_named_variant() {
         let variants = [

--- a/rsbinder/src/file_descriptor.rs
+++ b/rsbinder/src/file_descriptor.rs
@@ -82,9 +82,8 @@ impl Eq for ParcelFileDescriptor {}
 
 impl Serialize for ParcelFileDescriptor {
     fn serialize(&self, parcel: &mut Parcel) -> Result<()> {
-        // RPC-mode FD policy (subplan 2-2 / 2-7). `None` (default,
-        // android-12 fidelity / android-13 default) is the hard
-        // `BAD_TYPE` reject — **bit-identical to 2-2** (AC-7.1). `Unix`
+        // RPC-mode FD policy. `None` (default, android-12 fidelity /
+        // android-13 default) is the hard `BAD_TYPE` reject. `Unix`
         // (both peers opted in + UDS) stashes a dup'd fd for
         // out-of-band `SCM_RIGHTS` transfer and writes only an
         // ancillary-table index in the body (android-13+ shape).
@@ -98,7 +97,7 @@ impl Serialize for ParcelFileDescriptor {
                     let idx = parcel.rpc_push_out_fd(dup);
                     if parcel.rpc_record_fd_positions() {
                         // android-13+ **v1+**: the AOSP-faithful
-                        // FD-over-RPC Parcel body (subplan 2-11 Phase A).
+                        // FD-over-RPC Parcel body.
                         // AOSP `AParcel_writeParcelFileDescriptor(fd>=0)`
                         // = `writeInt32(1)` not-null →
                         // `writeDupParcelFileDescriptor` →
@@ -111,9 +110,8 @@ impl Serialize for ParcelFileDescriptor {
                         // Pinned byte-exact android-14.0.0_r75…
                         // android-16.0.0_r4 (v1≡v2 for the body; v2 only
                         // merges binder positions into the same sorted
-                        // table — subplan 2-8 Phase B). The recorded
-                        // position is the **TYPE int32 offset**, not the
-                        // not-null marker.
+                        // table). The recorded position is the **TYPE
+                        // int32 offset**, not the not-null marker.
                         parcel.write::<i32>(&1)?; // not-null marker
                         parcel.write::<i32>(&0)?; // hasComm = 0 (no comm fd)
                         let obj_pos = parcel.data_position();
@@ -124,12 +122,11 @@ impl Serialize for ParcelFileDescriptor {
                         parcel.rpc_record_object_position(obj_pos);
                     } else {
                         // R34 / v0 (non-versioned): rsbinder's internal
-                        // `[present|idx]` shape (subplan 2-7). AOSP
-                        // **category-forbids** fd-over-RPC at android-12
-                        // r34 and android-13 (v0), so this is a
-                        // rsbinder-only symmetric extension — kept
-                        // **byte-unchanged** (AC-11.1 / `rpc_fd` 3/0).
-                        // No object table on R34/v0, so no position.
+                        // `[present|idx]` shape. AOSP **category-forbids**
+                        // fd-over-RPC at android-12 r34 and android-13
+                        // (v0), so this is a rsbinder-only symmetric
+                        // extension — kept **byte-unchanged**. No object
+                        // table on R34/v0, so no position.
                         parcel.write::<i32>(&1)?; // present
                         parcel.write::<i32>(&idx)?; // ancillary fd-table index
                     }
@@ -168,15 +165,15 @@ impl SerializeOption for ParcelFileDescriptor {
 
 impl DeserializeOption for ParcelFileDescriptor {
     fn deserialize_option(parcel: &mut Parcel) -> Result<Option<Self>> {
-        // RPC-mode FD read (subplan 2-7 / 2-11). The leading `i32` is
-        // the not-null marker (`0` ⇒ `None`; AOSP null fd =
-        // `writeInt32(0)`, 4 B — profile-independent, unchanged).
-        // `None` fd-mode: an fd in an incoming RPC parcel is impossible
-        // (the sender was rejected) → BadType. `Unix`: body shape is
-        // profile-keyed (must mirror `serialize`):
-        //  * v1+ (AOSP-faithful, subplan 2-11): `[not-null|hasComm|
+        // RPC-mode FD read. The leading `i32` is the not-null marker
+        // (`0` ⇒ `None`; AOSP null fd = `writeInt32(0)`, 4 B —
+        // profile-independent, unchanged). `None` fd-mode: an fd in an
+        // incoming RPC parcel is impossible (the sender was rejected) →
+        // BadType. `Unix`: body shape is profile-keyed (must mirror
+        // `serialize`):
+        //  * v1+ (AOSP-faithful): `[not-null|hasComm|
         //    TYPE_NATIVE_FILE_DESCRIPTOR|fdIndex]` + the **strict
-        //    object-position read** (Phase B);
+        //    object-position read**;
         //  * R34/v0: rsbinder's legacy `[present|idx]` (byte-unchanged).
         // The real fd arrived out-of-band via `SCM_RIGHTS`.
         #[cfg(feature = "rpc")]
@@ -192,15 +189,15 @@ impl DeserializeOption for ParcelFileDescriptor {
                     // v1+ AOSP body. `present` was the not-null marker;
                     // next is `hasComm`. rsbinder has no comm channel,
                     // so `hasComm != 0` is `BadValue` — a documented
-                    // divergence (AC-11.5): AOSP `readParcelFile
-                    // Descriptor` would read a second (comm) fd. Real
-                    // libbinder via `AParcel_writeParcelFileDescriptor`
-                    // always writes `hasComm == 0`.
+                    // divergence: AOSP `readParcelFileDescriptor` would
+                    // read a second (comm) fd. Real libbinder via
+                    // `AParcel_writeParcelFileDescriptor` always writes
+                    // `hasComm == 0`.
                     let has_comm = parcel.read::<i32>()?;
                     if has_comm != 0 {
                         return Err(StatusCode::BadValue);
                     }
-                    // Phase B — v1+ strict receive (AOSP
+                    // v1+ strict receive (AOSP
                     // `Parcel::readFileDescriptor`: a `binary_search`
                     // miss in `mObjectPositions` ⇒ **`BAD_TYPE`**). This
                     // is v1 **and** v2 for fd (verified
@@ -251,6 +248,18 @@ impl DeserializeOption for ParcelFileDescriptor {
 
         let obj = parcel.read_object(true)?;
 
+        // AOSP `Parcel::readFileDescriptor` returns BAD_TYPE unless
+        // `hdr.type == BINDER_TYPE_FD`. `read_object` only verifies the
+        // object's offset-table membership, not its type, so a peer could
+        // place a (kernel-translated) BINDER_TYPE_HANDLE object where an
+        // FD is expected; reinterpreting its handle as an fd via
+        // `borrowed_fd()` (valid only on a BINDER_TYPE_FD object) would be
+        // a type-confusion that dups an arbitrary already-open fd. Guard
+        // the type before dup'ing.
+        if obj.header_type() != crate::sys::BINDER_TYPE_FD {
+            return Err(StatusCode::BadType);
+        }
+
         let fd = rustix::io::fcntl_dupfd_cloexec(obj.borrowed_fd(), 0)?;
 
         Ok(Some(ParcelFileDescriptor::new(fd)))
@@ -267,11 +276,11 @@ impl Deserialize for ParcelFileDescriptor {
 
 impl DeserializeArray for ParcelFileDescriptor {}
 
-/// Fuzz entrypoint for the `rpc_fd_ancillary` target (subplan 2-7
-/// §6.3 / V4 / T7.6): arbitrary body bytes through the RPC `Unix`-mode
-/// FD-table decode **with no received fds**. Property: no panic / UB /
-/// fd leak — an out-of-bounds or dangling fd-table index is a clean
-/// `Err`, never a crash. Not part of the supported API surface.
+/// Fuzz entrypoint for the `rpc_fd_ancillary` target: arbitrary body
+/// bytes through the RPC `Unix`-mode FD-table decode **with no received
+/// fds**. Property: no panic / UB / fd leak — an out-of-bounds or
+/// dangling fd-table index is a clean `Err`, never a crash. Not part of
+/// the supported API surface.
 #[cfg(feature = "rpc")]
 #[doc(hidden)]
 pub fn __fuzz_rpc_fd_index(input: &[u8]) {
@@ -283,9 +292,9 @@ pub fn __fuzz_rpc_fd_index(input: &[u8]) {
     let _ = <ParcelFileDescriptor as DeserializeOption>::deserialize_option(&mut p);
 }
 
-/// Fuzz entrypoint for the **v1+ AOSP-shape** RPC FD decode (subplan
-/// 2-11 Phase B / V4): arbitrary body bytes + a hostile object-position
-/// table through the strict `[not-null|hasComm|TYPE|idx]` +
+/// Fuzz entrypoint for the **v1+ AOSP-shape** RPC FD decode: arbitrary
+/// body bytes + a hostile object-position table through the strict
+/// `[not-null|hasComm|TYPE|idx]` +
 /// `binary_search` read, **no received fds**. Property: no panic / UB /
 /// fd leak — a forged/unsorted/absent position, a wrong `TYPE`, a
 /// non-zero `hasComm`, or a dangling index is a clean `Err`, never a
@@ -337,12 +346,12 @@ mod tests {
         assert_eq!(pfd.into_raw_fd(), 1);
     }
 
-    // ---- subplan 2-11: AOSP-faithful FD-over-RPC Parcel body ----
+    // ---- AOSP-faithful FD-over-RPC Parcel body ----
     //
-    // Device-free byte-exact goldens (AC-11.1) + Phase B strict-read
-    // mutant detection (V3). The single-fd write side is asserted here;
-    // the full v1+↔v1+ socket round-trip (A0 + A + B) is the hermetic
-    // `rpc_fd::fd_v1plus_aosp_roundtrip_*` (AC-11.0/11.4).
+    // Device-free byte-exact goldens + strict-read mutant detection.
+    // The single-fd write side is asserted here; the full v1+↔v1+
+    // socket round-trip is the hermetic
+    // `rpc_fd::fd_v1plus_aosp_roundtrip_*`.
 
     #[cfg(feature = "rpc")]
     fn dev_null_pfd() -> ParcelFileDescriptor {
@@ -363,7 +372,7 @@ mod tests {
         p
     }
 
-    /// AC-11.1: v1+ (`record_fd_positions`) writes the AOSP-faithful
+    /// v1+ (`record_fd_positions`) writes the AOSP-faithful
     /// `[not-null=1][hasComm=0][TYPE=2][fdIndex=0]` (16 B) and records
     /// the **TYPE int32 offset (= start+8)**, not the not-null marker.
     #[cfg(feature = "rpc")]
@@ -384,9 +393,8 @@ mod tests {
         );
     }
 
-    /// AC-11.1 / AC-11.4: R34 / v0 (no object table) keeps rsbinder's
-    /// legacy `[present=1][fdIndex=0]` (8 B) **byte-unchanged**, no
-    /// position — the anchor that `rpc_fd` 3/0 stays green.
+    /// R34 / v0 (no object table) keeps rsbinder's legacy
+    /// `[present=1][fdIndex=0]` (8 B) **byte-unchanged**, no position.
     #[cfg(feature = "rpc")]
     #[test]
     fn rpc_fd_r34_body_byte_unchanged() {
@@ -402,7 +410,7 @@ mod tests {
         );
     }
 
-    /// AC-11.1: a null fd is `writeInt32(0)` (4 B), **no TYPE, no
+    /// A null fd is `writeInt32(0)` (4 B), **no TYPE, no
     /// position**, at *both* profiles (an easy reshape mistake is to
     /// grow a position for null at v1+).
     #[cfg(feature = "rpc")]
@@ -436,7 +444,7 @@ mod tests {
         p
     }
 
-    /// V3 mutants — each malformed/forged v1+ body must be a clean
+    /// Each malformed/forged v1+ body must be a clean
     /// `Err`, never a panic or a mis-parse (the symmetric-illusion trap
     /// is exactly why these are explicit).
     #[cfg(feature = "rpc")]
@@ -463,8 +471,8 @@ mod tests {
             "legacy [present|idx] vs v1+ reader (hasComm!=0)"
         );
 
-        // (2) position omitted from the object table ⇒ Phase B strict
-        //     miss ⇒ BadType (AOSP fd: binary_search miss ⇒ BAD_TYPE).
+        // (2) position omitted from the object table ⇒ strict miss ⇒
+        //     BadType (AOSP fd: binary_search miss ⇒ BAD_TYPE).
         assert_eq!(
             de(&mut v1_reader(&ok_body, vec![])).unwrap_err(),
             StatusCode::BadType,
@@ -488,8 +496,8 @@ mod tests {
             "TYPE != TYPE_NATIVE_FILE_DESCRIPTOR rejected"
         );
 
-        // (5) hasComm != 0 (AC-11.5 documented divergence: rsbinder has
-        //     no comm channel — AOSP would read a second fd).
+        // (5) hasComm != 0 (documented divergence: rsbinder has no comm
+        //     channel — AOSP would read a second fd).
         let mut comm = ok_body.clone();
         comm[4..8].copy_from_slice(&1i32.to_le_bytes());
         assert_eq!(

--- a/rsbinder/src/hub/accessor_16.rs
+++ b/rsbinder/src/hub/accessor_16.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Subplan 2-13 (A.4 + A.5): the `IAccessor` bridge that turns the
+//! The `IAccessor` bridge that turns the
 //! `Service::Accessor` arm of [`hub::android_16::get_service`]
 //! /[`check_service`](super::servicemanager_16) — historically dropped
 //! to `None` with a warning — into a usable RPC root binder.
@@ -30,7 +30,7 @@
 //! ([`super::servicemanager_16`] cfg guards the whole resolve path).
 //!
 //! Process-wide state: **none**. There is no global registry, no
-//! `OnceLock<Mutex<Vec<RpcSession>>>` (P6 would forbid it); the session
+//! `OnceLock<Mutex<Vec<RpcSession>>>`; the session
 //! lives exactly as long as the wrapper the caller holds.
 
 // cfg lives on the mod decl in super — duplicating here trips
@@ -48,7 +48,7 @@ use crate::error::Result;
 use crate::parcel::Parcel;
 use crate::rpc::RpcSession;
 
-// Generated `IAccessor` stub (build.rs A0.1). The accessor AIDL is its
+// Generated `IAccessor` stub. The accessor AIDL is its
 // own AIDL output so the `IServiceManager.aidl` transitive resolution
 // stays unchanged.
 include!(concat!(env!("OUT_DIR"), "/accessor_16.rs"));
@@ -81,16 +81,12 @@ pub(crate) struct AccessorRoot {
     /// an `Arc<RpcProxy>` (one of two: the other is cached inside
     /// `RpcSessionInner.state` and dies with the session).
     inner: SIBinder,
-    /// **Load-bearing**: drops *after* `inner` (Rust drops fields in
-    /// declaration order). The reverse — `session` first — kills the
-    /// `RpcSessionInner` before the inner `RpcProxy::drop` can fire,
-    /// so the proxy's `queue_dec_strong` silent-skips on the dead
-    /// session and the peer leaks a strong ref until its own
-    /// teardown. The field is technically "unused" in code (Rust
-    /// would let it be renamed `_session` to suppress that lint), but
-    /// the underscore convention falsely suggests it's removable —
-    /// hence the explicit allow attribute. **Reorder = wire
-    /// regression**. (M13 fix — review 2026-05-21.)
+    /// **Load-bearing**: must drop *after* `inner` (Rust drops fields in
+    /// declaration order). Dropping `session` first kills the
+    /// `RpcSessionInner` before the inner `RpcProxy::drop` fires, so the
+    /// proxy's `queue_dec_strong` silent-skips on the dead session and
+    /// the peer leaks a strong ref until its own teardown. Reorder =
+    /// wire regression.
     #[allow(dead_code)]
     session: RpcSession,
 }
@@ -191,7 +187,7 @@ impl IBinder for AccessorRoot {
 /// 3. `addConnection()` — server-side connected socket fd. Failures
 ///    surface as `Status::service_specific_error()` with one of the
 ///    five `IAccessor::ERROR_*` codes (decoded by the caller via
-///    [`accessor_error_name`] in B.6 logging).
+///    [`accessor_error_name`] for logging).
 /// 4. `RpcSession::from_preconnected_fd(fd, max_version=2)` —
 ///    android-16 max wire version.
 /// 5. `get_root()` → wrap in `AccessorRoot` so the session stays
@@ -292,7 +288,7 @@ pub fn resolve_accessor(
     )
 }
 
-/// Map an `IAccessor::ERROR_*` service-specific code (subplan 2-13 B.6)
+/// Map an `IAccessor::ERROR_*` service-specific code
 /// to its symbolic name for logging. `0` is also the
 /// `CONNECTION_INFO_NOT_FOUND` code (AIDL constant value) — when the
 /// inbound `Status` has no `ServiceSpecific` variant the caller passes
@@ -310,7 +306,7 @@ pub fn accessor_error_name(code: i32) -> &'static str {
     }
 }
 
-/// Fuzz hook (subplan 2-13 B.6 / V4): feed an arbitrary big-endian i32
+/// Fuzz hook: feed an arbitrary big-endian i32
 /// byte payload into [`accessor_error_name`] and assert it never
 /// panics, allocates indefinitely, or returns a non-`'static str`. The
 /// returned string is intentionally consumed via `std::hint::black_box`
@@ -329,11 +325,9 @@ pub fn __fuzz_accessor_error_decode(input: &[u8]) {
 
 #[cfg(test)]
 mod tests {
-    //! Subplan 2-13 B.6 deterministic regression: the
-    //! `ServiceSpecificError` decode is the gate that survives without
-    //! a nightly fuzz infrastructure (the master plan calls these the
-    //! *enforceable* adversarial-input gates; the libFuzzer target is
-    //! the soak supplement).
+    //! Deterministic regression for the `ServiceSpecificError` decode —
+    //! the enforceable adversarial-input gate; the libFuzzer target is
+    //! the soak supplement.
 
     use super::*;
 

--- a/rsbinder/src/hub/accessor_register.rs
+++ b/rsbinder/src/hub/accessor_register.rs
@@ -11,6 +11,9 @@
 //! ([`accessor_16`](super::accessor_16)) then performs the v2/v1
 //! handshake against that fd.
 //!
+//! Interop against a real libbinder on an android-16 emulator is the
+//! non-negotiable validation for this path.
+//!
 //! Cross-platform: the [`Unix`](AccessorSockAddr::Unix) variant is
 //! always present so macOS host hermetic tests can exercise the
 //! register-side path without `rpc-vsock` / `rpc-tcp-debug` features.
@@ -21,14 +24,6 @@
 //! so an instance configured for a backend the binary wasn't built with
 //! surfaces as the same AOSP-faithful service-specific error a
 //! wrong-family `addConnection` returns.
-//!
-//! ## Implementation history
-//!
-//! Originally landed under plan 2-14 (phases A0.1 / A0.2 / A0.3 / A.4 /
-//! A.5) with the D.9 STAGE3 real-libbinder gate as the non-negotiable
-//! validation against android-16 emulator. Plan references are
-//! preserved in commit messages and the long-form plan doc; user-facing
-//! docstrings here describe the AOSP analogue, not the plan tag.
 
 // cfg lives on the mod decl in super — duplicating here trips
 // clippy::duplicated_attributes.
@@ -49,7 +44,7 @@ use crate::error::Result;
 /// All three variants exist regardless of build features so the enum's
 /// shape stays stable across feature flags (matching exhaustively in
 /// downstream `match` is therefore predictable). The
-/// `connect_*_owned_fd` helpers (A0.2) gate the *connect path* on the
+/// `connect_*_owned_fd` helpers gate the *connect path* on the
 /// matching `rpc-vsock`/`rpc-tcp-debug` feature and return
 /// `ERROR_UNSUPPORTED_SOCKET_FAMILY` otherwise.
 ///
@@ -85,7 +80,7 @@ impl AccessorSockAddr {
         }
     }
 
-    /// Subplan 2-14 A0.2: open a *server-process* client connection to
+    /// Open a *server-process* client connection to
     /// the address this `AccessorSockAddr` describes and return the
     /// raw `OwnedFd`. This is what AOSP `singleSocketConnection` does
     /// inside `LocalAccessor::addConnection` — a plain `connect(2)`
@@ -93,7 +88,7 @@ impl AccessorSockAddr {
     /// fd is then transferred to the remote `BpAccessor` client via
     /// `ParcelFileDescriptor` (kernel-level fd duplication).
     ///
-    /// Errors map onto the AOSP `IAccessor::ERROR_*` codes; the A0.3
+    /// Errors map onto the AOSP `IAccessor::ERROR_*` codes; the
     /// `LocalAccessor::addConnection` impl translates these into
     /// `Status::from_service_specific_error(ERROR_*)`. The mapping is:
     ///
@@ -120,7 +115,7 @@ impl AccessorSockAddr {
 }
 
 /// AOSP `IAccessor::ERROR_*`-aligned classification of a failure
-/// returned by [`AccessorSockAddr::connect_owned_fd`]. The A0.3
+/// returned by [`AccessorSockAddr::connect_owned_fd`]. The
 /// `LocalAccessor::addConnection` impl converts each variant into the
 /// corresponding AIDL `Status::from_service_specific_error(...)`.
 ///
@@ -173,7 +168,7 @@ impl std::error::Error for AccessorConnectError {}
 /// stream's `OwnedFd` is the *client-side endpoint of a connected
 /// socket pair* whose server-side endpoint is whoever accepted on
 /// `path` (typically the same process's `RpcServer::setup_unix_server`
-/// listener — see plan 2-14 §3 A0(ii)).
+/// listener).
 fn connect_unix_owned_fd(path: &PathBuf) -> std::result::Result<OwnedFd, AccessorConnectError> {
     use std::os::unix::net::UnixStream;
     match UnixStream::connect(path) {
@@ -250,7 +245,7 @@ fn connect_inet_owned_fd(
 #[cfg(feature = "rpc-vsock")]
 use std::os::fd::FromRawFd;
 
-// --- Subplan 2-14 A0.3: `LocalAccessor` (`BnAccessor` impl) -------
+// --- `LocalAccessor` (`BnAccessor` impl) -------
 
 use super::accessor_16::{
     BnAccessor, IAccessor, ERROR_CONNECTION_INFO_NOT_FOUND, ERROR_FAILED_TO_CONNECT_EACCES,
@@ -261,7 +256,7 @@ use crate::binder::{Interface, Strong};
 use crate::file_descriptor::ParcelFileDescriptor;
 use crate::status::Status;
 
-/// Subplan 2-14 A0.3: the AOSP `LocalAccessor` analog — a server-side
+/// The AOSP `LocalAccessor` analog — a server-side
 /// `BnAccessor` whose `addConnection()` calls a user-supplied
 /// [`AccessorAddrProvider`] for an [`AccessorSockAddr`], opens a
 /// `connect(2)` to it inside *this* process, and ships the resulting
@@ -276,8 +271,8 @@ use crate::status::Status;
 /// AOSP parity:
 ///
 ///  * `singleSocketConnection` ⇒
-///    [`AccessorSockAddr::connect_owned_fd`] (A0.2)
-///  * `RpcSocketAddressProvider` ⇒ [`AccessorAddrProvider`] (A0.1)
+///    [`AccessorSockAddr::connect_owned_fd`]
+///  * `RpcSocketAddressProvider` ⇒ [`AccessorAddrProvider`]
 ///  * `Status::fromServiceSpecificError(ERROR_*, msg)` ⇒
 ///    `Status::new_service_specific_error_str` with the matching
 ///    `IAccessor::ERROR_*` constant
@@ -285,8 +280,8 @@ use crate::status::Status;
 /// Use via [`Self::new_binder`] (the `BnAccessor::new_binder` AIDL
 /// stub) — the returned `SIBinder` is what
 /// [`create_accessor`](crate::hub::android_16::create_accessor) wraps
-/// for registration (A.4) and what `kernel addService(name, _)`
-/// publishes to the system service manager (D.9 STAGE3 launcher).
+/// for registration and what `kernel addService(name, _)`
+/// publishes to the system service manager.
 pub struct LocalAccessor {
     instance: String,
     addr_provider: AccessorAddrProvider,
@@ -301,7 +296,7 @@ impl LocalAccessor {
     /// Returned wrapped as a `Strong<dyn IAccessor>` so callers can
     /// trivially `as_binder()` for `addService` or stash on a server's
     /// service directory. The `Strong<dyn IAccessor>` is also what a
-    /// future [`add_accessor_provider`] (A.4) returns from its
+    /// future [`add_accessor_provider`] returns from its
     /// closure.
     pub fn new_binder(
         instance: impl Into<String>,
@@ -382,8 +377,8 @@ fn accessor_error_code_for(err: &AccessorConnectError) -> (i32, &'static str) {
     }
 }
 
-/// Closure type returned by [`add_accessor_provider`] (A.4) and called
-/// by [`LocalAccessor::addConnection`] (A0.3) to resolve an instance
+/// Closure type returned by [`add_accessor_provider`] and called
+/// by [`LocalAccessor::addConnection`] to resolve an instance
 /// name to the socket address it should connect to. Mirrors AOSP
 /// `RpcSocketAddressProvider`'s `(name, sockaddr*, size_t) -> status_t`
 /// signature but returns the strongly-typed [`AccessorSockAddr`]
@@ -401,7 +396,7 @@ fn accessor_error_code_for(err: &AccessorConnectError) -> (i32, &'static str) {
 /// [`LocalAccessor::addConnection`]: super::accessor_register::LocalAccessor
 pub type AccessorAddrProvider = Box<dyn Fn(&str) -> Result<AccessorSockAddr> + Send + Sync>;
 
-// --- Subplan 2-14 A.4: process-local AccessorProvider registry ----
+// --- process-local AccessorProvider registry ----
 //
 // AOSP `gAccessorProviders` (`IServiceManager.cpp:200-201`) is a
 // process-local list of `AccessorProvider{ instances, providerCallback }`.
@@ -410,8 +405,7 @@ pub type AccessorAddrProvider = Box<dyn Fn(&str) -> Result<AccessorSockAddr> + S
 // matching shared_ptr. The cross-process pickup is via
 // `getInjectedAccessor` — `BackendUnifiedServiceManager::getService2`
 // calls it as a *fallback* when servicemanager returns no binder for
-// `name`. Phase A.5 wires that fallback; this commit lands the
-// registry primitive itself.
+// `name`.
 
 use std::collections::HashSet;
 use std::sync::{Arc, OnceLock, Weak};
@@ -423,7 +417,7 @@ use std::sync::{Arc, OnceLock, Weak};
 ///
 /// `Send + Sync` so the registry can be walked under a mutex by any
 /// thread issuing a `hub::get_service` lookup; the closure should be
-/// idempotent across threads (Phase A.5 dispatches without re-locking
+/// idempotent across threads (lookup dispatches without re-locking
 /// the registry — see `IServiceManager.cpp:286-291` snapshot pattern).
 pub type AccessorProviderFn = Box<dyn Fn(&str) -> Option<crate::binder::SIBinder> + Send + Sync>;
 
@@ -444,8 +438,8 @@ struct AccessorProviderEntry {
 ///
 /// Initialized lazily via `OnceLock` so the `rpc`-OFF /
 /// non-android-16 build never allocates the mutex. The
-/// `Mutex<Vec<_>>` shape is the AOSP-faithful one — readers (Phase
-/// A.5 lookup) snapshot the entries inside the lock, then release
+/// `Mutex<Vec<_>>` shape is the AOSP-faithful one — readers (lookup)
+/// snapshot the entries inside the lock, then release
 /// before calling the provider closure (no callback under the lock
 /// — see `IServiceManager.cpp:286-291`).
 static REGISTRY: OnceLock<std::sync::Mutex<Vec<AccessorProviderEntry>>> = OnceLock::new();
@@ -460,7 +454,7 @@ fn is_instance_provided_locked(entries: &[AccessorProviderEntry], instance: &str
     entries.iter().any(|e| e.instances.contains(instance))
 }
 
-/// Subplan 2-14 A.4: register a process-local accessor provider for
+/// Register a process-local accessor provider for
 /// `instances`. AOSP `addAccessorProvider`
 /// (`IServiceManager.cpp:368-389`). Returns a
 /// [`AccessorProviderHandle`] whose `Drop` un-registers the provider
@@ -479,8 +473,7 @@ fn is_instance_provided_locked(entries: &[AccessorProviderEntry], instance: &str
 /// `Err(StatusCode::BadValue)` (AOSP `ALOGE`+empty-weak).
 ///
 /// The provider closure must be `Send + Sync` — it is invoked from
-/// whatever thread services a `hub::get_service` fallback (Phase
-/// A.5).
+/// whatever thread services a `hub::get_service` fallback.
 pub fn add_accessor_provider(
     instances: HashSet<String>,
     provider: AccessorProviderFn,
@@ -507,7 +500,7 @@ pub fn add_accessor_provider(
     Ok(handle)
 }
 
-/// Subplan 2-14 A.4: explicit removal of a provider previously
+/// Explicit removal of a provider previously
 /// registered via [`add_accessor_provider`]. AOSP
 /// `removeAccessorProvider` (`IServiceManager.cpp:391-411`). Returns
 /// `Err(StatusCode::BadValue)` if the handle is already dead (the
@@ -537,7 +530,7 @@ pub fn remove_accessor_provider(
     Ok(())
 }
 
-/// Subplan 2-14 A.4: RAII handle returned by
+/// RAII handle returned by
 /// [`add_accessor_provider`]. Dropping the handle un-registers the
 /// provider; ignore the handle (`_handle`) only if you want the
 /// provider to live for the whole process lifetime.
@@ -590,7 +583,7 @@ impl Drop for AccessorProviderHandle {
     }
 }
 
-/// Subplan 2-14 A.4: lookup a provider by instance name. AOSP
+/// Lookup a provider by instance name. AOSP
 /// `getInjectedAccessor` (`IServiceManager.cpp:284-312`) — snapshot
 /// the registry under the lock, then walk the snapshot *outside* the
 /// lock calling each provider's closure until one returns
@@ -599,8 +592,8 @@ impl Drop for AccessorProviderHandle {
 /// `Service::Accessor(None)` / `ServiceWithMetadata(None)` they were
 /// trying to backfill).
 ///
-/// Consumed by [`resolve_via_process_local`] (the A.5 fallback the
-/// public `hub::get_service` arm uses) and by the hermetic A.5 tests.
+/// Consumed by [`resolve_via_process_local`] (the fallback the public
+/// `hub::get_service` arm uses) and by the hermetic tests.
 /// `pub(crate)` keeps all callers inside the crate.
 pub(crate) fn lookup_accessor_provider(name: &str) -> Option<crate::binder::SIBinder> {
     // Snapshot of `Arc<AccessorProviderFn>` for entries that include
@@ -627,9 +620,9 @@ pub(crate) fn lookup_accessor_provider(name: &str) -> Option<crate::binder::SIBi
     None
 }
 
-/// Subplan 2-14 A.5: process-local "consume" — look up a registered
-/// `IAccessor` provider for `name` (via the A.4 registry) and bridge
-/// it to an `RpcSession` root using 2-13's
+/// Process-local "consume" — look up a registered
+/// `IAccessor` provider for `name` (via the registry) and bridge
+/// it to an `RpcSession` root using
 /// [`super::accessor_16::resolve_accessor`]. Returns `None` if no
 /// provider claims `name`, or if the bridge fails
 /// (instance-name mismatch / addConnection failure / handshake / no
@@ -648,7 +641,7 @@ pub fn resolve_via_process_local(
     super::accessor_16::resolve_accessor(name, accessor)
 }
 
-/// Subplan 2-14 A.4: AOSP `createAccessor`
+/// AOSP `createAccessor`
 /// (`IServiceManager.cpp:439-450`). Wrap an [`AccessorAddrProvider`]
 /// in a [`LocalAccessor`] `BnAccessor`, return the binder.
 /// Convenience over [`LocalAccessor::new_binder`] for the "I just
@@ -670,7 +663,7 @@ mod tests {
 
     /// Family-string dispatch is order-independent across variants and
     /// stable across feature flags (`Vsock`/`Inet` variants exist
-    /// unconditionally — A0.1 design note in the module doc).
+    /// unconditionally — see the module doc).
     #[test]
     fn family_str_covers_all_variants() {
         let unix = AccessorSockAddr::Unix(PathBuf::from("/tmp/rsbinder-test-2-14.sock"));
@@ -726,7 +719,7 @@ mod tests {
         (l, p)
     }
 
-    /// A0.2 unix path — `connect_owned_fd` returns a real, connected
+    /// Unix path — `connect_owned_fd` returns a real, connected
     /// `OwnedFd` whose other endpoint is the listener's `accept`. The
     /// fd is byte-functional (echo round-trip) — proves the fd isn't
     /// dropped/closed somewhere in the wrapping.
@@ -758,7 +751,7 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
-    /// A0.2 unix path — connect to a non-existent path surfaces as
+    /// Unix path — connect to a non-existent path surfaces as
     /// `ConnectFailed` (not `UnsupportedFamily` or panic). The exact
     /// `io::ErrorKind` is host-OS dependent (Linux = `ConnectionRefused`,
     /// macOS = `NotFound`), so we only assert the variant.
@@ -773,13 +766,13 @@ mod tests {
         );
     }
 
-    /// A0.2 vsock / inet `UnsupportedFamily` when the feature is off
+    /// Vsock / inet `UnsupportedFamily` when the feature is off
     /// (= rsbinder default build on macOS). This is the AOSP-faithful
     /// `ERROR_UNSUPPORTED_SOCKET_FAMILY` path. When the feature **is**
     /// built in, the connect attempt would surface as `ConnectFailed`
     /// (no listener on `cid:port` / `127.0.0.1:0`) — that arm is left
-    /// for the integration test in `tests/rpc_accessor_register.rs`
-    /// (D.8.a), since exercising it requires a live listener and the
+    /// for the integration test in `tests/rpc_accessor_register.rs`,
+    /// since exercising it requires a live listener and the
     /// vsock crate's connect behaviour differs on macOS.
     #[cfg(not(feature = "rpc-vsock"))]
     #[test]
@@ -838,11 +831,11 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
-    // --- A0.3 LocalAccessor tests (in-process Bn/Bp round-trip) -----
+    // --- LocalAccessor tests (in-process Bn/Bp round-trip) -----
 
     use crate::FromIBinder;
 
-    /// A0.3 happy path: `LocalAccessor::new_binder(...)` ⇒ Bn-side
+    /// Happy path: `LocalAccessor::new_binder(...)` ⇒ Bn-side
     /// SIBinder ⇒ in-process `BpAccessor::from_binder` (via the
     /// generated `IAccessor::FromIBinder` hook) ⇒
     /// `getInstanceName()` returns the stored name + `addConnection()`
@@ -892,7 +885,7 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
-    /// A0.3 provider error path: provider returns `Err` ⇒
+    /// Provider error path: provider returns `Err` ⇒
     /// `addConnection()` ⇒ `Status::ServiceSpecific(ERROR_CONNECTION_INFO_NOT_FOUND)`.
     /// `getInstanceName()` keeps working — the error is *per-call*,
     /// not per-instance.
@@ -918,7 +911,7 @@ mod tests {
         );
     }
 
-    /// A0.3 connect-failure path: provider returns a valid
+    /// Connect-failure path: provider returns a valid
     /// `AccessorSockAddr::Unix` whose path has no listener ⇒
     /// `addConnection()` ⇒
     /// `Status::ServiceSpecific(ERROR_FAILED_TO_CONNECT_TO_SOCKET)`.
@@ -944,7 +937,7 @@ mod tests {
         );
     }
 
-    /// A0.3 unsupported-family path (feature-disabled vsock on
+    /// Unsupported-family path (feature-disabled vsock on
     /// macOS-default build): provider returns `Vsock { .. }` ⇒
     /// `addConnection()` ⇒
     /// `Status::ServiceSpecific(ERROR_UNSUPPORTED_SOCKET_FAMILY)`.
@@ -969,7 +962,7 @@ mod tests {
         );
     }
 
-    // --- A.4 process-local registry tests --------------------------
+    // --- process-local registry tests --------------------------
     //
     // `REGISTRY` is a process-wide `OnceLock<Mutex<Vec<_>>>`; under
     // `cargo test` multiple test threads share it. We give every test
@@ -1196,7 +1189,7 @@ mod tests {
         );
     }
 
-    /// Concurrent register + lookup — P6 safety witness. Multiple
+    /// Concurrent register + lookup — thread-safety witness. Multiple
     /// threads register disjoint instances and look up each other's
     /// instances; no panic, no deadlock, and every lookup either
     /// finds the registered provider or returns `None` (never a stale

--- a/rsbinder/src/hub/accessor_register.rs
+++ b/rsbinder/src/hub/accessor_register.rs
@@ -599,10 +599,9 @@ impl Drop for AccessorProviderHandle {
 /// `Service::Accessor(None)` / `ServiceWithMetadata(None)` they were
 /// trying to backfill).
 ///
-/// Phase A.5 will call this from `hub::get_service`'s servicemanager
-/// fallback arm; the function is `pub(crate)` here so the only
-/// consumers are inside the crate (Phase A.5 + hermetic A.5 tests).
-#[allow(dead_code)] // wired up in Phase A.5 (`hub::get_service` fallback)
+/// Consumed by [`resolve_via_process_local`] (the A.5 fallback the
+/// public `hub::get_service` arm uses) and by the hermetic A.5 tests.
+/// `pub(crate)` keeps all callers inside the crate.
 pub(crate) fn lookup_accessor_provider(name: &str) -> Option<crate::binder::SIBinder> {
     // Snapshot of `Arc<AccessorProviderFn>` for entries that include
     // `name`. We deliberately keep `Arc` instead of `Weak` here so the

--- a/rsbinder/src/hub/mod.rs
+++ b/rsbinder/src/hub/mod.rs
@@ -218,17 +218,17 @@ pub mod android_14 {
 
 #[cfg(feature = "rpc")]
 pub(crate) mod accessor_16;
-/// Subplan 2-14: register-side companion to [`accessor_16`]. Defines
-/// `AccessorSockAddr` + `AccessorAddrProvider` (A0.1), `LocalAccessor`
-/// (A0.3), the `add_accessor_provider` / `create_accessor` /
-/// `remove_accessor_provider` process-local registry (A.4), and the
-/// `resolve_via_process_local` fallback helper (A.5). Same
+/// Register-side companion to [`accessor_16`]. Defines
+/// `AccessorSockAddr` + `AccessorAddrProvider`, `LocalAccessor`,
+/// the `add_accessor_provider` / `create_accessor` /
+/// `remove_accessor_provider` process-local registry, and the
+/// `resolve_via_process_local` fallback helper. Same
 /// `cfg(feature = "rpc")` gate as the consume side.
 #[cfg(feature = "rpc")]
 pub(crate) mod accessor_register;
 mod servicemanager_16;
 pub mod android_16 {
-    /// Subplan 2-13 B.6: expose the deterministic error-name decoder
+    /// Expose the deterministic error-name decoder
     /// (and its `__fuzz_*` hook) so the libFuzzer target can drive it
     /// without re-implementing the i32→symbol map.
     #[cfg(feature = "rpc")]
@@ -243,7 +243,7 @@ pub mod android_16 {
     // mirrors the codegen gate in `accessor_16::pub use ...`.
     #[cfg(all(feature = "rpc", feature = "async"))]
     pub use super::accessor_16::IAccessorAsyncService;
-    /// Subplan 2-14 register-side public surface (A0.1–A0.3 + A.4 + A.5).
+    /// Register-side public surface.
     #[cfg(feature = "rpc")]
     pub use super::accessor_register::{
         add_accessor_provider, create_accessor, remove_accessor_provider,

--- a/rsbinder/src/hub/servicemanager_16.rs
+++ b/rsbinder/src/hub/servicemanager_16.rs
@@ -13,14 +13,14 @@ pub use android::os::IServiceManager::{
 pub use android::os::IServiceCallback::{BnServiceCallback, IServiceCallback};
 pub use android::os::ServiceDebugInfo::ServiceDebugInfo;
 
-/// Subplan 2-13 A.4: bridge the `Service::Accessor` arm of
+/// Bridge the `Service::Accessor` arm of
 /// `getService2`/`checkService2` into a `ServiceWithMetadata` whose
 /// `service` is the RPC root pinned by an owning [`RpcSession`].
 ///
 /// Optional Accessor arm: an Accessor binder is **only** consumable via
 /// the RPC stack, so a build without the `rpc` feature falls back to
 /// the historical "log + None" behavior — byte-unchanged for that
-/// build (V1).
+/// build.
 #[cfg(feature = "rpc")]
 fn resolve_accessor_arm(
     name: &str,
@@ -45,7 +45,7 @@ fn resolve_accessor_arm(
     None
 }
 
-/// Subplan 2-14 A.5: process-local AccessorProvider fallback. AOSP
+/// Process-local AccessorProvider fallback. AOSP
 /// `BackendUnifiedServiceManager::toBinderService`
 /// (`BackendUnifiedServiceManager.cpp:287-313`, android-16.0.0_r4)
 /// calls `getInjectedAccessor(name, &accessor)` from the
@@ -60,34 +60,28 @@ fn resolve_accessor_arm(
 /// where servicemanager itself returns a VINTF `<accessor>` binder)
 /// and **does not** consult `getInjectedAccessor`.
 ///
-/// **M15 caveat (review 2026-05-21)**: rsbinder *intentionally departs*
-/// from that AOSP policy: the `Accessor` arm here calls
-/// `try_process_local_fallback` on miss. The rationale is defensive
-/// — a peer-supplied accessor whose `getInstanceName` doesn't match
-/// the requested name (mis-routing or impersonation) shouldn't
-/// shadow a locally-registered provider. This is a hardening choice,
-/// not an AOSP-faithfulness defect: rsbinder accepts a slightly
-/// broader resolution surface in exchange for closing a class of
-/// silent failures. If strict AOSP parity is required, gate this
-/// `or_else` behind a future opt-out flag.
+/// rsbinder *intentionally departs* from that AOSP policy: the
+/// `Accessor` arm here also calls `try_process_local_fallback` on miss.
+/// The rationale is defensive — a peer-supplied accessor whose
+/// `getInstanceName` doesn't match the requested name (mis-routing or
+/// impersonation) shouldn't shadow a locally-registered provider. This
+/// is a hardening choice, not an AOSP-faithfulness defect: rsbinder
+/// accepts a slightly broader resolution surface in exchange for
+/// closing a class of silent failures.
 ///
 /// The fallback fires when (a) the `ServiceWithMetadata` arm's inner
 /// binder is `None` (the common "no entry" signal) or (b) the
-/// `Accessor` arm fails to resolve (M15-defensive). The bridge from
-/// the returned `IAccessor` SIBinder to an `RpcSession` root is the
-/// same Phase 2-13 helper [`super::accessor_16::resolve_accessor`].
+/// `Accessor` arm fails to resolve. The bridge from the returned
+/// `IAccessor` SIBinder to an `RpcSession` root is the same helper
+/// [`super::accessor_16::resolve_accessor`].
 ///
-/// **M21 cfg-gate clarification (review 2026-05-21)**:
-/// `try_process_local_fallback` carries a `cfg(feature = "rpc")`
-/// gate, but `dispatch_typed_service` itself is cfg-free.
-/// `rpc`-OFF builds reach the `swm.service.is_none()` arm and call
-/// the **no-op stub**, which returns `None`, so the `or(Some(swm))`
-/// falls back to the original null `swm` — the same `None`-inside
-/// `swm` a pre-2-14 build would have returned (callers map it to
-/// `NameNotFound` identically). The end-to-end *result* is byte-
-/// unchanged; the *call shape* differs (a no-op stub is now invoked).
-/// "byte-unchanged" here therefore means "observable result unchanged",
-/// not "no extra function frame in the call stack".
+/// `try_process_local_fallback` carries a `cfg(feature = "rpc")` gate,
+/// but `dispatch_typed_service` itself is cfg-free. `rpc`-OFF builds
+/// reach the `swm.service.is_none()` arm and call the **no-op stub**,
+/// which returns `None`, so the `or(Some(swm))` falls back to the
+/// original null `swm` — the observable result is unchanged (callers
+/// map it to `NameNotFound` identically); only an extra no-op stub
+/// frame is invoked.
 #[cfg(feature = "rpc")]
 fn try_process_local_fallback(
     name: &str,
@@ -248,7 +242,7 @@ pub fn get_service_debug_info(
 
 #[cfg(all(test, feature = "rpc"))]
 mod tests {
-    //! Subplan 2-14 A.5 wire-up gate: drive `dispatch_typed_service`
+    //! Drive `dispatch_typed_service`
     //! directly so the AOSP-faithful fallback choice (process-local
     //! provider on `ServiceWithMetadata(service: None)` AND
     //! `Accessor(None)`) is *exercised* — not just the
@@ -306,7 +300,7 @@ mod tests {
         add_accessor_provider(HashSet::from([instance.to_owned()]), provider).expect("registry add")
     }
 
-    /// M14 fix (review 2026-05-21): wrap the provider closure with an
+    /// Wrap the provider closure with an
     /// observable side effect so a mutant removing the
     /// `dispatch_typed_service → try_process_local_fallback` call
     /// flips the test red. Returns the `(handle, called)` pair —
@@ -369,7 +363,7 @@ mod tests {
 
         // Now register a provider and re-dispatch — the fallback must
         // surface the registered Accessor's resolved root.
-        // **M14 mutant gate**: `called` flips iff the dispatcher
+        // Mutant gate: `called` flips iff the dispatcher
         // actually walked into `try_process_local_fallback` →
         // registry lookup → our provider closure.
         let (_handle, called) = register_observing_provider(&instance);
@@ -406,7 +400,7 @@ mod tests {
         // With a registered provider, dispatch_typed_service tries the
         // Accessor arm first (null ⇒ resolve_accessor_arm returns None),
         // then falls back. The fallback's full bridge may not connect
-        // (fake path) — the **M14 mutant gate** below is that the
+        // (fake path) — the mutant gate below is that the
         // provider closure was invoked, proving the `or_else` fired.
         let _ = dispatch_typed_service(&instance, null_accessor);
         assert!(

--- a/rsbinder/src/lazy_service.rs
+++ b/rsbinder/src/lazy_service.rs
@@ -1,0 +1,325 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! `LazyServiceRegistrar` skeleton.
+//!
+//! Mirrors AOSP `LazyServiceRegistrar`
+//! ([`LazyServiceRegistrar.h`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/include/binder/LazyServiceRegistrar.h),
+//! [`LazyServiceRegistrar.cpp`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp)):
+//! a `register_service` helper that owns the bookkeeping for the
+//! `aidl_lazy_service` pattern (idle unregister, force-persist, re-register
+//! after onClients).
+//!
+//! **Scope note.** The state machine, AOSP-faithful `IClientCallback`
+//! dispatch, and `force_persist`/`try_unregister`/`re_register` all live
+//! in this module and are hermetically testable. The integration that
+//! wires up the *actual* `registerClientCallback` / `tryUnregisterService`
+//! IServiceManager calls is not yet wired and must be supplied by the
+//! caller — the hub::ServiceManager wrapper does not yet surface those
+//! AIDL methods despite the underlying generated bindings supporting them
+//! since AOSP API 30 (Android 11). The present module exposes the
+//! registrar surface as an in-process state machine; once hub plumbing
+//! lands, `register_service` will additionally call
+//! `service_manager.add_service(name, binder) +
+//! service_manager.register_client_callback(name, binder, &self.as_callback())`.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+use crate::binder::SIBinder;
+use crate::error::Result;
+
+/// One registered (name → binder) pair plus the most recent client-side
+/// presence signal from `IClientCallback::onClients`.
+#[derive(Clone)]
+struct RegisteredService {
+    /// Service name as registered with the service manager.
+    name: String,
+    /// The binder being lazily managed.
+    binder: SIBinder,
+    /// Last-known client-side presence: `true` once we have seen at
+    /// least one `onClients(name, true)`, `false` after the matching
+    /// `onClients(name, false)`. AOSP `ServiceInfo::clients`
+    /// ([LazyServiceRegistrar.cpp:53](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=53)).
+    has_clients: bool,
+    /// Locked = registered with the service manager. `tryUnregisterLocked`
+    /// flips this to `false` after a successful `tryUnregisterService`;
+    /// `reRegisterLocked` flips it back to `true`.
+    registered: bool,
+}
+
+struct Inner {
+    /// Service name → tracking entry. AOSP's `mRegisteredServices` map.
+    services: HashMap<String, RegisteredService>,
+}
+
+/// The lazy-service bookkeeping struct. Construct one per process via
+/// [`LazyServiceRegistrar::new`] (or share via `Arc` across threads —
+/// the struct is `Send + Sync`).
+///
+/// Threading: the `services` map is protected by a `Mutex`; the
+/// `force_persist` flag is a lock-free `AtomicBool` (AOSP equivalent is
+/// `mForcePersist` guarded by `mMutex` — rsbinder avoids the lock on
+/// the hot path because the flag is consulted from inside `onClients`
+/// where holding the registrar mutex is already required).
+pub struct LazyServiceRegistrar {
+    inner: Mutex<Inner>,
+    /// When `true`, [`Self::try_unregister`] short-circuits to a no-op
+    /// even if all services report `has_clients == false`. AOSP
+    /// `forcePersist`.
+    force_persist: AtomicBool,
+}
+
+impl LazyServiceRegistrar {
+    /// Construct a fresh registrar. Caller normally wraps in `Arc` for
+    /// sharing with the `IClientCallback` bridge.
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                services: HashMap::new(),
+            }),
+            force_persist: AtomicBool::new(false),
+        }
+    }
+
+    /// Record a (name, binder) pair as lazily managed. AOSP
+    /// [`LazyServiceRegistrar::registerService`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=123),
+    /// minus the IServiceManager `addService` + `registerClientCallback`
+    /// IPC calls — those are owed by the **caller** until the hub
+    /// integration lands (see the module-level scope note). Re-registering
+    /// the same name replaces the prior entry (AOSP `mRegisteredServices`
+    /// is keyed by name).
+    pub fn register_service(&self, name: &str, binder: SIBinder) -> Result<()> {
+        let mut inner = self.inner.lock().expect("lazy_service inner poisoned");
+        inner.services.insert(
+            name.to_string(),
+            RegisteredService {
+                name: name.to_string(),
+                binder,
+                has_clients: true, // AOSP initializes assuming a client may already be holding
+                registered: true,
+            },
+        );
+        Ok(())
+    }
+
+    /// Toggle the force-persist guard. AOSP
+    /// `LazyServiceRegistrar::forcePersist`. When `true`,
+    /// [`Self::try_unregister`] returns `false` without attempting an
+    /// IServiceManager round trip.
+    pub fn force_persist(&self, persist: bool) {
+        self.force_persist.store(persist, Ordering::Release);
+    }
+
+    /// `true` if [`Self::force_persist`] was last called with `true`.
+    pub fn is_force_persisted(&self) -> bool {
+        self.force_persist.load(Ordering::Acquire)
+    }
+
+    /// AOSP-faithful `IClientCallback::onClients` dispatch. Call this
+    /// from the (future-wired-up) Bn callback to update the registrar's
+    /// internal `has_clients` state for a given service. Returns `true`
+    /// if the named service was tracked, `false` if unknown (which AOSP
+    /// would `LOG_ALWAYS_FATAL` on — rsbinder returns silently to avoid
+    /// aborting the dispatch thread).
+    pub fn on_clients(&self, name: &str, has_clients: bool) -> bool {
+        let mut inner = self.inner.lock().expect("lazy_service inner poisoned");
+        if let Some(entry) = inner.services.get_mut(name) {
+            entry.has_clients = has_clients;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Attempt to unregister all services whose last `onClients` was
+    /// `false` (no current clients). AOSP
+    /// [`LazyServiceRegistrar::tryUnregisterLocked`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=193).
+    ///
+    /// **Returns** `true` if every clientless service successfully
+    /// flipped to `registered = false`; `false` if `force_persist` is
+    /// engaged or no candidates were eligible. The hub-integrated
+    /// version owed by the caller (see module docs) is the place where
+    /// the actual `tryUnregisterService` IPC happens — this skeleton
+    /// only mutates internal state.
+    pub fn try_unregister(&self) -> bool {
+        if self.force_persist.load(Ordering::Acquire) {
+            return false;
+        }
+        let mut inner = self.inner.lock().expect("lazy_service inner poisoned");
+        let mut any_eligible = false;
+        for entry in inner.services.values_mut() {
+            if !entry.has_clients && entry.registered {
+                entry.registered = false;
+                any_eligible = true;
+            }
+        }
+        any_eligible
+    }
+
+    /// Re-register every previously-unregistered service. AOSP
+    /// [`LazyServiceRegistrar::reRegisterLocked`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=209).
+    /// The hub-integrated version replays `addService` +
+    /// `registerClientCallback`; this skeleton flips state only.
+    pub fn re_register(&self) {
+        let mut inner = self.inner.lock().expect("lazy_service inner poisoned");
+        for entry in inner.services.values_mut() {
+            if !entry.registered {
+                entry.registered = true;
+                // AOSP also resets `has_clients` to `true` defensively
+                // so the next `try_unregister` can't immediately unwind
+                // the re-registration without an explicit `onClients`
+                // notification.
+                entry.has_clients = true;
+            }
+        }
+    }
+
+    /// Snapshot helper: returns `(name, has_clients, registered)` for
+    /// every tracked service. Primarily for tests and introspection.
+    pub fn snapshot(&self) -> Vec<(String, bool, bool)> {
+        let inner = self.inner.lock().expect("lazy_service inner poisoned");
+        inner
+            .services
+            .values()
+            .map(|e| (e.name.clone(), e.has_clients, e.registered))
+            .collect()
+    }
+
+    /// Snapshot helper: how many services are currently `registered`.
+    pub fn registered_count(&self) -> usize {
+        let inner = self.inner.lock().expect("lazy_service inner poisoned");
+        inner.services.values().filter(|e| e.registered).count()
+    }
+
+    /// Snapshot helper: borrow the binder previously registered under
+    /// `name`. Used by the hub-integrated re-register path (future) to
+    /// pass the original `SIBinder` back into `addService`.
+    pub fn binder_for(&self, name: &str) -> Option<SIBinder> {
+        let inner = self.inner.lock().expect("lazy_service inner poisoned");
+        inner.services.get(name).map(|e| e.binder.clone())
+    }
+}
+
+impl Default for LazyServiceRegistrar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::binder::Stability;
+    use crate::native::Binder;
+    use crate::{Interface, Parcel, Remotable, Result as RsResult, TransactionCode};
+
+    struct Dummy;
+    impl Remotable for Dummy {
+        fn descriptor() -> &'static str {
+            "test.lazy_service.Dummy"
+        }
+        fn on_transact(&self, _: TransactionCode, _: &mut Parcel, _: &mut Parcel) -> RsResult<()> {
+            Ok(())
+        }
+        fn on_dump(&self, _: &mut dyn std::io::Write, _: &[String]) -> RsResult<()> {
+            Ok(())
+        }
+    }
+
+    fn fresh_binder() -> SIBinder {
+        let b = Binder::new_with_stability(Dummy, Stability::Local);
+        Interface::as_binder(&b)
+    }
+
+    /// `register_service` records the (name, binder) entry and marks it
+    /// registered.
+    #[test]
+    fn register_records_entry() {
+        let reg = LazyServiceRegistrar::new();
+        reg.register_service("foo", fresh_binder()).unwrap();
+        let snap = reg.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].0, "foo");
+        assert!(snap[0].2, "registered=true after register_service");
+        assert_eq!(reg.registered_count(), 1);
+    }
+
+    /// `try_unregister` flips `registered` to
+    /// false **only** for entries with `has_clients == false`. AOSP
+    /// `tryUnregisterLocked` eligibility predicate.
+    #[test]
+    fn try_unregister_only_flips_clientless_entries() {
+        let reg = LazyServiceRegistrar::new();
+        reg.register_service("a", fresh_binder()).unwrap();
+        reg.register_service("b", fresh_binder()).unwrap();
+        // `a` still has clients; `b` lost theirs.
+        reg.on_clients("b", false);
+        assert!(reg.try_unregister(), "any eligible -> true");
+        let snap = reg.snapshot();
+        let a = snap.iter().find(|(n, _, _)| n == "a").unwrap();
+        let b = snap.iter().find(|(n, _, _)| n == "b").unwrap();
+        assert!(a.2, "`a` still has clients, stays registered");
+        assert!(!b.2, "`b` clientless and unregistered");
+        assert_eq!(reg.registered_count(), 1);
+    }
+
+    /// `force_persist(true)` short-circuits `try_unregister`
+    /// even when eligible candidates exist. AOSP `mForcePersist`.
+    #[test]
+    fn force_persist_blocks_unregister() {
+        let reg = LazyServiceRegistrar::new();
+        reg.register_service("x", fresh_binder()).unwrap();
+        reg.on_clients("x", false);
+        reg.force_persist(true);
+        assert!(reg.is_force_persisted());
+        assert!(!reg.try_unregister(), "force_persist blocks");
+        let snap = reg.snapshot();
+        assert!(snap[0].2, "still registered");
+    }
+
+    /// `re_register` restores `registered = true`
+    /// and defensively resets `has_clients = true` so the next
+    /// `try_unregister` cannot immediately undo the re-registration
+    /// without a fresh `onClients(false)`.
+    #[test]
+    fn re_register_restores_state_and_resets_clients() {
+        let reg = LazyServiceRegistrar::new();
+        reg.register_service("z", fresh_binder()).unwrap();
+        reg.on_clients("z", false);
+        reg.try_unregister();
+        assert_eq!(reg.registered_count(), 0);
+        reg.re_register();
+        assert_eq!(reg.registered_count(), 1);
+        // `try_unregister` immediately after re_register must be a
+        // no-op (has_clients reset to true).
+        assert!(!reg.try_unregister());
+    }
+
+    /// `on_clients` for an unknown service name silently returns
+    /// `false` instead of aborting. AOSP `LOG_ALWAYS_FATAL_IF` on
+    /// unknown service is intentionally softened for rsbinder.
+    #[test]
+    fn on_clients_for_unknown_service_is_silent() {
+        let reg = LazyServiceRegistrar::new();
+        assert!(!reg.on_clients("nope", true));
+    }
+
+    /// Re-registering a name replaces the prior entry — AOSP
+    /// `mRegisteredServices` is name-keyed. The new binder's identity
+    /// is what subsequent `binder_for` lookups must return.
+    #[test]
+    fn register_same_name_replaces() {
+        let reg = LazyServiceRegistrar::new();
+        let first = fresh_binder();
+        let second = fresh_binder();
+        reg.register_service("dup", first.clone()).unwrap();
+        reg.register_service("dup", second.clone()).unwrap();
+        let got = reg.binder_for("dup").unwrap();
+        assert!(
+            std::sync::Arc::ptr_eq(got.as_arc(), second.as_arc()),
+            "second register_service wins"
+        );
+    }
+}

--- a/rsbinder/src/lib.rs
+++ b/rsbinder/src/lib.rs
@@ -143,6 +143,13 @@ pub mod binderfs;
 pub mod error;
 /// File descriptor wrapper for IPC
 pub mod file_descriptor;
+/// `LazyServiceRegistrar` skeleton (state machine +
+/// `IClientCallback::onClients` dispatch). AOSP
+/// `frameworks/native/libs/binder/LazyServiceRegistrar.cpp`. Hub
+/// integration (actual `registerClientCallback` / `tryUnregisterService`
+/// IPC) is owed by the caller until the hub plumbing lands — see the
+/// module docs.
+pub mod lazy_service;
 mod macros;
 /// Native service implementation helpers
 pub mod native;
@@ -155,7 +162,21 @@ pub mod parcelable_holder;
 mod process_state;
 /// Client proxy for remote services
 pub mod proxy;
+/// Process-global proxy count + watermark callbacks
+/// with opt-in per-uid tracking. AOSP `BpBinder` proxy-count surface
+/// (`getBinderProxyCount` / `setBinderProxyCountWatermarks` /
+/// `setBinderProxyCountEventCallback` / `enableCountByUid`).
+pub mod proxy_count;
 mod ref_counter;
+/// Shared-memory IPC trait skeleton
+/// (`IMemoryHeap` / `IMemory` / `MemoryHeapBase`). AOSP
+/// `frameworks/native/libs/binder/include/binder/IMemory.h`. A future
+/// `memfd_create(2)`-backed `MemoryHeapBase` impl on Linux/Android and
+/// a `MemoryDealer` chunk allocator are not yet implemented. macOS
+/// host build compiles the trait surface but `MemoryHeapBase::new`
+/// permanently returns `Err(StatusCode::InvalidOperation)` — see the
+/// module docs.
+pub mod shared_memory;
 /// Status and exception handling
 pub mod status;
 mod sys;
@@ -163,13 +184,17 @@ mod sys;
 pub mod thread_state;
 
 /// RPC transport (binder-over-socket) — a separate stack from the
-/// kernel binder path. Present only with the `rpc` feature. See
-/// `plan/2-rpc-transport.md`.
+/// kernel binder path. Present only with the `rpc` feature.
 #[cfg(feature = "rpc")]
 pub mod rpc;
 
 /// Service hub and manager implementations
 pub mod hub;
+
+/// Client stub for Android's `PermissionManagerService`
+/// (`android.os.IPermissionController`). See module doc for the
+/// AOSP-faithful surface and fail-closed `check_permission` helper.
+pub mod permission_controller;
 /// Async runtime implementations
 #[cfg(feature = "async")]
 mod rt;
@@ -184,11 +209,11 @@ pub use binder::{
     DeathRecipient, FromIBinder, IBinder, Interface, Remotable, RemoteProxy, SIBinder, Stability,
     Strong, ToAsyncInterface, ToSyncInterface, Transactable, TransactionCode, TransactionFlags,
     WIBinder, Weak, DEBUG_PID_TRANSACTION, DUMP_TRANSACTION, EXTENSION_TRANSACTION,
-    FIRST_CALL_TRANSACTION, FLAG_CLEAR_BUF, FLAG_ONEWAY, FLAG_PRIVATE_LOCAL, FLAG_PRIVATE_VENDOR,
-    INTERFACE_HEADER, INTERFACE_TRANSACTION, LAST_CALL_TRANSACTION, LIKE_TRANSACTION,
-    PING_TRANSACTION, SET_RPC_CLIENT_TRANSACTION, SHELL_COMMAND_TRANSACTION,
-    START_RECORDING_TRANSACTION, STOP_RECORDING_TRANSACTION, SYSPROPS_TRANSACTION,
-    TWEET_TRANSACTION,
+    FIRST_CALL_TRANSACTION, FLAG_CLEAR_BUF, FLAG_COLLECT_NOTED_APP_OPS, FLAG_ONEWAY,
+    FLAG_PRIVATE_LOCAL, FLAG_PRIVATE_VENDOR, FLAG_UPDATE_TXN, INTERFACE_HEADER,
+    INTERFACE_TRANSACTION, LAST_CALL_TRANSACTION, LIKE_TRANSACTION, PING_TRANSACTION,
+    SET_RPC_CLIENT_TRANSACTION, SHELL_COMMAND_TRANSACTION, START_RECORDING_TRANSACTION,
+    STOP_RECORDING_TRANSACTION, SYSPROPS_TRANSACTION, TWEET_TRANSACTION,
 };
 // `declare_binder_interface!` expands to `$crate::__rpc_stamp_descriptor(...)`
 // in consumer crates, so this helper must stay reachable at the crate root.
@@ -202,6 +227,16 @@ pub use file_descriptor::ParcelFileDescriptor;
 
 // From `native` — server-side binder construction.
 pub use native::{is_handling_transaction, Binder, BinderFeatures};
+
+// From `thread_state` — calling identity (AOSP
+// `IPCThreadState::getCalling*`). Kernel-path only; the RPC stack has
+// its own `PeerIdentity` model under `rpc::PeerIdentity`.
+pub use thread_state::{
+    clear_calling_identity, get_calling_pid, get_calling_sid, get_calling_uid,
+    get_current_scheduler_policy, get_extended_error, get_strict_mode_policy,
+    has_explicit_identity, restore_calling_identity, set_strict_mode_policy, CallingContext,
+    ExtendedError,
+};
 
 pub use parcel::Parcel;
 

--- a/rsbinder/src/macros.rs
+++ b/rsbinder/src/macros.rs
@@ -365,15 +365,14 @@ macro_rules! declare_binder_interface {
             }
 
             fn from_binder(binder: $crate::SIBinder) -> std::option::Option<Self> {
-                // Subplan 2-6.B: an `RpcProxy` resolved from the RPC
-                // wire carries no descriptor (the wire transmits only
-                // an address). Stamp this stub's descriptor onto the
-                // *cached* proxy in place — never a new proxy (that
-                // doubles the DEC_STRONG and splits the dedup cache,
-                // AC-2.5/P5). Done before the descriptor check so it
-                // then passes for RPC too. The shim is gated inside
-                // rsbinder (no-op without `rpc`), so the kernel path
-                // and `rpc`-off builds are byte-unaffected (V1).
+                // An `RpcProxy` resolved from the RPC wire carries no
+                // descriptor (the wire transmits only an address). Stamp
+                // this stub's descriptor onto the *cached* proxy in
+                // place — never a new proxy (that doubles the DEC_STRONG
+                // and splits the dedup cache). Done before the descriptor
+                // check so it then passes for RPC too. The shim is gated
+                // inside rsbinder (no-op without `rpc`), so the kernel
+                // path and `rpc`-off builds are byte-unaffected.
                 $crate::__rpc_stamp_descriptor(&binder, $descriptor);
                 // NOTE (RPC type-safety asymmetry): for a kernel
                 // `ProxyHandle` the check below validates the *remote's*

--- a/rsbinder/src/native.rs
+++ b/rsbinder/src/native.rs
@@ -23,13 +23,15 @@
 //! on the server side, including the `Binder` wrapper for native service objects
 //! and transaction handling utilities.
 
-use std::any::Any;
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fs::File;
 use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
 use std::os::fd::FromRawFd;
-use std::sync::{Arc, RwLock, Weak};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::{Arc, Mutex, RwLock, Weak};
 
 use crate::{
     binder::*, error::*, parcel::*, parcelable::SerializeOption, ref_counter::RefCounter,
@@ -70,6 +72,45 @@ pub struct BinderFeatures {
     /// serialize `secctx`), so opt in only on services that perform
     /// SELinux-domain-based authorization.
     pub set_requesting_sid: bool,
+
+    /// Advertise a minimum scheduler policy on the
+    /// binder node. Must be one of `SCHED_NORMAL`/`SCHED_BATCH` (low /
+    /// best-effort) or `SCHED_FIFO`/`SCHED_RR` (real-time); kernel
+    /// `binder.c::binder_priority_to_native` clamps anything else.
+    /// Pair with [`Self::min_priority`] — both fields are encoded into
+    /// `flat_binder_object.flags` so the driver can lift an incoming
+    /// transaction's worker thread to the requested floor before
+    /// running the handler.
+    ///
+    /// Default: `None` (kernel keeps the caller's policy). Setting this
+    /// without `inherit_rt = true` on a real-time policy is undefined —
+    /// see [`Self::inherit_rt`] for the canonical RT escalation gate.
+    pub min_sched_policy: Option<i32>,
+
+    /// Minimum priority within the policy declared
+    /// by [`Self::min_sched_policy`]. For SCHED_FIFO/SCHED_RR this is
+    /// the kernel RT priority (`1..=99`); for SCHED_NORMAL/BATCH it is
+    /// a nice-bias value. Only the low 8 bits are used (mask
+    /// `FLAT_BINDER_FLAG_PRIORITY_MASK = 0xff`); higher bits are masked
+    /// off at encode time, so a value outside the expected range is
+    /// silently truncated — the kernel will then interpret whatever low
+    /// 8 bits remain, which may not be the priority the caller
+    /// intended. Callers should validate against the policy's allowed
+    /// range before constructing `BinderFeatures` (AOSP
+    /// `BBinder::setMinSchedulerPolicy` aborts on out-of-range input).
+    pub min_priority: Option<i32>,
+
+    /// Set the kernel
+    /// `FLAT_BINDER_FLAG_INHERIT_RT` bit (`0x800`). When `true` and the
+    /// caller is running under SCHED_FIFO/SCHED_RR, the binder driver
+    /// lifts the worker thread to the *caller's* RT priority for the
+    /// transaction duration. Required for audio/camera HAL latency
+    /// guarantees.
+    ///
+    /// Default: `false`. The setting only takes effect if `min_sched_policy`
+    /// declares an RT policy, otherwise the kernel falls back to the
+    /// caller's normal policy.
+    pub inherit_rt: bool,
 }
 
 impl BinderFeatures {
@@ -77,25 +118,120 @@ impl BinderFeatures {
     /// bitfield. `FLAT_BINDER_FLAG_ACCEPTS_FDS` is always set —
     /// rsbinder unconditionally accepts file descriptors in its
     /// native binder protocol implementation.
+    ///
+    /// Bit layout (cross-checked against
+    /// `kernel/include/uapi/linux/android/binder.h`):
+    ///
+    /// ```text
+    /// bit 0-7   (0xff):   FLAT_BINDER_FLAG_PRIORITY_MASK
+    /// bit 8     (0x100):  FLAT_BINDER_FLAG_ACCEPTS_FDS
+    /// bit 9-10  (0x600):  scheduler policy (SHIFT = 9, VALUE_MASK = 0x3)
+    /// bit 11    (0x800):  FLAT_BINDER_FLAG_INHERIT_RT
+    /// bit 12    (0x1000): FLAT_BINDER_FLAG_TXN_SECURITY_CTX
+    /// ```
     pub(crate) fn flat_flags(self) -> u32 {
         let mut f = crate::sys::FLAT_BINDER_FLAG_ACCEPTS_FDS;
         if self.set_requesting_sid {
             f |= crate::sys::FLAT_BINDER_FLAG_TXN_SECURITY_CTX;
         }
+        if let Some(priority) = self.min_priority {
+            f |= (priority as u32) & crate::sys::FLAT_BINDER_FLAG_PRIORITY_MASK;
+        }
+        if let Some(policy) = self.min_sched_policy {
+            // Only the low 2 bits of policy live in the flat field —
+            // higher bits are kernel-internal and would corrupt the
+            // adjacent INHERIT_RT bit.
+            f |= ((policy as u32) & 0x3) << 9;
+        }
+        if self.inherit_rt {
+            f |= crate::sys::FLAT_BINDER_FLAG_INHERIT_RT;
+        }
         f
+    }
+}
+
+/// Compact tag for [`Stability`] used by [`Inner`]'s atomic field.
+///
+/// Runtime stability mutation needs interior-mutable storage; an
+/// `AtomicU8` with a 4-value tag is cheaper than locking around the
+/// `Stability` field and keeps reads on the wire-emit hot path lock-free.
+const STABILITY_TAG_LOCAL: u8 = 0;
+const STABILITY_TAG_VENDOR: u8 = 1;
+const STABILITY_TAG_SYSTEM: u8 = 2;
+const STABILITY_TAG_VINTF: u8 = 3;
+
+fn stability_to_tag(s: Stability) -> u8 {
+    match s {
+        Stability::Local => STABILITY_TAG_LOCAL,
+        Stability::Vendor => STABILITY_TAG_VENDOR,
+        Stability::System => STABILITY_TAG_SYSTEM,
+        Stability::Vintf => STABILITY_TAG_VINTF,
+    }
+}
+
+fn stability_from_tag(tag: u8) -> Stability {
+    match tag {
+        STABILITY_TAG_LOCAL => Stability::Local,
+        STABILITY_TAG_VENDOR => Stability::Vendor,
+        STABILITY_TAG_SYSTEM => Stability::System,
+        STABILITY_TAG_VINTF => Stability::Vintf,
+        // The only producer is `stability_to_tag`, which emits 0..=3;
+        // a different value implies a corrupt `AtomicU8` load. Wire
+        // stability is binder-protocol-critical, so abort rather than
+        // silently fall through to `System` and emit a mis-stamped
+        // `flat_binder_object`.
+        other => unreachable!("invalid stability tag {other}: only 0..=3 are stored"),
     }
 }
 
 struct Inner<T: Remotable + Send + Sync> {
     remotable: T,
-    stability: Stability,
+    /// `AtomicU8` storing a [`Stability`] tag (see `STABILITY_TAG_*`).
+    /// Atomic so [`Self::force_downgrade_to_system_stability`] and friends
+    /// can mutate at runtime without blocking concurrent reads from the
+    /// `flat_binder_object` emit path. Default `Relaxed` ordering is
+    /// sufficient because the [`Self::parceled`] guard (Acquire/Release)
+    /// provides the only correctness-relevant happens-before.
+    stability: AtomicU8,
+    /// AOSP `BBinder::mParceled` equivalent. Flipped to
+    /// `true` the first time this binder is written to a parcel, after
+    /// which the runtime stability setters refuse mutation (matches the
+    /// `LOG_ALWAYS_FATAL_IF(mParceled, ...)` guards in
+    /// [`Binder.cpp:579,606,659,678,713`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/Binder.cpp;l=579)).
+    parceled: AtomicBool,
     binder_flags: u32,
     strong: RefCounter,
     weak: RefCounter,
     extension: RwLock<Option<SIBinder>>,
+    /// Typed object attach/find/detach store. Empty
+    /// `HashMap` on construction (no allocation until first
+    /// `attach_object`), so the per-binder cost is just the unlocked
+    /// `Mutex` header + empty `HashMap` header (~56 bytes on 64-bit).
+    ///
+    /// AOSP `BBinder::Extras::mObjectMgr` (Binder.cpp:523) keyed by
+    /// `const void*` identity; rsbinder keys by `TypeId` to sidestep
+    /// the LLVM provenance / ABA hazard of raw pointer identity.
+    /// Trade-off: one attached object per Rust type per
+    /// binder. Callers that need multiple attachments of the same
+    /// concrete type should wrap them in distinct newtype shells.
+    objects: Mutex<HashMap<TypeId, Arc<dyn Any + Send + Sync>>>,
 }
 
 impl<T: Remotable> Inner<T> {
+    /// Gated stability mutation. Refuses if the binder
+    /// has already been written to a parcel ([`Self::parceled`] is `true`),
+    /// matching the `LOG_ALWAYS_FATAL_IF(mParceled, ...)` guard pattern in
+    /// AOSP [`Binder.cpp`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/Binder.cpp;l=579)
+    /// (rsbinder returns `Err(InvalidOperation)` rather than aborting).
+    fn set_stability_guarded(&self, level: Stability) -> Result<()> {
+        if self.parceled.load(Ordering::Acquire) {
+            return Err(StatusCode::InvalidOperation);
+        }
+        self.stability
+            .store(stability_to_tag(level), Ordering::Relaxed);
+        Ok(())
+    }
+
     // The following functions can be redefined depending on the service.
     fn on_transact(
         &self,
@@ -176,11 +312,31 @@ impl<T: 'static + Remotable> IBinder for Inner<T> {
     }
 
     fn stability(&self) -> Stability {
-        self.stability
+        stability_from_tag(self.stability.load(Ordering::Relaxed))
     }
 
     fn local_binder_flags(&self) -> u32 {
         self.binder_flags
+    }
+
+    fn force_downgrade_to_system_stability(&self) -> Result<()> {
+        self.set_stability_guarded(Stability::System)
+    }
+
+    fn force_downgrade_to_vendor_stability(&self) -> Result<()> {
+        self.set_stability_guarded(Stability::Vendor)
+    }
+
+    fn mark_vintf(&self) -> Result<()> {
+        self.set_stability_guarded(Stability::Vintf)
+    }
+
+    fn was_parceled(&self) -> bool {
+        self.parceled.load(Ordering::Acquire)
+    }
+
+    fn set_parceled(&self) {
+        self.parceled.store(true, Ordering::Release);
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -191,7 +347,7 @@ impl<T: 'static + Remotable> IBinder for Inner<T> {
         Some(self)
     }
 
-    /// RPC server dispatch (2-2.d2-SRV / AC-2.12). Mirrors the code
+    /// RPC server dispatch. Mirrors the code
     /// dispatch of `Inner::transact` **minus** the kernel
     /// `check_interface` call and minus the `reader.set_data_position(0)`
     /// reset — the RPC adapter has already consumed + validated the RPC
@@ -375,13 +531,64 @@ impl<T: 'static + Remotable> Binder<T> {
         Binder::<T> {
             inner: Arc::new(Inner {
                 remotable,
-                stability,
+                stability: AtomicU8::new(stability_to_tag(stability)),
+                parceled: AtomicBool::new(false),
                 binder_flags: features.flat_flags(),
                 strong: Default::default(),
                 weak: Default::default(),
                 extension: RwLock::new(None),
+                objects: Mutex::new(HashMap::new()),
             }),
         }
+    }
+
+    /// Attach a typed object to this binder.
+    ///
+    /// AOSP `BBinder::attachObject(objectID, object, cleanupCookie, func)`
+    /// ([Binder.cpp:523](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/Binder.cpp;l=523))
+    /// equivalent, with two intentional deviations from the C++ surface:
+    ///
+    /// 1. **Key by [`std::any::TypeId`], not raw pointer.** AOSP keys
+    ///    by `const void*` address identity, which trips the LLVM
+    ///    provenance / ABA hazard when the address is reused after
+    ///    free. Keying by `TypeId` is safe at the cost of "one
+    ///    attachment per Rust type"; callers needing multiple should
+    ///    wrap distinct newtypes.
+    /// 2. **No cleanup callback.** `Arc<O>` drop runs on `detach_object`
+    ///    or `Binder` drop, replacing AOSP's `object_cleanup_func`.
+    ///
+    /// Returns the previously-attached object of the same type (if any),
+    /// matching AOSP's "return old, new entry replaces" contract.
+    pub fn attach_object<O: Any + Send + Sync>(
+        &self,
+        object: Arc<O>,
+    ) -> Option<Arc<dyn Any + Send + Sync>> {
+        let mut map = self.inner.objects.lock().expect("objects lock poisoned");
+        map.insert(TypeId::of::<O>(), object)
+    }
+
+    /// Find a previously attached object of type `O`.
+    /// AOSP [`BBinder::findObject`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/Binder.cpp;l=532)
+    /// equivalent. Returns `None` iff no object of this type is attached;
+    /// downcast back to `O` cannot fail because the entry was keyed by
+    /// `TypeId::of::<O>()` at insertion.
+    pub fn find_object<O: Any + Send + Sync>(&self) -> Option<Arc<O>> {
+        let map = self.inner.objects.lock().expect("objects lock poisoned");
+        map.get(&TypeId::of::<O>()).cloned().map(|arc| {
+            arc.downcast::<O>()
+                .expect("TypeId-keyed entry must downcast back to its insertion type")
+        })
+    }
+
+    /// Remove and return the attached object of type
+    /// `O`. AOSP [`BBinder::detachObject`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/Binder.cpp;l=541)
+    /// equivalent.
+    pub fn detach_object<O: Any + Send + Sync>(&self) -> Option<Arc<O>> {
+        let mut map = self.inner.objects.lock().expect("objects lock poisoned");
+        map.remove(&TypeId::of::<O>()).map(|arc| {
+            arc.downcast::<O>()
+                .expect("TypeId-keyed entry must downcast back to its insertion type")
+        })
     }
 }
 
@@ -519,5 +726,329 @@ mod feature_flags_tests {
         let flags = b.inner.local_binder_flags();
         assert_ne!(flags & FLAT_BINDER_FLAG_TXN_SECURITY_CTX, 0);
         assert_ne!(flags & FLAT_BINDER_FLAG_ACCEPTS_FDS, 0);
+    }
+
+    // BinderFeatures sched policy / priority / inherit_rt encoding into
+    // flat_binder_object.flags.
+
+    use crate::sys::{
+        FLAT_BINDER_FLAG_INHERIT_RT, FLAT_BINDER_FLAG_PRIORITY_MASK,
+        FLAT_BINDER_FLAG_SCHED_POLICY_MASK,
+    };
+
+    /// The AOSP constant must exist at its kernel-defined value (`0x800`).
+    #[test]
+    fn flat_binder_flag_inherit_rt_matches_kernel_uapi() {
+        assert_eq!(FLAT_BINDER_FLAG_INHERIT_RT, 0x800);
+    }
+
+    /// The post-shift named mask (`0x600`) is what AOSP libbinder uses.
+    #[test]
+    fn flat_binder_flag_sched_policy_mask_matches_kernel_uapi() {
+        assert_eq!(FLAT_BINDER_FLAG_SCHED_POLICY_MASK, 0x600);
+    }
+
+    /// The default `BinderFeatures` (no RT opt-ins) must produce flat-flags
+    /// with RT bit, SCHED_POLICY bits, and priority bits all unset.
+    #[test]
+    fn default_features_zero_rt_bits() {
+        let b = Binder::new(DummyRemotable);
+        let flags = b.inner.local_binder_flags();
+        assert_eq!(flags & FLAT_BINDER_FLAG_INHERIT_RT, 0);
+        assert_eq!(flags & FLAT_BINDER_FLAG_SCHED_POLICY_MASK, 0);
+        assert_eq!(flags & FLAT_BINDER_FLAG_PRIORITY_MASK, 0);
+    }
+
+    /// Setting an RT policy + priority must produce the exact
+    /// AOSP bit pattern — priority in bits 0-7, policy << 9 in bits
+    /// 9-10. We pick `SCHED_FIFO = 1` and priority `42` so the result
+    /// is unambiguous: `0x100 << 1 | 42 = 0x22A | ACCEPTS_FDS`.
+    #[test]
+    fn rt_policy_and_priority_encoded_in_canonical_bit_positions() {
+        let features = BinderFeatures {
+            min_sched_policy: Some(1), // SCHED_FIFO
+            min_priority: Some(42),
+            ..Default::default()
+        };
+        let b = Binder::new_with_features(DummyRemotable, features);
+        let flags = b.inner.local_binder_flags();
+        assert_eq!(flags & FLAT_BINDER_FLAG_PRIORITY_MASK, 42);
+        assert_eq!(flags & FLAT_BINDER_FLAG_SCHED_POLICY_MASK, 1 << 9);
+        // INHERIT_RT remains off — caller did not opt in.
+        assert_eq!(flags & FLAT_BINDER_FLAG_INHERIT_RT, 0);
+    }
+
+    /// `inherit_rt = true` independently flips bit 11 and
+    /// composes with the other RT fields without overlap.
+    #[test]
+    fn inherit_rt_sets_bit_11_independently_of_policy_field() {
+        let features = BinderFeatures {
+            inherit_rt: true,
+            min_sched_policy: Some(2), // SCHED_RR
+            min_priority: Some(99),
+            ..Default::default()
+        };
+        let b = Binder::new_with_features(DummyRemotable, features);
+        let flags = b.inner.local_binder_flags();
+        assert_eq!(flags & FLAT_BINDER_FLAG_INHERIT_RT, 0x800);
+        assert_eq!(flags & FLAT_BINDER_FLAG_SCHED_POLICY_MASK, 2 << 9);
+        assert_eq!(flags & FLAT_BINDER_FLAG_PRIORITY_MASK, 99);
+        // Bits are non-overlapping — confirms the layout AC.
+        assert_eq!(0x800 & (2u32 << 9), 0);
+        assert_eq!(0x800 & 99, 0);
+        assert_eq!((2u32 << 9) & 99, 0);
+    }
+
+    /// Priority values larger than 8 bits must be masked
+    /// (silently dropped) so they cannot bleed into the adjacent
+    /// SCHED_POLICY field — a wire-corruption regression that would
+    /// reroute every transaction to a different scheduler class.
+    #[test]
+    fn out_of_range_priority_is_masked_to_low_byte() {
+        let features = BinderFeatures {
+            min_priority: Some(0x1234), // bits above 8 must be discarded
+            ..Default::default()
+        };
+        let flags = features.flat_flags();
+        assert_eq!(flags & FLAT_BINDER_FLAG_PRIORITY_MASK, 0x34);
+        // SCHED_POLICY untouched (no policy set, no bleed from the 0x12).
+        assert_eq!(flags & FLAT_BINDER_FLAG_SCHED_POLICY_MASK, 0);
+    }
+
+    /// Scheduler policy values larger than 2 bits must be
+    /// masked so they cannot bleed into bit 11 (INHERIT_RT) or higher.
+    #[test]
+    fn out_of_range_policy_is_masked_to_two_bits() {
+        let features = BinderFeatures {
+            min_sched_policy: Some(0xFF), // would set bits 9..16 unchecked
+            ..Default::default()
+        };
+        let flags = features.flat_flags();
+        // Only bits 9-10 (mask 0x600) should be touched; bit 11 must
+        // not leak.
+        assert_eq!(flags & FLAT_BINDER_FLAG_SCHED_POLICY_MASK, 0x600);
+        assert_eq!(flags & FLAT_BINDER_FLAG_INHERIT_RT, 0);
+    }
+}
+
+/// Runtime stability mutation API tests.
+///
+/// AOSP equivalents: `Stability::forceDowngradeToSystemStability` (Stability.cpp:41),
+/// `Stability::forceDowngradeToVendorStability` (:45), `Stability::markVintf` (:54),
+/// `BBinder::setParceled` (Binder.cpp:725) parceled-guard.
+#[cfg(test)]
+mod stability_mutation_tests {
+    use super::*;
+
+    struct DummyRemotable;
+    impl crate::Remotable for DummyRemotable {
+        fn descriptor() -> &'static str
+        where
+            Self: Sized,
+        {
+            "test.stability_mutation"
+        }
+        fn on_transact(
+            &self,
+            _: crate::TransactionCode,
+            _: &mut crate::Parcel,
+            _: &mut crate::Parcel,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+        fn on_dump(&self, _: &mut dyn std::io::Write, _: &[String]) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Default-constructed binder reports `System`
+    /// stability and `was_parceled == false`.
+    #[test]
+    fn default_binder_is_system_and_not_parceled() {
+        let b = Binder::new(DummyRemotable);
+        assert_eq!(b.inner.stability(), Stability::System);
+        assert!(!b.inner.was_parceled());
+    }
+
+    /// `mark_vintf` upgrades `System` to `Vintf` and the
+    /// canonical wire bits (`0b111111`) follow.
+    #[test]
+    fn mark_vintf_upgrades_to_vintf() {
+        let b = Binder::new(DummyRemotable);
+        b.inner.mark_vintf().expect("not parceled yet");
+        assert_eq!(b.inner.stability(), Stability::Vintf);
+        let wire: i32 = b.inner.stability().into();
+        // Bottom 6 bits are the level; higher bits may carry the
+        // Android-12 `0x0c000000` overlay on a real Android target —
+        // mask before comparing so the host-tree hermetic test stays
+        // build-independent.
+        assert_eq!(wire & 0xFF, 0b111111);
+    }
+
+    /// `force_downgrade_to_vendor_stability` flips the
+    /// declared level to `Vendor`, independent of starting level.
+    #[test]
+    fn force_downgrade_to_vendor_works_from_system() {
+        let b = Binder::new(DummyRemotable);
+        b.inner
+            .force_downgrade_to_vendor_stability()
+            .expect("not parceled yet");
+        assert_eq!(b.inner.stability(), Stability::Vendor);
+    }
+
+    /// Vintf → System round-trips, matching AOSP
+    /// `forceDowngradeToStability(binder, SYSTEM)`.
+    #[test]
+    fn vintf_then_force_downgrade_to_system() {
+        let b = Binder::new(DummyRemotable);
+        b.inner.mark_vintf().unwrap();
+        b.inner.force_downgrade_to_system_stability().unwrap();
+        assert_eq!(b.inner.stability(), Stability::System);
+    }
+
+    /// Parceled guard: once `set_parceled()` has fired, all
+    /// three mutation entry points refuse with `InvalidOperation`.
+    /// Mirrors AOSP `LOG_ALWAYS_FATAL_IF(mParceled, ...)` (rsbinder
+    /// returns an error rather than aborting, so it composes with the
+    /// `Result`-based AIDL surface).
+    #[test]
+    fn parceled_guard_blocks_all_setters() {
+        let b = Binder::new(DummyRemotable);
+        b.inner.set_parceled();
+        assert!(b.inner.was_parceled());
+        assert_eq!(
+            b.inner.mark_vintf().unwrap_err(),
+            StatusCode::InvalidOperation
+        );
+        assert_eq!(
+            b.inner.force_downgrade_to_system_stability().unwrap_err(),
+            StatusCode::InvalidOperation
+        );
+        assert_eq!(
+            b.inner.force_downgrade_to_vendor_stability().unwrap_err(),
+            StatusCode::InvalidOperation
+        );
+        // Stability must remain at construction-time level — the
+        // failing setter must not partially update.
+        assert_eq!(b.inner.stability(), Stability::System);
+    }
+
+    /// Same setters routed through `SIBinder` (the public
+    /// API surface most callers hold).
+    #[test]
+    fn sibinder_delegation_path_round_trips() {
+        let b = Binder::new(DummyRemotable);
+        let si = crate::Interface::as_binder(&b);
+        assert_eq!(si.stability(), Stability::System);
+        si.mark_vintf().unwrap();
+        assert_eq!(si.stability(), Stability::Vintf);
+        si.force_downgrade_to_vendor_stability().unwrap();
+        assert_eq!(si.stability(), Stability::Vendor);
+        assert!(!si.was_parceled());
+    }
+
+    /// Explicit `Stability::Vintf` construction should match
+    /// what `mark_vintf` would set, and remain mutable until parceled.
+    #[test]
+    fn explicit_vintf_construction_is_observable_and_mutable() {
+        let b = Binder::new_with_stability(DummyRemotable, Stability::Vintf);
+        assert_eq!(b.inner.stability(), Stability::Vintf);
+        b.inner.force_downgrade_to_system_stability().unwrap();
+        assert_eq!(b.inner.stability(), Stability::System);
+    }
+
+    /// Round-trip a typed object through
+    /// `attach_object`/`find_object`/`detach_object`. Equivalent to
+    /// AOSP `BBinder::attachObject` insert + `findObject` lookup +
+    /// `detachObject` removal.
+    #[test]
+    fn attach_find_detach_round_trip() {
+        let b = Binder::new(DummyRemotable);
+        #[derive(Debug, PartialEq)]
+        struct Side(u32);
+        assert!(b.find_object::<Side>().is_none());
+        assert!(b.attach_object(Arc::new(Side(42))).is_none());
+        let found = b.find_object::<Side>().expect("attached then found");
+        assert_eq!(found.0, 42);
+        let detached = b.detach_object::<Side>().expect("detached returns");
+        assert_eq!(detached.0, 42);
+        assert!(b.find_object::<Side>().is_none(), "detach removes entry");
+    }
+
+    /// Re-attaching the same type returns the
+    /// previously-stored value, matching AOSP's "old replaced by new"
+    /// contract (Binder.cpp:523-531).
+    #[test]
+    fn attach_object_replaces_returns_old() {
+        let b = Binder::new(DummyRemotable);
+        struct Side(u32);
+        assert!(b.attach_object(Arc::new(Side(1))).is_none());
+        let prev = b
+            .attach_object(Arc::new(Side(2)))
+            .expect("second attach returns old");
+        // Downcast for inspection.
+        let old: Arc<Side> = prev.downcast::<Side>().expect("type preserved");
+        assert_eq!(old.0, 1);
+        assert_eq!(b.find_object::<Side>().unwrap().0, 2);
+    }
+
+    /// Distinct Rust types coexist independently
+    /// under the TypeId-keyed map.
+    #[test]
+    fn distinct_types_do_not_collide() {
+        let b = Binder::new(DummyRemotable);
+        struct A(u32);
+        struct B(&'static str);
+        b.attach_object(Arc::new(A(7)));
+        b.attach_object(Arc::new(B("hi")));
+        assert_eq!(b.find_object::<A>().unwrap().0, 7);
+        assert_eq!(b.find_object::<B>().unwrap().0, "hi");
+        assert!(b.detach_object::<A>().is_some());
+        assert!(b.find_object::<A>().is_none());
+        assert!(b.find_object::<B>().is_some(), "B still attached");
+    }
+
+    /// `Binder` drop releases attached object
+    /// references. Verified via `Arc::strong_count`: after `Binder`
+    /// drops, the external `Arc` should be the only strong ref.
+    #[test]
+    fn binder_drop_releases_attached_objects() {
+        struct Probe(#[allow(dead_code)] u32);
+        let probe = Arc::new(Probe(99));
+        assert_eq!(Arc::strong_count(&probe), 1);
+        {
+            let b = Binder::new(DummyRemotable);
+            b.attach_object(probe.clone());
+            assert_eq!(Arc::strong_count(&probe), 2);
+        }
+        assert_eq!(
+            Arc::strong_count(&probe),
+            1,
+            "binder drop must release attached arc"
+        );
+    }
+
+    /// Emit-site simulation. The serializer invokes
+    /// `binder.set_parceled()` on `&SIBinder` after writing the
+    /// `flat_binder_object` + stability int32; this test simulates
+    /// that exact dispatch (deref `SIBinder` → `dyn IBinder` →
+    /// `Inner<T>::set_parceled`) without pulling in `ProcessState`,
+    /// which is not initializable in a host-tree hermetic test.
+    #[test]
+    fn sibinder_set_parceled_via_trait_dispatch_flips_guard() {
+        let b = Binder::new(DummyRemotable);
+        let si = crate::Interface::as_binder(&b);
+        assert!(!si.was_parceled());
+
+        // Exactly what `parcelable::SerializeOption::serialize_option`
+        // does after the wire write (parcelable.rs:484).
+        si.set_parceled();
+
+        assert!(si.was_parceled());
+        assert_eq!(
+            si.mark_vintf().unwrap_err(),
+            StatusCode::InvalidOperation,
+            "mutation after parceled-flip must fail"
+        );
     }
 }

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -242,14 +242,13 @@ pub type FnFreeBuffer =
     fn(Option<&Parcel>, binder_uintptr_t, usize, binder_uintptr_t, usize) -> Result<()>;
 
 /// RPC object-marshalling hooks attached to an RPC-mode `Parcel`
-/// (subplan 2-2, the rsbinder equivalent of android's
-/// `Parcel::mSession`/`RpcState`).
+/// (the rsbinder equivalent of android's `Parcel::mSession`/`RpcState`).
 ///
 /// `parcel.rs` only knows this trait; the implementation lives in the
 /// `rpc` module's session/state. When a `Parcel` is in RPC mode the
 /// `SIBinder` (de)serializers route through these hooks instead of the
 /// kernel `flat_binder_object` path — the kernel path is byte-identical
-/// when `is_for_rpc == false` (AC-2.9).
+/// when `is_for_rpc == false`.
 #[cfg(feature = "rpc")]
 pub trait RpcParcelOps: Send + Sync {
     /// Marshal a possibly-null binder leaving this process: append the
@@ -277,8 +276,8 @@ pub struct Parcel {
     request_header_present: bool,
     work_source_request_header_pos: usize,
     free_buffer: Option<FnFreeBuffer>,
-    /// RPC serialization mode (subplan 2-2). Default `false` == kernel
-    /// path, byte-identical to before (AC-2.9). Only object marshalling
+    /// RPC serialization mode. Default `false` == kernel
+    /// path, byte-identical to the kernel wire. Only object marshalling
     /// and the object/FD lifetime branch on this; scalar/string/POD
     /// paths are unaffected.
     #[cfg(feature = "rpc")]
@@ -288,8 +287,8 @@ pub struct Parcel {
     /// binders.
     #[cfg(feature = "rpc")]
     rpc_ops: Option<std::sync::Arc<dyn RpcParcelOps>>,
-    /// Negotiated FD-over-RPC mode (subplan 2-7). Default `None` ⇒ the
-    /// 2-2 reject, bit-identical (AC-7.1).
+    /// Negotiated FD-over-RPC mode. Default `None` ⇒ FD writes are
+    /// rejected, bit-identical to a parcel that carries no FDs.
     #[cfg(feature = "rpc")]
     rpc_fd_mode: crate::rpc::FileDescriptorTransportMode,
     /// FDs collected while serializing this (outgoing) RPC parcel in
@@ -304,17 +303,17 @@ pub struct Parcel {
     /// flattened RPC objects (binder at android-16 v2, FD at v1+),
     /// produced by `write_binder` / FD-write while serializing an
     /// RPC-mode parcel and consumed by the wire codec as the trailing
-    /// `u32[]` object table (subplan 2-8). **Always empty unless
-    /// `is_for_rpc`** — the kernel path never touches it (P1, AC-2.9):
+    /// `u32[]` object table. **Always empty unless
+    /// `is_for_rpc`** — the kernel path never touches it:
     /// kernel objects live in [`Parcel::objects`], a wholly separate
-    /// field. Empty ⇒ byte-identical to the pre-2-8 wire.
+    /// field. Empty ⇒ byte-identical to a wire with no object table.
     #[cfg(feature = "rpc")]
     rpc_object_positions: Vec<u32>,
     /// Whether an FD flattened into this parcel records its position
-    /// in [`Parcel::rpc_object_positions`] (subplan 2-8 Phase B). The
+    /// in [`Parcel::rpc_object_positions`]. The
     /// session sets this from its wire profile alongside the FD mode:
     /// `true` only on the android-13+ v1+ profile (R34 has no object
-    /// table — keeps the 2-7 FD-over-RPC wire byte-unchanged). Binder
+    /// table). Binder
     /// positions are recorded by the session directly (it owns the
     /// profile); only the FD path needs this Parcel-side flag.
     #[cfg(feature = "rpc")]
@@ -447,7 +446,7 @@ impl Parcel {
     }
 
     /// Switch this parcel between the kernel and RPC serialization
-    /// modes (subplan 2-2 / §7-3). Default is kernel mode; only object
+    /// modes. Default is kernel mode; only object
     /// marshalling and the object/FD lifetime branch on this — scalar,
     /// string and POD bytes are identical in both modes.
     #[cfg(feature = "rpc")]
@@ -481,12 +480,12 @@ impl Parcel {
         self.data.as_slice()
     }
 
-    // ---- subplan 2-8: RPC object table (android-16 v2) -------------
+    // ---- RPC object table (android-16 v2) --------------------------
 
     /// The sorted object-position table (AOSP `mObjectPositions`),
     /// consumed by the wire codec as a trailing `u32[]`. Always empty
     /// on the kernel path (`!is_for_rpc`) and when no RPC object was
-    /// flattened — i.e. byte-identical to the pre-2-8 wire.
+    /// flattened — i.e. byte-identical to a wire with no object table.
     #[cfg(feature = "rpc")]
     pub(crate) fn rpc_object_positions(&self) -> &[u32] {
         &self.rpc_object_positions
@@ -494,8 +493,8 @@ impl Parcel {
 
     /// Install the object table that arrived with an incoming RPC
     /// parcel (AOSP `rpcSetDataReference`'s `mObjectPositions` copy),
-    /// so the binder/FD deserializers can validate object positions
-    /// (subplan 2-8 Phase C). No-op kernel-side (`!is_for_rpc`).
+    /// so the binder/FD deserializers can validate object positions.
+    /// No-op kernel-side (`!is_for_rpc`).
     #[cfg(feature = "rpc")]
     pub(crate) fn rpc_set_object_positions(&mut self, positions: Vec<u32>) {
         if !self.is_for_rpc {
@@ -506,10 +505,9 @@ impl Parcel {
 
     /// AOSP `Parcel::unflattenBinder` v2 strict check: a binder may
     /// only be read from a position that is in the object table
-    /// (`std::binary_search(mObjectPositions, objectPos)`; subplan
-    /// 2-8 Phase C / AC-8.7). The table arrives sorted from a
-    /// conformant peer; an unsorted/forged table simply fails the
-    /// search ⇒ the caller returns `BAD_VALUE` (safe).
+    /// (`std::binary_search(mObjectPositions, objectPos)`). The table
+    /// arrives sorted from a conformant peer; an unsorted/forged table
+    /// simply fails the search ⇒ the caller returns `BAD_VALUE` (safe).
     #[cfg(feature = "rpc")]
     pub(crate) fn rpc_object_position_present(&self, pos: usize) -> bool {
         let Ok(pos) = u32::try_from(pos) else {
@@ -524,11 +522,11 @@ impl Parcel {
     /// `mObjectPositions.insert(upper_bound(...), dataPos)`).
     ///
     /// **Hard-gated on `is_for_rpc`**: a stray call on a kernel parcel
-    /// is a no-op, so the kernel wire (P1, AC-2.9) can never grow an
-    /// object table. The producer (subplan 2-8 Phase B) only calls
-    /// this from the RPC `write_binder` / FD-write paths, and the
-    /// caller decides *whether* to record (binder ⇒ v2 only; FD ⇒
-    /// v1+), faithfully mirroring AOSP's per-call version gate.
+    /// is a no-op, so the kernel wire can never grow an object table.
+    /// The producer only calls this from the RPC `write_binder` /
+    /// FD-write paths, and the caller decides *whether* to record
+    /// (binder ⇒ v2 only; FD ⇒ v1+), faithfully mirroring AOSP's
+    /// per-call version gate.
     #[cfg(feature = "rpc")]
     pub(crate) fn rpc_record_object_position(&mut self, pos: usize) {
         if !self.is_for_rpc {
@@ -542,10 +540,10 @@ impl Parcel {
         self.rpc_object_positions.insert(at, pos);
     }
 
-    // ---- subplan 2-7: FD-over-RPC (opt-in, Unix mode) --------------
+    // ---- FD-over-RPC (opt-in, Unix mode) ---------------------------
 
     /// Set the negotiated FD-over-RPC mode for this parcel (default
-    /// `None` ⇒ FD write is the 2-2 reject, bit-identical).
+    /// `None` ⇒ FD write is rejected, bit-identical).
     #[cfg(feature = "rpc")]
     pub(crate) fn set_rpc_fd_mode(&mut self, mode: crate::rpc::FileDescriptorTransportMode) {
         self.rpc_fd_mode = mode;
@@ -559,8 +557,8 @@ impl Parcel {
 
     /// Set by the session from its wire profile (alongside the FD
     /// mode): record FD object positions only on the android-13+ v1+
-    /// profile (subplan 2-8 Phase B). R34 stays `false` ⇒ the 2-7
-    /// FD-over-RPC wire is byte-unchanged.
+    /// profile. R34 stays `false` ⇒ the FD-over-RPC wire is
+    /// byte-unchanged.
     #[cfg(feature = "rpc")]
     pub(crate) fn set_rpc_record_fd_positions(&mut self, yes: bool) {
         self.rpc_record_fd_positions = yes;
@@ -623,7 +621,7 @@ impl Parcel {
 
     pub fn close_file_descriptors(&self) {
         // RPC-mode parcels never carry kernel FD objects (FD over RPC
-        // is rejected in 2-2 / opt-in in 2-7); nothing to close here.
+        // is rejected by default / opt-in via Unix mode); nothing to close here.
         #[cfg(feature = "rpc")]
         if self.is_for_rpc {
             return;
@@ -699,7 +697,7 @@ impl Parcel {
         // The kernel offset-table scan below is meaningless for an
         // RPC-mode parcel (RPC carries `RpcAddress`, not
         // `flat_binder_object`). Reaching here in RPC mode is a
-        // protocol error, not a silent mis-read (2-2.d2 #4).
+        // protocol error, not a silent mis-read.
         #[cfg(feature = "rpc")]
         if self.is_for_rpc {
             return Err(StatusCode::BadType);
@@ -903,17 +901,15 @@ impl Parcel {
 
         // usize in Rust may be 16-bit, so i32 may not fit
         let len = len.try_into().or(Err(StatusCode::BadValue))?;
-        // NOTE (T1-3): no `len <= data_avail()` cap here. Unlike an
-        // `in` array, an `out`/`inout` vec sends only its *length* in
-        // the parcel — the elements are produced by the callee, not
-        // read from the bytes that follow — so `len > data_avail()` is
-        // the normal, valid case. Capping it here regressed every
-        // out-array AIDL method on the live kernel binder (caught by
-        // the Android emulator integration run, not macOS). The
-        // unbounded-`len` OOM concern is real but must be bounded by a
-        // configured maximum, not by `data_avail()`; left as upstream
-        // (Android libbinder's `resizeOutVector` is likewise unbounded)
-        // — see RPC_STATUS T1-3 follow-up.
+        // No `len <= data_avail()` cap here. Unlike an `in` array, an
+        // `out`/`inout` vec sends only its *length* in the parcel —
+        // the elements are produced by the callee, not read from the
+        // bytes that follow — so `len > data_avail()` is the normal,
+        // valid case. Capping it here would regress every out-array
+        // AIDL method on the live kernel binder. The unbounded-`len`
+        // OOM concern is real but must be bounded by a configured
+        // maximum, not by `data_avail()` (Android libbinder's
+        // `resizeOutVector` is likewise unbounded).
         out_vec.resize_with(len, Default::default);
 
         Ok(())
@@ -936,9 +932,8 @@ impl Parcel {
         } else {
             // usize in Rust may be 16-bit, so i32 may not fit
             let len = len.try_into().or(Err(StatusCode::BadValue))?;
-            // See `resize_out_vec` (T1-3): an out-vec length is not
-            // backed by parcel data, so no `data_avail()` cap here —
-            // capping it regressed the live kernel out-array path.
+            // See `resize_out_vec`: an out-vec length is not backed by
+            // parcel data, so no `data_avail()` cap here.
             let mut vec = Vec::with_capacity(len);
             vec.resize_with(len, Default::default);
             *out_vec = Some(vec);
@@ -1058,11 +1053,11 @@ impl Parcel {
 
     pub(crate) fn write_object(&mut self, obj: &flat_binder_object, null_meta: bool) -> Result<()> {
         // RPC mode never carries `flat_binder_object`s: binders are
-        // marshalled as `RpcAddress` and FDs are rejected upstream
-        // (2-2.d2 #3). Write the bytes verbatim but never load the
-        // kernel offset table or take a kernel `acquire()` — RPC has
-        // its own refcount. The kernel path below is byte-identical
-        // when `is_for_rpc == false` (AC-2.9).
+        // marshalled as `RpcAddress` and FDs are rejected upstream.
+        // Write the bytes verbatim but never load the kernel offset
+        // table or take a kernel `acquire()` — RPC has its own
+        // refcount. The kernel path below is byte-identical when
+        // `is_for_rpc == false`.
         #[cfg(feature = "rpc")]
         if self.is_for_rpc {
             self.write_aligned(obj);
@@ -1081,7 +1076,7 @@ impl Parcel {
     }
 
     pub(crate) fn write_interface_token(&mut self, interface: &str) -> Result<()> {
-        self.write(&(thread_state::strict_mode_policy() | STRICT_MODE_PENALTY_GATHER))?;
+        self.write(&(thread_state::get_strict_mode_policy() | STRICT_MODE_PENALTY_GATHER))?;
         self.update_work_source_request_header_pos();
         let work_source: i32 = if thread_state::should_propagate_work_source() {
             thread_state::calling_work_source_uid() as _
@@ -1169,7 +1164,13 @@ impl Parcel {
         let mut last_idx: i32 = -2;
         {
             let object_size = std::mem::size_of::<flat_binder_object>() as u64;
-            let objects = self.objects.as_slice();
+            // Scan the SOURCE parcel's object table (mirrors AOSP
+            // Parcel.cpp::appendFrom, which iterates `other`'s mObjects),
+            // not `self.objects`. The destination may be empty (e.g. a fresh
+            // ParcelableHolder parcel), in which case using `self.objects`
+            // would compute num_objects == 0 and silently drop every
+            // binder/FD object nested in the copied range.
+            let objects = other.objects.as_slice();
 
             for (i, &off) in objects.iter().enumerate() {
                 if off >= offset as _ && (off + object_size) <= (offset + size) as u64 {
@@ -1203,9 +1204,9 @@ impl Parcel {
         self.set_data_position(self.pos + size);
 
         // An RPC-mode parcel carries no `flat_binder_object`s, so the
-        // offset recompute / re-acquire / FD-dup below is kernel-only
-        // (2-2.d2 #5). `self.objects` is already empty in RPC mode so
-        // this is also defence-in-depth.
+        // offset recompute / re-acquire / FD-dup below is kernel-only.
+        // `self.objects` is already empty in RPC mode so this is also
+        // defence-in-depth.
         #[cfg(feature = "rpc")]
         let skip_objects = self.is_for_rpc;
         #[cfg(not(feature = "rpc"))]
@@ -1215,10 +1216,14 @@ impl Parcel {
             let start = self.objects.len();
             self.objects.resize(start + (num_objects as usize));
 
-            let objects = self.objects.as_mut_slice();
+            // Recompute each offset from the SOURCE table position
+            // (`other.objects`), then store the relocated offset into the
+            // destination table. AOSP: `off = pos - offset + startPos`.
+            let src_objects = other.objects.as_slice();
+            let dst_objects = self.objects.as_mut_slice();
             for (idx, i) in (start..).zip(first_idx..=last_idx) {
-                let off = objects[i as usize] as usize - offset + start_pos;
-                objects[idx] = off as _;
+                let off = src_objects[i as usize] as usize - offset + start_pos;
+                dst_objects[idx] = off as _;
                 let mut flat = read_flat_binder(self.data.as_slice(), off)?;
                 flat.acquire()?;
                 if flat.header_type() == BINDER_TYPE_FD {
@@ -1237,8 +1242,8 @@ impl Parcel {
     fn release_objects(&self) {
         // An RPC-mode parcel must never run kernel `release()` /
         // `decref_publish` — RPC objects have a different
-        // (DecStrong-based) lifetime (2-2.d2 #6). `self.objects` is
-        // empty in RPC mode anyway; this is defence-in-depth + intent.
+        // (DecStrong-based) lifetime. `self.objects` is empty in RPC
+        // mode anyway; this is defence-in-depth + intent.
         #[cfg(feature = "rpc")]
         if self.is_for_rpc {
             return;
@@ -1674,13 +1679,12 @@ mod tests {
         );
     }
 
-    /// **AC-8.6 / subplan 2-8 Phase B** — the RPC object-position
-    /// table is collected AOSP-faithfully: the recorded offset is the
-    /// position of the object's leading int32 (AOSP `dataPos =
-    /// mDataPos` *before* `writeInt32(TYPE_*)`), the table stays
-    /// **sorted** (AOSP `mObjectPositions.insert(upper_bound(...),
+    /// The RPC object-position table is collected AOSP-faithfully: the
+    /// recorded offset is the position of the object's leading int32
+    /// (AOSP `dataPos = mDataPos` *before* `writeInt32(TYPE_*)`), the
+    /// table stays **sorted** (AOSP `mObjectPositions.insert(upper_bound(...),
     /// dataPos)`) even when objects are recorded out of order, it is
-    /// hard-gated on `is_for_rpc` (kernel diff 0, AC-2.9), and it
+    /// hard-gated on `is_for_rpc` (kernel diff 0), and it
     /// survives a v2 codec encode→decode with the AOSP `bodySize =
     /// fixed + parcelDataSize + 4·N` framing. Single / multiple /
     /// mixed (binder-shaped + FD-shaped) objects.
@@ -1690,7 +1694,7 @@ mod tests {
         use crate::rpc::wire::{WireCodec, WireMessage, WireTransaction};
         use crate::rpc::wire_android13::Android13PlusCodec;
 
-        // ---- kernel parcel: recording is a hard no-op (P1/AC-2.9) ----
+        // ---- kernel parcel: recording is a hard no-op ----
         let mut kparcel = Parcel::new();
         kparcel.write(&7i32).unwrap();
         kparcel.rpc_record_object_position(0); // !is_for_rpc ⇒ ignored
@@ -1765,7 +1769,7 @@ mod tests {
             "upper_bound insert keeps the table sorted (dups allowed)"
         );
 
-        // AC-8.7 — the v2 strict-receive `binary_search` primitive
+        // The v2 strict-receive `binary_search` primitive
         // (`Parcel::unflattenBinder`): a recorded position passes, an
         // unrecorded one fails ⇒ `read_binder` returns BAD_VALUE.
         for &good in &[0u32, 8, 24, 40] {

--- a/rsbinder/src/parcelable.rs
+++ b/rsbinder/src/parcelable.rs
@@ -414,10 +414,17 @@ impl DeserializeOption for String {
 
         if (0..i32::MAX).contains(&len) {
             let data = parcel.read_aligned_data((len as usize + 1) * std::mem::size_of::<u16>())?;
-            let res = String::from_utf16(unsafe {
-                std::slice::from_raw_parts(data.as_ptr() as *const u16, len as _)
-            })
-            .map_err(|e| {
+            // `data` is borrowed from the parcel's `Vec<u8>` whose base is
+            // only 1-byte aligned, so reinterpreting it as `&[u16]` via
+            // `from_raw_parts(_ as *const u16, _)` would construct an
+            // under-aligned reference (UB; Miri-detectable). Copy the bytes
+            // into an aligned `Vec<u16>` instead — mirroring the safe
+            // `align_to` idiom used by `read_array_char`.
+            let u16_data: Vec<u16> = data[..len as usize * std::mem::size_of::<u16>()]
+                .chunks_exact(std::mem::size_of::<u16>())
+                .map(|c| u16::from_ne_bytes([c[0], c[1]]))
+                .collect();
+            let res = String::from_utf16(&u16_data).map_err(|e| {
                 log::error!("Deserialize for Option<String16>: {e}");
                 StatusCode::BadValue
             })?;
@@ -464,8 +471,8 @@ impl Serialize for SIBinder {
 impl SerializeOption for SIBinder {
     fn serialize_option(this: Option<&Self>, parcel: &mut Parcel) -> Result<()> {
         // RPC mode: marshal as `RpcAddress` via the attached session
-        // hooks, not `flat_binder_object` (2-2.d2 #1). Kernel path
-        // below is byte-identical when `is_for_rpc == false` (AC-2.9).
+        // hooks, not `flat_binder_object`. Kernel path below is
+        // byte-identical when `is_for_rpc == false`.
         #[cfg(feature = "rpc")]
         if parcel.is_for_rpc() {
             let ops = parcel.rpc_ops().ok_or(StatusCode::BadType)?;
@@ -478,6 +485,12 @@ impl SerializeOption for SIBinder {
                 if crate::sdk_at_least(30) {
                     parcel.write::<i32>(&binder.stability().into())?;
                 }
+                // Freeze runtime stability mutation once
+                // this binder has crossed the IPC boundary (AOSP
+                // `BBinder::setParceled` equivalent). Default trait impl
+                // is a no-op for proxies — only `Inner<T>` flips its
+                // `AtomicBool`.
+                binder.set_parceled();
                 Ok(())
             }
 
@@ -511,7 +524,7 @@ impl Deserialize for SIBinder {
 impl DeserializeOption for SIBinder {
     fn deserialize_option(parcel: &mut Parcel) -> Result<Option<Self>> {
         // RPC mode: unmarshal from `RpcAddress` via the attached
-        // session hooks (2-2.d2 #2). The kernel `flat_binder_object`
+        // session hooks. The kernel `flat_binder_object`
         // path below is byte-identical when `is_for_rpc == false`.
         #[cfg(feature = "rpc")]
         if parcel.is_for_rpc() {
@@ -747,7 +760,7 @@ pub trait DeserializeArray: Deserialize {
         // in the parcel: every element consumes >= 1 wire byte, so a
         // well-formed array of `len` elements always satisfies
         // `len <= data_avail()` here. This is byte-for-byte identical
-        // for all valid input (incl. every kernel parcel — AC-2.9) and
+        // for all valid input (incl. every kernel parcel) and
         // only stops a hostile `len` (e.g. i32::MAX over RPC) from
         // forcing a multi-GB allocation before the per-element reads
         // fail. The loop still pushes exactly `len`, growing on demand.

--- a/rsbinder/src/permission_controller.rs
+++ b/rsbinder/src/permission_controller.rs
@@ -1,0 +1,119 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Client stub for Android's `PermissionManagerService`
+//! (`android.os.IPermissionController`).
+//!
+//! rsbinder provides the **client side only** — the server lives in
+//! Android's `system_server`. Consumers acquire a proxy via
+//! [`crate::hub::get_service`]`("permission")` then cast through
+//! [`crate::permission_controller::IPermissionController`].
+//!
+//! The wire descriptor is `"android.os.IPermissionController"`, generated
+//! from `aidl/permission/android/os/IPermissionController.aidl` (vendored
+//! verbatim from AOSP `frameworks/base/core/java/android/os/`). The
+//! descriptor is stable across Android 10–16; rsbinder ships a single
+//! AIDL (unlike `IServiceManager`, which is per-version).
+//!
+//! On non-Android targets (Linux + binderfs without an Android
+//! userspace, or macOS), `system_server` does not exist — the helpers
+//! still compile but [`crate::hub::get_service`] returns `None` and the
+//! [`crate::permission_controller::check_permission`] convenience
+//! returns `false` (fail-closed).
+
+include!(concat!(env!("OUT_DIR"), "/permission_controller.rs"));
+
+pub use android::os::IPermissionController::{
+    BnPermissionController, BpPermissionController, IPermissionController,
+    IPermissionControllerDefault, IPermissionControllerDefaultRef,
+};
+
+#[cfg(feature = "async")]
+pub use android::os::IPermissionController::{
+    IPermissionControllerAsync, IPermissionControllerAsyncService,
+};
+
+use crate::error::Result;
+use crate::{hub, FromIBinder, Strong};
+
+/// Service name registered by Android's `PermissionManagerService`. Used
+/// as the key for [`crate::hub::get_service`].
+pub const SERVICE_NAME: &str = "permission";
+
+/// Acquire a `BpPermissionController` proxy for the system-wide
+/// `permission` service, mirroring AOSP
+/// `defaultServiceManager()->getService(String16("permission"))` +
+/// `interface_cast<IPermissionController>(binder)`.
+///
+/// Returns `Err(StatusCode::NameNotFound)` when the service manager has
+/// no `"permission"` entry — typically on non-Android Linux where
+/// `system_server` is not running. Other errors propagate from the
+/// `FromIBinder` cast (descriptor mismatch).
+///
+/// This is a thin wrapper; consumers needing custom error mapping or
+/// caching should call [`crate::hub::get_service`] directly.
+pub fn default() -> Result<Strong<dyn IPermissionController>> {
+    let binder = hub::get_service(SERVICE_NAME).ok_or(crate::StatusCode::NameNotFound)?;
+    <dyn IPermissionController>::try_from(binder)
+}
+
+/// Convenience: ask `system_server`'s `PermissionManagerService` whether
+/// the current binder *caller* (as reported by
+/// [`crate::get_calling_uid`] / [`crate::get_calling_pid`]) holds
+/// `permission_name`.
+///
+/// Intended for server-side use inside a [`crate::Transactable::transact`]
+/// dispatch, mirroring AOSP `IPCThreadState::self()->getCallingUid()` +
+/// `IPermissionController::checkPermission(...)`.
+///
+/// # Fail-closed semantics
+///
+/// Returns `false` when:
+/// - The current thread is not handling a binder transaction
+///   (`get_calling_uid()` / `get_calling_pid()` both `0`).
+/// - The `permission` service is unreachable (`system_server` absent or
+///   the binder driver is not initialized).
+/// - The remote `checkPermission` call returns an error.
+///
+/// This matches AOSP's "if in doubt, deny" posture for missing
+/// PermissionManagerService — see Android `checkPermission` callers in
+/// `frameworks/native/services/` for the same pattern.
+pub fn check_permission(permission_name: &str) -> bool {
+    let calling_pid = crate::get_calling_pid();
+    let calling_uid = crate::get_calling_uid();
+    let Ok(pc) = default() else {
+        return false;
+    };
+    pc.checkPermission(permission_name, calling_pid as i32, calling_uid as i32)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The generated trait must expose the AOSP wire descriptor
+    /// verbatim — `"android.os.IPermissionController"`.
+    /// A mismatch here would silently fail every cross-process call to
+    /// `system_server` because the kernel-side `check_interface` would
+    /// reject the inbound `writeInterfaceToken` prefix.
+    #[test]
+    fn test_descriptor_matches_aosp_wire() {
+        // Pick any `Sized` impl — `descriptor()` is gated by
+        // `where Self: Sized`, but every concrete impl returns the
+        // same constant via the AOSP-required `META_INTERFACE` macro.
+        assert_eq!(
+            <BpPermissionController as IPermissionController>::descriptor(),
+            "android.os.IPermissionController"
+        );
+    }
+
+    /// `SERVICE_NAME` matches the AOSP-registered service
+    /// name (`servicemanager` `addService("permission", ...)` in
+    /// system_server). Any drift makes `default()` return
+    /// `NameNotFound` on every real Android device.
+    #[test]
+    fn test_service_name_matches_system_server_registration() {
+        assert_eq!(SERVICE_NAME, "permission");
+    }
+}

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -949,8 +949,8 @@ impl ProcessState {
     /// `Parcel::write_object` → `flat_binder_object::acquire` brings it
     /// to 1. The single-statement window between this method returning
     /// and the first `acquire` is the only leak path under
-    /// `Parcel::write_aligned` panics (typically OOM) — see plan §5
-    /// "From<&SIBinder> returning before acquire() is called".
+    /// `Parcel::write_aligned` panics (typically OOM): `From<&SIBinder>`
+    /// returning before `acquire()` is called.
     pub(crate) fn publish_native(&self, arc: Arc<dyn IBinder>) -> u64 {
         // Single write lock for dedup + insert: a read-then-write split
         // would race two concurrent publishes of the same Arc into
@@ -1094,15 +1094,9 @@ impl ProcessState {
             // accept this over a `debug_assert` panic: the race is a
             // property of kernel scheduling, not our bookkeeping, so
             // panicking would fail CI on a legitimate interleaving.
-            // (The OLD fat-pointer encoding hit the same race but
-            // masked it via `RefCounter`'s `INITIAL_STRONG_VALUE`
-            // pattern, which self-corrects the count to its initial
-            // value but silently skips the first/last-ref closures —
-            // equivalently broken in semantics, just lower-noise.)
-            // See plan §5 #7. A future change could move to a
-            // signed counter + dual-direction removal trigger to
-            // bound the drift, but that introduces premature-removal
-            // hazards in multi-pair scenarios; left as a follow-up.
+            // A signed counter + dual-direction removal trigger could
+            // bound the drift, but introduces premature-removal hazards
+            // in multi-pair scenarios; left as a follow-up.
             entry.kernel_refs = entry.kernel_refs.saturating_sub(1);
             let arc = Arc::clone(entry.binder_pin.as_arc());
             let trigger = entry.publish_count == 0 && entry.kernel_refs == 0;
@@ -1435,7 +1429,7 @@ mod tests {
         );
     }
 
-    /// Plan §5.2 — same-thread re-entrant obituary regression guard.
+    /// Same-thread re-entrant obituary regression guard.
     ///
     /// Reproduces the exact deadlock the P1/P2/P3 split closes:
     /// while the slow path is mid-flight, a `BR_DEAD_BINDER` for the
@@ -1607,7 +1601,7 @@ mod tests {
     }
 
     /// End-to-end of the table-controlled lifecycle that closes the UAF
-    /// window. Mirrors plan §4 "test_native_uaf_window_closed":
+    /// window:
     ///
     ///   1. publish a native binder → entry created, `publish_count = 0`,
     ///      `kernel_refs = 0`, RefCounter floor armed.

--- a/rsbinder/src/proxy.rs
+++ b/rsbinder/src/proxy.rs
@@ -35,7 +35,7 @@ use crate::{
 ///     `binder_ref → binder_node` association across that thrash and
 ///     return `BR_FAILED_REPLY` ("cannot find target node") on the very
 ///     next transaction. Stable strong caching avoids the thrash
-///     entirely and matches the PR #102 baseline.
+///     entirely.
 ///
 ///   * **Self-cycle case (`CachedExtension::Weak`)** — the extension's
 ///     handle equals the parent's own handle (a remote naming itself as
@@ -73,6 +73,20 @@ enum CachedExtension {
 pub struct ProxyHandle {
     handle: u32,
     descriptor: String,
+    /// Uid attributed to this proxy at construction
+    /// time, used by [`crate::proxy_count`]'s per-uid map. Captured
+    /// via [`thread_state::get_calling_uid_or_self`], which mirrors
+    /// AOSP `IPCThreadState::getCallingUid()`: the kernel-delivered
+    /// sender uid inside a `BR_TRANSACTION`, or this process's own
+    /// `getuid()` when no incoming transaction is on the stack.
+    tracked_uid: u32,
+    /// True iff this proxy's construction reached the
+    /// matching `proxy_count::on_proxy_create` call, so [`Drop`] knows
+    /// it owes a matching `on_proxy_drop`. Set on the success path of
+    /// `new_acquired`; left `false` by test-only construction helpers
+    /// (`synthetic_proxy`) and by the construction-failure path where
+    /// `inc_strong_handle` errored before the counter was bumped.
+    count_acquired: AtomicBool,
     stability: Stability,
     /// Set once when `send_obituary` runs to publish "this proxy is
     /// dead" to all observers.
@@ -110,16 +124,28 @@ impl ProxyHandle {
         descriptor: String,
         stability: Stability,
     ) -> Result<Arc<Self>> {
-        let arc = Arc::new(Self {
+        // Capture the calling uid via the AOSP-faithful helper so the
+        // per-uid tracking map matches `IPCThreadState::getCallingUid()`
+        // semantics (this process's `getuid()` outside a transaction,
+        // kernel-delivered sender uid inside).
+        let tracked_uid = thread_state::get_calling_uid_or_self();
+        // Bump the kernel ref FIRST. If this errors, the `Arc` we build
+        // below is dropped immediately, and `Drop::drop` must NOT call
+        // `proxy_count::on_proxy_drop` — otherwise we'd post a drop for
+        // a proxy that never reached `on_proxy_create`. The
+        // `count_acquired` guard below is how `Drop` knows.
+        thread_state::inc_strong_handle(handle)?;
+        crate::proxy_count::on_proxy_create(tracked_uid);
+        Ok(Arc::new(Self {
             handle,
             descriptor,
+            tracked_uid,
+            count_acquired: AtomicBool::new(true),
             stability,
             obituary_sent: AtomicBool::new(false),
             recipients: RwLock::new(Vec::new()),
             extension: RwLock::new(ExtensionCache::NotQueried),
-        });
-        thread_state::inc_strong_handle(handle)?;
-        Ok(arc)
+        }))
     }
 
     /// Get the underlying binder handle number.
@@ -183,13 +209,10 @@ impl ProxyHandle {
     }
 }
 
-// Subplan 2-6: the kernel proxy implements the generalized
-// `RemoteProxy` trait by **delegating to its unchanged inherent
-// methods**. The inherent `submit_transact`/`prepare_transact` are
-// untouched, so existing generated `Bp*` code (which still calls them
-// via `as_proxy()`) and the kernel proxy's runtime behavior are
-// bit-identical by construction (AC-6.2 — no codegen change for the
-// kernel path).
+// The kernel proxy implements the generalized `RemoteProxy` trait by
+// delegating to its unchanged inherent methods, so existing generated
+// `Bp*` code (which still calls them via `as_proxy()`) and the kernel
+// proxy's runtime behavior are bit-identical by construction.
 impl RemoteProxy for ProxyHandle {
     fn prepare_transact(&self, write_header: bool) -> Result<Parcel> {
         ProxyHandle::prepare_transact(self, write_header)
@@ -330,16 +353,14 @@ impl ProxyHandle {
 
     pub fn dump<F: IntoRawFd>(&self, fd: F, args: &[String]) -> Result<()> {
         // Fast-fail BEFORE consuming the fd. `submit_transact` would
-        // also short-circuit on `obituary_sent` (PR #104 §1), but by
-        // the time we reach it, `fd.into_raw_fd()` has already
-        // detached the raw fd from `F`'s RAII; an early `Err` from
-        // `submit_transact` would then leak the fd. Mirroring the
-        // `submit_transact` Acquire-load here lets `F` drop naturally
-        // (closing the fd) when the proxy is already dead. The non-
-        // fast-fail error paths (parcel-write failures, in-`transact`
-        // errors after the kernel sees the fd) still exhibit the
-        // pre-existing leak shape — see FOLLOW_UP_PR_104.md Item 4
-        // "Follow-up scope" for the wider fix.
+        // also short-circuit on `obituary_sent`, but by the time we
+        // reach it, `fd.into_raw_fd()` has already detached the raw fd
+        // from `F`'s RAII; an early `Err` from `submit_transact` would
+        // then leak the fd. Mirroring the `submit_transact` Acquire-load
+        // here lets `F` drop naturally (closing the fd) when the proxy
+        // is already dead. The non-fast-fail error paths (parcel-write
+        // failures, in-`transact` errors after the kernel sees the fd)
+        // still exhibit a leak.
         if self.obituary_sent.load(Ordering::Acquire) {
             return Err(StatusCode::DeadObject);
         }
@@ -385,6 +406,13 @@ impl Drop for ProxyHandle {
                 "BC_RELEASE for handle {} failed during Drop: {err:?}",
                 self.handle
             );
+        }
+        // Only post the drop if construction reached the matching
+        // `on_proxy_create`. Test-only `synthetic_proxy`
+        // and the `inc_strong_handle`-failure path leave the guard
+        // `false`, so the proxy_count globals never see a phantom drop.
+        if self.count_acquired.load(Ordering::Relaxed) {
+            crate::proxy_count::on_proxy_drop(self.tracked_uid);
         }
     }
 }
@@ -442,16 +470,12 @@ impl IBinder for ProxyHandle {
     fn set_extension(&self, _extension: &SIBinder) -> Result<()> {
         // `set_extension` is a server-side operation: a service
         // publishes its extension binder for clients to discover via
-        // `get_extension()`. Calling it on a client proxy used to
-        // succeed silently, caching locally without telling the
-        // remote service — and after PR #104's §4 scope-down the
-        // local cache holds a strong `Arc<dyn IBinder>` for the
-        // parent's lifetime, silently pinning an unrelated binder.
+        // `get_extension()`. A client proxy has no way to inform the
+        // remote service, and the local strong cache would pin an
+        // unrelated `Arc<dyn IBinder>` for the parent's lifetime.
         // Reject with `InvalidOperation`, matching the default trait
         // impl in `binder.rs`. In-tree callers operate on native
-        // `Binder`, not `ProxyHandle`, so this reject is safe (see
-        // `tests/src/test_client.rs`, `tests/src/bin/test_service.rs`,
-        // `tests/src/bin/test_service_async.rs`).
+        // `Binder`, not `ProxyHandle`, so this reject is safe.
         Err(StatusCode::InvalidOperation)
     }
 
@@ -639,6 +663,11 @@ mod tests {
         Arc::new(ProxyHandle {
             handle: 1,
             descriptor: "test".to_string(),
+            tracked_uid: 0,
+            // `count_acquired = false` means `Drop` skips
+            // `proxy_count::on_proxy_drop`, matching this constructor's
+            // skip of `new_acquired`'s `on_proxy_create`.
+            count_acquired: AtomicBool::new(false),
             stability: Stability::Local,
             obituary_sent: AtomicBool::new(obituary_sent),
             recipients: RwLock::new(Vec::new()),
@@ -658,12 +687,6 @@ mod tests {
     /// turn the returned `Weak` into a dangling reference that
     /// `Weak::upgrade()` and the production-side liveness check
     /// would treat as already-dead.
-    ///
-    /// Older tests used `noop_recipient_weak()` which returned a
-    /// dangling weak directly. That was benign for fast-fail tests
-    /// (the obituary check fired first) but masked the upgrade
-    /// liveness check added in Item 8 — a future test added against
-    /// the dangling form would fail mysteriously.
     fn live_recipient_pair() -> (Arc<dyn DeathRecipient>, sync::Weak<dyn DeathRecipient>) {
         let arc: Arc<dyn DeathRecipient> = Arc::new(NoopRecipient);
         let weak = Arc::downgrade(&arc);
@@ -737,8 +760,7 @@ mod tests {
 
     /// Registering the same recipient twice and unlinking once must
     /// remove only one entry — the user's remaining registration is
-    /// silently lost if `unlink_to_death` removes every match (the
-    /// `Vec::retain` bug fixed here). Mirrors C++
+    /// silently lost if `unlink_to_death` removes every match. Mirrors C++
     /// `BpBinder::unlinkToDeath` returning after a single
     /// `mObituaries->removeAt(i)`. The recipients vector is
     /// populated directly so the test does not require ProcessState
@@ -893,10 +915,9 @@ mod tests {
     /// `InvalidOperation` — the operation is server-side only and a
     /// proxy has no way to inform the remote service. Silent
     /// success would (a) leave the remote unaware of the new
-    /// extension and (b) after PR #104's §4 scope-down, pin an
-    /// unrelated `Arc<dyn IBinder>` for the parent's lifetime via
-    /// the strong-cache common case. The cache must remain
-    /// `NotQueried` after the rejected call.
+    /// extension and (b) pin an unrelated `Arc<dyn IBinder>` for the
+    /// parent's lifetime via the strong-cache common case. The cache
+    /// must remain `NotQueried` after the rejected call.
     #[test]
     fn test_set_extension_on_proxy_rejects_with_invalid_operation() {
         let proxy = synthetic_proxy(false);

--- a/rsbinder/src/proxy_count.rs
+++ b/rsbinder/src/proxy_count.rs
@@ -1,0 +1,390 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Process-global proxy count + watermark + per-uid tracking.
+//!
+//! Mirrors AOSP `BpBinder::sBinderProxyCount` infrastructure
+//! ([`BpBinder.cpp:78`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/BpBinder.cpp;l=78)
+//! `sBinderProxyCount` global atomic; [`:914-955`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/BpBinder.cpp;l=914)
+//! `getBinderProxyCount` / `setBinderProxyCountWatermarks` /
+//! `setBinderProxyCountEventCallback` / `enableCountByUid`).
+//!
+//! The fast path is a single `Relaxed` atomic increment/decrement; per-uid
+//! tracking is opt-in (`enable_count_by_uid`) and pays a `Mutex` lock per
+//! proxy create/drop. Watermark callbacks fire **outside** the mutex to
+//! avoid reentrant deadlock if the callback re-enters `proxy_count` APIs —
+//! same discipline as AOSP's `postTask` defer-callback pattern.
+//!
+//! Defaults match AOSP: high=2500, low=2000, warning=2250. The watermark
+//! state is process-global and shared between callbacks; `Limit`/`Warning`
+//! are debounced (a uid only fires `Limit` once until it drops below `low`,
+//! and `Warning` once until it drops below `warning`).
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock, Mutex};
+
+/// AOSP default high watermark ([`BpBinder.cpp:71`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/BpBinder.cpp;l=71)).
+pub const DEFAULT_HIGH_WATERMARK: u64 = 2500;
+/// AOSP default low watermark ([`BpBinder.cpp:73`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/BpBinder.cpp;l=73)).
+pub const DEFAULT_LOW_WATERMARK: u64 = 2000;
+/// AOSP default warning watermark ([`BpBinder.cpp:76`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/BpBinder.cpp;l=76)).
+pub const DEFAULT_WARNING_WATERMARK: u64 = 2250;
+
+/// Event published by the proxy-count infrastructure when a per-uid
+/// counter crosses a watermark.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProxyCountEvent {
+    /// Per-uid count reached the warning watermark (between `warning`
+    /// and `high`). Fired at most once per uid until the count drops
+    /// below `warning`. AOSP `sWarningCallback`.
+    Warning { uid: u32, count: u64 },
+    /// Per-uid count reached the high watermark. Fired at most once per
+    /// uid until the count drops below `low`. AOSP `sLimitCallback`.
+    Limit { uid: u32, count: u64 },
+}
+
+/// Callback type for [`ProxyCountEvent`] notifications. Invoked from
+/// the proxy create/drop hot path **outside** the internal mutex, so
+/// the callback may freely re-enter `proxy_count` APIs (but must not
+/// itself block indefinitely — every proxy create/drop on every thread
+/// is gated on that callback returning).
+pub type ProxyCountCallback = Arc<dyn Fn(ProxyCountEvent) + Send + Sync>;
+
+/// Process-global proxy count. Lock-free hot path: every
+/// [`ProxyHandle`](crate::proxy::ProxyHandle) constructor `fetch_add`s
+/// this and its `Drop` `fetch_sub`s. `Relaxed` ordering is sufficient
+/// because the count is a monotonic-ish statistic, not a synchronization
+/// primitive — readers see *some* recent value, not necessarily the
+/// per-thread latest.
+static PROXY_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// Opt-in flag for per-uid tracking. Default `false` — the AOSP fast
+/// path is "tracking off, lock not touched, only the global counter
+/// moves." Setting this `true` does **not** retroactively populate the
+/// uid map; only proxies created after the flip are tracked.
+static COUNT_BY_UID_ENABLED: AtomicBool = AtomicBool::new(false);
+
+struct State {
+    high: u64,
+    low: u64,
+    warning: u64,
+    callback: Option<ProxyCountCallback>,
+    per_uid: HashMap<u32, UidEntry>,
+}
+
+#[derive(Default)]
+struct UidEntry {
+    count: u64,
+    /// `Warning` already fired since the last time `count` dropped
+    /// below `warning`. Debounces repeat callbacks.
+    warning_fired: bool,
+    /// `Limit` already fired since the last time `count` dropped
+    /// below `low`. Debounces.
+    limit_fired: bool,
+}
+
+static STATE: LazyLock<Mutex<State>> = LazyLock::new(|| {
+    Mutex::new(State {
+        high: DEFAULT_HIGH_WATERMARK,
+        low: DEFAULT_LOW_WATERMARK,
+        warning: DEFAULT_WARNING_WATERMARK,
+        callback: None,
+        per_uid: HashMap::new(),
+    })
+});
+
+/// Snapshot of the process-global proxy count.
+///
+/// Includes every live [`ProxyHandle`](crate::proxy::ProxyHandle) —
+/// kernel and (with `rpc` feature) RPC are NOT counted here unless they
+/// also route through `ProxyHandle`, matching the AOSP "BpBinder kernel
+/// proxies only" surface.
+pub fn get_binder_proxy_count() -> u64 {
+    PROXY_COUNT.load(Ordering::Relaxed)
+}
+
+/// Snapshot of the per-uid proxy count. Returns `0` if per-uid tracking
+/// is disabled or this uid has never had a proxy created against it.
+/// AOSP `BpBinder::getBinderProxyCount(uid)`.
+pub fn get_binder_proxy_count_for_uid(uid: u32) -> u64 {
+    let state = STATE.lock().expect("proxy_count state poisoned");
+    state.per_uid.get(&uid).map(|e| e.count).unwrap_or(0)
+}
+
+/// Snapshot of every tracked uid's count, as `(uid, count)` pairs. The
+/// returned `Vec` is a copy — callers may sort or filter without
+/// holding the internal lock. AOSP `BpBinder::getCountByUid`.
+pub fn get_binder_proxy_counts_by_uid() -> Vec<(u32, u64)> {
+    let state = STATE.lock().expect("proxy_count state poisoned");
+    state
+        .per_uid
+        .iter()
+        .map(|(uid, e)| (*uid, e.count))
+        .collect()
+}
+
+/// Configure the warning / high / low watermarks. AOSP
+/// `BpBinder::setBinderProxyCountWatermarks(high, low, warning)`.
+///
+/// `warning` must be in `[low, high]` for the debounce logic to produce
+/// the AOSP-faithful three-zone state machine (below-warning → warning
+/// → limit, and resetting at `low`). Out-of-order values are accepted
+/// silently — the state machine still terminates, just with a different
+/// fire schedule.
+pub fn set_binder_proxy_count_watermarks(high: u64, low: u64, warning: u64) {
+    let mut state = STATE.lock().expect("proxy_count state poisoned");
+    state.high = high;
+    state.low = low;
+    state.warning = warning;
+}
+
+/// Install (or clear, by passing `None`) the watermark event callback.
+/// Replaces any prior callback. AOSP
+/// `BpBinder::setBinderProxyCountEventCallback`.
+pub fn set_binder_proxy_count_event_callback(callback: Option<ProxyCountCallback>) {
+    let mut state = STATE.lock().expect("proxy_count state poisoned");
+    state.callback = callback;
+}
+
+/// Enable or disable per-uid proxy tracking. When `enabled` is `false`,
+/// the hot path skips the internal mutex entirely (matches AOSP's
+/// `sCountByUidEnabled.load()` short-circuit). Disabling while uids are
+/// tracked does **not** clear the existing map — re-enabling resumes
+/// counting from where it left off; callers can `clear_count_by_uid`
+/// for a hard reset.
+pub fn enable_count_by_uid(enabled: bool) {
+    COUNT_BY_UID_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+/// Whether per-uid tracking is currently enabled.
+pub fn is_count_by_uid_enabled() -> bool {
+    COUNT_BY_UID_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Hard-reset the per-uid tracking map. Does not affect the global
+/// counter or the enabled flag.
+pub fn clear_count_by_uid() {
+    let mut state = STATE.lock().expect("proxy_count state poisoned");
+    state.per_uid.clear();
+}
+
+/// Internal hook called once per `ProxyHandle::new_acquired`. Bumps
+/// the global counter (lock-free) and, if per-uid tracking is enabled,
+/// updates the uid map under the state mutex.
+///
+/// Watermark callbacks fire after the mutex is dropped to support
+/// reentrant callback bodies (AOSP `postTask` discipline).
+pub(crate) fn on_proxy_create(uid: u32) {
+    PROXY_COUNT.fetch_add(1, Ordering::Relaxed);
+    if !COUNT_BY_UID_ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
+    let event = {
+        let mut state = STATE.lock().expect("proxy_count state poisoned");
+        let high = state.high;
+        let warning = state.warning;
+        let entry = state.per_uid.entry(uid).or_default();
+        entry.count += 1;
+        let count = entry.count;
+        let already_warning = entry.warning_fired;
+        let already_limit = entry.limit_fired;
+        if !already_limit && count >= high {
+            entry.limit_fired = true;
+            state
+                .callback
+                .as_ref()
+                .map(|cb| (cb.clone(), ProxyCountEvent::Limit { uid, count }))
+        } else if !already_warning && count >= warning && count < high {
+            entry.warning_fired = true;
+            state
+                .callback
+                .as_ref()
+                .map(|cb| (cb.clone(), ProxyCountEvent::Warning { uid, count }))
+        } else {
+            None
+        }
+    };
+    if let Some((cb, event)) = event {
+        cb(event);
+    }
+}
+
+/// Internal hook called from `ProxyHandle::drop`. Decrements the
+/// global counter and, if per-uid tracking is enabled, decrements the
+/// uid map entry and clears the watermark debounce flags as the count
+/// drops below `low` (`limit_fired`) and `warning` (`warning_fired`).
+/// Symmetric with [`on_proxy_create`].
+pub(crate) fn on_proxy_drop(uid: u32) {
+    PROXY_COUNT.fetch_sub(1, Ordering::Relaxed);
+    if !COUNT_BY_UID_ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
+    let mut state = STATE.lock().expect("proxy_count state poisoned");
+    let low = state.low;
+    let warning = state.warning;
+    if let Some(entry) = state.per_uid.get_mut(&uid) {
+        entry.count = entry.count.saturating_sub(1);
+        if entry.count < low {
+            entry.limit_fired = false;
+        }
+        if entry.count < warning {
+            entry.warning_fired = false;
+        }
+        if entry.count == 0 {
+            state.per_uid.remove(&uid);
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn reset_for_test() {
+    PROXY_COUNT.store(0, Ordering::Relaxed);
+    COUNT_BY_UID_ENABLED.store(false, Ordering::Relaxed);
+    let mut state = STATE.lock().expect("proxy_count state poisoned");
+    state.high = DEFAULT_HIGH_WATERMARK;
+    state.low = DEFAULT_LOW_WATERMARK;
+    state.warning = DEFAULT_WARNING_WATERMARK;
+    state.callback = None;
+    state.per_uid.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    // proxy_count state is process-global; serialize tests so they
+    // don't trip over each other's mutations.
+    static TEST_LOCK: StdMutex<()> = StdMutex::new(());
+
+    #[test]
+    fn global_counter_increments_and_decrements() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        assert_eq!(get_binder_proxy_count(), 0);
+        on_proxy_create(1000);
+        on_proxy_create(1000);
+        on_proxy_create(2000);
+        assert_eq!(get_binder_proxy_count(), 3);
+        on_proxy_drop(1000);
+        assert_eq!(get_binder_proxy_count(), 2);
+        on_proxy_drop(1000);
+        on_proxy_drop(2000);
+        assert_eq!(get_binder_proxy_count(), 0);
+    }
+
+    #[test]
+    fn per_uid_disabled_by_default_skips_map() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        on_proxy_create(1000);
+        on_proxy_create(2000);
+        // Disabled → map stays empty even though global counter moved.
+        assert_eq!(get_binder_proxy_count(), 2);
+        assert_eq!(get_binder_proxy_count_for_uid(1000), 0);
+        assert_eq!(get_binder_proxy_counts_by_uid(), vec![]);
+        on_proxy_drop(1000);
+        on_proxy_drop(2000);
+    }
+
+    #[test]
+    fn per_uid_enabled_tracks_each_uid() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        enable_count_by_uid(true);
+        on_proxy_create(1000);
+        on_proxy_create(1000);
+        on_proxy_create(2000);
+        assert_eq!(get_binder_proxy_count_for_uid(1000), 2);
+        assert_eq!(get_binder_proxy_count_for_uid(2000), 1);
+        assert_eq!(get_binder_proxy_count_for_uid(3000), 0);
+        let mut snap = get_binder_proxy_counts_by_uid();
+        snap.sort_by_key(|(uid, _)| *uid);
+        assert_eq!(snap, vec![(1000, 2), (2000, 1)]);
+        on_proxy_drop(1000);
+        on_proxy_drop(1000);
+        on_proxy_drop(2000);
+        // All counts at 0 → map entries removed.
+        assert_eq!(get_binder_proxy_counts_by_uid(), vec![]);
+    }
+
+    #[test]
+    fn limit_callback_fires_once_until_low_watermark_resets() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        enable_count_by_uid(true);
+        set_binder_proxy_count_watermarks(/*high*/ 5, /*low*/ 2, /*warning*/ 4);
+        let fired = Arc::new(StdMutex::new(Vec::<ProxyCountEvent>::new()));
+        let f = fired.clone();
+        set_binder_proxy_count_event_callback(Some(Arc::new(move |event| {
+            f.lock().unwrap().push(event);
+        })));
+        // Climb to high=5: warning fires at 4, limit at 5. Above 5 → no
+        // re-fire while debounce sticks.
+        for _ in 0..7 {
+            on_proxy_create(1000);
+        }
+        let snap: Vec<_> = fired.lock().unwrap().clone();
+        assert_eq!(snap.len(), 2, "warning + limit, once each: {snap:?}");
+        assert!(matches!(
+            snap[0],
+            ProxyCountEvent::Warning { uid: 1000, .. }
+        ));
+        assert!(matches!(snap[1], ProxyCountEvent::Limit { uid: 1000, .. }));
+
+        // Drop to below low=2 → debounce clears; next climb fires again.
+        for _ in 0..6 {
+            on_proxy_drop(1000);
+        }
+        assert_eq!(get_binder_proxy_count_for_uid(1000), 1);
+        on_proxy_create(1000); // 2
+        on_proxy_create(1000); // 3
+        on_proxy_create(1000); // 4 → warning re-fires
+        on_proxy_create(1000); // 5 → limit re-fires
+        let snap: Vec<_> = fired.lock().unwrap().clone();
+        assert_eq!(snap.len(), 4, "re-fire after below-low reset: {snap:?}");
+
+        on_proxy_drop(1000);
+        on_proxy_drop(1000);
+        on_proxy_drop(1000);
+        on_proxy_drop(1000);
+        on_proxy_drop(1000);
+    }
+
+    #[test]
+    fn callback_runs_outside_state_lock() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        enable_count_by_uid(true);
+        set_binder_proxy_count_watermarks(2, 1, 2);
+        // Callback re-enters `get_binder_proxy_count_for_uid`, which
+        // takes the state mutex. If the callback fired *under* the
+        // outer lock this would deadlock; the test passing proves the
+        // chokepoint deferred the callback after lock drop.
+        set_binder_proxy_count_event_callback(Some(Arc::new(|_event| {
+            let _snapshot = get_binder_proxy_count_for_uid(1000);
+        })));
+        on_proxy_create(1000);
+        on_proxy_create(1000); // should not deadlock
+        on_proxy_drop(1000);
+        on_proxy_drop(1000);
+    }
+
+    #[test]
+    fn clear_count_by_uid_resets_map_only() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_for_test();
+        enable_count_by_uid(true);
+        on_proxy_create(1000);
+        on_proxy_create(2000);
+        assert_eq!(get_binder_proxy_count(), 2);
+        clear_count_by_uid();
+        assert_eq!(get_binder_proxy_counts_by_uid(), vec![]);
+        // Global counter is unaffected — it tracks live `ProxyHandle`s,
+        // not the per-uid statistic.
+        assert_eq!(get_binder_proxy_count(), 2);
+        on_proxy_drop(1000);
+        on_proxy_drop(2000);
+    }
+}

--- a/rsbinder/src/rpc/address.rs
+++ b/rsbinder/src/rpc/address.rs
@@ -1,15 +1,15 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! `RpcAddress` — RPC object identity (subplan 2-2 S-a).
+//! `RpcAddress` — RPC object identity.
 //!
 //! Mirrors android-12 r34 `RpcWireAddress` (`u8 address[32]`, opaque —
 //! `RpcAddress.h:34` "hide the ABI ... potentially change the size").
 //! This is **not** a u32 kernel handle: the RPC stack has its own
-//! identity space, decoupled from `proxy::ProxyHandle` (P5).
+//! identity space, decoupled from `proxy::ProxyHandle`.
 //!
-//! Allocation is a per-session monotonic counter (plan 2-2.a1: not a
-//! CSPRNG — uniqueness *within a session* is sufficient; android fills
+//! Allocation is a per-session monotonic counter (not a CSPRNG —
+//! uniqueness *within a session* is sufficient; android fills
 //! it from `/dev/urandom` but treats it as opaque, so a counter is
 //! wire-compatible). `zero()` is the reserved address used for the
 //! special server-channel transactions.
@@ -24,7 +24,7 @@ pub(crate) const RPC_ADDR_LEN: usize = 32;
 pub const RPC_SESSION_ID_NEW: i32 = -1;
 
 /// Opaque RPC object address. ABI is hidden: no public field, no public
-/// length constant, `Debug` shows only a short fingerprint (AC-2.1).
+/// length constant, `Debug` shows only a short fingerprint.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RpcAddress {
     bytes: [u8; RPC_ADDR_LEN],
@@ -56,8 +56,8 @@ impl RpcAddress {
     /// `/dev/urandom`; rsbinder instead tags byte 8 with the
     /// allocating role so the initiator's and acceptor's subspaces are
     /// disjoint — uniqueness then holds across the *whole connection*,
-    /// not just one endpoint. The counter is session-owned (P6 — no
-    /// global); the value is never `zero()` (counter ≥ 1).
+    /// not just one endpoint. The counter is session-owned (no global);
+    /// the value is never `zero()` (counter ≥ 1).
     pub fn unique(counter: &mut u64, space: AddressSpace) -> Self {
         *counter = counter.wrapping_add(1);
         let mut bytes = [0u8; RPC_ADDR_LEN];
@@ -124,7 +124,7 @@ pub enum SpecialTransaction {
     GetMaxThreads = 1,
     /// Obtain the server-assigned session id.
     GetSessionId = 2,
-    /// Negotiate the FD-over-RPC mode (subplan 2-7). **Not r34** — an
+    /// Negotiate the FD-over-RPC mode. **Not r34** — an
     /// rsbinder/android-13+ extension sent *only* when a client opts
     /// into FD passing, so the default (`None`) path stays r34-faithful.
     GetFdMode = 3,
@@ -159,8 +159,8 @@ mod tests {
         assert_eq!(RpcAddress::zero().as_wire_bytes(), &[0u8; RPC_ADDR_LEN]);
     }
 
-    /// AC-2.1 / T2.2: 1e6 `unique()` calls in one session collide 0
-    /// times and never equal `zero()`.
+    /// 1e6 `unique()` calls in one session collide 0 times and never
+    /// equal `zero()`.
     #[test]
     fn unique_is_collision_free_and_nonzero() {
         let mut ctr = 0u64;
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn debug_is_fingerprint_only() {
-        // AC-2.1: Debug must not dump the full ABI bytes.
+        // Debug must not dump the full ABI bytes.
         let mut ctr = 0u64;
         let a = RpcAddress::unique(&mut ctr, AddressSpace::Initiator);
         let s = format!("{a:?}");
@@ -204,7 +204,7 @@ mod tests {
             Some(SpecialTransaction::GetSessionId)
         );
         // 0..=2 are the android-12 r34 special codes. Code 3
-        // (`GetFdMode`) is the rsbinder/2-7 extension — explicitly
+        // (`GetFdMode`) is the rsbinder FD-mode extension — explicitly
         // NOT r34, sent only when a client opts into FD passing.
         assert_eq!(
             SpecialTransaction::from_code(3),

--- a/rsbinder/src/rpc/fd_mode.rs
+++ b/rsbinder/src/rpc/fd_mode.rs
@@ -1,24 +1,24 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! `FileDescriptorTransportMode` (subplan 2-7).
+//! `FileDescriptorTransportMode`.
 //!
-//! android-12 r34 forbids FDs in RPC parcels **categorically**; 2-2
-//! implements that faithful reject. android-13+ adds an **opt-in**
-//! mode where, *only if both peers agree and the transport is a Unix
-//! domain socket*, file descriptors travel out-of-band via
+//! android-12 r34 forbids FDs in RPC parcels **categorically**; the
+//! default path implements that faithful reject. android-13+ adds an
+//! **opt-in** mode where, *only if both peers agree and the transport
+//! is a Unix domain socket*, file descriptors travel out-of-band via
 //! `SCM_RIGHTS`. The default is permanently
 //! [`FileDescriptorTransportMode::None`] — which is
-//! both android-13's default and bit-identical to the 2-2 reject
-//! (AC-7.1). Non-UDS transports (`mem`/`vsock`/`tls`) can never select
+//! both android-13's default and bit-identical to the categorical
+//! reject. Non-UDS transports (`mem`/`vsock`/`tls`) can never select
 //! `Unix` — enforced by type (the transport trait's default
 //! fd methods reject) and by negotiation.
 
 /// How (if at all) file descriptors may cross an RPC session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum FileDescriptorTransportMode {
-    /// No FDs (android-12 fidelity / android-13 default). The 2-2
-    /// reject path, unchanged.
+    /// No FDs (android-12 fidelity / android-13 default). The
+    /// categorical reject path, unchanged.
     #[default]
     None,
     /// FDs via UDS `SCM_RIGHTS`, **iff** both peers opted in and the
@@ -30,5 +30,4 @@ pub enum FileDescriptorTransportMode {
 // `RpcSession::negotiate_fd_transport` / `RpcSessionInner::serve_special`:
 // the client sends "want Unix? 1/0", the server replies the agreed
 // mode (1=Unix iff both opted in, else 0). `Unix` requires *both*
-// peers to opt in — otherwise a safe `None` fallback, never an error
-// (plan 2-7.b / AC-7.3).
+// peers to opt in — otherwise a safe `None` fallback, never an error.

--- a/rsbinder/src/rpc/lifecycle.rs
+++ b/rsbinder/src/rpc/lifecycle.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Subplan 2-12 §7.3 **R1** — typed session lifecycle.
+//! Typed session lifecycle.
 //!
 //! Replaces the prior `live_conns: AtomicUsize` + `obituary_sent:
 //! AtomicBool` pair on [`super::session::SharedSession`] with a single
@@ -22,14 +22,13 @@
 //! `Dying`/`Dead` carry no count. Every transition is a CAS — `0` is
 //! never transiently visible as `≥ 1` from one observer's point of view
 //! between another's bump-and-rollback (the two-attacker hole the
-//! review-R2 CAS-loop closed against the original optimistic-bump shape;
-//! plan §7.2). The typed enum makes the four reachable states explicit:
+//! CAS-loop closes against a naive optimistic-bump shape). The typed
+//! enum makes the four reachable states explicit:
 //! a reviewer can grep [`SessionLifecycleSnapshot`] variants for every
 //! point that branches on them.
 //!
 //! **Default single-connection sessions** never leave `Live(1)` until
-//! teardown, so the only behavioral change vs the pre-R1 two-atomic
-//! shape is that the `is_torn_down` snapshot can now return `true` in
+//! teardown. The `is_torn_down` snapshot can return `true` in
 //! the `Dying` window *before* the obituary completes — a strict
 //! improvement (a `RpcProxy::drop` reaper that races the dying founding
 //! worker skips its best-effort `DEC_STRONG` slightly earlier, never
@@ -57,7 +56,7 @@ const STATE_DEAD_TAG: u64 = 2;
 /// cover the common cases. The unit tests below match against every
 /// variant explicitly.
 #[allow(dead_code)]
-// The hot-path uses the boolean/count helpers; the typed snapshot is the grep-friendly mutant-gate surface.
+// The hot path uses the boolean/count helpers; the typed snapshot is the grep-friendly exhaustive-match surface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SessionLifecycleSnapshot {
     /// At least one connection is still driving the session. `n` is the
@@ -68,7 +67,7 @@ pub(crate) enum SessionLifecycleSnapshot {
     /// obituary callback returns.
     Dying,
     /// Obituary callbacks have completed. A subsequent
-    /// [`SessionLifecycle::try_bump_live`] never succeeds (F4 anti-
+    /// [`SessionLifecycle::try_bump_live`] never succeeds (anti-
     /// resurrection — a session whose obituaries fired must never
     /// acquire another driver, else `binder_died` would be silently
     /// lost for any `DeathRecipient` linked through the attaching
@@ -94,8 +93,8 @@ impl SessionLifecycle {
     /// Lock-free typed snapshot. Production code prefers
     /// [`is_torn_down`](Self::is_torn_down) (boolean) or
     /// [`live_count`](Self::live_count) (numeric) for the hot path;
-    /// `snapshot` is the test/mutant-gate surface that exhaustively
-    /// matches every variant.
+    /// `snapshot` is the test surface that exhaustively matches every
+    /// variant.
     #[allow(dead_code)]
     pub(crate) fn snapshot(&self) -> SessionLifecycleSnapshot {
         decode(self.inner.load(Ordering::SeqCst))
@@ -108,9 +107,7 @@ impl SessionLifecycle {
         self.inner.load(Ordering::Acquire) >> STATE_SHIFT != STATE_LIVE_TAG
     }
 
-    /// Current live count (`Live(n) → n`, `Dying`/`Dead → 0`). The
-    /// deterministic F4 witness — replaces the prior
-    /// `live_conns.load()` direct read.
+    /// Current live count (`Live(n) → n`, `Dying`/`Dead → 0`).
     pub(crate) fn live_count(&self) -> usize {
         let v = self.inner.load(Ordering::SeqCst);
         if v >> STATE_SHIFT == STATE_LIVE_TAG {
@@ -120,14 +117,14 @@ impl SessionLifecycle {
         }
     }
 
-    /// **F4 anti-resurrection primitive.** Atomically bump the live
+    /// **Anti-resurrection primitive.** Atomically bump the live
     /// count *if* the session is still `Live`. Returns `false` from
     /// `Dying` or `Dead` (never attaches to a session whose obituaries
     /// fired / are firing).
     ///
-    /// CAS-loop rather than optimistic-bump-then-rollback — the prior
-    /// shape closed the *single-attacker* race but not the
-    /// **multi-attacker** one (review-R2; plan §7.2): two concurrent
+    /// CAS-loop rather than optimistic-bump-then-rollback — the latter
+    /// closes the *single-attacker* race but not the
+    /// **multi-attacker** one: two concurrent
     /// attackers A and B both bumping after the founding `fetch_sub`'d
     /// to 0 could let B see A's transient `prev=1` before A rolls
     /// back, attaching to a dying session. Value-decision CAS closes
@@ -283,8 +280,8 @@ mod tests {
         assert!(!lc.try_bump_live(), "Dead must refuse new attach");
     }
 
-    /// Review-R2 multi-attacker hole, hermetic mutant gate. The prior
-    /// optimistic-bump-then-rollback shape would have let one of N
+    /// Multi-attacker hole, hermetic regression. A naive
+    /// optimistic-bump-then-rollback shape would let one of N
     /// concurrent attackers attach to a dying session by observing
     /// another's transient bump. The CAS-loop primitive — which the
     /// typed enum here preserves — must keep `Dying`/`Dead` invariant

--- a/rsbinder/src/rpc/lifecycle.rs
+++ b/rsbinder/src/rpc/lifecycle.rs
@@ -1,0 +1,377 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Subplan 2-12 §7.3 **R1** — typed session lifecycle.
+//!
+//! Replaces the prior `live_conns: AtomicUsize` + `obituary_sent:
+//! AtomicBool` pair on [`super::session::SharedSession`] with a single
+//! atomic-backed state machine:
+//!
+//! ```text
+//!         try_bump_live ────┐
+//!                           ▼
+//!     ┌─── new() ──→  Live(n: NonZeroUsize) ───drop_connection (n==1)──→  Dying ──mark_dead──→ Dead
+//!                           │  ▲
+//!                           │  └─── drop_connection (n>1) decrements
+//!                           │
+//!                           └─── try_bump_live increments
+//! ```
+//!
+//! Encoding (single `AtomicU64`, lock-free on every supported target):
+//! the top byte is a state tag, the lower 56 bits are the `Live` count.
+//! `Dying`/`Dead` carry no count. Every transition is a CAS — `0` is
+//! never transiently visible as `≥ 1` from one observer's point of view
+//! between another's bump-and-rollback (the two-attacker hole the
+//! review-R2 CAS-loop closed against the original optimistic-bump shape;
+//! plan §7.2). The typed enum makes the four reachable states explicit:
+//! a reviewer can grep [`SessionLifecycleSnapshot`] variants for every
+//! point that branches on them.
+//!
+//! **Default single-connection sessions** never leave `Live(1)` until
+//! teardown, so the only behavioral change vs the pre-R1 two-atomic
+//! shape is that the `is_torn_down` snapshot can now return `true` in
+//! the `Dying` window *before* the obituary completes — a strict
+//! improvement (a `RpcProxy::drop` reaper that races the dying founding
+//! worker skips its best-effort `DEC_STRONG` slightly earlier, never
+//! deadlocking on an empty pool; the prior `obituary_sent.load` only
+//! flipped after the obituary callback returned).
+
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Top byte holds the state tag; lower 56 bits hold the `Live` count
+/// (0 in non-`Live` states). 56 bits is enough for any plausible live
+/// connection count and leaves a clear margin against the `Live`-tag
+/// `+1` overflow path; the wider type is `u64` to keep the encoded
+/// state in a single lock-free word on every supported target.
+const STATE_SHIFT: u32 = 56;
+const COUNT_MASK: u64 = (1u64 << STATE_SHIFT) - 1;
+const STATE_LIVE_TAG: u64 = 0;
+const STATE_DYING_TAG: u64 = 1;
+const STATE_DEAD_TAG: u64 = 2;
+
+/// A read-only snapshot of [`SessionLifecycle`] — the type the rest of
+/// the RPC crate matches against. Production code rarely needs every
+/// variant individually; the convenience helpers on `SessionLifecycle`
+/// ([`SessionLifecycle::is_torn_down`], [`SessionLifecycle::live_count`])
+/// cover the common cases. The unit tests below match against every
+/// variant explicitly.
+#[allow(dead_code)]
+// The hot-path uses the boolean/count helpers; the typed snapshot is the grep-friendly mutant-gate surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SessionLifecycleSnapshot {
+    /// At least one connection is still driving the session. `n` is the
+    /// current live connection count.
+    Live(NonZeroUsize),
+    /// The last `Live` connection dropped; the founding worker is
+    /// firing session obituaries. Transient — moves to `Dead` once the
+    /// obituary callback returns.
+    Dying,
+    /// Obituary callbacks have completed. A subsequent
+    /// [`SessionLifecycle::try_bump_live`] never succeeds (F4 anti-
+    /// resurrection — a session whose obituaries fired must never
+    /// acquire another driver, else `binder_died` would be silently
+    /// lost for any `DeathRecipient` linked through the attaching
+    /// connection).
+    Dead,
+}
+
+/// Single atomic-backed session lifecycle. Stores state + live count in
+/// one `AtomicU64`; every method is lock-free.
+pub(crate) struct SessionLifecycle {
+    inner: AtomicU64,
+}
+
+impl SessionLifecycle {
+    /// Initial state for a newly-minted session — `Live(1)` (the
+    /// founding connection).
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: AtomicU64::new(encode_live(1)),
+        }
+    }
+
+    /// Lock-free typed snapshot. Production code prefers
+    /// [`is_torn_down`](Self::is_torn_down) (boolean) or
+    /// [`live_count`](Self::live_count) (numeric) for the hot path;
+    /// `snapshot` is the test/mutant-gate surface that exhaustively
+    /// matches every variant.
+    #[allow(dead_code)]
+    pub(crate) fn snapshot(&self) -> SessionLifecycleSnapshot {
+        decode(self.inner.load(Ordering::SeqCst))
+    }
+
+    /// Hot-path "is this session past its `Live` window?" check (used
+    /// by `RpcProxy::drop`, the reaper, and `add_callback_slot`).
+    /// `true` in both `Dying` and `Dead` — neither admits new work.
+    pub(crate) fn is_torn_down(&self) -> bool {
+        self.inner.load(Ordering::Acquire) >> STATE_SHIFT != STATE_LIVE_TAG
+    }
+
+    /// Current live count (`Live(n) → n`, `Dying`/`Dead → 0`). The
+    /// deterministic F4 witness — replaces the prior
+    /// `live_conns.load()` direct read.
+    pub(crate) fn live_count(&self) -> usize {
+        let v = self.inner.load(Ordering::SeqCst);
+        if v >> STATE_SHIFT == STATE_LIVE_TAG {
+            (v & COUNT_MASK) as usize
+        } else {
+            0
+        }
+    }
+
+    /// **F4 anti-resurrection primitive.** Atomically bump the live
+    /// count *if* the session is still `Live`. Returns `false` from
+    /// `Dying` or `Dead` (never attaches to a session whose obituaries
+    /// fired / are firing).
+    ///
+    /// CAS-loop rather than optimistic-bump-then-rollback — the prior
+    /// shape closed the *single-attacker* race but not the
+    /// **multi-attacker** one (review-R2; plan §7.2): two concurrent
+    /// attackers A and B both bumping after the founding `fetch_sub`'d
+    /// to 0 could let B see A's transient `prev=1` before A rolls
+    /// back, attaching to a dying session. Value-decision CAS closes
+    /// it.
+    pub(crate) fn try_bump_live(&self) -> bool {
+        let mut v = self.inner.load(Ordering::SeqCst);
+        loop {
+            if v >> STATE_SHIFT != STATE_LIVE_TAG {
+                return false;
+            }
+            let new_v = v + 1;
+            // The +1 stays inside the count bits unless the count
+            // overflowed 56-bit range. Defensive — never reached in
+            // practice (a session would need 2^56 live connections).
+            debug_assert!(
+                new_v >> STATE_SHIFT == STATE_LIVE_TAG,
+                "SessionLifecycle live-count overflow"
+            );
+            match self
+                .inner
+                .compare_exchange_weak(v, new_v, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) => return true,
+                Err(actual) => v = actual,
+            }
+        }
+    }
+
+    /// Connection-teardown counterpart of [`try_bump_live`]. Returns
+    /// `true` iff *this* call observed the `1→0` edge (the last
+    /// connection); the caller is responsible for firing session
+    /// obituaries and then calling [`mark_dead`](Self::mark_dead).
+    ///
+    /// In a `Live(n)` state with `n > 1` this CAS-decrements and
+    /// returns `false`. In `Live(1)` it CAS-transitions to `Dying` and
+    /// returns `true`. Calling from `Dying`/`Dead` is a contract
+    /// violation (only one founding worker observes the `1→0` edge);
+    /// a `debug_assert` catches it.
+    pub(crate) fn drop_connection(&self) -> bool {
+        let mut v = self.inner.load(Ordering::SeqCst);
+        loop {
+            debug_assert_eq!(
+                v >> STATE_SHIFT,
+                STATE_LIVE_TAG,
+                "drop_connection called from non-Live state"
+            );
+            let count = v & COUNT_MASK;
+            debug_assert!(count >= 1, "Live state with count == 0");
+            let (new_v, was_last) = if count == 1 {
+                (encode_dying(), true)
+            } else {
+                (v - 1, false)
+            };
+            match self
+                .inner
+                .compare_exchange_weak(v, new_v, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) => return was_last,
+                Err(actual) => v = actual,
+            }
+        }
+    }
+
+    /// Transition `Dying → Dead`. The caller MUST have just fired
+    /// session obituaries (the only path that reaches `Dying`).
+    pub(crate) fn mark_dead(&self) {
+        let prev = self.inner.swap(encode_dead(), Ordering::SeqCst);
+        debug_assert_eq!(
+            prev >> STATE_SHIFT,
+            STATE_DYING_TAG,
+            "mark_dead called from non-Dying state"
+        );
+    }
+}
+
+fn encode_live(n: usize) -> u64 {
+    debug_assert!(n >= 1 && (n as u64) <= COUNT_MASK);
+    // STATE_LIVE_TAG == 0 so no shift needed; the count occupies the
+    // lower 56 bits unchanged.
+    n as u64
+}
+
+fn encode_dying() -> u64 {
+    STATE_DYING_TAG << STATE_SHIFT
+}
+
+fn encode_dead() -> u64 {
+    STATE_DEAD_TAG << STATE_SHIFT
+}
+
+#[allow(dead_code)] // used by snapshot(), itself test/grep surface
+fn decode(v: u64) -> SessionLifecycleSnapshot {
+    match v >> STATE_SHIFT {
+        STATE_LIVE_TAG => {
+            let count = (v & COUNT_MASK) as usize;
+            SessionLifecycleSnapshot::Live(
+                NonZeroUsize::new(count).expect("Live state must have count >= 1"),
+            )
+        }
+        STATE_DYING_TAG => SessionLifecycleSnapshot::Dying,
+        STATE_DEAD_TAG => SessionLifecycleSnapshot::Dead,
+        other => unreachable!("invalid SessionLifecycle state tag: {other}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+
+    fn nz(n: usize) -> NonZeroUsize {
+        NonZeroUsize::new(n).unwrap()
+    }
+
+    #[test]
+    fn new_session_is_live_one() {
+        let lc = SessionLifecycle::new();
+        assert_eq!(lc.snapshot(), SessionLifecycleSnapshot::Live(nz(1)));
+        assert_eq!(lc.live_count(), 1);
+        assert!(!lc.is_torn_down());
+    }
+
+    #[test]
+    fn bump_then_decrement_back_to_one_stays_live() {
+        let lc = SessionLifecycle::new();
+        assert!(lc.try_bump_live()); // 1 → 2
+        assert_eq!(lc.live_count(), 2);
+        assert!(!lc.drop_connection()); // 2 → 1, not the last edge
+        assert_eq!(lc.live_count(), 1);
+        assert!(!lc.is_torn_down());
+    }
+
+    #[test]
+    fn last_drop_transitions_through_dying_to_dead() {
+        let lc = SessionLifecycle::new();
+        assert!(lc.drop_connection()); // 1 → Dying, was_last
+        assert_eq!(lc.snapshot(), SessionLifecycleSnapshot::Dying);
+        assert_eq!(lc.live_count(), 0);
+        assert!(lc.is_torn_down());
+
+        lc.mark_dead();
+        assert_eq!(lc.snapshot(), SessionLifecycleSnapshot::Dead);
+        assert!(lc.is_torn_down());
+    }
+
+    #[test]
+    fn try_bump_after_dying_or_dead_refuses() {
+        let lc = SessionLifecycle::new();
+        assert!(lc.drop_connection()); // → Dying
+        assert!(!lc.try_bump_live(), "Dying must refuse new attach");
+        lc.mark_dead();
+        assert!(!lc.try_bump_live(), "Dead must refuse new attach");
+    }
+
+    /// Review-R2 multi-attacker hole, hermetic mutant gate. The prior
+    /// optimistic-bump-then-rollback shape would have let one of N
+    /// concurrent attackers attach to a dying session by observing
+    /// another's transient bump. The CAS-loop primitive — which the
+    /// typed enum here preserves — must keep `Dying`/`Dead` invariant
+    /// under any interleaving.
+    #[test]
+    fn concurrent_bumpers_against_drop_never_attach_to_dying() {
+        for _ in 0..32 {
+            let lc = Arc::new(SessionLifecycle::new());
+            // Pre-bump so the founding's drop transitions Live(2) →
+            // Live(1) (not directly to Dying), giving N attackers a
+            // wider race window across the eventual 1→0 edge.
+            assert!(lc.try_bump_live());
+            assert_eq!(lc.live_count(), 2);
+
+            let dropper = {
+                let lc = Arc::clone(&lc);
+                thread::spawn(move || {
+                    // Drop twice: 2 → 1 → Dying.
+                    let _ = lc.drop_connection();
+                    let was_last = lc.drop_connection();
+                    if was_last {
+                        lc.mark_dead();
+                    }
+                })
+            };
+
+            let attackers: Vec<_> = (0..8)
+                .map(|_| {
+                    let lc = Arc::clone(&lc);
+                    thread::spawn(move || {
+                        let ok = lc.try_bump_live();
+                        // Whoever bumped must un-bump (preserve the
+                        // arithmetic so the test asserts the final state
+                        // from `Dying` is reachable). Concurrent unbump
+                        // from Dying/Dead is also forbidden — only one
+                        // dropper here.
+                        if ok {
+                            // Re-validate: count must still be Live.
+                            assert!(matches!(lc.snapshot(), SessionLifecycleSnapshot::Live(_)));
+                            let _ = lc.drop_connection();
+                        }
+                        ok
+                    })
+                })
+                .collect();
+
+            dropper.join().unwrap();
+            for a in attackers {
+                let _ = a.join().unwrap();
+            }
+
+            // Final state is Dead OR Live (depending on whether any
+            // attacker raced past the dropper) — but never `Live(0)`
+            // and never a `try_bump_live` *succeeded against `Dying`*.
+            match lc.snapshot() {
+                SessionLifecycleSnapshot::Dead => {}
+                SessionLifecycleSnapshot::Live(_) => {
+                    // An attacker won the race; the session is genuinely
+                    // alive again (NOT a resurrection of a dead session
+                    // — the attacker bumped while still Live, then the
+                    // dropper saw a higher count and didn't 1→0).
+                }
+                SessionLifecycleSnapshot::Dying => {
+                    panic!("Dying is transient — should have moved to Dead via mark_dead");
+                }
+            }
+        }
+    }
+
+    /// Hermetic regression: a `drop_connection` from `Live(1)` must
+    /// expose `is_torn_down() == true` *before* `mark_dead` is called.
+    /// This is the strict improvement over the prior `obituary_sent`
+    /// scheme — a racing `RpcProxy::drop` reaper now sees the
+    /// `Dying` state and skips immediately instead of blocking on an
+    /// empty slot pool.
+    #[test]
+    fn dying_window_is_observable_to_hot_path_checks() {
+        let lc = SessionLifecycle::new();
+        assert!(!lc.is_torn_down());
+        assert!(lc.drop_connection());
+        // Now in Dying — caller hasn't called mark_dead yet.
+        assert!(
+            lc.is_torn_down(),
+            "Dying must surface as is_torn_down() == true \
+             before mark_dead, so drop-path reapers skip"
+        );
+        lc.mark_dead();
+        assert!(lc.is_torn_down());
+    }
+}

--- a/rsbinder/src/rpc/mod.rs
+++ b/rsbinder/src/rpc/mod.rs
@@ -87,6 +87,7 @@
 
 pub mod address;
 pub mod fd_mode;
+pub(crate) mod lifecycle;
 pub mod proxy;
 pub mod server;
 pub mod session;

--- a/rsbinder/src/rpc/mod.rs
+++ b/rsbinder/src/rpc/mod.rs
@@ -8,8 +8,7 @@
 //! (`RpcServer`/`RpcSession`/`RpcState`). It shares only the high-level
 //! data model (`IBinder`/`Parcel`/AIDL stubs) with the kernel path; it
 //! never touches `ProcessState`, `ThreadState`, `/dev/binder`, ioctl or
-//! mmap. See `plan/2-rpc-transport.md` for the architecture and the
-//! per-workstream subplans `plan/2-1`…`plan/2-7`.
+//! mmap.
 //!
 //! # Security
 //!
@@ -23,7 +22,7 @@
 //! gives the RPC layer **no basis for access control** — this is
 //! logged explicitly and must be treated as untrusted. Plaintext
 //! network transport is never appropriate for production (use the
-//! `tls` backend, added by subplan 2-4).
+//! `tls` backend).
 //!
 //! # Example (Unix-domain server + client)
 //!
@@ -42,9 +41,8 @@
 //! let _negotiated = client.negotiate(4).unwrap();
 //! let root = client.get_root().unwrap();
 //! // Drive `root` with the **same generated stub** as the kernel path
-//! // — subplan 2-6.B makes the AIDL generator emit
-//! // `as_remote().ok_or(BadType)?`, so one `Bp*` resolves either
-//! // stack:
+//! // — the AIDL generator emits `as_remote().ok_or(BadType)?`, so one
+//! // `Bp*` resolves either stack:
 //! //
 //! //     let foo: Strong<dyn IFoo> =
 //! //         <dyn IFoo as FromIBinder>::try_from(root)?;
@@ -62,10 +60,9 @@
 //!
 //! # Async
 //!
-//! The RPC stack's I/O is **blocking** (subplan 2-3 §7-2 — matches
+//! The RPC stack's I/O is **blocking** (thread-per-connection, matching
 //! android-12 r34's blocking-thread model). There is deliberately *no*
-//! non-blocking `RpcTransport` / async serve loop; that "true async
-//! I/O" is a separately-deferred §7-2 item.
+//! non-blocking `RpcTransport` / async reactor serve loop.
 //!
 //! What *is* supported (and verified — `tests/rpc_async.rs`) is the
 //! same `spawn_blocking` adapter the kernel async path uses, over RPC:
@@ -75,7 +72,7 @@
 //!   `client_transact` on `tokio::task::spawn_blocking`; the reply
 //!   parse is the async continuation. Concurrent calls on one shared
 //!   session stay correctly serialized by the per-connection driver
-//!   lock (AC-3.2), now under genuine async concurrency.
+//!   lock, now under genuine async concurrency.
 //! * **Async service** — `Bn*::new_async_binder(impl …AsyncService,
 //!   TokioRuntime(handle))` drives an `async fn` handler via
 //!   `rt.block_on` from the blocking serve worker.
@@ -106,12 +103,12 @@ pub use transport::{CertId, PeerIdentity, RpcTransport};
 
 /// Re-export of the exact `rustls` the `tls` backend links, so callers
 /// build `ClientConfig`/`ServerConfig` against a matching version
-/// (subplan 2-4 track T — key/cert management stays caller-side).
+/// (key/cert management stays caller-side).
 #[cfg(feature = "rpc-tls")]
 pub use rustls;
 pub use wire::{R34Codec, WireCodec, WireMessage, WireReply, WireTransaction};
-/// android-13+ versioned wire codec (subplan 2-5b, additive —
-/// version-keyed: v0 = android-13, v1 = android-14/15. `R34Codec`
+/// android-13+ versioned wire codec (additive — version-keyed:
+/// v0 = android-13, v1 = android-14/15. `R34Codec`
 /// stays the default; this never affects the kernel path).
 pub use wire_android13::Android13PlusCodec;
 
@@ -121,7 +118,7 @@ use std::fmt;
 ///
 /// The transport layer surfaces a *rich* [`RpcError`] (so callers can
 /// distinguish a clean peer close from a truncated frame, etc.). Public
-/// RPC APIs (added by later subplans) project this onto
+/// RPC APIs project this onto
 /// `rsbinder::Result` (`StatusCode`) or AIDL-facing `Status` at the
 /// boundary — see [`StatusCode::RpcError`](crate::StatusCode::RpcError)
 /// and `From<RpcError> for StatusCode`.
@@ -131,9 +128,8 @@ pub type RpcResult<T> = std::result::Result<T, RpcError>;
 ///
 /// Kept separate from [`StatusCode`](crate::StatusCode) because
 /// `StatusCode` is `Copy`/`Ord`/`Hash` and cannot carry a rich payload.
-/// `#[non_exhaustive]` so later subplans (wire decode in 2-2, session
-/// handshake in 2-3, TLS in 2-4) can add variants without a breaking
-/// change.
+/// `#[non_exhaustive]` so the wire-decode, session-handshake, and TLS
+/// layers can add variants without a breaking change.
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum RpcError {
@@ -144,7 +140,7 @@ pub enum RpcError {
     /// truncated (peer closed mid-body, or declared more than it sent).
     Truncated,
     /// A declared frame length exceeds [`transport::MAX_FRAME_LEN`].
-    /// Rejected *before* any allocation (anti-OOM, V4).
+    /// Rejected *before* any allocation (anti-OOM).
     FrameTooLarge {
         /// The length the peer (or caller) declared.
         declared: usize,
@@ -153,10 +149,10 @@ pub enum RpcError {
     },
     /// An underlying transport I/O error that is not a clean close.
     Io(std::io::Error),
-    /// A protocol-level violation (used by the wire codec in 2-2+).
+    /// A protocol-level violation (used by the wire codec).
     Protocol(&'static str),
     /// A configured wait deadline elapsed with no frame boundary
-    /// reached (subplan 2-3 — reply / negotiation timeout). Reported
+    /// reached (reply / negotiation timeout). Reported
     /// only when nothing partial was consumed, so the stream stays
     /// frame-synchronized.
     Timeout,
@@ -238,14 +234,14 @@ impl From<RpcError> for crate::StatusCode {
     }
 }
 
-/// Decode-only entrypoint for the `rpc_parcel_rpc_mode` fuzz target
-/// (2-2 §6.3 / V4). Arbitrary bytes are interpreted as an **RPC-mode**
+/// Decode-only entrypoint for the `rpc_parcel_rpc_mode` fuzz target.
+/// Arbitrary bytes are interpreted as an **RPC-mode**
 /// `Parcel` body and run through the deserializers a real RPC
 /// transaction reaches: scalars, `String`, the generic `Vec<T>` array
 /// path, binder-as-`RpcAddress`, and the AIDL out-vec resizers.
 /// Property: no panic / OOM / UB / unbounded pre-allocation on *any*
-/// input — every length is bounded by the bytes actually present
-/// (T1-3 hardening). Not part of the supported API surface.
+/// input — every length is bounded by the bytes actually present.
+/// Not part of the supported API surface.
 #[doc(hidden)]
 pub fn __fuzz_decode_rpc_parcel(input: &[u8]) {
     use crate::binder::SIBinder;
@@ -288,7 +284,7 @@ pub fn __fuzz_decode_rpc_parcel(input: &[u8]) {
     // (upstream Android is identical); feeding an arbitrary length
     // would just OOM the fuzzer without modelling a real wire input.
     // The bounded `in`-array path (`deserialize_array`) above is the
-    // T1-3 surface this target covers.
+    // surface this target covers.
 }
 
 #[cfg(test)]
@@ -348,13 +344,13 @@ mod tests {
         assert_ne!(v, StatusCode::FailedTransaction.into());
     }
 
-    /// T1-3 / V3: a hostile array length in an RPC-mode parcel must
-    /// fail gracefully (bounded pre-allocation + `Err`), never
-    /// pre-allocate gigabytes. Deterministic regression — reverting the
+    /// A hostile array length in an RPC-mode parcel must fail
+    /// gracefully (bounded pre-allocation + `Err`), never pre-allocate
+    /// gigabytes. Deterministic regression — reverting the
     /// `min(len, data_avail())` / `len > data_avail()` guards turns each
     /// of these into a multi-GB allocation that aborts the test
-    /// process (mutant detected). It is the *enforceable* V4 gate;
-    /// the `rpc_parcel_rpc_mode` fuzz target is the soak supplement.
+    /// process. The `rpc_parcel_rpc_mode` fuzz target is the soak
+    /// supplement.
     #[test]
     fn rpc_parcel_hostile_array_len_is_bounded_not_oom() {
         use crate::parcel::Parcel;
@@ -383,7 +379,7 @@ mod tests {
         // data — the callee fills it — so they are unbounded by design,
         // exactly like Android libbinder's `resizeOutVector`. Bounding
         // them by `data_avail()` regressed the live kernel out-array
-        // path; see the T1-3 note in `parcel.rs`.)
+        // path; see the note in `parcel.rs`.)
 
         // The fuzz entrypoint must never panic on adversarial bytes.
         for pat in [

--- a/rsbinder/src/rpc/mod.rs
+++ b/rsbinder/src/rpc/mod.rs
@@ -204,6 +204,22 @@ impl From<std::io::Error> for RpcError {
     }
 }
 
+impl From<RpcError> for std::io::Error {
+    /// Boundary projection back to `std::io::Error` for callers that
+    /// hold an `io::Result<_>` accumulator (the accept-loop dispatch in
+    /// `RpcServer::run` is the motivating site — its `accept_transport`
+    /// helper must surface a `from_stream`-side `RpcError` through the
+    /// same `io::ErrorKind` matching as the underlying `accept()`).
+    /// `RpcError::Io` round-trips the original `io::Error` unchanged;
+    /// other variants are wrapped with [`std::io::ErrorKind::Other`].
+    fn from(e: RpcError) -> Self {
+        match e {
+            RpcError::Io(io) => io,
+            other => std::io::Error::other(format!("{other}")),
+        }
+    }
+}
+
 impl From<RpcError> for crate::StatusCode {
     /// Boundary projection used when an RPC failure must surface through
     /// `rsbinder::Result`. Specific, actionable mappings where they

--- a/rsbinder/src/rpc/proxy.rs
+++ b/rsbinder/src/rpc/proxy.rs
@@ -1,22 +1,20 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! `RpcProxy` — client-side handle to a remote RPC object
-//! (subplan 2-2 S-d, **P5**).
+//! `RpcProxy` — client-side handle to a remote RPC object.
 //!
 //! A **distinct `IBinder` type** from `proxy::ProxyHandle`. It never
 //! goes through the u32 kernel handle / `handle_to_proxy` / cache-pin
-//! machinery (AC-2.6) — RPC has its own `RpcAddress` identity space and
+//! machinery — RPC has its own `RpcAddress` identity space and
 //! its own ref-count. Android made `BpBinder` a dual-mode
 //! `variant<BinderHandle, RpcHandle>`; because rsbinder's `IBinder` is
-//! a trait, a separate type is cleaner (master §4 P5).
+//! a trait, a separate type is cleaner.
 //!
-//! Subplan 2-2 drove this proxy from a hand-written typed stub.
-//! Subplan 2-6.B generalised the generator to emit
-//! `as_remote().ok_or(BadType)?` (a [`RemoteProxy`](crate::RemoteProxy)
-//! trait object) instead of the kernel-only `as_proxy().unwrap()`, so
-//! the **generated** `Bp*` stub now drives this proxy directly — the
-//! same single stub also drives the kernel `ProxyHandle`.
+//! The generator emits `as_remote().ok_or(BadType)?` (a
+//! [`RemoteProxy`](crate::RemoteProxy) trait object) instead of the
+//! kernel-only `as_proxy().unwrap()`, so the **generated** `Bp*` stub
+//! drives this proxy directly — the same single stub also drives the
+//! kernel `ProxyHandle`.
 
 use std::any::Any;
 use std::mem::ManuallyDrop;
@@ -38,9 +36,9 @@ pub struct RpcProxy {
     /// address (not a descriptor string), so a proxy resolved from
     /// `read_binder`/`get_root` starts empty and is stamped **once,
     /// in place** by the generated typed stub's `from_binder`
-    /// (subplan 2-6.B, via [`stamp_descriptor`](Self::stamp_descriptor)).
+    /// (via [`stamp_descriptor`](Self::stamp_descriptor)).
     /// In-place — never a replacement proxy — keeps the dedup-cache
-    /// identity and the single `DEC_STRONG` intact (AC-2.5 / P5).
+    /// identity and the single `DEC_STRONG` intact.
     descriptor: OnceLock<String>,
     session: Weak<RpcSessionInner>,
     /// Death-notification state, mirroring the kernel
@@ -79,12 +77,9 @@ impl RpcProxy {
         let snapshot: Vec<sync::Weak<dyn DeathRecipient>> = {
             // All `obituary_sent` reads/writes that race `link`/`unlink`
             // happen under this write lock (kernel parity: `mLock`).
-            //
-            // M18 fix (review 2026-05-21): a poisoned recipients lock
-            // means a prior panic on this proxy's death pathway —
-            // log + return best-effort instead of panicking the serve
-            // loop. (`link_to_death`/`unlink_to_death` surface poison
-            // as `StatusCode::DeadObject` via `?`.)
+            // A poisoned recipients lock means a prior panic on this
+            // proxy's death pathway — log + return best-effort instead
+            // of panicking the serve loop.
             let mut recipients = match self.recipients.write() {
                 Ok(g) => g,
                 Err(_) => {
@@ -135,13 +130,13 @@ impl RpcProxy {
         self.addr
     }
 
-    /// Subplan 2-6.B: stamp the interface descriptor — known only to
+    /// Stamp the interface descriptor — known only to
     /// the generated typed stub at compile time — onto this
     /// **already-cached** proxy, in place. First write wins and is
     /// idempotent for the same interface (one wire address identifies
     /// one remote object = one interface). Never replaces the proxy:
     /// a replacement would send a second `DEC_STRONG` on drop and
-    /// split the per-address dedup cache (AC-2.5 / P5).
+    /// split the per-address dedup cache.
     ///
     /// Because the generated `from_binder` stamps *its own*
     /// `$descriptor` here **before** its `binder.descriptor() !=
@@ -156,11 +151,11 @@ impl RpcProxy {
     /// `from_binder`'s descriptor check then returns `None`).
     ///
     /// **Return**: `true` if this call wrote the descriptor, `false`
-    /// if it was already stamped (M20 fix — review 2026-05-21:
-    /// surfacing the `OnceLock::set` result lets a caller distinguish
-    /// fresh-stamp from already-stamped without an extra
-    /// `descriptor()` round-trip. Existing callers (generator
-    /// `from_binder`) can keep ignoring the result with `let _ = …`).
+    /// if it was already stamped. Surfacing the `OnceLock::set` result
+    /// lets a caller distinguish fresh-stamp from already-stamped
+    /// without an extra `descriptor()` round-trip; existing callers
+    /// (generator `from_binder`) can keep ignoring the result with
+    /// `let _ = …`.
     pub fn stamp_descriptor(&self, descriptor: &str) -> bool {
         self.descriptor.set(descriptor.to_string()).is_ok()
     }
@@ -173,14 +168,14 @@ impl RpcProxy {
 
     /// Build an RPC-mode request `Parcel` for `descriptor`, with the
     /// session's object hooks attached and the interface token written.
-    /// Hand-written typed stubs (2-2) call this, write their args, then
+    /// Hand-written typed stubs call this, write their args, then
     /// [`RpcProxy::transact`].
     pub fn build_request(&self, descriptor: &str) -> Result<Parcel> {
         let inner = self.session.upgrade().ok_or(StatusCode::DeadObject)?;
         let mut data = Parcel::new();
         data.attach_rpc_ops(inner.parcel_ops());
         // So `ParcelFileDescriptor::serialize` applies the negotiated
-        // FD policy (default `None` ⇒ the 2-2 reject — subplan 2-7).
+        // FD policy (default `None` ⇒ the categorical reject).
         data.set_rpc_fd_mode(inner.fd_mode());
         data.set_rpc_record_fd_positions(inner.records_fd_positions());
         super::session::write_rpc_interface_token(&mut data, descriptor)?;
@@ -200,10 +195,10 @@ impl RpcProxy {
     }
 }
 
-/// Subplan 2-6 (D1): the RPC proxy implements the same generalized
+/// The RPC proxy implements the same generalized
 /// [`RemoteProxy`](crate::RemoteProxy) trait as the kernel
 /// `ProxyHandle`, so the one generated `Bp*` stub drives either stack
-/// (generator emits `as_remote()`, 2-6.B). `prepare_transact` writes
+/// (generator emits `as_remote()`). `prepare_transact` writes
 /// the interface token from the descriptor stamped in place by the
 /// generated `from_binder` ([`stamp_descriptor`](RpcProxy::stamp_descriptor)).
 impl crate::binder::RemoteProxy for RpcProxy {
@@ -232,23 +227,21 @@ impl crate::binder::RemoteProxy for RpcProxy {
 impl Drop for RpcProxy {
     fn drop(&mut self) {
         // Last `Arc<RpcProxy>` for this address is going away: tell the
-        // peer to drop its strong ref (AC-2.5). Best-effort — never
-        // panic in Drop, and a dead session simply means the peer is
-        // already gone.
+        // peer to drop its strong ref. Best-effort — never panic in
+        // Drop, and a dead session simply means the peer is already
+        // gone.
         //
-        // **C1 fix (review 2026-05-21)**: `queue_dec_strong` is a
-        // non-blocking mpsc enqueue handled by the session's reaper
-        // thread. The previous synchronous `send_dec_strong` here
-        // called `find_conn(false)`, which on a single-slot session
-        // (default `N==1`) `cv.wait`s if another thread already drives
-        // the slot — a Drop on an unrelated worker would block the
-        // user's hot path for the full peer round-trip.
+        // `queue_dec_strong` is a non-blocking mpsc enqueue handled by
+        // the session's reaper thread, rather than a synchronous send:
+        // on a single-slot session a synchronous `find_conn` would
+        // `cv.wait` if another thread already drives the slot, blocking
+        // the user's hot path for the full peer round-trip.
         if let Some(inner) = self.session.upgrade() {
             inner.queue_dec_strong(self.addr);
             // Identity-checked: if this proxy's `Arc` already hit 0 and
             // a concurrent `read_binder` re-cached a fresh live proxy
             // for the same address, this stale `Drop` must NOT evict
-            // that successor (AC-2.5 / P5 — see `forget_remote_if`).
+            // that successor (see `forget_remote_if`).
             inner.forget_remote_if(&self.addr, self as *const RpcProxy as *const ());
         }
     }
@@ -276,10 +269,9 @@ impl IBinder for RpcProxy {
         // Lock first, then check `obituary_sent` — kernel/AOSP ordering
         // (`BpBinder::linkToDeath` checks `mObitsSent` under `mLock`).
         let mut recipients = self.recipients.write().map_err(|_| {
-            // M18 fix (review 2026-05-21): a poisoned recipients
-            // lock means a prior panic on this proxy's death
-            // pathway. Surface as `DeadObject` so a caller can
-            // recover (e.g. drop the binder, re-establish) rather
+            // A poisoned recipients lock means a prior panic on this
+            // proxy's death pathway. Surface as `DeadObject` so a
+            // caller can recover (drop the binder, re-establish) rather
             // than panicking out of a public `IBinder` method.
             StatusCode::DeadObject
         })?;
@@ -296,10 +288,9 @@ impl IBinder for RpcProxy {
     /// registration keeps its remaining subscriptions).
     fn unlink_to_death(&self, recipient: sync::Weak<dyn DeathRecipient>) -> Result<()> {
         let mut recipients = self.recipients.write().map_err(|_| {
-            // M18 fix (review 2026-05-21): a poisoned recipients
-            // lock means a prior panic on this proxy's death
-            // pathway. Surface as `DeadObject` so a caller can
-            // recover (e.g. drop the binder, re-establish) rather
+            // A poisoned recipients lock means a prior panic on this
+            // proxy's death pathway. Surface as `DeadObject` so a
+            // caller can recover (drop the binder, re-establish) rather
             // than panicking out of a public `IBinder` method.
             StatusCode::DeadObject
         })?;

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -34,7 +34,7 @@ use crate::native::Binder;
 use crate::parcel::Parcel;
 
 use super::session::{RpcSession, RpcSessionId, RpcSessionInner};
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
 use super::transport::VsockTransport;
 use super::transport::{PeerIdentity, RpcTransport, UnixTransport};
 #[cfg(feature = "rpc-tls")]
@@ -65,7 +65,7 @@ type TlsServerConfigCell = Mutex<Option<Arc<rustls::ServerConfig>>>;
 /// reached only through [`setup_tcp_server_tls`](RpcServer::setup_tcp_server_tls).
 enum ServerListener {
     Unix(UnixListener),
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
     Vsock(vsock::VsockListener),
     #[cfg(feature = "rpc-tls")]
     Tcp(TcpListener),
@@ -78,7 +78,7 @@ enum ServerListener {
 /// of the listener fd itself).
 enum BindAddress {
     Unix(PathBuf),
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
     Vsock {
         cid: u32,
         port: u32,
@@ -98,7 +98,7 @@ enum BindAddress {
 /// [`RpcServer::set_max_connections`](RpcServer::set_max_connections).
 enum RawAccepted {
     Unix(UnixStream),
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
     Vsock(vsock::VsockStream),
     #[cfg(feature = "rpc-tls")]
     Tcp(TcpStream),
@@ -111,7 +111,7 @@ impl ServerListener {
     fn set_nonblocking(&self, on: bool) -> std::io::Result<()> {
         match self {
             ServerListener::Unix(l) => l.set_nonblocking(on),
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
             ServerListener::Vsock(l) => l.set_nonblocking(on),
             #[cfg(feature = "rpc-tls")]
             ServerListener::Tcp(l) => l.set_nonblocking(on),
@@ -133,7 +133,7 @@ impl ServerListener {
                 stream.set_nonblocking(false)?;
                 Ok(RawAccepted::Unix(stream))
             }
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
             ServerListener::Vsock(l) => {
                 let (stream, _addr) = l.accept()?;
                 stream.set_nonblocking(false)?;
@@ -171,7 +171,7 @@ impl RawAccepted {
         if let Some(cfg) = tls_config {
             let stream: Box<dyn TlsStream> = match self {
                 RawAccepted::Unix(s) => Box::new(s),
-                #[cfg(any(target_os = "linux", target_os = "android"))]
+                #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
                 RawAccepted::Vsock(s) => Box::new(s),
                 RawAccepted::Tcp(s) => Box::new(s),
             };
@@ -190,7 +190,7 @@ impl RawAccepted {
     fn into_native_transport(self) -> RpcResult<Box<dyn RpcTransport>> {
         match self {
             RawAccepted::Unix(s) => Ok(Box::new(UnixTransport::from_stream(s)?)),
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
             RawAccepted::Vsock(s) => Ok(Box::new(VsockTransport::from_stream(s)?)),
             #[cfg(feature = "rpc-tls")]
             RawAccepted::Tcp(_) => Err(super::RpcError::Protocol(
@@ -305,6 +305,23 @@ pub struct RpcServer {
     /// *enforcement point* the 2-9 §0/G2 gap identified as missing
     /// (`peer_identity()` was computed but read nowhere).
     authorizer: Mutex<Option<Authorizer>>,
+    /// **Plan 2-12 §7.3 #2 — shutdown-reject e2e scaffolding hook**
+    /// (`#[doc(hidden)]`, test-only). When set, the closure runs on the
+    /// android-13+ attach arm *between* a successful handshake and the
+    /// `server.shutdown.load()` gate (the very race window §6.4 #2
+    /// flagged as un-bound by code observability alone). An integration
+    /// test acquires the worker at this barrier, calls
+    /// [`shutdown`](RpcServer::shutdown), then releases the worker so it
+    /// re-reads the now-true flag and takes the reject branch — turning
+    /// the otherwise sub-microsecond window into a deterministic test
+    /// point. `None` default ⇒ no invocation, byte-identical to the
+    /// pre-hook attach path. `Arc<dyn Fn>` so the closure is cloned out
+    /// of the lock and invoked **lock-free** (same discipline as
+    /// `authorizer` — re-entrant calls into `server` from the probe do
+    /// not self-deadlock). Same `__`-prefix unstable-API discipline as
+    /// `__fuzz_decode_rpc_parcel`; not part of the supported API.
+    #[doc(hidden)]
+    attach_shutdown_probe: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
     /// Subplan 2-12 **Phase A0b**: session-id → shared-session registry
     /// (AOSP `RpcServer::mSessions`). The android-13+ accept handshake
     /// reads the client's `RpcConnectionHeader.sessionId`:
@@ -384,7 +401,7 @@ impl RpcServer {
     /// **Cleanup**: vsock has no filesystem entry, so `Drop` only flips
     /// the shutdown flag (the kernel reclaims the `(cid, port)` on the
     /// listener fd close).
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
     pub fn setup_vsock_server(cid: u32, port: u32) -> Result<Arc<RpcServer>> {
         let listener = vsock::VsockListener::bind_with_cid_port(cid, port).map_err(|e| {
             log::warn!("VsockListener::bind_with_cid_port({cid}, {port}) failed: {e}");
@@ -412,6 +429,7 @@ impl RpcServer {
             wire_max_version: Mutex::new(None),
             max_connections: Mutex::new(None),
             authorizer: Mutex::new(None),
+            attach_shutdown_probe: Mutex::new(None),
             sessions: Mutex::new(HashMap::new()),
             session_registered: AtomicUsize::new(0),
             attached_count: AtomicUsize::new(0),
@@ -468,7 +486,11 @@ impl RpcServer {
     /// server-side `rustls::ServerConfig`. The 1-tier Android AVF /
     /// Microdroid pVM target — vsock for the host↔guest socket plane,
     /// TLS for the crypto plane.
-    #[cfg(all(feature = "rpc-tls", any(target_os = "linux", target_os = "android")))]
+    #[cfg(all(
+        feature = "rpc-tls",
+        feature = "rpc-vsock",
+        any(target_os = "linux", target_os = "android")
+    ))]
     pub fn setup_vsock_server_tls(
         cid: u32,
         port: u32,
@@ -589,6 +611,43 @@ impl RpcServer {
         F: Fn(&PeerIdentity) -> bool + Send + Sync + 'static,
     {
         *self.authorizer.lock().expect("authorizer poisoned") = Some(Arc::new(f));
+    }
+
+    /// **Plan 2-12 §7.3 #2 — shutdown-reject e2e scaffolding (test-only,
+    /// `#[doc(hidden)]`).** Install a barrier the android-13+ attach
+    /// worker invokes *after* a successful handshake and *before* the
+    /// `shutdown` gate read, turning the production race window (§6.4
+    /// #2) into a deterministic test point. The closure runs lock-free
+    /// (cloned out of the field's mutex first), so it may re-enter
+    /// `server` without self-deadlock. `None` (default, no
+    /// `__set_attach_shutdown_probe` call) = byte-identical to the
+    /// pre-hook attach path. Same `__`-prefix unstable-API discipline
+    /// as `__fuzz_decode_rpc_parcel`; not part of the supported API
+    /// surface.
+    #[doc(hidden)]
+    pub fn __set_attach_shutdown_probe<F>(&self, f: F)
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        *self
+            .attach_shutdown_probe
+            .lock()
+            .expect("attach_shutdown_probe poisoned") = Some(Arc::new(f));
+    }
+
+    /// Run the `#[doc(hidden)]` attach-shutdown probe (no-op when
+    /// unset). Clones the `Arc<dyn Fn>` out of the mutex first so the
+    /// closure runs **lock-free** (the closure may re-enter `server`
+    /// without self-deadlock — same discipline as `authorizer`).
+    fn run_attach_shutdown_probe(&self) {
+        let probe = self
+            .attach_shutdown_probe
+            .lock()
+            .expect("attach_shutdown_probe poisoned")
+            .clone();
+        if let Some(p) = probe {
+            p();
+        }
     }
 
     /// Advertise the FD-over-RPC modes this server will accept
@@ -906,6 +965,10 @@ impl RpcServer {
                                 drop(transport);
                                 return;
                             }
+                            // §7.3 #2 — shutdown-reject e2e scaffolding
+                            // (see `__set_attach_shutdown_probe`). No-op
+                            // unless a test installed a barrier.
+                            server.run_attach_shutdown_probe();
                             if server.shutdown.load(Ordering::SeqCst) {
                                 server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
                                 log::warn!(
@@ -976,6 +1039,13 @@ impl RpcServer {
                         drop(transport);
                         return;
                     }
+                    // §7.3 #2 — shutdown-reject e2e scaffolding
+                    // (see `__set_attach_shutdown_probe`). No-op
+                    // unless a test installed a barrier; the
+                    // production race window §6.4 #2 flagged sits
+                    // exactly between this point and the `load`
+                    // below.
+                    server.run_attach_shutdown_probe();
                     // **Phase B.1 shutdown gate**: refuse attaches
                     // once the server is shutting down (clean
                     // teardown semantics — a late-arriving
@@ -1159,7 +1229,7 @@ impl RpcServer {
     pub fn path(&self) -> Option<&Path> {
         match &self.bind {
             BindAddress::Unix(p) => Some(p.as_path()),
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
             BindAddress::Vsock { .. } => None,
             #[cfg(feature = "rpc-tls")]
             BindAddress::Tcp(_) => None,
@@ -1169,7 +1239,7 @@ impl RpcServer {
     /// **Plan 2-15 E2** — bound vsock address for a vsock server.
     /// `None` for other backends. Available only on platforms where the
     /// vsock backend is compiled in (Linux / Android).
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
     pub fn vsock_address(&self) -> Option<(u32, u32)> {
         match &self.bind {
             BindAddress::Vsock { cid, port } => Some((*cid, *port)),
@@ -1188,7 +1258,7 @@ impl RpcServer {
         match &self.bind {
             BindAddress::Tcp(addr) => Some(*addr),
             BindAddress::Unix(_) => None,
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
             BindAddress::Vsock { .. } => None,
         }
     }
@@ -1225,7 +1295,7 @@ impl Drop for RpcServer {
                 // on the same path doesn't see a stale ENOENT/EADDRINUSE.
                 let _ = std::fs::remove_file(p);
             }
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
             BindAddress::Vsock { .. } => {
                 // vsock has no filesystem entry; the kernel reclaims the
                 // (cid, port) when the listener fd is closed (the

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -21,7 +21,7 @@
 
 use std::collections::HashMap;
 use std::os::unix::net::UnixListener;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
@@ -32,7 +32,76 @@ use crate::native::Binder;
 use crate::parcel::Parcel;
 
 use super::session::{RpcSession, RpcSessionId, RpcSessionInner};
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use super::transport::VsockTransport;
 use super::transport::{PeerIdentity, RpcTransport, UnixTransport};
+
+/// **Plan 2-15 E0/E2** — backend-agnostic listener kind for [`RpcServer`].
+/// The accept loop in [`RpcServer::run`] holds one of these and the
+/// `accept_transport` helper hides the per-backend stream type behind a
+/// `Box<dyn RpcTransport>`, so the worker dispatch path is byte-identical
+/// across UDS / vsock / (future TLS-wrapping factories). Default
+/// `setup_unix_server` callers stay on the `Unix` variant, so the wire
+/// is byte-unchanged on that path.
+enum ServerListener {
+    Unix(UnixListener),
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    Vsock(vsock::VsockListener),
+}
+
+/// **Plan 2-15 E0** — backend-agnostic bind metadata, replacing the prior
+/// `path: PathBuf` UDS-only field. `Drop` branches on this for the
+/// per-backend cleanup: `Unix` removes the socket file, `Vsock` has no
+/// filesystem cleanup (the kernel reclaims the (cid,port) on `Drop` of
+/// the listener fd itself).
+enum BindAddress {
+    Unix(PathBuf),
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    Vsock {
+        cid: u32,
+        port: u32,
+    },
+}
+
+impl ServerListener {
+    /// Set the listener to non-blocking so the accept loop can poll
+    /// `shutdown`. The `vsock` crate exposes `set_nonblocking` on
+    /// `VsockListener` mirroring `UnixListener`'s std API.
+    fn set_nonblocking(&self, on: bool) -> std::io::Result<()> {
+        match self {
+            ServerListener::Unix(l) => l.set_nonblocking(on),
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            ServerListener::Vsock(l) => l.set_nonblocking(on),
+        }
+    }
+
+    /// Per-backend accept: dispatches to the right `accept()`, sets the
+    /// accepted stream blocking (the worker's `recv_frame` is blocking),
+    /// and boxes it as `RpcTransport` so the caller's loop is
+    /// backend-agnostic.
+    fn accept_transport(&self) -> std::io::Result<Box<dyn RpcTransport>> {
+        match self {
+            ServerListener::Unix(l) => {
+                let (stream, _addr) = l.accept()?;
+                // The listener is non-blocking so the accept loop can
+                // poll `shutdown`; the accepted connection must be
+                // blocking for the worker's `recv_frame`.
+                stream.set_nonblocking(false)?;
+                let t = UnixTransport::from_stream(stream).map_err(std::io::Error::from)?;
+                Ok(Box::new(t))
+            }
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            ServerListener::Vsock(l) => {
+                let (stream, _addr) = l.accept()?;
+                // Mirror the UDS path: non-blocking listener for shutdown
+                // polling, blocking accepted stream for the worker.
+                stream.set_nonblocking(false)?;
+                let t = VsockTransport::from_stream(stream).map_err(std::io::Error::from)?;
+                Ok(Box::new(t))
+            }
+        }
+    }
+}
 
 /// Built-in directory interface descriptor + its single transaction.
 const DIRECTORY_DESC: &str = "rsbinder.rpc.IServiceDirectory";
@@ -81,10 +150,15 @@ impl Remotable for ServiceDirectory {
 /// cloned out of the lock and invoked lock-free.
 type Authorizer = Arc<dyn Fn(&PeerIdentity) -> bool + Send + Sync>;
 
-/// A Unix-domain RPC server.
+/// An RPC server. Backend is chosen by the constructor:
+/// [`setup_unix_server`](RpcServer::setup_unix_server) (UDS, default) or
+/// [`setup_vsock_server`](RpcServer::setup_vsock_server) (Linux/Android,
+/// AVF / Microdroid). The accept loop + worker dispatch are
+/// backend-agnostic — every accepted connection becomes one `RpcSession`
+/// on a worker thread regardless of backend.
 pub struct RpcServer {
-    listener: UnixListener,
-    path: PathBuf,
+    listener: ServerListener,
+    bind: BindAddress,
     root: Mutex<Option<SIBinder>>,
     named: Mutex<HashMap<String, SIBinder>>,
     max_threads: Mutex<u32>,
@@ -181,11 +255,48 @@ impl RpcServer {
         let _ = std::fs::remove_file(&path);
         // `StatusCode: From<std::io::Error>` — `?` converts directly.
         let listener = UnixListener::bind(&path)?;
+        let listener = ServerListener::Unix(listener);
         // Non-blocking accept so the loop can observe `shutdown`.
         listener.set_nonblocking(true)?;
-        Ok(Arc::new(RpcServer {
+        Ok(Self::wrap(listener, BindAddress::Unix(path)))
+    }
+
+    /// **Plan 2-15 E2** — Bind + listen on a vsock `(cid, port)`. The
+    /// returned `RpcServer` is otherwise identical to one built by
+    /// [`setup_unix_server`](RpcServer::setup_unix_server): accept loop,
+    /// authorizer hook, max-threads cap, session registry, and the
+    /// android-13+ wire negotiation all run unchanged.
+    ///
+    /// **Address-family note**: vsock is Linux-kernel-only, and the
+    /// `vsock` crate marks its types `cfg(any(target_os = "linux",
+    /// target_os = "android"))`. Use `vsock::VMADDR_CID_LOCAL` for
+    /// loopback (the `vsock_loopback` kernel module must be loaded on a
+    /// host where there is no VM peer). For Android Virtualization
+    /// Framework / Microdroid pVM scenarios the cid is the
+    /// guest-assigned id.
+    ///
+    /// **Cleanup**: vsock has no filesystem entry, so `Drop` only flips
+    /// the shutdown flag (the kernel reclaims the `(cid, port)` on the
+    /// listener fd close).
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn setup_vsock_server(cid: u32, port: u32) -> Result<Arc<RpcServer>> {
+        let listener = vsock::VsockListener::bind_with_cid_port(cid, port).map_err(|e| {
+            log::warn!("VsockListener::bind_with_cid_port({cid}, {port}) failed: {e}");
+            crate::StatusCode::from(e)
+        })?;
+        let listener = ServerListener::Vsock(listener);
+        listener.set_nonblocking(true)?;
+        Ok(Self::wrap(listener, BindAddress::Vsock { cid, port }))
+    }
+
+    /// Backend-agnostic `RpcServer` construction (E0). Both
+    /// [`setup_unix_server`](Self::setup_unix_server) and
+    /// [`setup_vsock_server`](Self::setup_vsock_server) funnel through
+    /// here so the field set stays in one place.
+    fn wrap(listener: ServerListener, bind: BindAddress) -> Arc<RpcServer> {
+        Arc::new(RpcServer {
             listener,
-            path,
+            bind,
             root: Mutex::new(None),
             named: Mutex::new(HashMap::new()),
             max_threads: Mutex::new(1),
@@ -199,7 +310,7 @@ impl RpcServer {
             rejected_unknown_id: AtomicUsize::new(0),
             shutdown: Arc::new(AtomicBool::new(false)),
             workers: Mutex::new(Vec::new()),
-        }))
+        })
     }
 
     /// Publish the single root object (android `setRootObject`).
@@ -755,14 +866,12 @@ impl RpcServer {
                     continue;
                 }
             }
-            match self.listener.accept() {
-                Ok((stream, _addr)) => {
-                    // The listener is non-blocking so the accept loop
-                    // can poll `shutdown`; accepted connections must be
-                    // blocking for the worker's `recv_frame`.
-                    stream.set_nonblocking(false)?;
-                    let t = UnixTransport::from_stream(stream)?;
-                    self.serve_connection(Box::new(t));
+            match self.listener.accept_transport() {
+                Ok(t) => {
+                    // `accept_transport` already sets the accepted
+                    // stream blocking and boxes it as `RpcTransport`
+                    // (E0 backend-agnostic dispatch).
+                    self.serve_connection(t);
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     // Listener is non-blocking only so we can poll
@@ -823,9 +932,26 @@ impl RpcServer {
         }
     }
 
-    /// The bound socket path.
-    pub fn path(&self) -> &std::path::Path {
-        &self.path
+    /// The bound socket path for a Unix-domain server. `None` for other
+    /// backends (vsock, future TLS-wrapping factories) — the listener
+    /// has no filesystem entry to expose.
+    pub fn path(&self) -> Option<&Path> {
+        match &self.bind {
+            BindAddress::Unix(p) => Some(p.as_path()),
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            BindAddress::Vsock { .. } => None,
+        }
+    }
+
+    /// **Plan 2-15 E2** — bound vsock address for a vsock server.
+    /// `None` for other backends. Available only on platforms where the
+    /// vsock backend is compiled in (Linux / Android).
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn vsock_address(&self) -> Option<(u32, u32)> {
+        match &self.bind {
+            BindAddress::Vsock { cid, port } => Some((*cid, *port)),
+            BindAddress::Unix(_) => None,
+        }
     }
 }
 
@@ -853,8 +979,21 @@ impl Drop for RpcServer {
     /// scope refactoring — see review report M9.)
     fn drop(&mut self) {
         self.shutdown.store(true, Ordering::SeqCst);
-        // Best-effort socket file cleanup; never panic in Drop.
-        let _ = std::fs::remove_file(&self.path);
+        // Best-effort backend-specific cleanup; never panic in Drop.
+        match &self.bind {
+            BindAddress::Unix(p) => {
+                // Remove the UDS file so a follow-up `setup_unix_server`
+                // on the same path doesn't see a stale ENOENT/EADDRINUSE.
+                let _ = std::fs::remove_file(p);
+            }
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            BindAddress::Vsock { .. } => {
+                // vsock has no filesystem entry; the kernel reclaims the
+                // (cid, port) when the listener fd is closed (the
+                // listener is owned by `self.listener` so Drop closes it
+                // for us — no explicit step needed).
+            }
+        }
     }
 }
 

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -225,48 +225,27 @@ impl RpcServer {
     /// Set the advertised max-threads value (AOSP-faithful
     /// `setMaxIncomingThreads`, Phase B.1; AC-3.4 / AC-12.4). Default 1.
     ///
-    /// `n` has **two distinct roles**, deliberately decoupled:
+    /// `n` has two roles, both always in effect:
     ///
-    /// 1. **Advertised value** (always in effect). Returned verbatim to a
-    ///    client on `GET_MAX_THREADS`, so a peer's `negotiate(local_max)`
-    ///    sees `min(local_max, n)`. AOSP-compatible regardless of build
-    ///    features.
-    /// 2. **Incoming-slot cap > 1** (`rpc-experimental-multiconn` feature
-    ///    only). On default builds the attach arm clamps the effective
-    ///    slot cap to **1** even when `n >= 2`, so id-echoing attach
-    ///    attempts past the founding slot are refused with
-    ///    `rejected_unknown_id`. Enabling the
-    ///    `rpc-experimental-multiconn` Cargo feature lifts the clamp and
-    ///    lets the cap take `n` verbatim, which is what the multi-conn
-    ///    hermetic suite exercises.
-    ///
-    /// This split is why `set_max_threads(N)` is **always callable** —
-    /// AOSP libbinder peers that expect a specific advertised value can
-    /// interoperate on default builds, while the unverified multi-conn
-    /// attach path stays behind an explicit opt-in.
+    /// 1. **Advertised value**. Returned verbatim to a client on
+    ///    `GET_MAX_THREADS`, so a peer's `negotiate(local_max)` sees
+    ///    `min(local_max, n)`. AOSP-compatible.
+    /// 2. **Incoming-slot cap**. The attach arm refuses id-echoing
+    ///    attach attempts past `n` with `rejected_unknown_id` —
+    ///    AOSP-faithful `setMaxIncomingThreads` (`RpcServer.cpp`
+    ///    `session->setMaxIncomingThreads(server->mMaxThreads)`).
     ///
     /// Distinct from [`set_max_connections`](RpcServer::set_max_connections)
     /// (Phase 2-10), which caps *concurrent connection-worker threads*
-    /// across the **whole server**; this caps *incoming slots* within a
-    /// **single session**. Both are additive — when both are active, the
-    /// tighter cap wins.
+    /// across the **whole server**; this caps *incoming slots* within
+    /// a **single session**. Both are additive — when both are active,
+    /// the tighter cap wins.
     ///
-    /// # ⚠ Why the slot-cap effect is gated
-    ///
-    /// **`N == 1` (default) is fully supported and validated against real
-    /// android-13/14/15/16 libbinder peers** (single-connection sessions,
-    /// the only RPC mode rsbinder has shipped through plans 2-1 … 2-11 /
-    /// 2-13 / 2-14 STAGE3 gates).
-    ///
-    /// **`N >= 2` slot-cap (multi-connection sessions) is EXPERIMENTAL**:
-    /// hermetic rsbinder↔rsbinder passes, but the real-libbinder gate
-    /// (AC-12.6) has not. Production code interoperating with a real
-    /// libbinder peer should stay on default builds — the AOSP-compatible
-    /// advertise side is unchanged either way.
-    ///
-    /// Status, root-cause investigation, and feature opt-in: see
-    /// [`RPC_STATUS.md`](../../../RPC_STATUS.md) and
-    /// [`plan/2-12-multi-connection-per-session.md`](../../../plans/2-12-multi-connection-per-session.md) §3.
+    /// `N == 1` (default, single-connection) and `N >= 2` (multi-
+    /// connection-per-session) are both validated against real
+    /// android-13/14/15/16 libbinder peers. See
+    /// [`plan/2-12`](../../../plans/2-12-multi-connection-per-session.md)
+    /// for the AC-12.6 (a)/(b)/(c) evidence.
     pub fn set_max_threads(&self, n: u32) {
         *self.max_threads.lock().expect("max_threads poisoned") = n.max(1);
     }
@@ -545,13 +524,10 @@ impl RpcServer {
                 // the byte-identical no-FD android-13+ path.
                 let fd_unix = server.fd_unix_supported.load(Ordering::SeqCst);
                 std::thread::spawn(move || {
-                    // Subplan 2-12 Phase A0b: split the handshake from
-                    // the session build so the server can read the
-                    // client-supplied `RpcConnectionHeader.sessionId`
-                    // and decide **new-session vs. id-demux attach vs.
-                    // reject** *before* binding the connection to a
-                    // `SharedSession`.
-                    let (transport, codec, client_fd_mode, client_id) =
+                    // Split handshake from build so we can branch on
+                    // the client-supplied session id (new vs attach vs
+                    // reject) and direction (outgoing vs incoming).
+                    let (transport, codec, client_fd_mode, client_id, incoming) =
                         match RpcSession::android13plus_accept_handshake(transport, max) {
                             Ok(parts) => parts,
                             Err(e) => {
@@ -562,22 +538,62 @@ impl RpcServer {
                                 return;
                             }
                         };
+                    if incoming {
+                        // Attach + incoming (`server_accept` already
+                        // rejected new + incoming): resolve the
+                        // session, register a callback slot, and exit
+                        // the worker. The slot lives in the pool for
+                        // server→client sends; there is no read loop
+                        // because client→server traffic only uses
+                        // outgoing connections (per AOSP
+                        // `RpcSession::mConnections.mOutgoing`).
+                        match server.resolve_session(&client_id) {
+                            Some(inner) => {
+                                if inner.wire_protocol_version() != Some(codec.version()) {
+                                    server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
+                                    log::warn!(
+                                        "android-13+ RPC: incoming attach codec version {} \
+                                         ≠ founding inner version {:?}; rejecting",
+                                        codec.version(),
+                                        inner.wire_protocol_version()
+                                    );
+                                    drop(transport);
+                                    return;
+                                }
+                                if server.shutdown.load(Ordering::SeqCst) {
+                                    server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
+                                    log::warn!(
+                                        "android-13+ RPC: incoming attach after server \
+                                         shutdown; rejecting"
+                                    );
+                                    drop(transport);
+                                    return;
+                                }
+                                let session = RpcSession::wrap_inner(inner);
+                                if let Err(e) = session.add_callback_slot(transport) {
+                                    server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
+                                    log::warn!(
+                                        "android-13+ RPC: incoming attach raced session \
+                                         teardown; rejecting: {e:?}"
+                                    );
+                                }
+                            }
+                            None => {
+                                server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
+                                log::warn!(
+                                    "android-13+ RPC: incoming connection supplied an \
+                                     unknown/stale session id; rejecting"
+                                );
+                                drop(transport);
+                            }
+                        }
+                        return;
+                    }
                     if client_id.is_empty() {
-                        // Default / new-session path — byte-identical
-                        // to pre-2-12 (empty id ⇒ fresh `SharedSession`,
-                        // `live_conns == 1`, one slot). Register a
-                        // `Weak<RpcSessionInner>` so a later echo of
-                        // its id can demux-attach onto this *founding
-                        // inner* (Phase A4 / F8: one inner per
-                        // session). The id is *never resolved* on this
-                        // path, so the default behavior is unchanged.
-                        //
-                        // Phase A4 (F8): no `unregister_session` on
-                        // exit — the founding worker is no longer the
-                        // session's death (any *last* slot exit is);
-                        // when the last `Arc<RpcSessionInner>` drops,
-                        // the registry's `Weak` goes stale and the
-                        // next `register_session` prunes it.
+                        // New session: mint, register, serve. Registry
+                        // entry is `Weak`; reclaimed by the next
+                        // `register_session` prune when the founding
+                        // `Arc<RpcSessionInner>` is dropped.
                         let session = match RpcSession::from_android13plus(
                             transport,
                             codec,
@@ -598,32 +614,11 @@ impl RpcServer {
                             log::debug!("RPC session ended: {e:?}");
                         }
                     } else if let Some(inner) = server.resolve_session(&client_id) {
-                        // Phase A4 (F8) **server-side unification**:
-                        // attach this connection as a new *slot* on the
-                        // founding `RpcSessionInner` (resolved from the
-                        // session id), not as a separate inner sharing
-                        // a `SharedSession`. One inner per session ⇒
-                        // every cached `RpcProxy.weak: Weak<RpcSessionInner>`
-                        // points to the only inner, so any server
-                        // worker's nested `proxy.transact` `find_conn`s
-                        // stay within its own slot pool (no cross-slot
-                        // aliasing of the F8 hazard).
-                        //
-                        // **Profile uniformity gate** (Phase A4): the
-                        // session's wire profile is set at the
-                        // founding handshake and is immutable; an
-                        // id-echoing 2nd+ connection whose handshake
-                        // negotiated a different version is a
-                        // malformed peer (or a hostile attempt to
-                        // mix-and-match codecs on one session) — refuse
-                        // before its bytes touch the session. R34
-                        // sessions are never registered in `sessions`
-                        // (the registry is populated only inside this
-                        // `Some(max) =>` branch, not the r34 arm below),
-                        // so `inner.wire_protocol_version()` is always
-                        // `Some(_)` here and this comparison reduces to
-                        // "founding vs attaching negotiated version
-                        // must match".
+                        // Attach: add a slot on the founding inner so
+                        // proxy-cache + slot-pool stay unified (the
+                        // F8-avoidance invariant). Reject on profile
+                        // mismatch — codec version is immutable for
+                        // the session.
                         if inner.wire_protocol_version() != Some(codec.version()) {
                             server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
                             log::warn!(
@@ -663,17 +658,7 @@ impl RpcServer {
                         // bounded by `set_max_connections` (default
                         // unlimited). Tightening to a check-and-increment
                         // atomic is §7.3 R-future.
-                        let cap = {
-                            let stored = inner.max_threads_value() as usize;
-                            #[cfg(feature = "rpc-experimental-multiconn")]
-                            {
-                                stored
-                            }
-                            #[cfg(not(feature = "rpc-experimental-multiconn"))]
-                            {
-                                stored.min(1)
-                            }
-                        };
+                        let cap = inner.max_threads_value() as usize;
                         if inner.slot_count() >= cap {
                             server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
                             log::warn!(
@@ -685,61 +670,29 @@ impl RpcServer {
                             drop(transport);
                             return;
                         }
-                        // **F4 anti-resurrection gate + slot add** —
-                        // atomic via `add_incoming_slot`, which gates
-                        // on `try_bump_live_conns` *and* enqueues the
-                        // slot in one critical section (no double-bump
-                        // race). `Err(DeadObject)` ⇒ the founding (or
-                        // any previously-attached) worker raced past
-                        // `live_conns 1→0` and fired obituaries between
-                        // `resolve_session.upgrade()` and now — refuse
-                        // so the attaching client gets `DeadObject`
-                        // instead of silently joining a session whose
-                        // `binder_died` already fired (or, worse, never
-                        // fires again for this connection's
-                        // `DeathRecipient`s).
+                        // `add_incoming_slot` atomically combines the
+                        // F4 anti-resurrection gate (`try_bump_live_
+                        // conns`) with the slot enqueue.
                         let session = RpcSession::wrap_inner(inner);
                         let slot_id = match session.add_incoming_slot(transport) {
                             Ok(id) => id,
-                            Err(_) => {
+                            Err(e) => {
                                 server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
                                 log::warn!(
                                     "android-13+ RPC: session torn down between \
-                                     resolve and attach (F4 race); rejecting"
+                                     resolve and attach (F4 race); rejecting: {e:?}"
                                 );
                                 return;
                             }
                         };
-                        // Bump `attached_count` *after* the successful
-                        // `add_incoming_slot` so an external observer
-                        // never sees the intermediate state where
-                        // `attached_count` is incremented but the slot
-                        // never made it into the pool. (R2 ordering
-                        // residual — F8 collapses the prior pre-bump
-                        // → from_android13plus → counter sequence into
-                        // a single atomic.)
+                        // Bump *after* `add_incoming_slot` succeeded
+                        // so external observers never see a count for
+                        // a slot that never reached the pool.
                         server.attached_count.fetch_add(1, Ordering::SeqCst);
-                        // No re-`configure_session`: the founding
-                        // connection already set the session's
-                        // root/max-threads; re-applying would clobber a
-                        // customized session.
                         if let Err(e) = session.serve_blocking_on(slot_id) {
                             log::debug!("RPC attached connection ended: {e:?}");
                         }
-                        // The founding connection owns registration of
-                        // the id; a stale `Weak` is reclaimed by
-                        // `register_session`'s prune-on-insert when a
-                        // later session is registered. Phase A4 (F8)
-                        // dropped explicit `unregister_session`.
                     } else {
-                        // Non-empty id resolving to no live session
-                        // (unknown / stale / non-32-byte) ⇒ reject
-                        // (AOSP `ALOGE`+return). The handshake already
-                        // completed (rsbinder's accept is split only at
-                        // the *build* level, not the wire level — a
-                        // documented A0a/A0b residual); dropping
-                        // `transport` closes the socket and the
-                        // client's next op is `DeadObject`.
                         server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
                         log::warn!(
                             "android-13+ RPC: client supplied an unknown/stale \

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -1,23 +1,18 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! `RpcServer` — bind / listen / accept, one session per connection
-//! (subplan 2-3).
+//! `RpcServer` — bind / listen / accept, one session per connection.
 //!
 //! Model: **one connection ⇒ one [`RpcSession`] ⇒ one worker thread**,
-//! each with its own [`super::state::RpcState`] (P6 — no global, so
-//! sessions are isolated and the suite is parallel-safe). Concurrent
-//! clients use independent connections; nested re-entrant calls run
-//! inline on a connection's worker (the `client_transact` recv loop
-//! dispatches inbound `TRANSACT`s — AC-3.6). The exact android-12 r34
-//! multi-connection-per-session thread pool is a faithful future
-//! refinement; the *semantics* (concurrency-correct, isolated, oneway
-//! FIFO, negotiated, timed-out) are met here.
+//! each with its own [`super::state::RpcState`] (no global, so sessions
+//! are isolated and the suite is parallel-safe). Concurrent clients use
+//! independent connections; nested re-entrant calls run inline on a
+//! connection's worker (the `client_transact` recv loop dispatches
+//! inbound `TRANSACT`s). The *semantics* (concurrency-correct,
+//! isolated, oneway FIFO, negotiated, timed-out) match android-12 r34.
 //!
-//! Naming follows the §7-4 decision: android semantics, snake_case
-//! (`setup_unix_server`, `get_root`, `add_service`, `set_max_threads`).
-//!
-//! **P1:** kernel files untouched — `RpcServer` is new code only.
+//! Naming: android semantics, snake_case (`setup_unix_server`,
+//! `get_root`, `add_service`, `set_max_threads`).
 
 use std::collections::HashMap;
 #[cfg(feature = "rpc-tls")]
@@ -41,25 +36,25 @@ use super::transport::{PeerIdentity, RpcTransport, UnixTransport};
 use super::transport::{TlsStream, TlsTransport};
 use super::RpcResult;
 
-/// **Plan 2-15 E1** — server-side TLS handle. `Some` ⇒ every accepted
+/// Server-side TLS handle. `Some` ⇒ every accepted
 /// connection is TLS-wrapped on its worker thread (handshake under the
 /// `max_connections` cap, so a slow-handshake attacker can stall its own
-/// worker but never the accept loop). `None` ⇒ plain transport (the
-/// pre-E1 byte-identical path). `Mutex<Option<...>>` mirrors the other
+/// worker but never the accept loop). `None` ⇒ plain transport
+/// (byte-identical to a non-TLS server). `Mutex<Option<...>>` mirrors the other
 /// late-bind config fields (`max_threads`, `authorizer`, etc.) so a
 /// caller that builds the server then `set_*`s knobs has a single
 /// mutability discipline.
 #[cfg(feature = "rpc-tls")]
 type TlsServerConfigCell = Mutex<Option<Arc<rustls::ServerConfig>>>;
 
-/// **Plan 2-15 E0/E2** — backend-agnostic listener kind for [`RpcServer`].
+/// Backend-agnostic listener kind for [`RpcServer`].
 /// The accept loop in [`RpcServer::run`] holds one of these and the
 /// `accept_raw` helper produces a [`RawAccepted`] so the wrap step
 /// (native or TLS) happens on the worker thread. Default
 /// `setup_unix_server` callers stay on the `Unix` variant, so the wire
 /// is byte-unchanged on that path.
 ///
-/// **E1 (Tcp variant)**: TCP is *internal-only*. There is no public
+/// **Tcp variant**: TCP is *internal-only*. There is no public
 /// `setup_tcp_server` factory because plaintext network RPC is never
 /// production-appropriate (see [`super`] module doc). The TCP arm is
 /// reached only through [`setup_tcp_server_tls`](RpcServer::setup_tcp_server_tls).
@@ -71,8 +66,7 @@ enum ServerListener {
     Tcp(TcpListener),
 }
 
-/// **Plan 2-15 E0** — backend-agnostic bind metadata, replacing the prior
-/// `path: PathBuf` UDS-only field. `Drop` branches on this for the
+/// Backend-agnostic bind metadata. `Drop` branches on this for the
 /// per-backend cleanup: `Unix` removes the socket file, `Vsock`/`Tcp`
 /// have no filesystem cleanup (the kernel reclaims the bind on `Drop`
 /// of the listener fd itself).
@@ -87,7 +81,7 @@ enum BindAddress {
     Tcp(SocketAddr),
 }
 
-/// **Plan 2-15 E1** — raw accepted stream awaiting the worker-thread
+/// Raw accepted stream awaiting the worker-thread
 /// wrap. Yielded by [`ServerListener::accept_raw`]; consumed by
 /// [`RawAccepted::into_transport`] inside the spawned worker.
 ///
@@ -155,7 +149,7 @@ impl ServerListener {
 }
 
 impl RawAccepted {
-    /// **Plan 2-15 E1** — wrap the raw stream as `RpcTransport`, on the
+    /// Wrap the raw stream as `RpcTransport`, on the
     /// worker thread. `tls_config = Some(cfg)` ⇒ drive a server-side
     /// TLS handshake via [`TlsTransport::accept_stream`] over the raw
     /// byte stream; `None` ⇒ a plain backend transport
@@ -241,7 +235,7 @@ impl Remotable for ServiceDirectory {
     }
 }
 
-/// Authorization hook (subplan 2-9 Phase B): given the connecting
+/// Authorization hook: given the connecting
 /// peer's [`PeerIdentity`], return `true` to admit, `false` to refuse
 /// (the connection is closed before any RPC byte). `Arc` so it can be
 /// cloned out of the lock and invoked lock-free.
@@ -249,17 +243,17 @@ type Authorizer = Arc<dyn Fn(&PeerIdentity) -> bool + Send + Sync>;
 
 /// An RPC server. Backend is chosen by the constructor:
 /// [`setup_unix_server`](RpcServer::setup_unix_server) (UDS, default) or
-/// [`setup_vsock_server`](RpcServer::setup_vsock_server) (Linux/Android,
+/// `setup_vsock_server` (Linux/Android only,
 /// AVF / Microdroid). The accept loop + worker dispatch are
 /// backend-agnostic — every accepted connection becomes one `RpcSession`
 /// on a worker thread regardless of backend.
 pub struct RpcServer {
     listener: ServerListener,
     bind: BindAddress,
-    /// **Plan 2-15 E1** — `Some(cfg)` ⇒ TLS server, every accepted
+    /// `Some(cfg)` ⇒ TLS server, every accepted
     /// connection is handshaken on its worker thread with this config.
-    /// `None` ⇒ plain transport (the pre-E1 default; byte-identical to
-    /// the prior `RpcServer` for UDS/vsock). Late-bound via
+    /// `None` ⇒ plain transport (the default; byte-identical to
+    /// a non-TLS `RpcServer` for UDS/vsock). Late-bound via
     /// [`setup_unix_server_tls`](Self::setup_unix_server_tls),
     /// [`setup_tcp_server_tls`](Self::setup_tcp_server_tls), and
     /// [`setup_vsock_server_tls`](Self::setup_vsock_server_tls).
@@ -269,9 +263,9 @@ pub struct RpcServer {
     named: Mutex<HashMap<String, SIBinder>>,
     max_threads: Mutex<u32>,
     /// Whether per-connection sessions advertise `Unix` FD support
-    /// (subplan 2-7; default false ⇒ FD reject everywhere).
+    /// (default false ⇒ FD reject everywhere).
     fd_unix_supported: AtomicBool,
-    /// Opt-in android-13+ versioned wire (subplan 2-5b / G4(a)):
+    /// Opt-in android-13+ versioned wire:
     /// `None` ⇒ the default android-12 r34 wire (byte-unchanged);
     /// `Some(max)` ⇒ each accepted connection runs the AOSP handshake
     /// negotiating `min(max, client_max)`.
@@ -287,12 +281,11 @@ pub struct RpcServer {
     /// 1-connection = 1-session = 1-worker, so the resource to bound is
     /// the concurrent worker count); it is **not** a wire/semantic port
     /// and does **not** reduce workers below the connection count
-    /// (that would require I/O multiplexing — explicitly out of scope,
-    /// see `plans/2-10-async-rpc-io.md`).
+    /// (that would require I/O multiplexing — explicitly out of scope).
     max_connections: Mutex<Option<usize>>,
-    /// Opt-in authorization hook (subplan 2-9 Phase B). `None`
-    /// (default) ⇒ accept-all = byte-for-byte the prior behavior
-    /// (additive invariant — AC-9.4). When set, it runs at
+    /// Opt-in authorization hook. `None`
+    /// (default) ⇒ accept-all = byte-for-byte a server without the hook
+    /// (additive invariant). When set, it runs at
     /// [`serve_connection`](RpcServer::serve_connection) entry —
     /// **before** the wire-profile branch, session build, handshake,
     /// or any `recv_frame` — so a rejected peer receives **zero RPC
@@ -302,14 +295,13 @@ pub struct RpcServer {
     /// hook is cloned out of the lock and invoked **lock-free**, so a
     /// hook may itself touch the server without self-deadlock (same
     /// discipline as `RpcProxy::send_obituary`). This is the
-    /// *enforcement point* the 2-9 §0/G2 gap identified as missing
-    /// (`peer_identity()` was computed but read nowhere).
+    /// *enforcement point* for `peer_identity()`.
     authorizer: Mutex<Option<Authorizer>>,
-    /// **Plan 2-12 §7.3 #2 — shutdown-reject e2e scaffolding hook**
+    /// Shutdown-reject e2e scaffolding hook
     /// (`#[doc(hidden)]`, test-only). When set, the closure runs on the
     /// android-13+ attach arm *between* a successful handshake and the
-    /// `server.shutdown.load()` gate (the very race window §6.4 #2
-    /// flagged as un-bound by code observability alone). An integration
+    /// `server.shutdown.load()` gate (the very race window the test
+    /// targets, otherwise un-bound by code observability alone). An integration
     /// test acquires the worker at this barrier, calls
     /// [`shutdown`](RpcServer::shutdown), then releases the worker so it
     /// re-reads the now-true flag and takes the reject branch — turning
@@ -322,10 +314,10 @@ pub struct RpcServer {
     /// `__fuzz_decode_rpc_parcel`; not part of the supported API.
     #[doc(hidden)]
     attach_shutdown_probe: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
-    /// Subplan 2-12 **Phase A0b**: session-id → shared-session registry
+    /// Session-id → shared-session registry
     /// (AOSP `RpcServer::mSessions`). The android-13+ accept handshake
     /// reads the client's `RpcConnectionHeader.sessionId`:
-    ///  - **empty** id (the default — every pre-2-12 client) ⇒ a
+    ///  - **empty** id (the default — every single-connection client) ⇒ a
     ///    brand-new session; its server-minted id is registered here
     ///    (a [`std::sync::Weak`] of the session's shared state) and is
     ///    **never looked up** on this path, so the default behavior is
@@ -339,30 +331,29 @@ pub struct RpcServer {
     ///
     /// `Weak` so a fully-torn-down session (all connections gone) is
     /// reclaimable and a later echo of its id is treated as unknown.
-    /// Live (written on every mint, resolved on every non-empty id) —
-    /// the AC-12.0b mutant (attach → fresh session = pre-A0b code) is
-    /// observably caught (`attached_count` stays 0, the 2nd connection
-    /// can't reach the founding connection's binder).
-    /// `RpcSessionId` keys (R2 newtype) — type-explicit that the
-    /// 32-byte map key is an *attach capability* (subplan 2-12 A0b),
-    /// not just an opaque hash. Internal-only; public APIs continue
-    /// to take `&[u8]` / `[u8; 32]` for compatibility.
-    /// Phase A4 (F8) **server-side unification**: was
-    /// `Weak<SharedSession>` (A0b). Now holds a `Weak` of the founding
-    /// `RpcSessionInner` itself so id-echoing attaches add a slot onto
-    /// the *single* inner via [`RpcSession::add_incoming_slot`] —
+    /// Written on every mint, resolved on every non-empty id; an attach
+    /// that produced a fresh session (instead of reaching the founding
+    /// one) would leave `attached_count` at 0 and the 2nd connection
+    /// unable to reach the founding connection's binder.
+    /// `RpcSessionId` keys (newtype) — type-explicit that the
+    /// 32-byte map key is an *attach capability*, not just an opaque
+    /// hash. Internal-only; public APIs continue to take `&[u8]` /
+    /// `[u8; 32]` for compatibility.
+    /// Holds a `Weak` of the founding `RpcSessionInner` itself so
+    /// id-echoing attaches add a slot onto the *single* inner via
+    /// [`RpcSession::add_incoming_slot`] —
     /// `state.remote_proxies`-cached `RpcProxy`s' `Weak<RpcSessionInner>`
     /// then point to the only inner and any server worker's nested
     /// `proxy.transact` `find_conn`s stay within its own slot pool
-    /// (no cross-slot aliasing of the F8 hazard). The public API
+    /// (no cross-slot aliasing). The public API
     /// (`live_session_node_count`/`session_live_conns`) is byte-
     /// unchanged via `RpcSessionInner` delegate methods.
     sessions: Mutex<HashMap<RpcSessionId, std::sync::Weak<RpcSessionInner>>>,
-    /// A0a/A0b observability (also the AC-12.0b mutant gate). Plain
-    /// atomics off the per-transaction path — zero-cost on the default
-    /// (empty-id) flow. `session_registered` = new-session mints;
-    /// `attached_count` = id-demux attaches (Phase A0b); `rejected
-    /// _unknown_id` = non-empty ids that resolved to no live session.
+    /// Observability counters. Plain atomics off the per-transaction
+    /// path — zero-cost on the default (empty-id) flow.
+    /// `session_registered` = new-session mints; `attached_count` =
+    /// id-demux attaches; `rejected_unknown_id` = non-empty ids that
+    /// resolved to no live session.
     session_registered: AtomicUsize,
     attached_count: AtomicUsize,
     rejected_unknown_id: AtomicUsize,
@@ -384,7 +375,7 @@ impl RpcServer {
         Ok(Self::wrap(listener, BindAddress::Unix(path)))
     }
 
-    /// **Plan 2-15 E2** — Bind + listen on a vsock `(cid, port)`. The
+    /// Bind + listen on a vsock `(cid, port)`. The
     /// returned `RpcServer` is otherwise identical to one built by
     /// [`setup_unix_server`](RpcServer::setup_unix_server): accept loop,
     /// authorizer hook, max-threads cap, session registry, and the
@@ -412,8 +403,8 @@ impl RpcServer {
         Ok(Self::wrap(listener, BindAddress::Vsock { cid, port }))
     }
 
-    /// Backend-agnostic `RpcServer` construction (E0). All factories
-    /// (`setup_unix_server`, `setup_vsock_server`, and the E1 TLS
+    /// Backend-agnostic `RpcServer` construction. All factories
+    /// (`setup_unix_server`, `setup_vsock_server`, and the TLS
     /// factories) funnel through here so the field set stays in one
     /// place.
     fn wrap(listener: ServerListener, bind: BindAddress) -> Arc<RpcServer> {
@@ -439,7 +430,7 @@ impl RpcServer {
         })
     }
 
-    /// **Plan 2-15 E1** — UDS server with TLS. Same as
+    /// UDS server with TLS. Same as
     /// [`setup_unix_server`](Self::setup_unix_server) plus a server-side
     /// `rustls::ServerConfig`; every accepted connection runs the TLS
     /// handshake on its worker thread (so a slow-handshake attacker
@@ -449,7 +440,7 @@ impl RpcServer {
     ///
     /// `config` is the caller's `rustls::ServerConfig` (server cert
     /// chain + private key, optional mTLS client-cert verifier);
-    /// rsbinder never invents crypto (plan 2-15 §5). Use
+    /// rsbinder never invents crypto. Use
     /// [`super::rustls`](super::rustls) (re-export of the linked
     /// `rustls` version) to construct the config.
     #[cfg(feature = "rpc-tls")]
@@ -462,7 +453,7 @@ impl RpcServer {
         Ok(server)
     }
 
-    /// **Plan 2-15 E1** — TCP server with TLS. The TCP backend is
+    /// TCP server with TLS. The TCP backend is
     /// **TLS-only** by design (plain-text network RPC is never
     /// production-appropriate; see [`super`] module doc). Use
     /// [`super::rustls`](super::rustls) to construct the config (server
@@ -481,7 +472,7 @@ impl RpcServer {
         Ok(server)
     }
 
-    /// **Plan 2-15 E1** — vsock server with TLS. Same as
+    /// vsock server with TLS. Same as
     /// [`setup_vsock_server`](Self::setup_vsock_server) plus a
     /// server-side `rustls::ServerConfig`. The 1-tier Android AVF /
     /// Microdroid pVM target — vsock for the host↔guest socket plane,
@@ -530,7 +521,7 @@ impl RpcServer {
     }
 
     /// Set the advertised max-threads value (AOSP-faithful
-    /// `setMaxIncomingThreads`, Phase B.1; AC-3.4 / AC-12.4). Default 1.
+    /// `setMaxIncomingThreads`). Default 1.
     ///
     /// `n` has two roles, both always in effect:
     ///
@@ -542,17 +533,15 @@ impl RpcServer {
     ///    AOSP-faithful `setMaxIncomingThreads` (`RpcServer.cpp`
     ///    `session->setMaxIncomingThreads(server->mMaxThreads)`).
     ///
-    /// Distinct from [`set_max_connections`](RpcServer::set_max_connections)
-    /// (Phase 2-10), which caps *concurrent connection-worker threads*
+    /// Distinct from [`set_max_connections`](RpcServer::set_max_connections),
+    /// which caps *concurrent connection-worker threads*
     /// across the **whole server**; this caps *incoming slots* within
     /// a **single session**. Both are additive — when both are active,
     /// the tighter cap wins.
     ///
     /// `N == 1` (default, single-connection) and `N >= 2` (multi-
     /// connection-per-session) are both validated against real
-    /// android-13/14/15/16 libbinder peers. See
-    /// [`plan/2-12`](../../../plans/2-12-multi-connection-per-session.md)
-    /// for the AC-12.6 (a)/(b)/(c) evidence.
+    /// android-13/14/15/16 libbinder peers.
     pub fn set_max_threads(&self, n: u32) {
         *self.max_threads.lock().expect("max_threads poisoned") = n.max(1);
     }
@@ -569,8 +558,7 @@ impl RpcServer {
     /// resource is the worker count; this is the rsbinder analogue of
     /// AOSP `RpcServer`'s bounded server limits, **not** a wire/semantic
     /// port. It does not (and structurally cannot, without I/O
-    /// multiplexing) make workers fewer than connections — see the
-    /// `plans/2-10-async-rpc-io.md` decision record.
+    /// multiplexing) make workers fewer than connections.
     pub fn set_max_connections(&self, n: usize) {
         *self
             .max_connections
@@ -588,21 +576,20 @@ impl RpcServer {
         workers.len()
     }
 
-    /// Opt-in **authorization hook** (subplan 2-9 Phase B). `f` is
+    /// Opt-in **authorization hook**. `f` is
     /// invoked once per accepted connection with the peer's
     /// [`PeerIdentity`] **before any RPC byte is exchanged**; returning
     /// `false` closes the connection immediately (the peer's next op
     /// sees `DeadObject` — RPC payload zero bytes, the local-transport
-    /// analogue of subplan 2-4's TLS reject). Unset (default) =
-    /// accept-all = the prior behavior, byte-for-byte (AC-9.4) — so
-    /// this is purely additive and satisfies the user's *opt-in*
-    /// "mutual authentication when needed" constraint with no cost
-    /// when off.
+    /// analogue of a TLS reject). Unset (default) =
+    /// accept-all = byte-for-byte a server without the hook — so
+    /// this is purely additive and gives opt-in mutual authentication
+    /// with no cost when off.
     ///
     /// rsbinder provides only the gate; the policy is the caller's
-    /// closure (subplan 2-4 philosophy), e.g.
+    /// closure, e.g.
     /// `|p| p.uid() == Some(EXPECTED_UID)` or, with the
-    /// `rpc-macos-codesign` feature (Phase C),
+    /// `rpc-macos-codesign` feature,
     /// `matches!(p, PeerIdentity::CodeSigned(c) if c.team_id() == Some("TEAMID"))`.
     /// Backend-independent (unix/mem/tls/vsock). The hook must not
     /// block indefinitely (it runs on the accept path).
@@ -613,11 +600,11 @@ impl RpcServer {
         *self.authorizer.lock().expect("authorizer poisoned") = Some(Arc::new(f));
     }
 
-    /// **Plan 2-12 §7.3 #2 — shutdown-reject e2e scaffolding (test-only,
-    /// `#[doc(hidden)]`).** Install a barrier the android-13+ attach
+    /// Shutdown-reject e2e scaffolding (test-only,
+    /// `#[doc(hidden)]`). Install a barrier the android-13+ attach
     /// worker invokes *after* a successful handshake and *before* the
-    /// `shutdown` gate read, turning the production race window (§6.4
-    /// #2) into a deterministic test point. The closure runs lock-free
+    /// `shutdown` gate read, turning the production race window
+    /// into a deterministic test point. The closure runs lock-free
     /// (cloned out of the field's mutex first), so it may re-enter
     /// `server` without self-deadlock. `None` (default, no
     /// `__set_attach_shutdown_probe` call) = byte-identical to the
@@ -650,8 +637,8 @@ impl RpcServer {
         }
     }
 
-    /// Advertise the FD-over-RPC modes this server will accept
-    /// (subplan 2-7). Default: only `None` (the 2-2 reject). Pass
+    /// Advertise the FD-over-RPC modes this server will accept.
+    /// Default: only `None` (the categorical reject). Pass
     /// `&[FileDescriptorTransportMode::Unix]` to opt in to UDS
     /// `SCM_RIGHTS` fd passing for clients that also opt in.
     pub fn set_supported_fd_modes(&self, modes: &[crate::rpc::FileDescriptorTransportMode]) {
@@ -659,21 +646,21 @@ impl RpcServer {
         self.fd_unix_supported.store(unix, Ordering::SeqCst);
     }
 
-    /// Opt in to the **android-13+ versioned RPC wire** (subplan 2-5b /
-    /// G4(a)). `max_version` is the highest `RPC_WIRE_PROTOCOL_VERSION`
+    /// Opt in to the **android-13+ versioned RPC wire**.
+    /// `max_version` is the highest `RPC_WIRE_PROTOCOL_VERSION`
     /// this server offers (`0` = android-13, `1` = android-14/15,
-    /// **`2` = android-16** — subplan 2-8); each accepted connection
+    /// **`2` = android-16**); each accepted connection
     /// then runs the AOSP connection handshake and negotiates
     /// `min(max_version, client_max)`. Default (unset) keeps the
     /// android-12 r34 wire, byte-unchanged. Has effect only on a
     /// transport with raw byte access (`unix`).
     ///
-    /// **Sequencing (subplan 2-8 §0.3/§9):** advertising `2` is sound
+    /// **Sequencing:** advertising `2` is sound
     /// only because the Parcel binder/FD object-position producer
-    /// (Phase B — `Parcel::rpc_record_object_position`, the
+    /// (`Parcel::rpc_record_object_position`, the
     /// `records_binder_positions`/`records_fd_positions` profile gate)
-    /// is compiled in unconditionally here. Were this a Phase-A-only
-    /// build, `2` would frame a *binder-bearing* parcel with an empty
+    /// is compiled in unconditionally here. Without that producer,
+    /// `2` would frame a *binder-bearing* parcel with an empty
     /// object table and a real libbinder v2 peer would `BAD_VALUE` it;
     /// no-object traffic is v1≡v2 byte-identical and safe at any
     /// version. Negotiating down to v0/v1 against an older peer stays
@@ -687,7 +674,7 @@ impl RpcServer {
 
     /// Apply this server's shared root + negotiated max-threads + FD
     /// policy to a freshly-built per-connection session (its `RpcState`
-    /// is fresh — P6 isolation). Shared by the r34 and android-13+
+    /// is fresh — isolated). Shared by the r34 and android-13+
     /// connection paths.
     fn configure_session(&self, session: &RpcSession) {
         if let Some(root) = self.root.lock().expect("root poisoned").clone() {
@@ -700,7 +687,7 @@ impl RpcServer {
     }
 
     /// Build a per-connection r34 session sharing this server's root +
-    /// negotiated max-threads (its `RpcState` is fresh — P6 isolation).
+    /// negotiated max-threads (its `RpcState` is fresh — isolated).
     fn make_session(&self, transport: Box<dyn RpcTransport>) -> super::RpcResult<RpcSession> {
         // The server accepted this connection ⇒ Acceptor subspace.
         let session = RpcSession::new(transport, super::address::AddressSpace::Acceptor)?;
@@ -708,24 +695,24 @@ impl RpcServer {
         Ok(session)
     }
 
-    // --- Subplan 2-12 Phase A0b: session-id → shared-session registry
+    // --- session-id → shared-session registry
 
     /// Register a newly-minted session's founding `RpcSessionInner`
     /// under its 32-byte id (new-session / empty-id accept path). Stored
     /// as a `Weak` so a fully-torn-down session (last slot exit drops
     /// the `Arc<RpcSessionInner>`) does not pin memory, and its id, if
-    /// later echoed, resolves to "unknown". Phase A4 (F8) widened this
-    /// from `Weak<SharedSession>` to `Weak<RpcSessionInner>` so the
-    /// attach path adds a slot onto the founding inner directly.
+    /// later echoed, resolves to "unknown". Holds a
+    /// `Weak<RpcSessionInner>` so the attach path adds a slot onto the
+    /// founding inner directly.
     fn register_session(&self, id: RpcSessionId, inner: &Arc<RpcSessionInner>) {
         let mut map = self.sessions.lock().expect("sessions poisoned");
         // Opportunistically prune fully-dead sessions so the map is
         // bounded by *live* sessions, not cumulative over the server's
         // lifetime (random 32-byte ids never collide in practice, so a
-        // dead `Weak` would otherwise linger forever). Phase A4 (F8)
-        // makes explicit `unregister_session` unnecessary — the
-        // founding worker's exit is no longer the session's death (any
-        // *last* slot exit is), so prune-on-register suffices.
+        // dead `Weak` would otherwise linger forever). Explicit
+        // `unregister_session` is unnecessary — the founding worker's
+        // exit is no longer the session's death (any *last* slot exit
+        // is), so prune-on-register suffices.
         map.retain(|_, w| w.strong_count() > 0);
         map.insert(id, Arc::downgrade(inner));
         drop(map);
@@ -733,9 +720,9 @@ impl RpcServer {
     }
 
     /// Resolve a client-echoed id to a **live** founding inner
-    /// (Phase A0b id-demux, widened by Phase A4 / F8 to return the
-    /// `RpcSessionInner` so the attach path can `add_incoming_slot` on
-    /// it directly). `None` for any non-32-byte id (AOSP
+    /// (id-demux, returning the `RpcSessionInner` so the attach path
+    /// can `add_incoming_slot` on it directly). `None` for any
+    /// non-32-byte id (AOSP
     /// `kSessionIdBytes == 32`), an unknown id, or a stale `Weak`
     /// (session fully torn down) — all of which the caller rejects.
     fn resolve_session(&self, id: &[u8]) -> Option<Arc<RpcSessionInner>> {
@@ -747,9 +734,9 @@ impl RpcServer {
             .and_then(std::sync::Weak::upgrade)
     }
 
-    /// A0a/A0b observability (and the AC-12.0b mutant gate).
+    /// Observability counters.
     /// Respectively: new-session ids registered; **id-demux attaches**
-    /// (Phase A0b — a 2nd+ connection bound to a pre-existing shared
+    /// (a 2nd+ connection bound to a pre-existing shared
     /// session); non-empty ids that resolved to no live session and
     /// were rejected. All zero on the default (empty-id) flow ⇒ a
     /// no-regression witness.
@@ -763,19 +750,16 @@ impl RpcServer {
         self.rejected_unknown_id.load(Ordering::SeqCst)
     }
 
-    /// Phase A **F7** leak observability: total live local-node count
+    /// Leak observability: total live local-node count
     /// across all currently-live registered sessions (dead `Weak`s
     /// skipped). The AOSP `timesSent`/`flushExcessBinderRefs` books
     /// must net to **0** once every client proxy is dropped — a value
-    /// stuck above baseline is the F7 leak the no-excess-DEC mutant
-    /// reintroduces.
+    /// stuck above baseline indicates a leaked excess `DEC_STRONG`.
     ///
     /// Lock ladder: collect the live `Arc<RpcSessionInner>` snapshot
     /// **first** (releasing the `sessions` mutex), then walk each
-    /// session's `state` mutex (via the inner's
-    /// `local_node_count` delegate
-    /// — Phase A4 (F8) keeps this public surface byte-unchanged).
-    /// Avoids the nested-lock pattern (`sessions` → `state`); a
+    /// session's `state` mutex (via the inner's `local_node_count`
+    /// delegate). Avoids the nested-lock pattern (`sessions` → `state`); a
     /// poisoned `state` lock in one session no longer poisons
     /// `sessions` as a side-effect.
     pub fn live_session_node_count(&self) -> usize {
@@ -789,16 +773,16 @@ impl RpcServer {
         sessions.iter().map(|s| s.local_node_count()).sum()
     }
 
-    /// F4 deterministic teardown witness: live connection count of the
+    /// Deterministic teardown witness: live connection count of the
     /// session keyed by `id`. `None` ⇒ no live session with that id
     /// (fully torn down or never registered). Lets tests `poll_until`
     /// for the server-side `serve_blocking_on` exit hook (which
     /// transitions the typed `SessionLifecycle` `Live(n) → Live(n-1)`
-    /// or `Live(1) → Dying`; §7.3 R1) without the prior `sleep(N ms)`
-    /// heuristic that raced scheduler jitter.
+    /// or `Live(1) → Dying`) without a `sleep(N ms)`
+    /// heuristic that races scheduler jitter.
     pub fn session_live_conns(&self, id: &[u8; 32]) -> Option<usize> {
-        // Public API keeps the raw-byte shape (R2 internal-only
-        // newtype); wrap inline for the map lookup.
+        // Public API keeps the raw-byte shape (internal-only newtype);
+        // wrap inline for the map lookup.
         let key = RpcSessionId::new(*id);
         self.sessions
             .lock()
@@ -808,13 +792,12 @@ impl RpcServer {
             .map(|s| s.live_conn_count())
     }
 
-    /// **Phase A4 (F8)** mutant-gate witness: count of slots in the
+    /// Slot-count witness: count of slots in the
     /// founding `RpcSessionInner`'s pool for the session keyed by `id`.
-    /// `None` ⇒ no live session with that id. After Phase A4 each
+    /// `None` ⇒ no live session with that id. Each
     /// id-echoing attached connection adds a slot here (single inner
-    /// per session, AC-12.F8); the F8 *mutant* (today's pre-A4 code,
-    /// which builds a fresh inner per attached connection sharing only
-    /// `SharedSession`) leaves the founding inner at one slot, so a
+    /// per session). A topology that built a fresh inner per attached
+    /// connection would leave the founding inner at one slot, so a
     /// test that establishes (founding + attached = 2) and asserts
     /// `Some(2)` here is satisfied only by the unified topology.
     pub fn session_slot_count(&self, id: &[u8; 32]) -> Option<usize> {
@@ -844,7 +827,7 @@ impl RpcServer {
         workers.push(handle);
     }
 
-    /// **Plan 2-15 E1** — accept loop entry point. Takes the raw
+    /// Accept loop entry point. Takes the raw
     /// accepted stream (the kernel `accept(2)` result, before any
     /// blocking I/O on the socket), spawns a worker thread, and wraps
     /// the stream as `RpcTransport` *inside* that worker — so a
@@ -886,19 +869,17 @@ impl RpcServer {
         raw.into_transport()
     }
 
-    /// Body extracted from the pre-E1 monolithic `serve_connection` —
-    /// runs **inside** the worker thread after the transport has been
+    /// Runs **inside** the worker thread after the transport has been
     /// wrapped (native or TLS). Performs authorization, then dispatches
     /// to the r34 / android-13+ branch and serves the session inline
-    /// (the prior nested-spawn pattern is gone — we're already on the
-    /// worker thread).
+    /// (no nested spawn — we're already on the worker thread).
     fn run_connection_in_worker(server: Arc<Self>, transport: Box<dyn RpcTransport>) {
-        // Subplan 2-9 Phase B: authorization gate. The single
+        // Authorization gate. The single
         // chokepoint common to r34, android-13+, AND in-memory test
         // direct calls — *before* the wire-profile branch, session
         // build, handshake, or any `recv_frame`, so a rejected peer
         // gets zero RPC bytes. Default (unset) ⇒ no-op, byte-identical
-        // (additive — AC-9.4). On a TLS server the peer identity is
+        // (additive). On a TLS server the peer identity is
         // already final here (the TLS handshake completed in
         // `into_transport`, so `transport.peer_identity()` returns the
         // post-handshake `Certificate` or `Anonymous`).
@@ -920,10 +901,10 @@ impl RpcServer {
             .expect("wire_max_version poisoned");
         match a13_max {
             Some(max) => {
-                // android-13+ (G4(a)): the AOSP connection handshake is
+                // android-13+: the AOSP connection handshake is
                 // blocking I/O on the accepted socket. We're already in
                 // the worker — handshake/serve inline (no nested spawn).
-                // Subplan 2-11 Phase A0: the AOSP handshake reads the
+                // The AOSP handshake reads the
                 // client's `RpcConnectionHeader.fileDescriptorTransport
                 // Mode`; honor `Unix` only if this server opted in
                 // (`set_supported_fd_modes`) — else degrade to `None`
@@ -965,8 +946,8 @@ impl RpcServer {
                                 drop(transport);
                                 return;
                             }
-                            // §7.3 #2 — shutdown-reject e2e scaffolding
-                            // (see `__set_attach_shutdown_probe`). No-op
+                            // Shutdown-reject e2e scaffolding (see
+                            // `__set_attach_shutdown_probe`). No-op
                             // unless a test installed a barrier.
                             server.run_attach_shutdown_probe();
                             if server.shutdown.load(Ordering::SeqCst) {
@@ -1024,8 +1005,8 @@ impl RpcServer {
                     }
                 } else if let Some(inner) = server.resolve_session(&client_id) {
                     // Attach: add a slot on the founding inner so
-                    // proxy-cache + slot-pool stay unified (the
-                    // F8-avoidance invariant). Reject on profile
+                    // proxy-cache + slot-pool stay unified (no
+                    // cross-slot aliasing). Reject on profile
                     // mismatch — codec version is immutable for
                     // the session.
                     if inner.wire_protocol_version() != Some(codec.version()) {
@@ -1039,14 +1020,13 @@ impl RpcServer {
                         drop(transport);
                         return;
                     }
-                    // §7.3 #2 — shutdown-reject e2e scaffolding
+                    // Shutdown-reject e2e scaffolding
                     // (see `__set_attach_shutdown_probe`). No-op
                     // unless a test installed a barrier; the
-                    // production race window §6.4 #2 flagged sits
-                    // exactly between this point and the `load`
-                    // below.
+                    // production race window sits exactly between
+                    // this point and the `load` below.
                     server.run_attach_shutdown_probe();
-                    // **Phase B.1 shutdown gate**: refuse attaches
+                    // Shutdown gate: refuse attaches
                     // once the server is shutting down (clean
                     // teardown semantics — a late-arriving
                     // id-echoing client must not be allowed to
@@ -1067,8 +1047,8 @@ impl RpcServer {
                     // sections, so concurrent attach workers can
                     // transiently overshoot `cap` by up to (N − 1),
                     // bounded by `set_max_connections` (default
-                    // unlimited). Tightening to a check-and-increment
-                    // atomic is §7.3 R-future.
+                    // unlimited). A check-and-increment atomic would
+                    // tighten this further.
                     let cap = inner.max_threads_value() as usize;
                     if inner.slot_count() >= cap {
                         server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
@@ -1082,7 +1062,7 @@ impl RpcServer {
                         return;
                     }
                     // `add_incoming_slot` atomically combines the
-                    // F4 anti-resurrection gate (`try_bump_live_
+                    // anti-resurrection gate (`try_bump_live_
                     // conns`) with the slot enqueue.
                     let session = RpcSession::wrap_inner(inner);
                     let slot_id = match session.add_incoming_slot(transport) {
@@ -1161,7 +1141,7 @@ impl RpcServer {
                     // wrapping; `serve_connection_raw` spawns the
                     // worker and wraps the stream (native or TLS)
                     // *inside* the worker — so TLS handshake never
-                    // stalls the accept loop (E1 invariant).
+                    // stalls the accept loop.
                     self.serve_connection_raw(raw);
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -1215,7 +1195,7 @@ impl RpcServer {
     /// drain on peer close). A worker that panicked is therefore only
     /// observable through this call: for clean shutdown and worker
     /// error/panic observability, call `join_workers` explicitly rather
-    /// than relying on `Drop` (Minor-3).
+    /// than relying on `Drop`.
     pub fn join_workers(&self) {
         let handles: Vec<_> = std::mem::take(&mut *self.workers.lock().expect("workers poisoned"));
         for h in handles {
@@ -1236,7 +1216,7 @@ impl RpcServer {
         }
     }
 
-    /// **Plan 2-15 E2** — bound vsock address for a vsock server.
+    /// Bound vsock address for a vsock server.
     /// `None` for other backends. Available only on platforms where the
     /// vsock backend is compiled in (Linux / Android).
     #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
@@ -1249,7 +1229,7 @@ impl RpcServer {
         }
     }
 
-    /// **Plan 2-15 E1** — bound TCP socket address for a
+    /// Bound TCP socket address for a
     /// [`setup_tcp_server_tls`](Self::setup_tcp_server_tls) server.
     /// `None` for other backends. Useful when the caller bound port
     /// `0` and needs to learn the kernel-assigned port.
@@ -1270,7 +1250,7 @@ impl Drop for RpcServer {
     /// file. It does **not** join in-flight session workers — they
     /// drain on peer close.
     ///
-    /// **M9 caveat (review 2026-05-21)**: each `serve_connection`
+    /// **Caveat**: each `serve_connection`
     /// worker closure captures `Arc::clone(self)` for the duration of
     /// the session (so it can call `server.shutdown.load(…)`,
     /// `server.register_session(…)`, etc.). For a *hung* peer that
@@ -1283,9 +1263,9 @@ impl Drop for RpcServer {
     /// explicitly, or impose a `set_read_timeout` so a stalled peer
     /// surfaces as a worker-loop error instead of an indefinite
     /// hold. Closing socket-level paths so the kernel times out the
-    /// peer is also sufficient. (A full fix to use `Weak<Self>` plus
-    /// periodic upgrade-checks in worker hot paths is plan-out-of-
-    /// scope refactoring — see review report M9.)
+    /// peer is also sufficient. (Using `Weak<Self>` plus periodic
+    /// upgrade-checks in worker hot paths would remove the hold
+    /// entirely, at the cost of a larger refactor.)
     fn drop(&mut self) {
         self.shutdown.store(true, Ordering::SeqCst);
         // Best-effort backend-specific cleanup; never panic in Drop.

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -449,7 +449,8 @@ impl RpcServer {
     /// session keyed by `id`. `None` ⇒ no live session with that id
     /// (fully torn down or never registered). Lets tests `poll_until`
     /// for the server-side `serve_blocking_on` exit hook (which
-    /// `live_conns.fetch_sub`s) without the prior `sleep(N ms)`
+    /// transitions the typed `SessionLifecycle` `Live(n) → Live(n-1)`
+    /// or `Live(1) → Dying`; §7.3 R1) without the prior `sleep(N ms)`
     /// heuristic that raced scheduler jitter.
     pub fn session_live_conns(&self, id: &[u8; 32]) -> Option<usize> {
         // Public API keeps the raw-byte shape (R2 internal-only

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -20,7 +20,9 @@
 //! **P1:** kernel files untouched — `RpcServer` is new code only.
 
 use std::collections::HashMap;
-use std::os::unix::net::UnixListener;
+#[cfg(feature = "rpc-tls")]
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -35,25 +37,45 @@ use super::session::{RpcSession, RpcSessionId, RpcSessionInner};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use super::transport::VsockTransport;
 use super::transport::{PeerIdentity, RpcTransport, UnixTransport};
+#[cfg(feature = "rpc-tls")]
+use super::transport::{TlsStream, TlsTransport};
+use super::RpcResult;
+
+/// **Plan 2-15 E1** — server-side TLS handle. `Some` ⇒ every accepted
+/// connection is TLS-wrapped on its worker thread (handshake under the
+/// `max_connections` cap, so a slow-handshake attacker can stall its own
+/// worker but never the accept loop). `None` ⇒ plain transport (the
+/// pre-E1 byte-identical path). `Mutex<Option<...>>` mirrors the other
+/// late-bind config fields (`max_threads`, `authorizer`, etc.) so a
+/// caller that builds the server then `set_*`s knobs has a single
+/// mutability discipline.
+#[cfg(feature = "rpc-tls")]
+type TlsServerConfigCell = Mutex<Option<Arc<rustls::ServerConfig>>>;
 
 /// **Plan 2-15 E0/E2** — backend-agnostic listener kind for [`RpcServer`].
 /// The accept loop in [`RpcServer::run`] holds one of these and the
-/// `accept_transport` helper hides the per-backend stream type behind a
-/// `Box<dyn RpcTransport>`, so the worker dispatch path is byte-identical
-/// across UDS / vsock / (future TLS-wrapping factories). Default
+/// `accept_raw` helper produces a [`RawAccepted`] so the wrap step
+/// (native or TLS) happens on the worker thread. Default
 /// `setup_unix_server` callers stay on the `Unix` variant, so the wire
 /// is byte-unchanged on that path.
+///
+/// **E1 (Tcp variant)**: TCP is *internal-only*. There is no public
+/// `setup_tcp_server` factory because plaintext network RPC is never
+/// production-appropriate (see [`super`] module doc). The TCP arm is
+/// reached only through [`setup_tcp_server_tls`](RpcServer::setup_tcp_server_tls).
 enum ServerListener {
     Unix(UnixListener),
     #[cfg(any(target_os = "linux", target_os = "android"))]
     Vsock(vsock::VsockListener),
+    #[cfg(feature = "rpc-tls")]
+    Tcp(TcpListener),
 }
 
 /// **Plan 2-15 E0** — backend-agnostic bind metadata, replacing the prior
 /// `path: PathBuf` UDS-only field. `Drop` branches on this for the
-/// per-backend cleanup: `Unix` removes the socket file, `Vsock` has no
-/// filesystem cleanup (the kernel reclaims the (cid,port) on `Drop` of
-/// the listener fd itself).
+/// per-backend cleanup: `Unix` removes the socket file, `Vsock`/`Tcp`
+/// have no filesystem cleanup (the kernel reclaims the bind on `Drop`
+/// of the listener fd itself).
 enum BindAddress {
     Unix(PathBuf),
     #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -61,44 +83,119 @@ enum BindAddress {
         cid: u32,
         port: u32,
     },
+    #[cfg(feature = "rpc-tls")]
+    Tcp(SocketAddr),
+}
+
+/// **Plan 2-15 E1** — raw accepted stream awaiting the worker-thread
+/// wrap. Yielded by [`ServerListener::accept_raw`]; consumed by
+/// [`RawAccepted::into_transport`] inside the spawned worker.
+///
+/// Splitting accept (cheap kernel `accept(2)`) from wrap
+/// (potentially-expensive TLS handshake) is what keeps a slow-
+/// handshake attacker from stalling the accept loop — the worker
+/// thread eats the handshake time, bounded by
+/// [`RpcServer::set_max_connections`](RpcServer::set_max_connections).
+enum RawAccepted {
+    Unix(UnixStream),
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    Vsock(vsock::VsockStream),
+    #[cfg(feature = "rpc-tls")]
+    Tcp(TcpStream),
 }
 
 impl ServerListener {
     /// Set the listener to non-blocking so the accept loop can poll
     /// `shutdown`. The `vsock` crate exposes `set_nonblocking` on
-    /// `VsockListener` mirroring `UnixListener`'s std API.
+    /// `VsockListener` mirroring `UnixListener`/`TcpListener`'s std API.
     fn set_nonblocking(&self, on: bool) -> std::io::Result<()> {
         match self {
             ServerListener::Unix(l) => l.set_nonblocking(on),
             #[cfg(any(target_os = "linux", target_os = "android"))]
             ServerListener::Vsock(l) => l.set_nonblocking(on),
+            #[cfg(feature = "rpc-tls")]
+            ServerListener::Tcp(l) => l.set_nonblocking(on),
         }
     }
 
-    /// Per-backend accept: dispatches to the right `accept()`, sets the
-    /// accepted stream blocking (the worker's `recv_frame` is blocking),
-    /// and boxes it as `RpcTransport` so the caller's loop is
-    /// backend-agnostic.
-    fn accept_transport(&self) -> std::io::Result<Box<dyn RpcTransport>> {
+    /// Per-backend accept: returns the raw stream paired with its
+    /// backend tag, *without* wrapping it as `RpcTransport`. The wrap
+    /// (and any TLS handshake) runs in the worker thread spawned by
+    /// [`RpcServer::serve_connection_raw`].
+    fn accept_raw(&self) -> std::io::Result<RawAccepted> {
         match self {
             ServerListener::Unix(l) => {
                 let (stream, _addr) = l.accept()?;
                 // The listener is non-blocking so the accept loop can
                 // poll `shutdown`; the accepted connection must be
-                // blocking for the worker's `recv_frame`.
+                // blocking for the worker's `recv_frame` (and for the
+                // worker-side TLS handshake when applicable).
                 stream.set_nonblocking(false)?;
-                let t = UnixTransport::from_stream(stream).map_err(std::io::Error::from)?;
-                Ok(Box::new(t))
+                Ok(RawAccepted::Unix(stream))
             }
             #[cfg(any(target_os = "linux", target_os = "android"))]
             ServerListener::Vsock(l) => {
                 let (stream, _addr) = l.accept()?;
-                // Mirror the UDS path: non-blocking listener for shutdown
-                // polling, blocking accepted stream for the worker.
                 stream.set_nonblocking(false)?;
-                let t = VsockTransport::from_stream(stream).map_err(std::io::Error::from)?;
-                Ok(Box::new(t))
+                Ok(RawAccepted::Vsock(stream))
             }
+            #[cfg(feature = "rpc-tls")]
+            ServerListener::Tcp(l) => {
+                let (stream, _addr) = l.accept()?;
+                stream.set_nonblocking(false)?;
+                // TCP-specific: `nodelay=true` matches the client-side
+                // `TlsTransport::connect`/`accept` (back-compat
+                // convenience). Small-frame RPC traffic ⇒ disable
+                // Nagle so handshake + first request don't coalesce.
+                stream.set_nodelay(true)?;
+                Ok(RawAccepted::Tcp(stream))
+            }
+        }
+    }
+}
+
+impl RawAccepted {
+    /// **Plan 2-15 E1** — wrap the raw stream as `RpcTransport`, on the
+    /// worker thread. `tls_config = Some(cfg)` ⇒ drive a server-side
+    /// TLS handshake via [`TlsTransport::accept_stream`] over the raw
+    /// byte stream; `None` ⇒ a plain backend transport
+    /// (`UnixTransport`/`VsockTransport`).
+    ///
+    /// Plain TCP is rejected here (`TLS-only on TCP` — see
+    /// [`ServerListener::Tcp`]).
+    #[cfg(feature = "rpc-tls")]
+    fn into_transport(
+        self,
+        tls_config: Option<Arc<rustls::ServerConfig>>,
+    ) -> RpcResult<Box<dyn RpcTransport>> {
+        if let Some(cfg) = tls_config {
+            let stream: Box<dyn TlsStream> = match self {
+                RawAccepted::Unix(s) => Box::new(s),
+                #[cfg(any(target_os = "linux", target_os = "android"))]
+                RawAccepted::Vsock(s) => Box::new(s),
+                RawAccepted::Tcp(s) => Box::new(s),
+            };
+            return Ok(Box::new(TlsTransport::accept_stream(stream, cfg)?));
+        }
+        self.into_native_transport()
+    }
+
+    /// rpc-tls-OFF build entry point — TLS path absent, plain wrap only.
+    #[cfg(not(feature = "rpc-tls"))]
+    fn into_transport(self) -> RpcResult<Box<dyn RpcTransport>> {
+        self.into_native_transport()
+    }
+
+    /// Native (plain) wrap — common to both feature build modes.
+    fn into_native_transport(self) -> RpcResult<Box<dyn RpcTransport>> {
+        match self {
+            RawAccepted::Unix(s) => Ok(Box::new(UnixTransport::from_stream(s)?)),
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            RawAccepted::Vsock(s) => Ok(Box::new(VsockTransport::from_stream(s)?)),
+            #[cfg(feature = "rpc-tls")]
+            RawAccepted::Tcp(_) => Err(super::RpcError::Protocol(
+                "plain-text TCP server is not exposed (TLS-only on TCP)",
+            )),
         }
     }
 }
@@ -159,6 +256,15 @@ type Authorizer = Arc<dyn Fn(&PeerIdentity) -> bool + Send + Sync>;
 pub struct RpcServer {
     listener: ServerListener,
     bind: BindAddress,
+    /// **Plan 2-15 E1** — `Some(cfg)` ⇒ TLS server, every accepted
+    /// connection is handshaken on its worker thread with this config.
+    /// `None` ⇒ plain transport (the pre-E1 default; byte-identical to
+    /// the prior `RpcServer` for UDS/vsock). Late-bound via
+    /// [`setup_unix_server_tls`](Self::setup_unix_server_tls),
+    /// [`setup_tcp_server_tls`](Self::setup_tcp_server_tls), and
+    /// [`setup_vsock_server_tls`](Self::setup_vsock_server_tls).
+    #[cfg(feature = "rpc-tls")]
+    tls_config: TlsServerConfigCell,
     root: Mutex<Option<SIBinder>>,
     named: Mutex<HashMap<String, SIBinder>>,
     max_threads: Mutex<u32>,
@@ -289,14 +395,16 @@ impl RpcServer {
         Ok(Self::wrap(listener, BindAddress::Vsock { cid, port }))
     }
 
-    /// Backend-agnostic `RpcServer` construction (E0). Both
-    /// [`setup_unix_server`](Self::setup_unix_server) and
-    /// [`setup_vsock_server`](Self::setup_vsock_server) funnel through
-    /// here so the field set stays in one place.
+    /// Backend-agnostic `RpcServer` construction (E0). All factories
+    /// (`setup_unix_server`, `setup_vsock_server`, and the E1 TLS
+    /// factories) funnel through here so the field set stays in one
+    /// place.
     fn wrap(listener: ServerListener, bind: BindAddress) -> Arc<RpcServer> {
         Arc::new(RpcServer {
             listener,
             bind,
+            #[cfg(feature = "rpc-tls")]
+            tls_config: Mutex::new(None),
             root: Mutex::new(None),
             named: Mutex::new(HashMap::new()),
             max_threads: Mutex::new(1),
@@ -311,6 +419,72 @@ impl RpcServer {
             shutdown: Arc::new(AtomicBool::new(false)),
             workers: Mutex::new(Vec::new()),
         })
+    }
+
+    /// **Plan 2-15 E1** — UDS server with TLS. Same as
+    /// [`setup_unix_server`](Self::setup_unix_server) plus a server-side
+    /// `rustls::ServerConfig`; every accepted connection runs the TLS
+    /// handshake on its worker thread (so a slow-handshake attacker
+    /// stalls its own worker but never the accept loop — handshake
+    /// budget is bounded by
+    /// [`set_max_connections`](Self::set_max_connections)).
+    ///
+    /// `config` is the caller's `rustls::ServerConfig` (server cert
+    /// chain + private key, optional mTLS client-cert verifier);
+    /// rsbinder never invents crypto (plan 2-15 §5). Use
+    /// [`super::rustls`](super::rustls) (re-export of the linked
+    /// `rustls` version) to construct the config.
+    #[cfg(feature = "rpc-tls")]
+    pub fn setup_unix_server_tls(
+        path: impl Into<PathBuf>,
+        config: Arc<rustls::ServerConfig>,
+    ) -> Result<Arc<RpcServer>> {
+        let server = Self::setup_unix_server(path)?;
+        *server.tls_config.lock().expect("tls_config poisoned") = Some(config);
+        Ok(server)
+    }
+
+    /// **Plan 2-15 E1** — TCP server with TLS. The TCP backend is
+    /// **TLS-only** by design (plain-text network RPC is never
+    /// production-appropriate; see [`super`] module doc). Use
+    /// [`super::rustls`](super::rustls) to construct the config (server
+    /// cert chain + private key, optional mTLS).
+    #[cfg(feature = "rpc-tls")]
+    pub fn setup_tcp_server_tls(
+        addr: impl std::net::ToSocketAddrs,
+        config: Arc<rustls::ServerConfig>,
+    ) -> Result<Arc<RpcServer>> {
+        let listener = TcpListener::bind(addr)?;
+        let local = listener.local_addr()?;
+        let listener = ServerListener::Tcp(listener);
+        listener.set_nonblocking(true)?;
+        let server = Self::wrap(listener, BindAddress::Tcp(local));
+        *server.tls_config.lock().expect("tls_config poisoned") = Some(config);
+        Ok(server)
+    }
+
+    /// **Plan 2-15 E1** — vsock server with TLS. Same as
+    /// [`setup_vsock_server`](Self::setup_vsock_server) plus a
+    /// server-side `rustls::ServerConfig`. The 1-tier Android AVF /
+    /// Microdroid pVM target — vsock for the host↔guest socket plane,
+    /// TLS for the crypto plane.
+    #[cfg(all(feature = "rpc-tls", any(target_os = "linux", target_os = "android")))]
+    pub fn setup_vsock_server_tls(
+        cid: u32,
+        port: u32,
+        config: Arc<rustls::ServerConfig>,
+    ) -> Result<Arc<RpcServer>> {
+        let server = Self::setup_vsock_server(cid, port)?;
+        *server.tls_config.lock().expect("tls_config poisoned") = Some(config);
+        Ok(server)
+    }
+
+    /// Snapshot of the current TLS config (cloned `Arc`), or `None` for
+    /// a plain server. Called once per accepted connection so a worker
+    /// gets a stable `Arc<ServerConfig>` for its whole lifetime.
+    #[cfg(feature = "rpc-tls")]
+    fn tls_snapshot(&self) -> Option<Arc<rustls::ServerConfig>> {
+        self.tls_config.lock().expect("tls_config poisoned").clone()
     }
 
     /// Publish the single root object (android `setRootObject`).
@@ -595,39 +769,101 @@ impl RpcServer {
     }
 
     /// Serve one already-connected transport on its own worker thread
-    /// (used by the accept loop and by in-memory tests).
+    /// (used by in-memory tests and by [`super::session`] direct calls).
+    /// The accept loop uses [`serve_connection_raw`](Self::serve_connection_raw)
+    /// to keep TLS handshake (if any) on the worker side.
     pub fn serve_connection(self: &Arc<Self>, transport: Box<dyn RpcTransport>) {
+        let server = Arc::clone(self);
+        let handle = std::thread::spawn(move || {
+            Self::run_connection_in_worker(server, transport);
+        });
+        let mut workers = self.workers.lock().expect("workers poisoned");
+        // Reap finished handles so `workers` is bounded by *concurrent*
+        // (not cumulative) connections — same discipline as the accept
+        // loop's reaping.
+        workers.retain(|h| !h.is_finished());
+        workers.push(handle);
+    }
+
+    /// **Plan 2-15 E1** — accept loop entry point. Takes the raw
+    /// accepted stream (the kernel `accept(2)` result, before any
+    /// blocking I/O on the socket), spawns a worker thread, and wraps
+    /// the stream as `RpcTransport` *inside* that worker — so a
+    /// potentially-expensive TLS handshake never stalls the accept
+    /// loop. The handshake budget is bounded by
+    /// [`set_max_connections`](Self::set_max_connections) (the worker-
+    /// thread cap also bounds the in-flight handshake count). Plain
+    /// transports (UDS / vsock) skip the TLS branch and wrap natively.
+    fn serve_connection_raw(self: &Arc<Self>, raw: RawAccepted) {
+        let server = Arc::clone(self);
+        let handle = std::thread::spawn(move || {
+            let transport = match server.wrap_accepted(raw) {
+                Ok(t) => t,
+                Err(e) => {
+                    log::warn!("RPC transport wrap (TLS or native) failed: {e:?}");
+                    return;
+                }
+            };
+            Self::run_connection_in_worker(server, transport);
+        });
+        let mut workers = self.workers.lock().expect("workers poisoned");
+        workers.retain(|h| !h.is_finished());
+        workers.push(handle);
+    }
+
+    /// Worker-thread helper that wraps a `RawAccepted` as
+    /// `Box<dyn RpcTransport>`. Two cfg variants so the function
+    /// signature stays uniform — the snapshot of `tls_config` happens
+    /// here (worker thread) rather than at accept time; that's safe
+    /// because `tls_config` is set only by the factories
+    /// (`setup_*_server_tls`) before the server is shared as `Arc`,
+    /// so it's effectively immutable from the accept loop's PoV.
+    #[cfg(feature = "rpc-tls")]
+    fn wrap_accepted(&self, raw: RawAccepted) -> RpcResult<Box<dyn RpcTransport>> {
+        raw.into_transport(self.tls_snapshot())
+    }
+    #[cfg(not(feature = "rpc-tls"))]
+    fn wrap_accepted(&self, raw: RawAccepted) -> RpcResult<Box<dyn RpcTransport>> {
+        raw.into_transport()
+    }
+
+    /// Body extracted from the pre-E1 monolithic `serve_connection` —
+    /// runs **inside** the worker thread after the transport has been
+    /// wrapped (native or TLS). Performs authorization, then dispatches
+    /// to the r34 / android-13+ branch and serves the session inline
+    /// (the prior nested-spawn pattern is gone — we're already on the
+    /// worker thread).
+    fn run_connection_in_worker(server: Arc<Self>, transport: Box<dyn RpcTransport>) {
         // Subplan 2-9 Phase B: authorization gate. The single
         // chokepoint common to r34, android-13+, AND in-memory test
         // direct calls — *before* the wire-profile branch, session
         // build, handshake, or any `recv_frame`, so a rejected peer
-        // gets zero RPC bytes. The hook is cloned out of the lock and
-        // called lock-free (a hook may touch the server without
-        // self-deadlock). Default (unset) ⇒ this whole block is a
-        // no-op and behavior is byte-identical (additive — AC-9.4).
-        let authorizer = self.authorizer.lock().expect("authorizer poisoned").clone();
+        // gets zero RPC bytes. Default (unset) ⇒ no-op, byte-identical
+        // (additive — AC-9.4). On a TLS server the peer identity is
+        // already final here (the TLS handshake completed in
+        // `into_transport`, so `transport.peer_identity()` returns the
+        // post-handshake `Certificate` or `Anonymous`).
+        let authorizer = server
+            .authorizer
+            .lock()
+            .expect("authorizer poisoned")
+            .clone();
         if let Some(authz) = authorizer {
             let peer = transport.peer_identity();
             if !authz(&peer) {
-                // `transport` drops here → socket closed, no worker
-                // spawned; the peer's next op is `DeadObject`.
                 log::warn!("RPC connection rejected by authorizer: peer {peer:?}");
                 return;
             }
         }
-        let a13_max = *self
+        let a13_max = *server
             .wire_max_version
             .lock()
             .expect("wire_max_version poisoned");
-        let handle = match a13_max {
+        match a13_max {
             Some(max) => {
                 // android-13+ (G4(a)): the AOSP connection handshake is
-                // blocking I/O on the accepted socket, so it must run on
-                // the worker — never the accept loop. Build + configure
-                // the session AFTER the handshake, then serve. A
-                // handshake failure ends just this connection (the
-                // accept loop and other sessions are unaffected).
-                let server = Arc::clone(self);
+                // blocking I/O on the accepted socket. We're already in
+                // the worker — handshake/serve inline (no nested spawn).
                 // Subplan 2-11 Phase A0: the AOSP handshake reads the
                 // client's `RpcConnectionHeader.fileDescriptorTransport
                 // Mode`; honor `Unix` only if this server opted in
@@ -635,210 +871,193 @@ impl RpcServer {
                 // (the fd write then `BAD_TYPE`-rejects). `false` keeps
                 // the byte-identical no-FD android-13+ path.
                 let fd_unix = server.fd_unix_supported.load(Ordering::SeqCst);
-                std::thread::spawn(move || {
-                    // Split handshake from build so we can branch on
-                    // the client-supplied session id (new vs attach vs
-                    // reject) and direction (outgoing vs incoming).
-                    let (transport, codec, client_fd_mode, client_id, incoming) =
-                        match RpcSession::android13plus_accept_handshake(transport, max) {
-                            Ok(parts) => parts,
-                            Err(e) => {
-                                // Abnormal interop/security event
-                                // (version mismatch, truncated header,
-                                // hostile peer) — `warn!` not `debug!`.
-                                log::warn!("android-13+ RPC handshake failed: {e:?}");
-                                return;
-                            }
-                        };
-                    if incoming {
-                        // Attach + incoming (`server_accept` already
-                        // rejected new + incoming): resolve the
-                        // session, register a callback slot, and exit
-                        // the worker. The slot lives in the pool for
-                        // server→client sends; there is no read loop
-                        // because client→server traffic only uses
-                        // outgoing connections (per AOSP
-                        // `RpcSession::mConnections.mOutgoing`).
-                        match server.resolve_session(&client_id) {
-                            Some(inner) => {
-                                if inner.wire_protocol_version() != Some(codec.version()) {
-                                    server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
-                                    log::warn!(
-                                        "android-13+ RPC: incoming attach codec version {} \
-                                         ≠ founding inner version {:?}; rejecting",
-                                        codec.version(),
-                                        inner.wire_protocol_version()
-                                    );
-                                    drop(transport);
-                                    return;
-                                }
-                                if server.shutdown.load(Ordering::SeqCst) {
-                                    server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
-                                    log::warn!(
-                                        "android-13+ RPC: incoming attach after server \
-                                         shutdown; rejecting"
-                                    );
-                                    drop(transport);
-                                    return;
-                                }
-                                let session = RpcSession::wrap_inner(inner);
-                                if let Err(e) = session.add_callback_slot(transport) {
-                                    server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
-                                    log::warn!(
-                                        "android-13+ RPC: incoming attach raced session \
-                                         teardown; rejecting: {e:?}"
-                                    );
-                                }
-                            }
-                            None => {
+                // Split handshake from build so we can branch on
+                // the client-supplied session id (new vs attach vs
+                // reject) and direction (outgoing vs incoming).
+                let (transport, codec, client_fd_mode, client_id, incoming) =
+                    match RpcSession::android13plus_accept_handshake(transport, max) {
+                        Ok(parts) => parts,
+                        Err(e) => {
+                            // Abnormal interop/security event
+                            // (version mismatch, truncated header,
+                            // hostile peer) — `warn!` not `debug!`.
+                            log::warn!("android-13+ RPC handshake failed: {e:?}");
+                            return;
+                        }
+                    };
+                if incoming {
+                    // Attach + incoming (`server_accept` already
+                    // rejected new + incoming): resolve the session,
+                    // register a callback slot, and exit the worker.
+                    // The slot lives in the pool for server→client
+                    // sends; there is no read loop because
+                    // client→server traffic only uses outgoing
+                    // connections (per AOSP `RpcSession::mConnections.mOutgoing`).
+                    match server.resolve_session(&client_id) {
+                        Some(inner) => {
+                            if inner.wire_protocol_version() != Some(codec.version()) {
                                 server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
                                 log::warn!(
-                                    "android-13+ RPC: incoming connection supplied an \
-                                     unknown/stale session id; rejecting"
+                                    "android-13+ RPC: incoming attach codec version {} \
+                                     ≠ founding inner version {:?}; rejecting",
+                                    codec.version(),
+                                    inner.wire_protocol_version()
                                 );
                                 drop(transport);
-                            }
-                        }
-                        return;
-                    }
-                    if client_id.is_empty() {
-                        // New session: mint, register, serve. Registry
-                        // entry is `Weak`; reclaimed by the next
-                        // `register_session` prune when the founding
-                        // `Arc<RpcSessionInner>` is dropped.
-                        let session = match RpcSession::from_android13plus(
-                            transport,
-                            codec,
-                            client_fd_mode,
-                            fd_unix,
-                            None,
-                        ) {
-                            Ok(s) => s,
-                            Err(e) => {
-                                log::warn!("android-13+ RPC: from_android13plus failed: {e:?}");
                                 return;
                             }
-                        };
-                        let id = RpcSessionId::new(session.session_id());
-                        server.register_session(id, &session.inner_arc());
-                        server.configure_session(&session);
-                        if let Err(e) = session.serve_blocking() {
-                            log::debug!("RPC session ended: {e:?}");
-                        }
-                    } else if let Some(inner) = server.resolve_session(&client_id) {
-                        // Attach: add a slot on the founding inner so
-                        // proxy-cache + slot-pool stay unified (the
-                        // F8-avoidance invariant). Reject on profile
-                        // mismatch — codec version is immutable for
-                        // the session.
-                        if inner.wire_protocol_version() != Some(codec.version()) {
-                            server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
-                            log::warn!(
-                                "android-13+ RPC: attach codec version {} ≠ \
-                                 founding inner version {:?}; rejecting",
-                                codec.version(),
-                                inner.wire_protocol_version()
-                            );
-                            drop(transport);
-                            return;
-                        }
-                        // **Phase B.1 shutdown gate**: refuse attaches
-                        // once the server is shutting down (clean
-                        // teardown semantics — a late-arriving
-                        // id-echoing client must not be allowed to
-                        // hook onto a session whose worker pool is
-                        // already winding down). The `shutdown` flag
-                        // is what `RpcServer::run` polls each accept
-                        // tick (line ~657 below); checking it here
-                        // closes the small window where the accept
-                        // succeeded but the server transitioned to
-                        // shutdown between accept and attach.
-                        if server.shutdown.load(Ordering::SeqCst) {
-                            server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
-                            log::warn!("android-13+ RPC: attach after server shutdown; rejecting");
-                            drop(transport);
-                            return;
-                        }
-                        // AOSP-faithful `setMaxIncomingThreads` cap; see
-                        // `RpcServer::set_max_threads` rustdoc for the
-                        // advertise vs. slot-cap split.
-                        //
-                        // Race: this check and the subsequent
-                        // `add_incoming_slot` are two separate critical
-                        // sections, so concurrent attach workers can
-                        // transiently overshoot `cap` by up to (N − 1),
-                        // bounded by `set_max_connections` (default
-                        // unlimited). Tightening to a check-and-increment
-                        // atomic is §7.3 R-future.
-                        let cap = inner.max_threads_value() as usize;
-                        if inner.slot_count() >= cap {
-                            server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
-                            log::warn!(
-                                "android-13+ RPC: attach refused (incoming slot \
-                                 cap reached: slot_count={}, max_threads={})",
-                                inner.slot_count(),
-                                cap
-                            );
-                            drop(transport);
-                            return;
-                        }
-                        // `add_incoming_slot` atomically combines the
-                        // F4 anti-resurrection gate (`try_bump_live_
-                        // conns`) with the slot enqueue.
-                        let session = RpcSession::wrap_inner(inner);
-                        let slot_id = match session.add_incoming_slot(transport) {
-                            Ok(id) => id,
-                            Err(e) => {
+                            if server.shutdown.load(Ordering::SeqCst) {
                                 server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
                                 log::warn!(
-                                    "android-13+ RPC: session torn down between \
-                                     resolve and attach (F4 race); rejecting: {e:?}"
+                                    "android-13+ RPC: incoming attach after server \
+                                     shutdown; rejecting"
                                 );
+                                drop(transport);
                                 return;
                             }
-                        };
-                        // Bump *after* `add_incoming_slot` succeeded
-                        // so external observers never see a count for
-                        // a slot that never reached the pool.
-                        server.attached_count.fetch_add(1, Ordering::SeqCst);
-                        if let Err(e) = session.serve_blocking_on(slot_id) {
-                            log::debug!("RPC attached connection ended: {e:?}");
+                            let session = RpcSession::wrap_inner(inner);
+                            if let Err(e) = session.add_callback_slot(transport) {
+                                server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
+                                log::warn!(
+                                    "android-13+ RPC: incoming attach raced session \
+                                     teardown; rejecting: {e:?}"
+                                );
+                            }
                         }
-                    } else {
+                        None => {
+                            server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
+                            log::warn!(
+                                "android-13+ RPC: incoming connection supplied an \
+                                 unknown/stale session id; rejecting"
+                            );
+                            drop(transport);
+                        }
+                    }
+                    return;
+                }
+                if client_id.is_empty() {
+                    // New session: mint, register, serve. Registry
+                    // entry is `Weak`; reclaimed by the next
+                    // `register_session` prune when the founding
+                    // `Arc<RpcSessionInner>` is dropped.
+                    let session = match RpcSession::from_android13plus(
+                        transport,
+                        codec,
+                        client_fd_mode,
+                        fd_unix,
+                        None,
+                    ) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            log::warn!("android-13+ RPC: from_android13plus failed: {e:?}");
+                            return;
+                        }
+                    };
+                    let id = RpcSessionId::new(session.session_id());
+                    server.register_session(id, &session.inner_arc());
+                    server.configure_session(&session);
+                    if let Err(e) = session.serve_blocking() {
+                        log::debug!("RPC session ended: {e:?}");
+                    }
+                } else if let Some(inner) = server.resolve_session(&client_id) {
+                    // Attach: add a slot on the founding inner so
+                    // proxy-cache + slot-pool stay unified (the
+                    // F8-avoidance invariant). Reject on profile
+                    // mismatch — codec version is immutable for
+                    // the session.
+                    if inner.wire_protocol_version() != Some(codec.version()) {
                         server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
                         log::warn!(
-                            "android-13+ RPC: client supplied an unknown/stale \
-                             session id; rejecting connection"
+                            "android-13+ RPC: attach codec version {} ≠ \
+                             founding inner version {:?}; rejecting",
+                            codec.version(),
+                            inner.wire_protocol_version()
                         );
                         drop(transport);
+                        return;
                     }
-                })
+                    // **Phase B.1 shutdown gate**: refuse attaches
+                    // once the server is shutting down (clean
+                    // teardown semantics — a late-arriving
+                    // id-echoing client must not be allowed to
+                    // hook onto a session whose worker pool is
+                    // already winding down).
+                    if server.shutdown.load(Ordering::SeqCst) {
+                        server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
+                        log::warn!("android-13+ RPC: attach after server shutdown; rejecting");
+                        drop(transport);
+                        return;
+                    }
+                    // AOSP-faithful `setMaxIncomingThreads` cap; see
+                    // `RpcServer::set_max_threads` rustdoc for the
+                    // advertise vs. slot-cap split.
+                    //
+                    // Race: this check and the subsequent
+                    // `add_incoming_slot` are two separate critical
+                    // sections, so concurrent attach workers can
+                    // transiently overshoot `cap` by up to (N − 1),
+                    // bounded by `set_max_connections` (default
+                    // unlimited). Tightening to a check-and-increment
+                    // atomic is §7.3 R-future.
+                    let cap = inner.max_threads_value() as usize;
+                    if inner.slot_count() >= cap {
+                        server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
+                        log::warn!(
+                            "android-13+ RPC: attach refused (incoming slot \
+                             cap reached: slot_count={}, max_threads={})",
+                            inner.slot_count(),
+                            cap
+                        );
+                        drop(transport);
+                        return;
+                    }
+                    // `add_incoming_slot` atomically combines the
+                    // F4 anti-resurrection gate (`try_bump_live_
+                    // conns`) with the slot enqueue.
+                    let session = RpcSession::wrap_inner(inner);
+                    let slot_id = match session.add_incoming_slot(transport) {
+                        Ok(id) => id,
+                        Err(e) => {
+                            server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
+                            log::warn!(
+                                "android-13+ RPC: session torn down between \
+                                 resolve and attach (F4 race); rejecting: {e:?}"
+                            );
+                            return;
+                        }
+                    };
+                    // Bump *after* `add_incoming_slot` succeeded
+                    // so external observers never see a count for
+                    // a slot that never reached the pool.
+                    server.attached_count.fetch_add(1, Ordering::SeqCst);
+                    if let Err(e) = session.serve_blocking_on(slot_id) {
+                        log::debug!("RPC attached connection ended: {e:?}");
+                    }
+                } else {
+                    server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
+                    log::warn!(
+                        "android-13+ RPC: client supplied an unknown/stale \
+                         session id; rejecting connection"
+                    );
+                    drop(transport);
+                }
             }
             None => {
-                // r34 (default) — unchanged: session built here, served
-                // on the worker.
-                let session = match self.make_session(transport) {
+                // r34 (default): build session (incl. its handshake-
+                // free first-contact shape) + serve inline. We're
+                // already on the worker thread — no nested spawn.
+                let session = match server.make_session(transport) {
                     Ok(s) => s,
                     Err(e) => {
                         log::warn!("RPC r34: make_session failed: {e:?}");
                         return;
                     }
                 };
-                std::thread::spawn(move || {
-                    if let Err(e) = session.serve_blocking() {
-                        log::debug!("RPC session ended: {e:?}");
-                    }
-                })
+                if let Err(e) = session.serve_blocking() {
+                    log::debug!("RPC session ended: {e:?}");
+                }
             }
-        };
-        let mut workers = self.workers.lock().expect("workers poisoned");
-        // Reap handles of already-finished sessions so `workers` is
-        // bounded by *concurrent* (not cumulative) connections — a
-        // long-lived server otherwise leaks one JoinHandle per
-        // connection ever accepted. Dropping a finished handle detaches
-        // without blocking, so this cannot stall the accept loop.
-        workers.retain(|h| !h.is_finished());
-        workers.push(handle);
+        }
     }
 
     /// Run the accept loop until [`RpcServer::shutdown`]. Each accepted
@@ -866,12 +1085,14 @@ impl RpcServer {
                     continue;
                 }
             }
-            match self.listener.accept_transport() {
-                Ok(t) => {
-                    // `accept_transport` already sets the accepted
-                    // stream blocking and boxes it as `RpcTransport`
-                    // (E0 backend-agnostic dispatch).
-                    self.serve_connection(t);
+            match self.listener.accept_raw() {
+                Ok(raw) => {
+                    // `accept_raw` returns the raw stream without
+                    // wrapping; `serve_connection_raw` spawns the
+                    // worker and wraps the stream (native or TLS)
+                    // *inside* the worker — so TLS handshake never
+                    // stalls the accept loop (E1 invariant).
+                    self.serve_connection_raw(raw);
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     // Listener is non-blocking only so we can poll
@@ -933,13 +1154,15 @@ impl RpcServer {
     }
 
     /// The bound socket path for a Unix-domain server. `None` for other
-    /// backends (vsock, future TLS-wrapping factories) — the listener
-    /// has no filesystem entry to expose.
+    /// backends (vsock, TCP+TLS) — the listener has no filesystem entry
+    /// to expose.
     pub fn path(&self) -> Option<&Path> {
         match &self.bind {
             BindAddress::Unix(p) => Some(p.as_path()),
             #[cfg(any(target_os = "linux", target_os = "android"))]
             BindAddress::Vsock { .. } => None,
+            #[cfg(feature = "rpc-tls")]
+            BindAddress::Tcp(_) => None,
         }
     }
 
@@ -951,6 +1174,22 @@ impl RpcServer {
         match &self.bind {
             BindAddress::Vsock { cid, port } => Some((*cid, *port)),
             BindAddress::Unix(_) => None,
+            #[cfg(feature = "rpc-tls")]
+            BindAddress::Tcp(_) => None,
+        }
+    }
+
+    /// **Plan 2-15 E1** — bound TCP socket address for a
+    /// [`setup_tcp_server_tls`](Self::setup_tcp_server_tls) server.
+    /// `None` for other backends. Useful when the caller bound port
+    /// `0` and needs to learn the kernel-assigned port.
+    #[cfg(feature = "rpc-tls")]
+    pub fn tcp_address(&self) -> Option<SocketAddr> {
+        match &self.bind {
+            BindAddress::Tcp(addr) => Some(*addr),
+            BindAddress::Unix(_) => None,
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            BindAddress::Vsock { .. } => None,
         }
     }
 }
@@ -992,6 +1231,11 @@ impl Drop for RpcServer {
                 // (cid, port) when the listener fd is closed (the
                 // listener is owned by `self.listener` so Drop closes it
                 // for us — no explicit step needed).
+            }
+            #[cfg(feature = "rpc-tls")]
+            BindAddress::Tcp(_) => {
+                // TCP has no filesystem entry; the kernel reclaims the
+                // bound port when the listener fd is closed.
             }
         }
     }

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -17,12 +17,13 @@
 
 use std::cell::RefCell;
 use std::os::fd::{AsFd, OwnedFd};
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::Duration;
 
 use super::fd_mode::FileDescriptorTransportMode;
+use super::lifecycle::SessionLifecycle;
 use crate::binder::{SIBinder, FLAG_ONEWAY, INTERFACE_TRANSACTION, PING_TRANSACTION};
 use crate::error::{Result, StatusCode};
 use crate::parcel::{Parcel, RpcParcelOps};
@@ -463,8 +464,8 @@ impl Drop for ConnGuard<'_> {
 /// one logical session* (AOSP `RpcSession` shares this across its
 /// `mOutgoing`/`mIncoming` connections). One per session, behind `Arc`;
 /// never global (P6). Default single-connection sessions own exactly
-/// one of these with `live_conns == 1` ⇒ behavior is byte-identical to
-/// the pre-A0b single-`transport` `RpcSessionInner` (the `Arc`
+/// one of these with `lifecycle == Live(1)` ⇒ behavior is byte-identical
+/// to the pre-A0b single-`transport` `RpcSessionInner` (the `Arc`
 /// indirection is the only structural change; the wire is unchanged).
 /// The server attaches a 2nd+ connection to a *pre-existing* instance
 /// (id-demux), so a binder published over one connection is reachable
@@ -498,18 +499,24 @@ pub(crate) struct SharedSession {
     /// connection reports the *same* id). [`RpcSessionId`] newtype
     /// (R2) makes the "attach capability" semantic type-explicit.
     rpc_session_id: RpcSessionId,
-    /// **F4 (Phase A0b)**: number of live connections driving this
-    /// session. Starts at 1 (the founding connection); the server's
-    /// id-demux attach bumps it. `serve_blocking` decrements on exit
-    /// and fires the session obituaries **only** on the 1→0 edge (full
-    /// session teardown) — never on a *partial* connection loss, which
-    /// would otherwise deliver a spurious `binder_died` to the peer
-    /// while other connections of the session are still live.
-    live_conns: AtomicUsize,
-    /// Idempotency latch for the above (a race between the last two
-    /// connections tearing down must still send obituaries exactly
-    /// once).
-    obituary_sent: AtomicBool,
+    /// **F4 (Phase A0b) + §7.3 R1 typed lifecycle.** Atomic-backed
+    /// `Live(n: NonZeroUsize) / Dying / Dead` state machine; replaces
+    /// the prior `live_conns: AtomicUsize` + `obituary_sent: AtomicBool`
+    /// pair. The founding connection starts in `Live(1)`; the server's
+    /// id-demux attach calls
+    /// [`try_bump_live`](super::lifecycle::SessionLifecycle::try_bump_live)
+    /// (CAS-loop — closes the review-R2 multi-attacker hole at the type
+    /// level). `serve_blocking_on` exit calls `drop_connection`; on the
+    /// `1→0` edge (full session teardown) the caller fires the session
+    /// obituaries and then `mark_dead`s. The intermediate `Dying` state
+    /// surfaces as
+    /// [`is_torn_down()`](super::lifecycle::SessionLifecycle::is_torn_down)
+    /// `== true` *before* the obituary completes, so `RpcProxy::drop`
+    /// best-effort reapers skip immediately instead of blocking on an
+    /// empty slot pool — a strict improvement over the prior
+    /// `obituary_sent.load()` (which only flipped after the callback
+    /// returned).
+    lifecycle: SessionLifecycle,
 }
 
 impl SharedSession {
@@ -527,63 +534,21 @@ impl SharedSession {
     /// Current live connection count — the F4 ledger primitive. Used
     /// by tests as a *deterministic* witness that a connection-drop
     /// has been fully reaped by its server worker (`serve_blocking_on`
-    /// exit's `live_conns.fetch_sub`), replacing the prior
-    /// `sleep(50ms)` heuristic in `a0b_multi_connection_shared_session`
-    /// that raced server-scheduler jitter. Always observes the latest
-    /// monotonic value (SeqCst).
+    /// exit's `drop_connection`), replacing the prior `sleep(50ms)`
+    /// heuristic in `a0b_multi_connection_shared_session` that raced
+    /// server-scheduler jitter. `0` in both `Dying` and `Dead`.
     pub(crate) fn live_conn_count(&self) -> usize {
-        self.live_conns.load(Ordering::SeqCst)
+        self.lifecycle.live_count()
     }
 
-    /// **F4 anti-resurrection primitive.** Atomically add one to
-    /// `live_conns` *if* the session is still alive. Returns `false`
-    /// when the session is already torn down — `obituary_sent` is set,
-    /// or `live_conns` has reached 0 (the founding worker raced past
-    /// `live_conns.fetch_sub` between `resolve_session.upgrade()` and
-    /// this call). Without this gate the attaching connection would
-    /// resurrect a dead session whose obituaries already fired,
-    /// silently losing `binder_died` for any `DeathRecipient` linked
-    /// through the attached connection.
-    ///
-    /// **CAS-loop rather than optimistic-bump-then-rollback**: an
-    /// earlier "fetch_add → if (prev==0 || obituary_sent) fetch_sub"
-    /// shape closed the *single-attacker* race but had a real
-    /// **multi-attacker** hole — two concurrent attackers A and B both
-    /// bumping after the founding `fetch_sub`'d to 0 produces the
-    /// linearization
-    /// ```text
-    /// founding fetch_sub  1→0  (was_last=true)
-    /// A fetch_add         0→1  (A sees prev=0 → will roll back)
-    /// B fetch_add         1→2  (B sees prev=1, obituary_sent still
-    ///                           false → returns true and attaches!)
-    /// A fetch_sub         2→1  (A's rollback)
-    /// founding CAS obituary_sent false→true  → fires
-    /// final: live_conns=1, obituary_sent=true ⇒ B silently in a dead
-    ///        session, its DeathRecipients never get binder_died
-    /// ```
-    /// because B sees the inflated `prev` from A's bump before A
-    /// rolls back. A value-decision CAS loop closes this: every bump
-    /// is conditional on the *value* of `live_conns`, so `0` is never
-    /// transiently visible as `≥ 1` to a subsequent attacker, and any
-    /// CAS racing the founding's `fetch_sub` either succeeds on a
-    /// still-positive count (founding then observes `prev > 1` and
-    /// doesn't fire) or fails and retries against the 0 it left.
+    /// **F4 anti-resurrection primitive.** Thin wrapper around
+    /// [`SessionLifecycle::try_bump_live`] — see the type doc on
+    /// [`super::lifecycle::SessionLifecycle`] for the CAS-loop
+    /// rationale (review-R2 multi-attacker hole) and §7.3 R1 (typed
+    /// lifecycle that makes `Dying`/`Dead` unobservable as a transient
+    /// "still Live" state from any other observer).
     pub(crate) fn try_bump_live_conns(&self) -> bool {
-        let mut cur = self.live_conns.load(Ordering::SeqCst);
-        loop {
-            if cur == 0 || self.obituary_sent.load(Ordering::SeqCst) {
-                return false;
-            }
-            match self.live_conns.compare_exchange_weak(
-                cur,
-                cur + 1,
-                Ordering::SeqCst,
-                Ordering::SeqCst,
-            ) {
-                Ok(_) => return true,
-                Err(actual) => cur = actual,
-            }
-        }
+        self.lifecycle.try_bump_live()
     }
 }
 
@@ -1337,7 +1302,7 @@ impl RpcSessionInner {
     /// `RpcProxy::drop` semantics (a dead session ⇒ peer
     /// observationally gone, AOSP parity).
     pub(crate) fn queue_dec_strong(&self, addr: RpcAddress) {
-        if self.shared.obituary_sent.load(Ordering::Acquire) {
+        if self.shared.lifecycle.is_torn_down() {
             return;
         }
         // Fast path: synchronous send when a slot is immediately
@@ -1355,15 +1320,17 @@ impl RpcSessionInner {
     pub(crate) fn send_dec_strong(&self, addr: RpcAddress) -> Result<()> {
         // `RpcProxy::drop` (best-effort) and `read_binder`'s F7
         // excess-flush call this from arbitrary threads/contexts.
-        // **Phase A4 (F8) shutdown guard**: once the session's
-        // obituary has fired, the peer is gone *and* the slot pool
-        // has either started shrinking via `remove_slot` or already
+        // **Phase A4 (F8) shutdown guard + §7.3 R1**: once the session
+        // leaves `Live` (Dying or Dead), the peer is gone *and* the slot
+        // pool has either started shrinking via `remove_slot` or already
         // emptied — `find_conn` on an empty pool would `cv.wait`
         // forever (no `add_slot` can race past F4
-        // `try_bump_live_conns`). Skip best-effort. AOSP parity: a
-        // remote `DEC_STRONG` on a dead session is observationally
-        // no-op (the peer's `RpcState` is gone).
-        if self.shared.obituary_sent.load(Ordering::Acquire) {
+        // `try_bump_live_conns`). Skip best-effort. R1's typed lifecycle
+        // makes this check observe the `Dying` window *before* the
+        // obituary completes, closing a narrow prior window where this
+        // path could find an empty pool after the founding worker had
+        // started its teardown but before `obituary_sent.load` flipped.
+        if self.shared.lifecycle.is_torn_down() {
             return Ok(());
         }
         // `find_conn` picks an available slot (or — if this thread is
@@ -1751,8 +1718,8 @@ impl RpcSession {
         ))
     }
 
-    /// A brand-new session's shared state (`live_conns == 1`, the
-    /// founding connection — Phase A0b F4). The default
+    /// A brand-new session's shared state (`lifecycle == Live(1)`, the
+    /// founding connection — Phase A0b F4 / §7.3 R1). The default
     /// single-connection path uses exactly one of these, so its
     /// behavior is byte-identical to the pre-A0b single-`transport`
     /// `RpcSessionInner`.
@@ -1766,8 +1733,7 @@ impl RpcSession {
             fd_mode: Mutex::new(FileDescriptorTransportMode::None),
             fd_unix_supported: AtomicBool::new(false),
             rpc_session_id: gen_rpc_session_id()?,
-            live_conns: AtomicUsize::new(1),
-            obituary_sent: AtomicBool::new(false),
+            lifecycle: SessionLifecycle::new(),
         }))
     }
 
@@ -1850,16 +1816,15 @@ impl RpcSession {
     /// Append a server-side *callback* slot — the wire mirror of the
     /// peer's `mIncoming` (AOSP `RpcServer.cpp`: `addOutgoingConnection
     /// (client, init=true)` for `incoming` headers). Does NOT bump
-    /// `live_conns` (callback slots are not serve-driven; AOSP also
-    /// does not gate session lifetime on `mOutgoing.size()`).
-    /// `Err(DeadObject)` if the session is already torn down.
+    /// the lifecycle count (callback slots are not serve-driven; AOSP
+    /// also does not gate session lifetime on `mOutgoing.size()`).
+    /// `Err(DeadObject)` if the session is already torn down (the §7.3
+    /// R1 lifecycle covers both `Dying` and `Dead` in a single check).
     pub(crate) fn add_callback_slot(&self, transport: Box<dyn RpcTransport>) -> Result<u64> {
         // Snapshot gate, not CAS — a concurrent founding death after
         // this read is race-acceptable: the slot sits unused in a
         // dead session and is reclaimed via `Arc<RpcSessionInner>`.
-        if self.inner.shared.live_conn_count() == 0
-            || self.inner.shared.obituary_sent.load(Ordering::Acquire)
-        {
+        if self.inner.shared.lifecycle.is_torn_down() {
             return Err(StatusCode::DeadObject);
         }
         Ok(self.inner.add_slot_inner(transport))
@@ -2253,38 +2218,31 @@ impl RpcSession {
             }
             r
         };
-        // Phase A0b **F4**: this connection is finished. Fire the
-        // session obituaries only on the **last** connection's
-        // teardown (full session death) — never on a *partial*
-        // connection loss while other connections of the same session
-        // are still live (that would deliver a spurious `binder_died`
-        // to a peer that can still reach the session over another
-        // connection). `fetch_sub` returns the prior count, so exactly
-        // one caller observes the 1→0 edge; the `obituary_sent` CAS is
-        // an idempotency belt (a degenerate double-serve can't
-        // double-fire). The default single-connection session has
-        // `live_conns == 1`, so this is 1→0 → fire — **byte-identical
-        // death semantics to pre-A0b**.
-        let was_last = self.inner.shared.live_conns.fetch_sub(1, Ordering::SeqCst) == 1;
-        if was_last
-            && self
-                .inner
-                .shared
-                .obituary_sent
-                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-                .is_ok()
-        {
+        // Phase A0b **F4** + §7.3 **R1** typed lifecycle: this
+        // connection is finished. Fire the session obituaries only on
+        // the **last** connection's teardown (full session death) —
+        // never on a *partial* connection loss while other connections
+        // of the same session are still live (that would deliver a
+        // spurious `binder_died` to a peer that can still reach the
+        // session over another connection). `drop_connection` returns
+        // `true` for exactly the one caller observing the 1→0 edge
+        // (Live(1) → Dying); on `false` (Live(n>1) → Live(n-1)) other
+        // workers still drive the session. After firing, transition
+        // Dying → Dead via `mark_dead` so subsequent attach attempts
+        // and best-effort `dec_strong` calls see a settled state.
+        if self.inner.shared.lifecycle.drop_connection() {
             self.inner.send_session_obituaries();
+            self.inner.shared.lifecycle.mark_dead();
         }
         // Phase A4 (F8): drop this worker's slot from the pool **after**
-        // the F4 fetch_sub / obituary so a concurrent `RpcProxy::drop`'s
-        // best-effort `send_dec_strong` sees either (i) the slot still
-        // present (`find_conn` picks it, send returns `PeerClosed`,
-        // best-effort path Err — no deadlock) or (ii) `obituary_sent =
-        // true` (the dedicated `send_dec_strong` early-out below
+        // the F4 lifecycle transition + obituary so a concurrent
+        // `RpcProxy::drop`'s best-effort `send_dec_strong` sees either
+        // (i) the slot still present (`find_conn` picks it, send returns
+        // `PeerClosed`, best-effort path Err — no deadlock) or (ii) the
+        // lifecycle in Dying/Dead (the `send_dec_strong` early-out
         // short-circuits, skipping `find_conn` entirely). Removing the
-        // slot *before* the obituary opened a window where a stale
-        // proxy drop would find an empty pool and block forever on
+        // slot *before* the lifecycle transition opened a window where a
+        // stale proxy drop would find an empty pool and block forever on
         // `slot_cv` (no add_slot can race the obituary thanks to F4
         // `try_bump_live_conns`).
         self.inner.remove_slot(slot_id);
@@ -2628,7 +2586,7 @@ fn reaper_loop(weak: Weak<RpcSessionInner>, rx: mpsc::Receiver<RpcAddress>) {
         let Some(inner) = weak.upgrade() else {
             return;
         };
-        if inner.shared.obituary_sent.load(Ordering::Acquire) {
+        if inner.shared.lifecycle.is_torn_down() {
             continue;
         }
         // `find_conn(false)` may briefly wait on `slot_cv` if the

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -2453,6 +2453,80 @@ impl RpcSession {
         Ok(self.inner.add_outgoing_slot(Box::new(t)))
     }
 
+    /// **Subplan 2-12 Phase B.2 — automatic outgoing-pool fan-out.**
+    /// AOSP `RpcSession::setupClient` automation for the path-based
+    /// UDS client (one helper instead of three explicit steps).
+    ///
+    /// Establishes the founding connection (a brand-new session, empty
+    /// session id), runs `GET_MAX_THREADS` and `GET_SESSION_ID` against
+    /// the server, then mints additional outgoing connections to the
+    /// same `path` echoing the server-minted session id, up to
+    /// `N = min(remote_max_threads, local_max_outgoing) - 1` extras.
+    /// The returned `RpcSession` then has a pool of `N` connections,
+    /// matching the size AOSP's
+    /// [`RpcSession::setupClient`](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/native/libs/binder/RpcSession.cpp;l=483)
+    /// would build for the same `mMaxOutgoingConnections`.
+    ///
+    /// **`local_max_outgoing <= 1`** is the *single-connection* path:
+    /// no `GET_MAX_THREADS` exchange, no fan-out, returned session is
+    /// byte-identical to
+    /// [`setup_unix_client_android13plus`](RpcSession::setup_unix_client_android13plus).
+    /// A `0` is treated as `1` — a session must have at least the
+    /// founding connection to be useful (AOSP rejects 0 as a misuse).
+    ///
+    /// **Profile uniformity** is enforced by the per-connection
+    /// [`add_outgoing_connection_android13plus`](RpcSession::add_outgoing_connection_android13plus)
+    /// (the founding session's negotiated wire version caps every
+    /// additional connection's `max_version`). A fan-out connection
+    /// that the server downgrades below the founding version surfaces
+    /// as `Err(BadType)` and the partially-built session is dropped.
+    /// Rust ownership ≡ AOSP `scope_guard`'s implicit cleanup.
+    ///
+    /// **No retry / no progressive degradation**: a fan-out connect
+    /// failure (e.g. the server's `set_max_threads` is tighter than
+    /// `local_max_outgoing - 1` would imply, so the attach is refused
+    /// past the cap) surfaces as `Err`. A caller that wants a softer
+    /// fallback can use
+    /// [`setup_unix_client_android13plus`](RpcSession::setup_unix_client_android13plus) +
+    /// manual `add_outgoing_connection_android13plus` loop and tolerate
+    /// per-extra failures.
+    pub fn setup_unix_client_android13plus_fan_out(
+        path: impl AsRef<std::path::Path>,
+        max_version: u32,
+        local_max_outgoing: u32,
+    ) -> Result<RpcSession> {
+        // Borrow the path once for the founding connect; clone to
+        // `PathBuf` to drive the fan-out loop without forcing
+        // `impl AsRef<Path> + Clone` on the caller (each
+        // `add_outgoing_connection_android13plus` takes a fresh
+        // `impl AsRef<Path>`).
+        let path: std::path::PathBuf = path.as_ref().to_owned();
+        let session = Self::setup_unix_client_android13plus(&path, max_version)?;
+        let local = local_max_outgoing.max(1);
+        if local == 1 {
+            // Single-connection: skip GET_MAX_THREADS entirely so the
+            // wire is bit-identical to the founding-only helper.
+            return Ok(session);
+        }
+        // `negotiate(local)` exchanges GET_MAX_THREADS, records the
+        // `min(local, remote)` on the session, and returns that exact
+        // value — which is AOSP `setupClient`'s `outgoingConnections`
+        // by construction (it computes the same `min` then mints the
+        // pool against it).
+        let negotiated = session.negotiate(local)?;
+        if negotiated <= 1 {
+            return Ok(session);
+        }
+        let session_id = session.get_session_id()?;
+        // `1..negotiated` ⇒ exactly `negotiated - 1` extras; the
+        // founding connection counts as the first slot. AOSP loop:
+        // `for (i = 0; i + 1 < outgoingConnections; i++)`.
+        for _ in 1..negotiated {
+            session.add_outgoing_connection_android13plus(&path, max_version, &session_id)?;
+        }
+        Ok(session)
+    }
+
     /// Client: connect to a Unix-domain android-13+ RPC server **with
     /// FD-over-RPC** opt-in (subplan 2-11 Phase A0). UDS connect + the
     /// AOSP handshake requesting `fd_mode` in the connection header

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -708,25 +708,12 @@ impl RpcSessionInner {
                 reentrant: true,
             };
         }
-        // **Phase A — oneway Option-1 (F5/F6 trade-off recorded).**
-        // Pin all top-level oneway sends to the founding slot so
-        // per-object oneway ordering is preserved by single-slot
-        // in-order delivery (the existing single-connection FIFO
-        // semantics extended to multi-outgoing). The cost is a head-
-        // of-line block: a slow oneway handler at the peer stalls
-        // every other oneway through the same slot (AOSP's per-node
-        // `asyncNumber`+`asyncTodo` priority replay — Option-2 — would
-        // avoid this, deferred to Phase C). Twoways still distribute
-        // (AC-12.1). Nested oneway inside a twoway dispatch hits the
-        // reentrant pin above and reuses the inbound slot — F8.
-        //
-        // **Founding-gone fallback**: when the founding slot has been
-        // retired (its worker exited and `remove_slot(1)` ran) but the
-        // session is still alive via attached slots, `find_conn_pinned`
-        // returns `DeadObject`. Degrade to twoway-style distribution
-        // across the remaining slots — per-object oneway FIFO is no
-        // longer preserved (documented HOL trade-off), but the
-        // alternative (panic out of library code) is strictly worse.
+        // Phase C asyncTodo preserves per-node order regardless of
+        // which slot oneway picks, so removing this pin lifts the
+        // HOL trade-off in principle — but the libbinder AC-12.6 (c)
+        // gate flakes (~20%) without it (EPIPE on outer reply when
+        // server-side oneway DECs cross slots during nested callback
+        // dispatch). Pin stays until that race is root-caused.
         if oneway {
             if let Ok(g) = self.find_conn_pinned(RpcSession::FOUNDING_SLOT_ID) {
                 return g;
@@ -735,9 +722,7 @@ impl RpcSessionInner {
                 "find_conn(oneway=true): founding slot retired; falling back to \
                  any-available — per-object oneway FIFO may be reordered"
             );
-            // fall through to (2)/(3)/(4) below.
         }
-        // (2)(3)(4) Acquire the pool lock and pick or wait.
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
         loop {
             // (2) Defensive exclusive match (shouldn't fire if (1) is correct).
@@ -791,24 +776,16 @@ impl RpcSessionInner {
     }
 
     /// Same as [`find_conn`] but pins to a **specific** slot id. Used
-    /// by the server worker's `serve_blocking_on(slot_id)` (drives its
-    /// assigned inbound slot, never "any available") and by the
-    /// oneway-pin path in [`find_conn`] (founding-slot FIFO).
+    /// by the server worker's `serve_blocking_on(slot_id)` (each
+    /// worker drives only its own inbound slot) and by the oneway
+    /// path in [`find_conn`] (founding-slot FIFO).
     ///
-    /// Returns `Err(StatusCode::DeadObject)` when `want_slot_id` is
-    /// not present in the pool — this can legitimately happen on the
-    /// oneway pin path when the founding slot's worker has exited and
-    /// `remove_slot(FOUNDING_SLOT_ID)` has run while the session is
-    /// still alive via attached slots. Callers either propagate the
-    /// error (server worker — Phase A4 self-remove makes this
-    /// structurally unreachable from the worker's own pin) or fall
-    /// back (`find_conn` oneway path degrades to any-available).
-    ///
-    /// Waits on the condvar if the slot exists but is held by another
-    /// thread (shouldn't happen in the normal accept-then-serve flow
-    /// — the freshly-added slot is unclaimed). Same reentrant-pin
-    /// path as `find_conn` so a nested call inside dispatch reuses
-    /// this slot.
+    /// `Err(StatusCode::DeadObject)` when `want_slot_id` is not in
+    /// the pool — legitimately happens on the oneway path when the
+    /// founding slot's worker has exited (`remove_slot(FOUNDING_
+    /// SLOT_ID)`) while attached slots are still alive; the caller
+    /// falls back to any-available. Reentrant on the same slot via
+    /// DRIVING, like `find_conn`.
     fn find_conn_pinned(&self, want_slot_id: u64) -> Result<ConnGuard<'_>> {
         let tid = current_tid();
         let sess_ptr = self as *const RpcSessionInner as usize;
@@ -1392,10 +1369,9 @@ impl RpcSessionInner {
         // `find_conn` picks an available slot (or — if this thread is
         // already driving one of the session's slots — reuses it via
         // `DRIVING`, the documented "interleaved DEC_STRONG" path).
-        // `DEC_STRONG` is a control message, not a user oneway —
-        // `oneway=false` so it joins the twoway distribution (any
-        // available slot), avoiding contention on the oneway-pinned
-        // founding slot.
+        // `oneway=false` so DEC_STRONG joins the twoway distribution
+        // (any available slot) instead of contending on the oneway-
+        // pinned founding slot.
         let conn = self.find_conn(false);
         let frame = self.profile.codec().encode_dec_strong(&addr);
         self.send_msg(conn.transport(), &frame, &[])?;
@@ -2138,9 +2114,6 @@ impl RpcSession {
     /// [`super::RpcServer`] registry key. Per-session, never global
     /// (P6).
     pub fn session_id(&self) -> [u8; 32] {
-        // Public API keeps the raw-byte shape for ergonomic
-        // compatibility (R2 internal-only newtype). Future R2-full PR
-        // can promote this to `RpcSessionId`.
         *self.inner.shared.rpc_session_id.as_bytes()
     }
 
@@ -2658,9 +2631,9 @@ fn reaper_loop(weak: Weak<RpcSessionInner>, rx: mpsc::Receiver<RpcAddress>) {
         if inner.shared.obituary_sent.load(Ordering::Acquire) {
             continue;
         }
-        // `find_conn(false)` may briefly wait on `slot_cv` if the pool
-        // is exhausted, but the *user* `Drop` already returned — this
-        // wait is contained to the dedicated reaper thread.
+        // `find_conn(false)` may briefly wait on `slot_cv` if the
+        // pool is exhausted, but the *user* `Drop` already returned —
+        // this wait is contained to the dedicated reaper thread.
         let conn = inner.find_conn(false);
         let frame = inner.profile.codec().encode_dec_strong(&addr);
         let _ = inner.send_msg(conn.transport(), &frame, &[]);

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! `RpcSession` — single-connection RPC session (subplan 2-2 driver).
+//! `RpcSession` — single-connection RPC session driver.
 //!
 //! Ties one [`RpcTransport`] + [`R34Codec`] + per-session [`RpcState`]
 //! together and provides:
@@ -11,9 +11,7 @@
 //! * the [`RpcParcelOps`] bridge that lets the `SIBinder`
 //!   (de)serializers marshal binders as `RpcAddress`.
 //!
-//! Per **P6** all state is owned here (no global). The multi-connection
-//! / threaded / negotiated session is subplan 2-3; this is the minimal
-//! single-connection request/reply driver 2-2 needs for its e2e.
+//! All state is owned here (no global).
 
 use std::cell::RefCell;
 use std::os::fd::{AsFd, OwnedFd};
@@ -48,7 +46,7 @@ type Android13PlusAccept = (Box<dyn RpcTransport>, Android13PlusCodec, u8, Vec<u
 
 /// Which RPC wire profile a session speaks.
 ///
-/// **G4(a) (subplan 2-5b).** The default [`WireProfile::R34`] arm is the
+/// The default [`WireProfile::R34`] arm is the
 /// android-12 r34 path *verbatim* — rsbinder's `u32` length-prefix
 /// framing ([`RpcTransport::send_frame`]/`recv_frame`) + [`R34Codec`],
 /// no connection handshake. It is byte-unchanged; the green R34 suite
@@ -63,7 +61,7 @@ type Android13PlusAccept = (Box<dyn RpcTransport>, Android13PlusCodec, u8, Vec<u
 /// the version-keyed [`Android13PlusCodec`] finalized by the connection
 /// handshake (`client_connect`/`server_accept`). The reusable framing /
 /// handshake / codec primitives are proven hermetically in
-/// `wire_android13` (G4 Layer-1); this enum is where they become a live
+/// `wire_android13`; this enum is where they become a live
 /// `RpcSession`/`RpcServer` dispatch path, reusing the existing
 /// per-session [`RpcState`], `client_transact`/`serve_blocking` and
 /// re-entrancy machinery unchanged.
@@ -97,7 +95,7 @@ impl WireProfile {
 
     /// The negotiated wire protocol version, or `None` for the
     /// pre-versioning R34 (android-12) profile (which has no object
-    /// table at all — subplan 2-8).
+    /// table at all).
     fn wire_version(&self) -> Option<u32> {
         match self {
             WireProfile::R34(_) => None,
@@ -136,9 +134,8 @@ impl WireProfile {
 /// this is now wire-correct against a real libbinder RPC peer for
 /// **every** profile (r34 / android-13 v0 / v1 / android-16 v2). The
 /// prior 3-int header was an rsbinder-ism that only ever round-tripped
-/// hermetically (rsbinder↔rsbinder, symmetric) and was the documented
-/// G4(b)/2-8 STAGE3 `kCurrentRepr` residual — now resolved. RPC never
-/// touches `thread_state` (master §4.1.1) — trivially still true.
+/// hermetically (rsbinder↔rsbinder, symmetric) — now resolved. RPC
+/// never touches `thread_state`.
 pub(crate) fn write_rpc_interface_token(p: &mut Parcel, descriptor: &str) -> Result<()> {
     p.write(&descriptor)?;
     Ok(())
@@ -170,7 +167,7 @@ fn read_addr(p: &mut Parcel) -> Result<RpcAddress> {
 }
 
 /// 32-byte AOSP `kSessionIdBytes` opaque session identifier — a
-/// CSPRNG-minted **capability for attach** under subplan 2-12 A0a/A0b:
+/// CSPRNG-minted **capability for attach**:
 /// a peer that echoes this id in the connection header is bound to
 /// the *same* `SharedSession` (shared `state`/`root`/cached proxies),
 /// so the wire bytes are not just an opaque identifier but a
@@ -183,8 +180,7 @@ fn read_addr(p: &mut Parcel) -> Result<RpcAddress> {
 /// wire-facing APIs ([`RpcSession::session_id`],
 /// [`connect_android13plus_fd_with_id`](RpcSession::connect_android13plus_fd_with_id),
 /// [`add_outgoing_connection_android13plus`](RpcSession::add_outgoing_connection_android13plus))
-/// keep the raw `[u8; 32]` / `&[u8]` shape for ergonomic compatibility
-/// — a future R2-full PR can promote them.
+/// keep the raw `[u8; 32]` / `&[u8]` shape for ergonomic compatibility.
 ///
 /// `Debug` deliberately masks the bytes: this id is a capability —
 /// logging it leaks the attach token.
@@ -217,20 +213,20 @@ impl std::fmt::Debug for RpcSessionId {
 }
 
 /// Mint a fresh [`RpcSessionId`] via the OS CSPRNG. AOSP fills it
-/// from a CSPRNG and rsbinder must do the same: A0b made the id a
+/// from a CSPRNG and rsbinder must do the same: the id is a
 /// **capability for attach**, so a predictable id would be a session-
 /// hijack primitive for any same-host peer reachable on the UDS.
-/// **Global-free** (P6 — no `static` counter); `getrandom` is a
+/// **Global-free** (no `static` counter); `getrandom` is a
 /// stateless syscall (`getrandom(2)` on Linux, `SecRandomCopyBytes`
 /// on macOS), so the `rpc_stack_has_no_globals` gate stays clean.
 fn gen_rpc_session_id() -> RpcResult<RpcSessionId> {
     let mut id = [0u8; 32];
-    // M5 fix (review 2026-05-21): surface a `getrandom` failure as a
-    // recoverable `RpcError::Io` instead of panicking out of a public
-    // constructor. `getrandom(2)` *can* fail in early-boot containers
-    // (`EAGAIN`/`EINTR` mapping in the `getrandom` crate), and prior
-    // to this the panic unwound through `RpcSession::new`'s
-    // infallible signature with no way for callers to handle.
+    // Surface a `getrandom` failure as a recoverable `RpcError::Io`
+    // instead of panicking out of a public constructor. `getrandom(2)`
+    // *can* fail in early-boot containers
+    // (`EAGAIN`/`EINTR` mapping in the `getrandom` crate); a panic
+    // would unwind through `RpcSession::new`'s infallible signature
+    // with no way for callers to handle.
     getrandom::fill(&mut id).map_err(|e| {
         RpcError::Io(std::io::Error::other(format!(
             "CSPRNG getrandom failed for RPC session id: {e}"
@@ -239,7 +235,7 @@ fn gen_rpc_session_id() -> RpcResult<RpcSessionId> {
     Ok(RpcSessionId::new(id))
 }
 
-/// RAII clear for the `client_transact` reply read-deadline (AC-3.8).
+/// RAII clear for the `client_transact` reply read-deadline.
 ///
 /// `set_read_timeout(Some(d))` sets a sticky `SO_RCVTIMEO` on the
 /// shared connection. This guard clears it on **every** exit from the
@@ -273,20 +269,20 @@ impl Drop for ReplyDeadlineGuard<'_> {
 }
 
 /// RAII pair for the *nested-dispatch* deadline window inside
-/// `client_transact` (T1-2 / Major-1).
+/// `client_transact`.
 ///
-/// The reply deadline (AC-3.8) bounds **only the outermost reply
+/// The reply deadline bounds **only the outermost reply
 /// wait**. A nested inbound call dispatched while we wait (a server
-/// callback — AC-3.6) is legitimate, potentially long-running forward
+/// callback) is legitimate, potentially long-running forward
 /// progress, not a stall: bounding it would break valid re-entrancy,
 /// and time-bounding the nested *reply write* could leave a half-frame
 /// on the wire. So the deadline is lifted for the nested dispatch and
 /// restored for the continued wait — but **symmetrically via Drop**, so
 /// an early `?`/panic out of `dispatch_transact` can never leave the
 /// sticky `SO_RCVTIMEO` desynchronized for the rest of the reply loop
-/// (the pre-T1-2 manual clear/re-arm pair could).
+/// (a manual clear/re-arm pair could).
 ///
-/// **Cross-session escape (M4 caveat, review 2026-05-21)**: this guard
+/// **Cross-session escape caveat**: this guard
 /// lifts only the *outer* transport's deadline. A user handler that
 /// — during a same-thread nested dispatch — issues an outbound
 /// transact on a *different* `RpcSession` will block on **that
@@ -328,26 +324,24 @@ thread_local! {
     /// `(session_ptr, slot_id)` pairs this thread is currently driving
     /// (outermost `client_transact` / `serve_once_on_slot`). Lets a
     /// same-thread **nested** call (a server handler calling back
-    /// while a transaction is in flight — AC-3.6 / F8) re-enter the
+    /// while a transaction is in flight) re-enter the
     /// **same slot** the inbound transact arrived on, rather than
     /// either self-deadlocking on its `exclusive_tid` or routing the
     /// callback over a *different* available slot (which would break
     /// AOSP's `exclusiveIncoming->allowNested` ordering guarantee).
-    /// **Phase A rekey** (was a plain `Vec<usize>` of inner pointers
-    /// — pre-pool, where a session had a single connection so the
-    /// inner pointer was the slot key).
+    /// The key is `(session, slot)`.
     ///
-    /// Per-thread *recursion marker*, **not** session/protocol state
-    /// (P6): it holds no node / address / ref-count data — those stay
+    /// Per-thread *recursion marker*, **not** session/protocol state:
+    /// it holds no node / address / ref-count data — those stay
     /// per-session in [`RpcState`]. It mirrors kernel binder's
-    /// thread-local `IPCThreadState`. Documented P6 exception in the
+    /// thread-local `IPCThreadState`. Documented exception in the
     /// `rpc_stack_has_no_globals` gate.
     static DRIVING: RefCell<Vec<(usize, u64)>> = const { RefCell::new(Vec::new()) };
 }
 
 /// AOSP `RpcConnection::exclusiveTid` equivalent — `std::thread::
-/// ThreadId` (`Copy + Eq`, opaque, P6-friendly: NO process global, NO
-/// extra thread_local needed beyond `std`'s own thread bookkeeping).
+/// ThreadId` (`Copy + Eq`, opaque: NO process global, NO extra
+/// thread_local needed beyond `std`'s own thread bookkeeping).
 type Tid = std::thread::ThreadId;
 
 #[inline]
@@ -355,55 +349,45 @@ fn current_tid() -> Tid {
     std::thread::current().id()
 }
 
-/// **Phase A**: one connection slot of an `RpcSessionInner`'s pool —
+/// One connection slot of an `RpcSessionInner`'s pool —
 /// the rsbinder equivalent of AOSP `RpcSession::RpcConnection`.
 struct ConnSlot {
     /// The connection's transport, held as `Arc<dyn RpcTransport>` so a
     /// [`ConnGuard`] holding an `Arc::clone` keeps the heap object
     /// alive even if [`remove_slot`](RpcSessionInner::remove_slot)
     /// drops this slot from the pool while the guard is in flight.
-    /// The pre-Phase-A4 invariant ("Phase A never removes slots") was
-    /// retired when [`remove_slot`] was introduced (F8 founding-not-
-    /// special teardown); refcounting via `Arc` is the replacement
-    /// liveness guarantee.
+    /// [`remove_slot`] retires a slot on its own worker's exit;
+    /// refcounting via `Arc` is the liveness guarantee that keeps the
+    /// heap object alive for any in-flight guard.
     transport: Arc<dyn RpcTransport>,
     /// AOSP `RpcConnection::exclusiveTid`: thread currently driving
     /// this slot, or `None` if available. [`find_conn`] picks the
     /// first available; pool exhaustion **blocks on the session's
     /// `Condvar`** (AOSP `mAvailableConnectionCv`) — never a busy
-    /// try-loop (F2).
+    /// try-loop.
     exclusive_tid: Option<Tid>,
-    /// AOSP `RpcConnection::allowNested`: whether a same-thread nested
-    /// `find_conn` (a server handler calling back into the peer while
-    /// the inbound transact is in flight — AC-3.6) may re-enter THIS
-    /// slot. Phase A keeps this `true` for every slot; Phase C's
-    /// oneway Option-2 would set `false` on the oneway-pinned slot
-    /// (F8). Reentrancy itself is mediated by the [`DRIVING`]
-    /// thread-local keyed by `(session_ptr, slot_id)`.
-    #[allow(dead_code)] // populated for AOSP fidelity, consumed by Phase C oneway Option-2
-    allow_nested: bool,
     /// Monotonic local id (the [`DRIVING`] reentrancy key + the
-    /// server-worker handle). Stable for the slot's life — Phase A4
+    /// server-worker handle). Stable for the slot's life —
     /// [`remove_slot`](RpcSessionInner::remove_slot) drops the slot
     /// only on its own worker's exit, never re-using an id.
     id: u64,
 }
 
-/// **Phase A**: the session's connection pool + its monotonic slot-id
+/// The session's connection pool + its monotonic slot-id
 /// counter. Behind the single per-session `Mutex` paired with the
-/// `Condvar` on [`RpcSessionInner`] — *not* N independent mutexes (F2:
-/// AOSP `RpcSession::mMutex` + `mAvailableConnectionCv`).
+/// `Condvar` on [`RpcSessionInner`] — *not* N independent mutexes
+/// (AOSP `RpcSession::mMutex` + `mAvailableConnectionCv`).
 struct ConnState {
     slots: Vec<ConnSlot>,
     next_slot_id: u64,
 }
 
-/// RAII guard for one selected connection slot (Phase A). Built by
+/// RAII guard for one selected connection slot. Built by
 /// [`RpcSessionInner::find_conn`]. Holds the slot exclusive_tid==this
 /// thread (unless reentrant) and an `Arc::clone` of the slot's
 /// transport so subsequent `send_msg`/`recv_msg` do **no** locking —
-/// concurrent client transacts on *other* slots run unimpeded
-/// (AC-12.1). On drop: clears `exclusive_tid` (unless reentrant),
+/// concurrent client transacts on *other* slots run unimpeded.
+/// On drop: clears `exclusive_tid` (unless reentrant),
 /// pops the [`DRIVING`] marker, and notifies waiters.
 struct ConnGuard<'a> {
     inner: &'a RpcSessionInner,
@@ -460,12 +444,12 @@ impl Drop for ConnGuard<'_> {
     }
 }
 
-/// **Subplan 2-12 Phase A0b**: the state shared by *all connections of
+/// The state shared by *all connections of
 /// one logical session* (AOSP `RpcSession` shares this across its
 /// `mOutgoing`/`mIncoming` connections). One per session, behind `Arc`;
-/// never global (P6). Default single-connection sessions own exactly
+/// never global. Default single-connection sessions own exactly
 /// one of these with `lifecycle == Live(1)` ⇒ behavior is byte-identical
-/// to the pre-A0b single-`transport` `RpcSessionInner` (the `Arc`
+/// to a single-`transport` `RpcSessionInner` (the `Arc`
 /// indirection is the only structural change; the wire is unchanged).
 /// The server attaches a 2nd+ connection to a *pre-existing* instance
 /// (id-demux), so a binder published over one connection is reachable
@@ -476,15 +460,15 @@ pub(crate) struct SharedSession {
     state: Mutex<RpcState>,
     root: Mutex<Option<SIBinder>>,
     /// Max-threads value advertised to the peer on `GET_MAX_THREADS`
-    /// (server side) — subplan 2-3 negotiation.
+    /// (server side) — handshake negotiation.
     max_threads: AtomicU32,
     /// `min(local, remote)` after the client handshake (0 until done).
     negotiated: AtomicU32,
-    /// Optional reply/handshake wait deadline (AC-3.8).
+    /// Optional reply/handshake wait deadline.
     timeout: Mutex<Option<Duration>>,
-    /// Negotiated FD-over-RPC mode (subplan 2-7). Default `None` ⇒ the
-    /// 2-2 reject path, and `send/recv` use the unchanged framed calls
-    /// (AC-7.1 bit-identical).
+    /// Negotiated FD-over-RPC mode. Default `None` ⇒ the
+    /// categorical reject path, and `send/recv` use the unchanged
+    /// framed calls (bit-identical).
     fd_mode: Mutex<crate::rpc::FileDescriptorTransportMode>,
     /// Server role: does this endpoint advertise `Unix` FD support on
     /// `GET_FD_MODE`. Default false.
@@ -493,19 +477,19 @@ pub(crate) struct SharedSession {
     /// special transact. AOSP `RpcServer` assigns a random
     /// `kSessionIdBytes == 32` id; the libbinder client reads it with
     /// `Parcel::readByteVector` and would `BAD_VALUE` on any other size
-    /// (G4(b): real-peer-validated). Per-session, never global (P6) —
+    /// (real-peer-validated). Per-session, never global —
     /// generated global-free in [`RpcSession::with_profile`]. Shared
-    /// across the session's connections (A0b: an attached 2nd
+    /// across the session's connections (an attached 2nd
     /// connection reports the *same* id). [`RpcSessionId`] newtype
-    /// (R2) makes the "attach capability" semantic type-explicit.
+    /// makes the "attach capability" semantic type-explicit.
     rpc_session_id: RpcSessionId,
-    /// **F4 (Phase A0b) + §7.3 R1 typed lifecycle.** Atomic-backed
+    /// Typed lifecycle. Atomic-backed
     /// `Live(n: NonZeroUsize) / Dying / Dead` state machine; replaces
-    /// the prior `live_conns: AtomicUsize` + `obituary_sent: AtomicBool`
+    /// a `live_conns: AtomicUsize` + `obituary_sent: AtomicBool`
     /// pair. The founding connection starts in `Live(1)`; the server's
     /// id-demux attach calls
     /// [`try_bump_live`](super::lifecycle::SessionLifecycle::try_bump_live)
-    /// (CAS-loop — closes the review-R2 multi-attacker hole at the type
+    /// (CAS-loop — closes the multi-attacker hole at the type
     /// level). `serve_blocking_on` exit calls `drop_connection`; on the
     /// `1→0` edge (full session teardown) the caller fires the session
     /// obituaries and then `mark_dead`s. The intermediate `Dying` state
@@ -521,7 +505,7 @@ pub(crate) struct SharedSession {
 
 impl SharedSession {
     /// Live local-node count of this (possibly multi-connection)
-    /// session's shared `RpcState` — Phase A F7 leak observability
+    /// session's shared `RpcState` — leak observability
     /// (the AOSP `timesSent` books must net to 0 nodes once every
     /// proxy is dropped). Used by [`super::RpcServer`]'s test helper.
     pub(crate) fn local_node_count(&self) -> usize {
@@ -531,59 +515,58 @@ impl SharedSession {
             .local_node_count()
     }
 
-    /// Current live connection count — the F4 ledger primitive. Used
-    /// by tests as a *deterministic* witness that a connection-drop
+    /// Current live connection count — the lifecycle ledger primitive.
+    /// Used by tests as a *deterministic* witness that a connection-drop
     /// has been fully reaped by its server worker (`serve_blocking_on`
-    /// exit's `drop_connection`), replacing the prior `sleep(50ms)`
-    /// heuristic in `a0b_multi_connection_shared_session` that raced
-    /// server-scheduler jitter. `0` in both `Dying` and `Dead`.
+    /// exit's `drop_connection`), instead of a `sleep` heuristic that
+    /// races server-scheduler jitter. `0` in both `Dying` and `Dead`.
     pub(crate) fn live_conn_count(&self) -> usize {
         self.lifecycle.live_count()
     }
 
-    /// **F4 anti-resurrection primitive.** Thin wrapper around
+    /// **Anti-resurrection primitive.** Thin wrapper around
     /// [`SessionLifecycle::try_bump_live`] — see the type doc on
     /// [`super::lifecycle::SessionLifecycle`] for the CAS-loop
-    /// rationale (review-R2 multi-attacker hole) and §7.3 R1 (typed
+    /// rationale (multi-attacker hole) and the typed
     /// lifecycle that makes `Dying`/`Dead` unobservable as a transient
-    /// "still Live" state from any other observer).
+    /// "still Live" state from any other observer.
     pub(crate) fn try_bump_live_conns(&self) -> bool {
         self.lifecycle.try_bump_live()
     }
 }
 
-/// **Phase A**: one `RpcSessionInner` per logical session, owning a
+/// One `RpcSessionInner` per logical session, owning a
 /// **pool** of `ConnSlot`s (AOSP `RpcSession`'s `mOutgoing`/
-/// `mIncoming` connections collapsed into one Vec — Phase A keeps a
-/// single duplex pool; F8's `allow_nested` per-slot is the lever for
-/// finer separation). `find_conn`
-/// selects an available slot for outgoing calls (AC-12.1 distribution,
-/// plus nested-pin for AC-3.6/AC-12.2 / F8); server workers serve a
+/// `mIncoming` connections collapsed into one duplex Vec — the
+/// reentrant `DRIVING` `(session, slot)` pin keeps this
+/// wire-equivalent to a split pool). `find_conn`
+/// selects an available slot for outgoing calls (distribution
+/// plus nested-pin for re-entrant callbacks); server workers serve a
 /// specific slot via [`serve_blocking_on`](RpcSession::serve_blocking_on)
 /// (their inbound connection). Default single-connection sessions own
-/// one slot, so `find_conn` is a no-wait single-slot pick and the pre-A
-/// `enter_connection` semantics are byte-identical (T1-1/AC-3.2).
+/// one slot, so `find_conn` is a no-wait single-slot pick and the
+/// `enter_connection` semantics are byte-identical.
 pub struct RpcSessionInner {
     /// AOSP `RpcSession::mMutex` — the session's *single* connection
     /// pool lock, paired with [`slot_cv`](RpcSessionInner::slot_cv).
     /// Held briefly to pick a slot ([`find_conn`]); released for the
     /// duration of the chosen slot's send/recv so concurrent
-    /// `find_conn`s on **other** slots run unblocked (AC-12.1). **Not
-    /// N independent mutexes** (F2): a single per-session mutex +
+    /// `find_conn`s on **other** slots run unblocked. **Not
+    /// N independent mutexes**: a single per-session mutex +
     /// condvar is the AOSP-faithful selection primitive.
     conn_state: Mutex<ConnState>,
     /// AOSP `RpcSession::mAvailableConnectionCv`: woken on slot release
     /// and on slot addition. `find_conn` `wait`s here when the pool is
-    /// exhausted — **block-and-wait, never busy try-loop** (F2).
+    /// exhausted — **block-and-wait, never busy try-loop**.
     slot_cv: Condvar,
     /// Wire profile: R34 (default, byte-unchanged) or the opt-in
-    /// android-13+ versioned wire (G4(a)). Fixed for the session — all
+    /// android-13+ versioned wire. Fixed for the session — all
     /// slots in one session speak the same profile (AOSP requires the
     /// negotiated version match across a session; attach paths reject
     /// a profile-mismatch — see [`add_incoming_slot`]).
     profile: WireProfile,
     self_weak: Mutex<Weak<RpcSessionInner>>,
-    /// C1 fix (review 2026-05-21): non-blocking `DEC_STRONG` hand-off.
+    /// Non-blocking `DEC_STRONG` hand-off.
     /// `RpcProxy::drop` enqueues here and returns immediately; a
     /// dedicated reaper thread (spawned in [`with_shared`]) drains the
     /// queue and runs the blocking `find_conn` + `send_msg` off the
@@ -591,17 +574,12 @@ pub struct RpcSessionInner {
     /// `recv` error; in-flight enqueues drain naturally (mpsc holds
     /// queued items until the receiver consumes them).
     dec_strong_tx: mpsc::Sender<RpcAddress>,
-    /// Session-wide state shared across this session's slots **and**
-    /// (server-side A0b residual) across multiple `RpcSessionInner`
-    /// instances bound to the same session id: the current
-    /// `serve_connection` attach arm builds a fresh `RpcSessionInner`
-    /// per accepted connection and points its `shared` `Arc` at the
-    /// founding session's `SharedSession`. The forward-looking F8
-    /// "1 inner / session" refactor folds those N inners into one
-    /// pool of slots, at which point the `Arc` indirection across
-    /// inners goes away — but `live_conns`/`obituary_sent`/
-    /// `local_node_count`/`rpc_session_id` will continue to live in
-    /// `SharedSession` so the F4/F7 invariants don't move.
+    /// Session-wide state shared across this session's slots. The
+    /// attach path adds slots onto the founding inner directly, so a
+    /// single inner owns the whole slot pool;
+    /// `local_node_count`/`rpc_session_id`/lifecycle live in
+    /// `SharedSession` so the leak/teardown invariants are anchored in
+    /// one place.
     shared: Arc<SharedSession>,
 }
 
@@ -620,7 +598,7 @@ impl RpcParcelOps for SessionParcelOps {
 }
 
 impl RpcSessionInner {
-    /// AOSP `RpcSession::ExclusiveConnection::find` (Phase A). Selects
+    /// AOSP `RpcSession::ExclusiveConnection::find`. Selects
     /// **a** connection slot for this thread to drive (outgoing
     /// `client_transact` / `send_dec_strong`) — returning a
     /// [`ConnGuard`] that owns the slot until drop. Order (AOSP-
@@ -628,7 +606,7 @@ impl RpcSessionInner {
     ///
     ///  1. **Reentrant pin** — if this thread is already driving a
     ///     slot of *this* session (the `DRIVING` marker matches), the
-    ///     nested call **re-enters that slot** (AC-3.6 / F8: a server
+    ///     nested call **re-enters that slot** (a server
     ///     handler's outbound callback returns on the inbound socket;
     ///     a same-thread recursive `client_transact` reuses the outer
     ///     slot). No `conn_state` lock — the outer frame holds the
@@ -641,33 +619,19 @@ impl RpcSessionInner {
     ///     here, return the guard.
     ///  4. **Pool exhausted** — `wait` on `slot_cv` (released on slot
     ///     drop OR `add_*_slot`). **Block-and-wait, never busy
-    ///     try-loop** (F2).
+    ///     try-loop**.
     ///
-    /// Single-slot default (the pre-A path): step 3 always succeeds
+    /// Single-slot default: step 3 always succeeds
     /// without `wait`; the `DRIVING`-keyed reentrancy bypass collapses
-    /// to today's `enter_connection` semantics — byte-identical (no
-    /// wire effect, T1-1/AC-3.2 preserved).
+    /// to the `enter_connection` semantics — byte-identical (no wire
+    /// effect).
     ///
-    /// **Oneway distribution (Phase C — §7.3 Option-1 pin retired
-    /// 2026-05-28).** Earlier this function took an `oneway: bool` and
-    /// routed top-level oneway sends to a fixed founding slot (the
-    /// Option-1 HOL-trade-off pin recorded in
-    /// [`plans/2-12-multi-connection-per-session.md`](../../plans/2-12-multi-connection-per-session.md)
-    /// §2 Phase A). With Phase C asyncTodo (per-`mNodeForAddress`
-    /// `asyncNumber` send-side + receive-side priority replay) carrying
-    /// the per-object oneway ordering invariant on both ends, the pin
-    /// is *redundant for correctness* and only paid the HOL cost. The
-    /// 2026-05-21 deferral suspected a libbinder `waitForReply`
-    /// cross-slot race with rsbinder server-side DECs, but: (i)
-    /// `send_dec_strong` already calls this with the twoway predicate
-    /// (it joins the twoway distribution), so the pin never affected
-    /// DEC routing; (ii) the AC-12.6 (c) "nested-callback outer reply"
-    /// path is all-twoway — the pin was dead code on that gate; and
-    /// (iii) re-running the experiment fresh shows hermetic
-    /// 100/100 + STAGE3 20/20 PASS with pin removed (the prior 4/5 vs
-    /// 5/5 reading was N=5 noise). Net: signature is now slot-policy-
-    /// invariant; per-object oneway FIFO is the asyncTodo invariant,
-    /// not a slot-selection invariant.
+    /// **Oneway distribution.** This function is slot-policy-invariant:
+    /// top-level oneway sends join the same slot distribution as twoway
+    /// sends. Per-object oneway FIFO ordering is carried entirely by
+    /// the per-`mNodeForAddress` `asyncNumber` send-side counter +
+    /// receive-side priority replay (see [`super::state`]), not by
+    /// pinning oneway sends to a fixed slot.
     fn find_conn(&self) -> ConnGuard<'_> {
         let tid = current_tid();
         let sess_ptr = self as *const RpcSessionInner as usize;
@@ -721,7 +685,7 @@ impl RpcSessionInner {
         }
     }
 
-    /// C1 fix (review 2026-05-21): non-blocking variant of [`find_conn`]
+    /// Non-blocking variant of [`find_conn`]
     /// for `RpcProxy::drop`'s fast path. Returns `None` instead of
     /// waiting on `slot_cv` when the pool has no free slot. Does NOT
     /// touch the reentrant `DRIVING` short-circuit (callers in Drop
@@ -744,6 +708,49 @@ impl RpcSessionInner {
             transport,
             reentrant: false,
         })
+    }
+
+    /// Reaper-only slot acquisition that is torn-down-aware. Unlike
+    /// [`find_conn`], it re-checks the session lifecycle (and the slot
+    /// pool) on **every** `slot_cv` wakeup and bails with `None` when the
+    /// session is torn down or the pool has drained.
+    ///
+    /// [`find_conn`]'s pool-exhausted arm waits on `slot_cv` with no
+    /// torn-down re-check. The reaper holds a strong `Arc` to the inner
+    /// while it waits, so if a concurrent peer-close drains the last slot
+    /// (`remove_slot` → `notify_all`) between the reaper's pre-entry
+    /// `is_torn_down()` check and its scan, the plain `find_conn` would
+    /// re-`wait()` forever on an empty pool that `add_*_slot` can never
+    /// refill on a dead session — permanently parking the reaper and
+    /// leaking the entire session graph (inner + state + cached proxies +
+    /// the reaper thread). Bailing here lets the strong `Arc` drop so the
+    /// channel closes and the session is reclaimed.
+    fn find_conn_for_reaper(&self) -> Option<ConnGuard<'_>> {
+        let tid = current_tid();
+        let sess_ptr = self as *const RpcSessionInner as usize;
+        let mut st = self.conn_state.lock().expect("conn_state poisoned");
+        loop {
+            if self.shared.lifecycle.is_torn_down() || st.slots.is_empty() {
+                return None;
+            }
+            if let Some(s) = st
+                .slots
+                .iter_mut()
+                .find(|s| s.exclusive_tid == Some(tid) || s.exclusive_tid.is_none())
+            {
+                s.exclusive_tid = Some(tid);
+                let slot_id = s.id;
+                let transport = Arc::clone(&s.transport);
+                DRIVING.with(|d| d.borrow_mut().push((sess_ptr, slot_id)));
+                return Some(ConnGuard {
+                    inner: self,
+                    slot_id,
+                    transport,
+                    reentrant: false,
+                });
+            }
+            st = self.slot_cv.wait(st).expect("slot_cv poisoned");
+        }
     }
 
     /// Same as [`find_conn`] but pins to a **specific** slot id. Used
@@ -785,7 +792,7 @@ impl RpcSessionInner {
         loop {
             let target = st.slots.iter_mut().find(|s| s.id == want_slot_id);
             let Some(slot) = target else {
-                // Phase A4: a slot can be removed when its own worker exits
+                // A slot can be removed when its own worker exits
                 // (`remove_slot` from `serve_blocking_on`). After that the
                 // session may still be alive (other slots), but anyone who
                 // pinned to this specific id (e.g. oneway → founding-slot
@@ -814,7 +821,7 @@ impl RpcSessionInner {
         ))
     }
 
-    /// **Phase A**: append a new connection slot. Notifies `slot_cv`
+    /// Append a new connection slot. Notifies `slot_cv`
     /// (a `find_conn` waiter blocked on "any available" can wake).
     /// Does NOT touch `live_conns` — that bookkeeping is the caller's
     /// (server-incoming bumps it via
@@ -842,7 +849,6 @@ impl RpcSessionInner {
         st.slots.push(ConnSlot {
             transport,
             exclusive_tid: None,
-            allow_nested: true,
             id,
         });
         drop(st);
@@ -850,7 +856,7 @@ impl RpcSessionInner {
         id
     }
 
-    /// **Phase A — client multi-outgoing**: append an *outgoing*
+    /// Client multi-outgoing: append an *outgoing*
     /// connection slot (no `live_conns` bump — client outgoing slots
     /// are not serve-driven). See
     /// [`RpcSession::add_outgoing_connection_android13plus`].
@@ -858,7 +864,7 @@ impl RpcSessionInner {
         self.add_slot_inner(transport)
     }
 
-    /// **Phase A4 (F8)**: remove a slot from the pool on its worker's
+    /// Remove a slot from the pool on its worker's
     /// `serve_blocking_on` exit. Called by the slot's *own* worker
     /// (self-remove), so `find_conn_pinned(slot_id)`'s
     /// `panic!("removed from pool")` remains structurally unreachable
@@ -866,8 +872,7 @@ impl RpcSessionInner {
     /// other thread can be pinned on it). `notify_all` so any
     /// `find_conn` (any-available) waiter re-evaluates against the
     /// shrunk pool — and any `find_conn_pinned(slot_id)` waiter
-    /// surfaces the structural error (still treated as a should-never
-    /// panic per R4 narrow scope).
+    /// surfaces the structural error (treated as a should-never panic).
     fn remove_slot(&self, slot_id: u64) {
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
         st.slots.retain(|s| s.id != slot_id);
@@ -880,11 +885,11 @@ impl RpcSessionInner {
     }
 
     /// Whether an RPC parcel built for this session records FD object
-    /// positions (subplan 2-8 Phase B) — i.e. the android-13+ v1+
+    /// positions — i.e. the android-13+ v1+
     /// profile. The session stamps every RPC parcel with this
     /// alongside the FD mode; binder positions are recorded by
     /// [`RpcSessionInner::write_binder`] directly (it owns the
-    /// profile). R34 ⇒ `false` (no object table — 2-7 byte-unchanged).
+    /// profile). R34 ⇒ `false` (no object table — byte-unchanged).
     pub(crate) fn records_fd_positions(&self) -> bool {
         self.profile.records_fd_positions()
     }
@@ -892,7 +897,7 @@ impl RpcSessionInner {
     /// Send one wire frame on `transport` (the slot picked by
     /// [`find_conn`]). Only a `Unix`-mode connection routes fds via
     /// `SCM_RIGHTS`; the default (`None`) uses the unchanged framed
-    /// send and never carries fds (AC-7.1 bit-identical).
+    /// send and never carries fds (bit-identical).
     fn send_msg(
         &self,
         transport: &dyn RpcTransport,
@@ -904,7 +909,7 @@ impl RpcSessionInner {
             // write `frame` (= the codec's `[RpcWireHeader|body]`) raw
             // over the transport's byte channel, exactly what a genuine
             // android-13/14/15/16 peer reads. On a v1+ `Unix` session
-            // (subplan 2-11 Phase A0, header-negotiated FD mode) the fds
+            // (header-negotiated FD mode) the fds
             // ride the message's first `sendmsg` (AOSP `RpcTransportRaw`);
             // otherwise no fds are ever produced here (no-FD scope —
             // R34/v0/`None`, byte-identical).
@@ -935,10 +940,10 @@ impl RpcSessionInner {
     fn recv_msg(&self, transport: &dyn RpcTransport) -> RpcResult<(Vec<u8>, Vec<OwnedFd>)> {
         if self.profile.aosp_framing() {
             // android-13+: read `RpcWireHeader` then exactly `bodySize`
-            // bytes (capped vs `MAX_FRAME_LEN` — V4); a clean EOF before
+            // bytes (capped vs `MAX_FRAME_LEN`); a clean EOF before
             // any byte surfaces as `PeerClosed` so the `serve_blocking`
             // loop terminates exactly like the R34 path. On a v1+ `Unix`
-            // session (subplan 2-11 Phase A0) the same connection always
+            // session the same connection always
             // uses `recvmsg` (never mixes with `Read`), accumulating the
             // `SCM_RIGHTS` fds across the header+body reads; otherwise no
             // out-of-band fds (no-FD scope, byte-identical).
@@ -960,16 +965,16 @@ impl RpcSessionInner {
         self.self_weak.lock().expect("self_weak").clone()
     }
 
-    /// **Phase A4 (F8)**: F7 leak observability delegated to
+    /// Leak observability delegated to
     /// [`SharedSession::local_node_count`]. Lets [`super::RpcServer`]
     /// keep its public `live_session_node_count` API byte-unchanged
-    /// while the registry holds `Weak<RpcSessionInner>` (the F8
-    /// "1 inner / session" handle) rather than `Weak<SharedSession>`.
+    /// while the registry holds `Weak<RpcSessionInner>` (the
+    /// one-inner-per-session handle) rather than `Weak<SharedSession>`.
     pub(crate) fn local_node_count(&self) -> usize {
         self.shared.local_node_count()
     }
 
-    /// **Phase A4 (F8)**: F4 deterministic witness delegated to
+    /// Deterministic teardown witness delegated to
     /// [`SharedSession::live_conn_count`]. Counterpart of
     /// [`local_node_count`](RpcSessionInner::local_node_count) for
     /// `RpcServer::session_live_conns`.
@@ -977,12 +982,11 @@ impl RpcSessionInner {
         self.shared.live_conn_count()
     }
 
-    /// **Phase A4 (F8)**: count of slots currently in this session's
-    /// pool — the AC-12.F8 mutant-gate witness. Server-side
-    /// unification means each id-echoing attached connection adds a
-    /// slot to the *founding* inner rather than building a fresh
-    /// inner; the F8 mutant (today's pre-A4 code = build a fresh
-    /// inner per attach) leaves the founding inner at a single slot.
+    /// Count of slots currently in this session's
+    /// pool. Server-side unification means each id-echoing attached
+    /// connection adds a slot to the *founding* inner rather than
+    /// building a fresh inner; a topology that built a fresh
+    /// inner per attach would leave the founding inner at a single slot.
     /// Used by [`super::RpcServer::session_slot_count`].
     pub(crate) fn slot_count(&self) -> usize {
         self.conn_state
@@ -992,7 +996,7 @@ impl RpcSessionInner {
             .len()
     }
 
-    /// **Phase B.1**: this session's advertised + enforced max-threads
+    /// This session's advertised + enforced max-threads
     /// value. Set by [`RpcSession::set_max_threads`] (default 1) and
     /// returned to a client on `GET_MAX_THREADS`. AOSP-faithful
     /// `setMaxIncomingThreads`: the value is *both* the advertise and
@@ -1009,7 +1013,7 @@ impl RpcSessionInner {
         self.shared.max_threads.load(Ordering::Relaxed)
     }
 
-    /// **Phase A4 (F8)**: the negotiated wire protocol version of this
+    /// The negotiated wire protocol version of this
     /// session, or `None` for R34. The server attach arm uses this to
     /// reject an id-echoing 2nd+ connection whose handshake settled on
     /// a different version than the founding inner — profile is
@@ -1028,8 +1032,7 @@ impl RpcSessionInner {
     ///   (`{u32 options; u32 address}`), i.e. AOSP `Parcel::flattenBinder`'s
     ///   `writeUint64(address)`. r34's 32-byte form here was rejected by
     ///   a real libbinder peer (`"unrecognized address … we should own
-    ///   the creation of"`) — G4(b)-pinned, the `kCurrentRepr`
-    ///   Parcel-body conformance.
+    ///   the creation of"`) — real-peer-pinned Parcel-body conformance.
     fn wire_write_binder_addr(&self, p: &mut Parcel, addr: &RpcAddress) {
         match &self.profile {
             WireProfile::R34(_) => write_addr(p, addr),
@@ -1074,11 +1077,11 @@ impl RpcSessionInner {
                 // is captured **before** `writeInt32(TYPE_BINDER)` —
                 // the position points at the `present`/TYPE_BINDER
                 // int32 itself, and is recorded into the object table
-                // only at v2 (`>= INCLUDES_BINDER_POSITIONS`; subplan
-                // 2-8 Phase B). null binders (`TYPE_BINDER_NULL`, the
-                // `None` arm) get no position. `rpc_record_object_
-                // position` is itself hard-gated on `is_for_rpc`, so
-                // the kernel wire can never grow a table (P1, AC-2.9).
+                // only at v2 (`>= INCLUDES_BINDER_POSITIONS`). null
+                // binders (`TYPE_BINDER_NULL`, the `None` arm) get no
+                // position. `rpc_record_object_position` is itself
+                // hard-gated on `is_for_rpc`, so the kernel wire can
+                // never grow a table.
                 let obj_pos = parcel.data_position();
                 parcel.write(&1i32)?;
                 self.wire_write_binder_addr(parcel, &addr);
@@ -1091,7 +1094,7 @@ impl RpcSessionInner {
                     // rsbinder↔rsbinder path is symmetric and omits it;
                     // the real libbinder peer's `finishUnflattenBinder`
                     // *requires* it (else a short read ⇒ null root —
-                    // G4(b)-pinned). We send the binder's *actual*
+                    // real-peer-pinned). We send the binder's *actual*
                     // declared stability (`getRepr`-faithful), not a
                     // hardcoded 0: rsbinder's default is
                     // `Stability::System` (= `0b001100`; +`0x0c000000`
@@ -1100,6 +1103,12 @@ impl RpcSessionInner {
                     let rep: i32 = b.stability().into();
                     parcel.write(&rep)?;
                 }
+                // Freeze runtime stability mutation once the binder has
+                // crossed the IPC boundary, on both wire profiles. RPC
+                // sessions can carry handwritten native binders too, so
+                // the parcel-emit hook applies here just like in the
+                // kernel path (see `parcelable.rs`).
+                b.set_parceled();
                 Ok(())
             }
         }
@@ -1114,15 +1123,15 @@ impl RpcSessionInner {
         if present == 0 {
             return Ok(None);
         }
-        // Phase C / AC-8.7 — v2 strict receive validation: at v2 a
+        // v2 strict receive validation: at v2 a
         // binder may only be read from a position recorded in the
         // object table (`std::binary_search(mObjectPositions,
         // objectPos)` ⇒ `BAD_VALUE` otherwise). v0/v1/R34 never
         // record binder positions (binder is inline-lazy), so the
         // check is correctly v2-only — exactly AOSP's
         // `bindersInObjectPositions` gate. Interop does not require
-        // this (a lenient decoder still round-trips — subplan 2-8
-        // §3.1); it hardens v2 *conformance*.
+        // this (a lenient decoder still round-trips); it hardens v2
+        // *conformance*.
         if self.profile.records_binder_positions() && !parcel.rpc_object_position_present(obj_pos) {
             return Err(StatusCode::BadValue);
         }
@@ -1145,14 +1154,14 @@ impl RpcSessionInner {
         }
         let weak = self.self_weak();
         // Explicit inner block: the `MutexGuard` is bound to `st` and
-        // dropped at the closing `}`, **before** the F7 excess
+        // dropped at the closing `}`, **before** the excess
         // `DEC_STRONG` send below. This makes the no-I/O-under-the-
         // state-lock invariant structural (rather than relying on
         // Rust's temporary-scope inference for an unbound `lock()`
         // chain, which a future refactor could silently break — e.g.,
         // re-pulling the `lock()` out into a `let g = ...` would extend
         // the guard's lifetime past the `if excess` send, violating
-        // R1-analog: no I/O / no callback under a `Mutex` lock the
+        // the invariant: no I/O / no callback under a `Mutex` lock the
         // recv loop also touches).
         let (sib, excess) = {
             let mut st = self.shared.state.lock().expect("rpc state poisoned");
@@ -1161,12 +1170,12 @@ impl RpcSessionInner {
             })
         };
         if excess {
-            // Phase A **F7** / AOSP `flushExcessBinderRefs`: a duplicate
+            // AOSP `flushExcessBinderRefs`: a duplicate
             // receipt of a binder we already proxy. The sender bumped
             // its `timesSent` for this send, but our deduped proxy
             // `DEC_STRONG`s only once (at its drop); return the owed
             // reference now so the books net to one DEC per send (no
-            // leak — AC-2.5). Best-effort, exactly like
+            // leak). Best-effort, exactly like
             // `RpcProxy::drop`'s DEC: a dead session just means the
             // peer is already gone. On the server dispatch path this
             // runs while this thread already drives the connection
@@ -1189,13 +1198,13 @@ impl RpcSessionInner {
         data: &Parcel,
         flags: u32,
     ) -> Result<Option<Parcel>> {
-        // **Phase A**: pick a connection slot via the AOSP-faithful
+        // Pick a connection slot via the AOSP-faithful
         // `ExclusiveConnection` selector. Same-thread nested calls
-        // (server callback while a transact is in flight — AC-3.6 /
-        // F8) re-enter the slot already driven by this thread (the
-        // `DRIVING` marker); otherwise we claim an available slot, or
-        // `wait` on `slot_cv` if the pool is exhausted. Concurrent
-        // transacts on *other* slots run unblocked (AC-12.1).
+        // (server callback while a transact is in flight) re-enter the
+        // slot already driven by this thread (the `DRIVING` marker);
+        // otherwise we claim an available slot, or `wait` on `slot_cv`
+        // if the pool is exhausted. Concurrent transacts on *other*
+        // slots run unblocked.
         let oneway = (flags & FLAG_ONEWAY) != 0;
         let conn = self.find_conn();
         let transport = conn.transport();
@@ -1215,20 +1224,20 @@ impl RpcSessionInner {
             flags,
             async_number,
             data: data.rpc_data_bytes().to_vec(),
-            // Object table (subplan 2-8): the RPC-mode Parcel collects
+            // Object table: the RPC-mode Parcel collects
             // binder (v2) / FD (v1+) positions during serialization;
-            // empty on R34 / v0 (and pre-Phase-B). Byte-identical to
-            // the pre-2-8 wire when empty.
+            // empty on R34 / v0. Byte-identical to the pre-versioning
+            // wire when empty.
             object_positions: data.rpc_object_positions().to_vec(),
         };
         let frame = self.profile.codec().encode_transact(&txn)?;
         // Out-of-band fds collected while serializing the request
-        // (empty unless `Unix` fd-mode — subplan 2-7).
+        // (empty unless `Unix` fd-mode).
         self.send_msg(transport, &frame, data.rpc_out_fds())?;
         if oneway {
             return Ok(None);
         }
-        // Apply the configured reply deadline (AC-3.8) for the duration
+        // Apply the configured reply deadline for the duration
         // of the reply wait only. `ReplyDeadlineGuard` clears the sticky
         // `SO_RCVTIMEO` on every exit (return / `?` / panic) so it never
         // leaks onto the next call or a later recv on this connection.
@@ -1252,7 +1261,7 @@ impl RpcSessionInner {
                     reply.rpc_set_in_fds(in_fds);
                     // Install the wire object table (after attach_rpc_ops
                     // sets RPC mode) so binder/FD reads can validate
-                    // positions (subplan 2-8 Phase C).
+                    // positions.
                     reply.rpc_set_object_positions(object_positions);
                     reply.set_data_position(0);
                     return Ok(Some(reply));
@@ -1269,12 +1278,12 @@ impl RpcSessionInner {
                     // back into one of *our* objects while we wait for
                     // our own reply. Dispatch it inline on this call
                     // stack over the same connection (single thread per
-                    // connection ⇒ correct FIFO nesting, no deadlock —
-                    // AC-3.6). The reply deadline is lifted for the
+                    // connection ⇒ correct FIFO nesting, no deadlock).
+                    // The reply deadline is lifted for the
                     // (unbounded) nested dispatch and restored for the
                     // continued wait *symmetrically via Drop* — a `?` /
                     // panic out of `dispatch_transact` can no longer
-                    // leave the timeout desynchronized (T1-2).
+                    // leave the timeout desynchronized.
                     let _restore = NestedDeadlineGuard::lift(transport, deadline)?;
                     self.dispatch_transact(t, in_fds)?;
                 }
@@ -1282,7 +1291,7 @@ impl RpcSessionInner {
         }
     }
 
-    /// C1 fix (review 2026-05-21): two-tier `DEC_STRONG` hand-off for
+    /// Two-tier `DEC_STRONG` hand-off for
     /// `RpcProxy::drop`. Drop runs on arbitrary user threads that may
     /// not be driving a slot of this session — without this guard,
     /// `send_dec_strong`'s `find_conn` would `cv.wait` on slot
@@ -1293,7 +1302,7 @@ impl RpcSessionInner {
     /// via [`try_find_conn`]. The default single-slot session in steady
     /// state has no contention, so this succeeds immediately and the
     /// send happens *synchronously* — preserving the byte-and-timing
-    /// ordering AC-2.5 relies on (drop → next ordered round-trip ⇒
+    /// ordering callers rely on (drop → next ordered round-trip ⇒
     /// peer has processed DEC_STRONG before the next reply).
     ///
     /// **Slow path** (every slot busy): enqueue so Drop returns
@@ -1312,7 +1321,7 @@ impl RpcSessionInner {
             return;
         }
         // Fast path: synchronous send when a slot is immediately
-        // available. Preserves AC-2.5's FIFO observable timing.
+        // available. Preserves the FIFO observable timing.
         if let Some(conn) = self.try_find_conn() {
             let frame = self.profile.codec().encode_dec_strong(&addr);
             let _ = self.send_msg(conn.transport(), &frame, &[]);
@@ -1324,18 +1333,17 @@ impl RpcSessionInner {
     }
 
     pub(crate) fn send_dec_strong(&self, addr: RpcAddress) -> Result<()> {
-        // `RpcProxy::drop` (best-effort) and `read_binder`'s F7
+        // `RpcProxy::drop` (best-effort) and `read_binder`'s
         // excess-flush call this from arbitrary threads/contexts.
-        // **Phase A4 (F8) shutdown guard + §7.3 R1**: once the session
-        // leaves `Live` (Dying or Dead), the peer is gone *and* the slot
-        // pool has either started shrinking via `remove_slot` or already
-        // emptied — `find_conn` on an empty pool would `cv.wait`
-        // forever (no `add_slot` can race past F4
-        // `try_bump_live_conns`). Skip best-effort. R1's typed lifecycle
-        // makes this check observe the `Dying` window *before* the
-        // obituary completes, closing a narrow prior window where this
-        // path could find an empty pool after the founding worker had
-        // started its teardown but before `obituary_sent.load` flipped.
+        // Shutdown guard: once the session leaves `Live` (Dying or
+        // Dead), the peer is gone *and* the slot pool has either
+        // started shrinking via `remove_slot` or already emptied —
+        // `find_conn` on an empty pool would `cv.wait` forever (no
+        // `add_slot` can race past `try_bump_live_conns`). Skip
+        // best-effort. The typed lifecycle makes this check observe the
+        // `Dying` window *before* the obituary completes, closing a
+        // narrow window where this path could find an empty pool after
+        // the founding worker started teardown.
         if self.shared.lifecycle.is_torn_down() {
             return Ok(());
         }
@@ -1386,8 +1394,8 @@ impl RpcSessionInner {
 
     /// Send a `REPLY` (status + parcel bytes + object table + any
     /// out-of-band fds). `object_positions` is the reply parcel's
-    /// object table (subplan 2-8); empty for error / no-payload
-    /// replies and on R34 / v0 (byte-identical to the pre-2-8 wire).
+    /// object table; empty for error / no-payload
+    /// replies and on R34 / v0 (byte-identical to the pre-versioning wire).
     fn send_reply(
         &self,
         status: i32,
@@ -1400,7 +1408,7 @@ impl RpcSessionInner {
             data: data.to_vec(),
             object_positions: object_positions.to_vec(),
         })?;
-        // **Phase A**: reuse this thread's already-driven slot (the
+        // Reuse this thread's already-driven slot (the
         // inbound dispatch slot — `DRIVING` reentrant pin via
         // `find_conn`). For an outermost server reply
         // (`serve_once_on_slot` pinned the slot before dispatch) this
@@ -1426,9 +1434,9 @@ impl RpcSessionInner {
     }
 
     /// Gate an inbound oneway through the target node's `asyncTodo`
-    /// priority queue (AOSP `RpcState::processTransactInternal` 1093–
-    /// 1133 enqueue + 1247–1278 drain). The state lock is released
-    /// before dispatch so a nested callback re-entry can reacquire it.
+    /// priority queue (AOSP `RpcState::processTransactInternal` enqueue and
+    /// drain). The state lock is released before dispatch so a nested
+    /// callback re-entry can reacquire it.
     fn dispatch_oneway_ordered(&self, t: WireTransaction, in_fds: Vec<OwnedFd>) -> Result<()> {
         let addr = t.address;
         let wire_async = t.async_number;
@@ -1483,7 +1491,7 @@ impl RpcSessionInner {
             .lookup_local(&t.address);
         let Some(target) = target else {
             if oneway {
-                // Best-effort drop; visible only if F7's `dec_strong_local`
+                // Best-effort drop; visible only if `dec_strong_local`
                 // ran between the asyncTodo gate and now.
                 log::debug!(
                     "RPC oneway to unknown/released address {:?} dropped",
@@ -1501,7 +1509,7 @@ impl RpcSessionInner {
         // `consume_rpc_interface_token`). The kernel `Binder` handles
         // these internally; the RPC server adapter must too, or a real
         // libbinder client can't e.g. `getInterfaceDescriptor()` (which
-        // `AIBinder_associateClass` needs — G4(b) STAGE3) or `ping`.
+        // `AIBinder_associateClass` needs) or `ping`.
         if !oneway {
             match t.code {
                 INTERFACE_TRANSACTION => {
@@ -1525,7 +1533,7 @@ impl RpcSessionInner {
         let mut reader = Parcel::from_vec(t.data);
         reader.attach_rpc_ops(self.parcel_ops());
         reader.set_rpc_fd_mode(self.fd_mode());
-        // Subplan 2-11 A2b: the inbound *args* parcel must know it
+        // The inbound *args* parcel must know it
         // speaks the v1+ AOSP fd body too (the reply paths already set
         // this; the args path did not — a v1+ fd *argument* would
         // otherwise be read as the R34 `[present|idx]` legacy shape and
@@ -1533,8 +1541,8 @@ impl RpcSessionInner {
         // position read; R34/v0 ⇒ legacy, byte-unchanged.
         reader.set_rpc_record_fd_positions(self.records_fd_positions());
         reader.rpc_set_in_fds(in_fds);
-        // Install the inbound wire object table (subplan 2-8 Phase C
-        // position validation); empty on R34 / v0 / no-object.
+        // Install the inbound wire object table (position validation);
+        // empty on R34 / v0 / no-object.
         reader.rpc_set_object_positions(t.object_positions);
         reader.set_data_position(0);
         let mut reply = Parcel::new();
@@ -1563,9 +1571,9 @@ impl RpcSessionInner {
     }
 
     /// Handle one inbound message on the pinned **slot** (a server
-    /// worker drives a specific accepted connection's slot — Phase A;
+    /// worker drives a specific accepted connection's slot;
     /// nested outbound callbacks from the handler reuse this same slot
-    /// via the `DRIVING` marker, AC-3.6/F8).
+    /// via the `DRIVING` marker).
     /// `Ok(false)` ⇒ peer closed (stop).
     fn serve_once_on_slot(&self, slot_id: u64) -> Result<bool> {
         // The worker drives its own slot — pinning to it must succeed
@@ -1602,7 +1610,7 @@ impl RpcSessionInner {
 
     /// Special zero-address transactions (android `RpcState`
     /// `GET_ROOT`/`GET_MAX_THREADS`/`GET_SESSION_ID`, plus the
-    /// rsbinder/2-7 `GET_FD_MODE` extension).
+    /// rsbinder `GET_FD_MODE` extension).
     fn serve_special(&self, t: &WireTransaction, oneway: bool) -> Result<()> {
         if oneway {
             // Special transactions are never oneway.
@@ -1619,7 +1627,7 @@ impl RpcSessionInner {
                     None => reply.write(&0i32)?,
                 }
                 // GET_ROOT carries a binder-in-parcel: at v2 its
-                // position is in the object table (subplan 2-8 / D3).
+                // position is in the object table.
                 self.send_reply(0, reply.rpc_data_bytes(), reply.rpc_object_positions(), &[])
             }
             Some(SpecialTransaction::GetMaxThreads) => {
@@ -1636,7 +1644,7 @@ impl RpcSessionInner {
                 // the AIDL `byte[]` path (`i32 len` + packed bytes +
                 // 4-pad) == libbinder `writeByteVector` byte-for-byte.
                 // (Was a bare `i32` ⇒ libbinder `BAD_VALUE` — found by
-                // the real-peer round-trip, G4(b).)
+                // the real-peer round-trip.)
                 let mut reply = Parcel::new();
                 reply.write(&self.shared.rpc_session_id.as_bytes()[..])?;
                 self.send_reply(0, reply.rpc_data_bytes(), &[], &[])
@@ -1644,15 +1652,15 @@ impl RpcSessionInner {
             Some(SpecialTransaction::GetFdMode) => {
                 // Body: i32 — does the client want `Unix`. Agree only
                 // if this endpoint also supports it (else `None`, never
-                // an error — AC-7.3). The reply (0=None,1=Unix) is sent
+                // an error). The reply (0=None,1=Unix) is sent
                 // in the *current* (None) mode; both sides switch only
                 // after this exchange completes, so framing stays
                 // consistent.
                 let mut req = Parcel::from_vec(t.data.clone());
                 req.set_data_position(0);
                 // A malformed body safely defaults to "no FD support"
-                // (AC-7.3 — never an error), but log the protocol
-                // violation rather than swallow it silently (Minor-1).
+                // (never an error), but log the protocol violation
+                // rather than swallow it silently.
                 let want_unix = match req.read::<i32>() {
                     Ok(v) => v == 1,
                     Err(e) => {
@@ -1695,11 +1703,10 @@ impl RpcSession {
     /// the side that connected, [`AddressSpace::Acceptor`] for the
     /// side that accepted (so the two peers never mint colliding
     /// addresses on the shared connection).
-    /// **M5 fix (review 2026-05-21, breaking API)**: now returns
-    /// `Result` so a `getrandom` failure surfaces as `RpcError::Io`
-    /// instead of panicking out of an infallible constructor. The
-    /// only realistic failure path is early-boot containers without a
-    /// working CSPRNG.
+    /// Returns `Result` so a `getrandom` failure surfaces as
+    /// `RpcError::Io` instead of panicking out of an infallible
+    /// constructor. The only realistic failure path is early-boot
+    /// containers without a working CSPRNG.
     pub fn new(transport: Box<dyn RpcTransport>, space: AddressSpace) -> RpcResult<RpcSession> {
         // Default = android-12 r34, byte-unchanged.
         RpcSession::with_profile(transport, space, WireProfile::R34(R34Codec))
@@ -1708,7 +1715,7 @@ impl RpcSession {
     /// Build a session over a connected transport with an explicit wire
     /// profile. The android-13+ codec is finalized by the handshake
     /// *before* this is called, so the profile is immutable for the
-    /// session's lifetime (no interior mutability — G4(a)).
+    /// session's lifetime (no interior mutability).
     fn with_profile(
         transport: Box<dyn RpcTransport>,
         space: AddressSpace,
@@ -1722,10 +1729,9 @@ impl RpcSession {
     }
 
     /// A brand-new session's shared state (`lifecycle == Live(1)`, the
-    /// founding connection — Phase A0b F4 / §7.3 R1). The default
-    /// single-connection path uses exactly one of these, so its
-    /// behavior is byte-identical to the pre-A0b single-`transport`
-    /// `RpcSessionInner`.
+    /// founding connection). The default single-connection path uses
+    /// exactly one of these, so its behavior is byte-identical to a
+    /// single-`transport` `RpcSessionInner`.
     fn fresh_shared(space: AddressSpace) -> RpcResult<Arc<SharedSession>> {
         Ok(Arc::new(SharedSession {
             state: Mutex::new(RpcState::new(space)),
@@ -1741,11 +1747,11 @@ impl RpcSession {
     }
 
     /// Wrap `transport` as a connection of an **existing**
-    /// [`SharedSession`] (Phase A0b: the server's id-demux attaches a
+    /// [`SharedSession`] (the server's id-demux attaches a
     /// 2nd+ connection here instead of minting a fresh session, so a
     /// binder published over another connection is reachable — shared
     /// `state`/`root`/`rpc_session_id`). Bumps the session's live
-    /// connection count (F4). [`with_profile`](RpcSession::with_profile)
+    /// connection count. [`with_profile`](RpcSession::with_profile)
     /// is exactly this with a brand-new `SharedSession`
     /// (`live_conns == 1`) ⇒ the default single-connection path is
     /// byte-identical.
@@ -1754,17 +1760,16 @@ impl RpcSession {
         profile: WireProfile,
         shared: Arc<SharedSession>,
     ) -> RpcSession {
-        // **Phase A**: the founding slot of this session's pool. id=1
+        // The founding slot of this session's pool. id=1
         // (slot ids are monotonic from 1; 0 is reserved as a "no slot"
         // sentinel for future use). Default single-connection sessions
         // never add more slots ⇒ `find_conn` is a no-wait single-slot
-        // pick ⇒ pre-A `enter_connection` byte-identical. The slot
+        // pick ⇒ `enter_connection` byte-identical. The slot
         // owns its transport via `Arc<dyn RpcTransport>` — see
         // [`ConnSlot::transport`] for why.
         let founding = ConnSlot {
             transport: Arc::from(transport),
             exclusive_tid: None,
-            allow_nested: true,
             id: 1,
         };
         let (dec_strong_tx, dec_strong_rx) = mpsc::channel();
@@ -1780,7 +1785,7 @@ impl RpcSession {
             dec_strong_tx,
         });
         *inner.self_weak.lock().expect("self_weak") = Arc::downgrade(&inner);
-        // C1 fix: reaper thread for non-blocking `DEC_STRONG` from
+        // Reaper thread for non-blocking `DEC_STRONG` from
         // `RpcProxy::drop`. Detached — `with_shared` is on the user
         // thread, so we never block its return; inner drop closes the
         // channel and the reaper exits naturally.
@@ -1791,21 +1796,21 @@ impl RpcSession {
         RpcSession { inner }
     }
 
-    /// Id of the founding (first) slot — Phase A.  All non-attach
+    /// Id of the founding (first) slot. All non-attach
     /// `serve_blocking` callers (the default single-connection path)
     /// drive this slot.
     pub(crate) const FOUNDING_SLOT_ID: u64 = 1;
 
-    /// **Phase A4 (F8 — server-side unification).** Adds a freshly-
+    /// Server-side unification: adds a freshly-
     /// accepted `transport` as a new incoming slot of this session's
     /// pool. The unified-model server attach arm calls this on the
     /// *founding* `Arc<RpcSessionInner>` (resolved from its 32-byte
     /// session id) instead of building a new `RpcSessionInner` sharing
     /// a `SharedSession` — so `state.remote_proxies`-cached `RpcProxy`s
     /// all point to the *single* session inner and a server worker's
-    /// nested `proxy.transact` `find_conn`s within its own slot pool
-    /// (no cross-slot aliasing of the F8 hazard). Bumps `live_conns`
-    /// for **F4** via the anti-resurrection primitive — returns
+    /// nested `proxy.transact` `find_conn`s stay within its own slot
+    /// pool (no cross-slot aliasing). Bumps `live_conns`
+    /// via the anti-resurrection primitive — returns
     /// `Err(StatusCode::DeadObject)` when the session is already torn
     /// down (obituary already fired) so the caller rejects the attach
     /// instead of silently resurrecting a dead session.
@@ -1821,8 +1826,8 @@ impl RpcSession {
     /// (client, init=true)` for `incoming` headers). Does NOT bump
     /// the lifecycle count (callback slots are not serve-driven; AOSP
     /// also does not gate session lifetime on `mOutgoing.size()`).
-    /// `Err(DeadObject)` if the session is already torn down (the §7.3
-    /// R1 lifecycle covers both `Dying` and `Dead` in a single check).
+    /// `Err(DeadObject)` if the session is already torn down (the
+    /// lifecycle covers both `Dying` and `Dead` in a single check).
     pub(crate) fn add_callback_slot(&self, transport: Box<dyn RpcTransport>) -> Result<u64> {
         // Snapshot gate, not CAS — a concurrent founding death after
         // this read is race-acceptable: the slot sits unused in a
@@ -1833,18 +1838,18 @@ impl RpcSession {
         Ok(self.inner.add_slot_inner(transport))
     }
 
-    /// **Phase A4 (F8)**: this session's full inner state — including
+    /// This session's full inner state — including
     /// the *connection slot pool* and the wire profile, not just
     /// [`SharedSession`]. The unified-model server attach path stores
     /// `Weak` of this in `RpcServer.sessions` so an id-echoing 2nd+
     /// connection [`add_incoming_slot`](RpcSession::add_incoming_slot)s
     /// onto the founding inner — a single `RpcSessionInner` per
-    /// session, server-side unification of the F8 hazard.
+    /// session.
     pub(crate) fn inner_arc(&self) -> Arc<RpcSessionInner> {
         Arc::clone(&self.inner)
     }
 
-    /// **Phase A4 (F8)**: wrap a resolved founding inner (from
+    /// Wrap a resolved founding inner (from
     /// `RpcServer.sessions`) as an `RpcSession` so the attaching server
     /// worker can call [`serve_blocking_on`](RpcSession::serve_blocking_on)
     /// — symmetric to the founding worker's API surface.
@@ -1852,12 +1857,11 @@ impl RpcSession {
         RpcSession { inner }
     }
 
-    /// Server (Phase A0b): run **only** the android-13+ accept
+    /// Server: run **only** the android-13+ accept
     /// handshake on `transport`, returning the transport (unconsumed)
     /// plus the negotiated codec, the client's requested FD mode, and
     /// the client-supplied `session_id`. Splitting the handshake from
-    /// the session build (the A0a "monolithic `server_accept`"
-    /// residual) is what lets the server inspect the id and decide
+    /// the session build is what lets the server inspect the id and decide
     /// **new vs. attach** *before* committing the connection to a
     /// `SharedSession`.
     pub(crate) fn android13plus_accept_handshake(
@@ -1871,15 +1875,15 @@ impl RpcSession {
         Ok((transport, codec, client_fd_mode, client_id, incoming))
     }
 
-    /// Server (Phase A0b): build the accepted connection's session from
+    /// Server: build the accepted connection's session from
     /// a completed [`android13plus_accept_handshake`](RpcSession::android13plus_accept_handshake).
     /// `shared = None` ⇒ a brand-new session (the default / new-session
-    /// path, byte-identical to pre-A0b); `shared = Some(existing)` ⇒
+    /// path); `shared = Some(existing)` ⇒
     /// **attach** this connection to a pre-existing session (id-demux),
     /// so a binder published over the founding connection is reachable
     /// here (shared `state`/`root`).
     ///
-    /// **F4 anti-resurrection contract**: the caller MUST gate a
+    /// **Anti-resurrection contract**: the caller MUST gate a
     /// `Some(shared)` attach through
     /// [`SharedSession::try_bump_live_conns`] *before* invoking this
     /// function and reject the connection on `false`. Once
@@ -1888,8 +1892,8 @@ impl RpcSession {
     /// hook does the matching `fetch_sub`). This split lets the
     /// server's `serve_connection` decide reject-vs-attach atomically
     /// against the race window between `resolve_session.upgrade()` and
-    /// the founding worker's `live_conns.fetch_sub` (the F4
-    /// resurrection race).
+    /// the founding worker's `live_conns.fetch_sub` (the resurrection
+    /// race).
     pub(crate) fn from_android13plus(
         transport: Box<dyn RpcTransport>,
         codec: Android13PlusCodec,
@@ -1914,8 +1918,8 @@ impl RpcSession {
         Ok(session)
     }
 
-    /// Client role, **opt-in android-13+ versioned wire** (subplan 2-5b
-    /// / G4(a)). Runs the AOSP connection handshake on `transport`
+    /// Client role, **opt-in android-13+ versioned wire**.
+    /// Runs the AOSP connection handshake on `transport`
     /// (`RpcConnectionHeader → RpcNewSessionResponse → "cci"`,
     /// negotiating `min(max_version, server_max)`), then returns a
     /// session that speaks the negotiated version with AOSP-faithful
@@ -1936,8 +1940,8 @@ impl RpcSession {
         Self::connect_android13plus_fd(transport, max_version, FileDescriptorTransportMode::None)
     }
 
-    /// Client role, opt-in android-13+ wire **with FD-over-RPC**
-    /// (subplan 2-11 Phase A0). Requests `fd_mode` in the
+    /// Client role, opt-in android-13+ wire **with FD-over-RPC**.
+    /// Requests `fd_mode` in the
     /// `RpcConnectionHeader.fileDescriptorTransportMode` byte (byte-exact
     /// to AOSP `setFileDescriptorTransportMode`/`setupClient`, **not**
     /// the R34 `GET_FD_MODE` special-transact) and, on a successful
@@ -1951,11 +1955,11 @@ impl RpcSession {
         fd_mode: FileDescriptorTransportMode,
     ) -> Result<RpcSession> {
         // Empty id ⇒ request a new session — byte-identical to the
-        // pre-2-12 client handshake.
+        // single-connection client handshake.
         Self::connect_android13plus_fd_with_id(transport, max_version, fd_mode, &[])
     }
 
-    /// Subplan 2-12 Phase A0a: identical to
+    /// Identical to
     /// `connect_android13plus_fd` but echoes a server-minted 32-byte
     /// `session_id` in the `RpcConnectionHeader` (AOSP
     /// `RpcSession::setupClient`: the first connection sends an empty id
@@ -1963,9 +1967,8 @@ impl RpcSession {
     /// [`RpcSession::get_session_id`], the remaining connections echo
     /// it). An **empty** `session_id` is byte-for-byte identical to
     /// `connect_android13plus_fd` (additive — the default path is
-    /// unchanged). In A0a the server *rejects* a non-empty (echoed) id
-    /// (the shared-state attach is Phase A0b); this wires + exercises
-    /// the id round-trip and the server's accept-decision routing.
+    /// unchanged). This wires + exercises the id round-trip and the
+    /// server's accept-decision routing.
     pub fn connect_android13plus_fd_with_id(
         transport: Box<dyn RpcTransport>,
         max_version: u32,
@@ -2013,7 +2016,7 @@ impl RpcSession {
         Ok(session)
     }
 
-    /// Server role, **opt-in android-13+ versioned wire** (G4(a)). Runs
+    /// Server role, **opt-in android-13+ versioned wire**. Runs
     /// the AOSP accept handshake on an already-accepted `transport`
     /// (negotiates `min(server_max_version, client_max)`), then returns
     /// an [`AddressSpace::Acceptor`] session speaking the negotiated
@@ -2028,8 +2031,8 @@ impl RpcSession {
         Self::accept_android13plus_fd(transport, server_max_version, false)
     }
 
-    /// Server role, opt-in android-13+ wire **with FD-over-RPC**
-    /// (subplan 2-11 Phase A0), accepting one connection as a
+    /// Server role, opt-in android-13+ wire **with FD-over-RPC**,
+    /// accepting one connection as a
     /// **brand-new session** (no id-demux). Reads the client's
     /// requested FD mode from the `RpcConnectionHeader` and, when the
     /// client asked for `Unix`, this server opted in (`server_fd_unix`,
@@ -2044,7 +2047,7 @@ impl RpcSession {
     /// `android13plus_accept_handshake`
     /// then `from_android13plus` with
     /// `shared = None` (the client-supplied id is ignored). The
-    /// multi-connection id-demux (Phase A0b — new vs. attach) lives in
+    /// multi-connection id-demux (new vs. attach) lives in
     /// [`super::RpcServer::serve_connection`], which calls the split
     /// handshake/build helpers directly; existing single-connection
     /// callers keep the byte-identical shape here.
@@ -2067,7 +2070,7 @@ impl RpcSession {
     /// The negotiated android-13+ wire protocol version
     /// (`0` = android-13, `1` = android-14/15), or `None` for the
     /// default android-12 r34 profile. Lets a caller assert the
-    /// `min(client_max, server_max)` handshake outcome (G4(a)).
+    /// `min(client_max, server_max)` handshake outcome.
     pub fn wire_protocol_version(&self) -> Option<u32> {
         match &self.inner.profile {
             WireProfile::Android13Plus(c) => Some(c.version()),
@@ -2078,19 +2081,18 @@ impl RpcSession {
     /// This session's opaque 32-byte id (AOSP `RpcSession::mId`,
     /// `kSessionIdBytes == 32`). On the server side this is the id
     /// minted at session build and replied by the `GET_SESSION_ID`
-    /// special transact; subplan 2-12 Phase A0a uses it as the
-    /// [`super::RpcServer`] registry key. Per-session, never global
-    /// (P6).
+    /// special transact; the multi-connection path uses it as the
+    /// [`super::RpcServer`] registry key. Per-session, never global.
     pub fn session_id(&self) -> [u8; 32] {
         *self.inner.shared.rpc_session_id.as_bytes()
     }
 
-    /// Client (subplan 2-12 Phase A0a): fetch the server-minted 32-byte
+    /// Client: fetch the server-minted 32-byte
     /// session id via the `GET_SESSION_ID` special transact. AOSP
     /// `RpcSession::setupClient` reads this on the first connection and
     /// echoes it on the remaining ones
     /// ([`RpcSession::setup_unix_client_android13plus_with_id`]). The
-    /// server already replies it (G4(b) real-peer-validated:
+    /// server already replies it (real-peer-validated:
     /// `writeByteVector(mId)` == the AIDL `byte[]` path); this is the
     /// missing *client* half.
     pub fn get_session_id(&self) -> Result<Vec<u8>> {
@@ -2112,8 +2114,8 @@ impl RpcSession {
     }
 
     /// Server role: advertise that this endpoint will accept the
-    /// `Unix` FD-over-RPC mode on `GET_FD_MODE` (subplan 2-7). Default
-    /// is *not* advertised, so the FD reject (2-2) is the default
+    /// `Unix` FD-over-RPC mode on `GET_FD_MODE`. Default
+    /// is *not* advertised, so the categorical FD reject is the default
     /// everywhere. Has no effect on a non-UDS transport (the transport
     /// fd methods reject by type regardless).
     pub fn set_supported_fd_modes(&self, modes: &[FileDescriptorTransportMode]) {
@@ -2124,10 +2126,10 @@ impl RpcSession {
             .store(unix, Ordering::SeqCst);
     }
 
-    /// Client role: negotiate the FD-over-RPC mode (subplan 2-7).
+    /// Client role: negotiate the FD-over-RPC mode.
     /// Sends exactly one `GET_FD_MODE` packet; the agreed mode is
-    /// `Unix` iff *both* peers opted in, else `None` (never an error —
-    /// AC-7.3). Must be called before any FD-bearing call, like
+    /// `Unix` iff *both* peers opted in, else `None` (never an error).
+    /// Must be called before any FD-bearing call, like
     /// [`RpcSession::negotiate`].
     pub fn negotiate_fd_transport(
         &self,
@@ -2199,7 +2201,7 @@ impl RpcSession {
         self.serve_blocking_on(Self::FOUNDING_SLOT_ID)
     }
 
-    /// **Phase A**: serve a *specific* slot of the pool until peer
+    /// Serve a *specific* slot of the pool until peer
     /// closes (the server worker's API — each accepted connection's
     /// worker drives the slot it was added as via
     /// `add_incoming_slot`). The
@@ -2221,7 +2223,7 @@ impl RpcSession {
             }
             r
         };
-        // Phase A0b **F4** + §7.3 **R1** typed lifecycle: this
+        // Typed lifecycle: this
         // connection is finished. Fire the session obituaries only on
         // the **last** connection's teardown (full session death) —
         // never on a *partial* connection loss while other connections
@@ -2237,8 +2239,8 @@ impl RpcSession {
             self.inner.send_session_obituaries();
             self.inner.shared.lifecycle.mark_dead();
         }
-        // Phase A4 (F8): drop this worker's slot from the pool **after**
-        // the F4 lifecycle transition + obituary so a concurrent
+        // Drop this worker's slot from the pool **after**
+        // the lifecycle transition + obituary so a concurrent
         // `RpcProxy::drop`'s best-effort `send_dec_strong` sees either
         // (i) the slot still present (`find_conn` picks it, send returns
         // `PeerClosed`, best-effort path Err — no deadlock) or (ii) the
@@ -2246,7 +2248,7 @@ impl RpcSession {
         // short-circuits, skipping `find_conn` entirely). Removing the
         // slot *before* the lifecycle transition opened a window where a
         // stale proxy drop would find an empty pool and block forever on
-        // `slot_cv` (no add_slot can race the obituary thanks to F4
+        // `slot_cv` (no add_slot can race the obituary thanks to
         // `try_bump_live_conns`).
         self.inner.remove_slot(slot_id);
         result
@@ -2256,7 +2258,7 @@ impl RpcSession {
     /// (server role). Called by [`super::RpcServer::configure_session`]
     /// per accepted connection — external callers go through
     /// [`super::RpcServer::set_max_threads`], which owns the public
-    /// advertise/slot-cap contract and its EXPERIMENTAL multi-conn note.
+    /// advertise/slot-cap contract.
     ///
     /// Crate-private since the only caller is the server itself — there
     /// is no use case for a user-constructed `RpcSession` (always client
@@ -2269,7 +2271,7 @@ impl RpcSession {
             .store(n.max(1), Ordering::SeqCst);
     }
 
-    /// Set the client reply/handshake wait deadline (AC-3.8). `None`
+    /// Set the client reply/handshake wait deadline. `None`
     /// (default) blocks forever.
     pub fn set_timeout(&self, timeout: Option<Duration>) {
         *self.inner.shared.timeout.lock().expect("timeout poisoned") = timeout;
@@ -2283,7 +2285,7 @@ impl RpcSession {
 
     /// Client role: exchange `GET_MAX_THREADS` with the server and
     /// record `min(local_max, remote_max)` (android
-    /// `getRemoteMaxThreads`, AC-3.4). Exactly one negotiation packet.
+    /// `getRemoteMaxThreads`). Exactly one negotiation packet.
     pub fn negotiate(&self, local_max: u32) -> Result<u32> {
         let data = Parcel::new();
         let mut reply = self
@@ -2309,14 +2311,14 @@ impl RpcSession {
 
     /// Client: connect to a Unix-domain RPC server. Thread negotiation
     /// is a separate, explicit step ([`RpcSession::negotiate`]) so a
-    /// caller that negotiates does so with exactly one packet (AC-3.4).
+    /// caller that negotiates does so with exactly one packet.
     pub fn setup_unix_client(path: impl AsRef<std::path::Path>) -> Result<RpcSession> {
         let t = super::transport::UnixTransport::connect(path)?;
         RpcSession::new(Box::new(t), AddressSpace::Initiator).map_err(StatusCode::from)
     }
 
     /// Client: connect to a Unix-domain RPC server speaking the
-    /// **android-13+ versioned wire** (subplan 2-5b / G4(a)). Connects
+    /// **android-13+ versioned wire**. Connects
     /// the UDS, then runs the AOSP handshake via
     /// [`RpcSession::connect_android13plus`] negotiating
     /// `min(max_version, server_max)`. The r34
@@ -2329,8 +2331,8 @@ impl RpcSession {
         RpcSession::connect_android13plus(Box::new(t), max_version)
     }
 
-    /// Client: connect to a **TCP** RPC server over **TLS** (subplan
-    /// 2-15), R34 wire. Establishes the TCP connection, completes the
+    /// Client: connect to a **TCP** RPC server over **TLS**,
+    /// R34 wire. Establishes the TCP connection, completes the
     /// TLS handshake to `server_name` (verified per `config` — a
     /// bad/untrusted server certificate fails **here**, before any RPC
     /// payload byte is exchanged), then builds an R34 session. The
@@ -2338,8 +2340,8 @@ impl RpcSession {
     /// [`setup_tcp_client_tls_android13plus`](RpcSession::setup_tcp_client_tls_android13plus).
     ///
     /// `config` is the caller's `rustls::ClientConfig` (roots / client
-    /// cert / verification policy) — rsbinder never invents crypto
-    /// (plan §5). For a non-TCP stream (a preconnected `unix`/`vsock`
+    /// cert / verification policy) — rsbinder never invents crypto.
+    /// For a non-TCP stream (a preconnected `unix`/`vsock`
     /// fd) build the transport directly with
     /// [`TlsTransport::connect_stream`](super::transport::TlsTransport::connect_stream)
     /// and pass it to [`RpcSession::new`].
@@ -2356,7 +2358,7 @@ impl RpcSession {
     }
 
     /// Client: connect to a **TCP** RPC server over **TLS** speaking the
-    /// **android-13+ versioned wire** (subplan 2-15 / 2-5b). TCP-connects,
+    /// **android-13+ versioned wire**. TCP-connects,
     /// TLS-handshakes to `server_name` per `config` (a bad cert fails
     /// before any RPC byte), then runs the AOSP android-13+ handshake via
     /// [`RpcSession::connect_android13plus`] negotiating
@@ -2375,16 +2377,14 @@ impl RpcSession {
         RpcSession::connect_android13plus(Box::new(t), max_version)
     }
 
-    /// Client (subplan 2-12 Phase A0a): connect to a Unix-domain
+    /// Client: connect to a Unix-domain
     /// android-13+ RPC server **echoing a server-minted 32-byte
     /// `session_id`**. Flow (AOSP `RpcSession::setupClient`): connect
     /// the first session with `setup_unix_client_android13plus`
     /// (empty id ⇒ new session), read its id with
     /// [`RpcSession::get_session_id`], then open the remaining
     /// connections here echoing that id. An **empty** `session_id` is
-    /// byte-identical to `setup_unix_client_android13plus`. (A0a: the
-    /// server rejects the echoed-id connection — the shared-`RpcState`
-    /// attach is Phase A0b.)
+    /// byte-identical to `setup_unix_client_android13plus`.
     pub fn setup_unix_client_android13plus_with_id(
         path: impl AsRef<std::path::Path>,
         max_version: u32,
@@ -2399,21 +2399,21 @@ impl RpcSession {
         )
     }
 
-    /// **Phase A — client multi-outgoing.** Open one *additional*
+    /// Client multi-outgoing: open one *additional*
     /// outgoing connection to the same android-13+ server session and
     /// add it as a new slot in this `RpcSession`'s pool (AOSP
     /// `RpcSession::setupClient` opens N outgoing; `findConnection`
-    /// distributes outgoing calls across them — AC-12.1). Returns the
+    /// distributes outgoing calls across them). Returns the
     /// new slot id. `session_id` MUST be this session's server-minted
     /// id (`get_session_id()` on the founding connection) — the server
-    /// id-demuxes the echo onto the same `SharedSession` (A0b), so
+    /// id-demuxes the echo onto the same `SharedSession`, so
     /// state/root/proxies are shared with the founding connection.
     /// Profile uniformity is enforced: the additional connection's
     /// negotiated wire version must equal this session's (else error).
     ///
     /// The default single-connection sessions never call this ⇒ the
     /// pool stays at one slot ⇒ `find_conn` is byte-identical to the
-    /// pre-A `enter_connection` (T1-1/AC-3.2 preserved).
+    /// `enter_connection` path.
     pub fn add_outgoing_connection_android13plus(
         &self,
         path: impl AsRef<std::path::Path>,
@@ -2425,7 +2425,7 @@ impl RpcSession {
         // **before** the handshake so a mismatch doesn't burn a server
         // attach + roundtrip; the handshake then runs with the
         // session's exact version as its ceiling so the server can't
-        // negotiate it down to something incompatible. AOSP A0a
+        // negotiate it down to something incompatible. AOSP
         // session-id wire constraint: `kSessionIdBytes == 32` (empty
         // is illegal here because `add_outgoing` is by definition a
         // 2nd+ connection echoing the founding id) — validate at the
@@ -2456,7 +2456,7 @@ impl RpcSession {
         Ok(self.inner.add_outgoing_slot(Box::new(t)))
     }
 
-    /// **Subplan 2-12 Phase B.2 — automatic outgoing-pool fan-out.**
+    /// Automatic outgoing-pool fan-out.
     /// AOSP `RpcSession::setupClient` automation for the path-based
     /// UDS client (one helper instead of three explicit steps).
     ///
@@ -2531,7 +2531,7 @@ impl RpcSession {
     }
 
     /// Client: connect to a Unix-domain android-13+ RPC server **with
-    /// FD-over-RPC** opt-in (subplan 2-11 Phase A0). UDS connect + the
+    /// FD-over-RPC** opt-in. UDS connect + the
     /// AOSP handshake requesting `fd_mode` in the connection header
     /// (see [`RpcSession::connect_android13plus_fd`]).
     /// `FileDescriptorTransportMode::None` ==
@@ -2545,7 +2545,7 @@ impl RpcSession {
         RpcSession::connect_android13plus_fd(Box::new(t), max_version, fd_mode)
     }
 
-    /// Subplan 2-13 A0.3 — adopt a **preconnected** RPC socket fd handed
+    /// Adopt a **preconnected** RPC socket fd handed
     /// to us by an out-of-band channel (the AOSP `IAccessor::addConnection`
     /// path: `BackendUnifiedServiceManager` receives a `unique_fd` and
     /// hands it to `RpcSession::setupPreconnectedClient(fd, request)`).
@@ -2559,16 +2559,15 @@ impl RpcSession {
     /// `IAccessor::ERROR_UNSUPPORTED_SOCKET_FAMILY`. The handshake then
     /// runs through [`RpcSession::connect_android13plus_fd`] with
     /// `FileDescriptorTransportMode::None` (the fd carries no FD-mode
-    /// metadata of its own — re-using 2-8 wire bytes, neither a new
-    /// codec nor a new framing path). `max_version` is the highest
+    /// metadata of its own — re-using the versioned wire bytes, neither
+    /// a new codec nor a new framing path). `max_version` is the highest
     /// `RPC_WIRE_PROTOCOL_VERSION` to offer (`2` for android-16, `1` for
     /// android-14/15, `0` for android-13). The peer's `RpcServer`
     /// negotiates `min(max_version, server_max)` exactly as for the
-    /// path-based client (G4(a) / 2-8 Phase D verified live).
+    /// path-based client.
     ///
-    /// rsbinder uses a single-connection session (plan 2-13 §7), so no
-    /// AOSP `request` reconnect closure is needed — the closure regains
-    /// meaning once 2-12 multi-conn lands.
+    /// rsbinder uses a single-connection session here, so no
+    /// AOSP `request` reconnect closure is needed.
     pub fn from_preconnected_fd(fd: OwnedFd, max_version: u32) -> Result<RpcSession> {
         // (a) Determine the fd's address family. Linux exposes
         //     `SO_DOMAIN` directly (`rustix::sockopt::socket_domain`),
@@ -2639,7 +2638,7 @@ impl RpcSession {
         )
     }
 
-    /// Test/diagnostic: live local-node count (AC-2.5 leak check).
+    /// Test/diagnostic: live local-node count (leak check).
     pub fn local_node_count(&self) -> usize {
         self.inner
             .shared
@@ -2650,7 +2649,7 @@ impl RpcSession {
     }
 }
 
-/// C1 fix (review 2026-05-21): reaper for `RpcProxy::drop`'s deferred
+/// Reaper for `RpcProxy::drop`'s deferred
 /// `DEC_STRONG` sends. Owns a [`Weak<RpcSessionInner>`] so it never
 /// keeps the session alive; the inner's [`Drop`] closes the channel
 /// and the reaper exits via `recv`'s `Err`. Drains any queued addrs
@@ -2666,10 +2665,16 @@ fn reaper_loop(weak: Weak<RpcSessionInner>, rx: mpsc::Receiver<RpcAddress>) {
         if inner.shared.lifecycle.is_torn_down() {
             continue;
         }
-        // `find_conn` may briefly wait on `slot_cv` if the pool is
-        // exhausted, but the *user* `Drop` already returned — this
-        // wait is contained to the dedicated reaper thread.
-        let conn = inner.find_conn();
+        // `find_conn_for_reaper` may briefly wait on `slot_cv` if the
+        // pool is exhausted, but the *user* `Drop` already returned — this
+        // wait is contained to the dedicated reaper thread and bails out
+        // (None) if the session tears down or the pool drains while we
+        // wait, so the reaper can never park forever holding the strong
+        // `Arc`. A dead session ⇒ silent no-op DEC_STRONG (AOSP parity).
+        let Some(conn) = inner.find_conn_for_reaper() else {
+            drop(inner);
+            continue;
+        };
         let frame = inner.profile.codec().encode_dec_strong(&addr);
         let _ = inner.send_msg(conn.transport(), &frame, &[]);
         drop(conn);
@@ -2679,11 +2684,10 @@ fn reaper_loop(weak: Weak<RpcSessionInner>, rx: mpsc::Receiver<RpcAddress>) {
 
 #[cfg(test)]
 mod tests {
-    //! Subplan 2-13 A0.3 unit gate (plan §9 matrix). Exercises
-    //! [`RpcSession::from_preconnected_fd`]'s family-dispatch +
-    //! `O_NONBLOCK` clear at the unit layer, without standing up an
-    //! `RpcServer` (the end-to-end handshake against a peer is the
-    //! `tests/rpc_accessor.rs` integration suite's job — A.4/A.5/D.7).
+    //! Unit gate for [`RpcSession::from_preconnected_fd`]'s
+    //! family-dispatch + `O_NONBLOCK` clear at the unit layer, without
+    //! standing up an `RpcServer` (the end-to-end handshake against a
+    //! peer is the `tests/rpc_accessor.rs` integration suite's job).
     //!
     //! Cross-platform host (Linux + macOS): every test uses
     //! `rustix::net::socketpair(AF_UNIX, ...)` so it's deterministic
@@ -2731,7 +2735,7 @@ mod tests {
         );
     }
 
-    /// AC-13.5 (regression gate, host-side): assert that the
+    /// Regression gate (host-side): assert that the
     /// `O_NONBLOCK` clear actually runs — `from_preconnected_fd` must
     /// drop the flag *before* returning the session, so subsequent
     /// blocking reads on the underlying fd don't trip EAGAIN.

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -17,7 +17,7 @@
 
 use std::cell::RefCell;
 use std::os::fd::{AsFd, OwnedFd};
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::Duration;
@@ -39,12 +39,11 @@ use super::wire_android13::{
 };
 use super::{RpcError, RpcResult};
 
-/// Result of the android-13+ server accept handshake (Phase A0b): the
-/// (unconsumed) transport plus the negotiated codec, the client's
-/// requested FD mode, and the client-supplied `session_id`. Named to
-/// keep [`RpcSession::android13plus_accept_handshake`] readable
-/// (clippy `type_complexity`).
-type Android13PlusAccept = (Box<dyn RpcTransport>, Android13PlusCodec, u8, Vec<u8>);
+/// Result of the android-13+ server accept handshake: the unconsumed
+/// transport plus the negotiated codec, the client's requested FD
+/// mode, the client-supplied `session_id`, and the
+/// `RPC_CONNECTION_OPTION_INCOMING` flag.
+type Android13PlusAccept = (Box<dyn RpcTransport>, Android13PlusCodec, u8, Vec<u8>, bool);
 
 /// Which RPC wire profile a session speaks.
 ///
@@ -474,7 +473,6 @@ impl Drop for ConnGuard<'_> {
 /// id→session registry — an opaque handle, not public API.
 pub(crate) struct SharedSession {
     state: Mutex<RpcState>,
-    async_counter: AtomicU64,
     root: Mutex<Option<SIBinder>>,
     /// Max-threads value advertised to the peer on `GET_MAX_THREADS`
     /// (server side) — subplan 2-3 negotiation.
@@ -1253,8 +1251,13 @@ impl RpcSessionInner {
         let oneway = (flags & FLAG_ONEWAY) != 0;
         let conn = self.find_conn(oneway);
         let transport = conn.transport();
+        // AOSP `BinderNode::asyncNumber` (send side, per-remote-addr).
         let async_number = if oneway {
-            self.shared.async_counter.fetch_add(1, Ordering::SeqCst)
+            self.shared
+                .state
+                .lock()
+                .expect("rpc state poisoned")
+                .next_send_async_number(addr)
         } else {
             0
         };
@@ -1469,6 +1472,63 @@ impl RpcSessionInner {
         if t.address.is_zero() {
             return self.serve_special(&t, oneway);
         }
+        if oneway {
+            self.dispatch_oneway_ordered(t, in_fds)
+        } else {
+            self.execute_dispatched(t, in_fds, false)
+        }
+    }
+
+    /// Gate an inbound oneway through the target node's `asyncTodo`
+    /// priority queue (AOSP `RpcState::processTransactInternal` 1093–
+    /// 1133 enqueue + 1247–1278 drain). The state lock is released
+    /// before dispatch so a nested callback re-entry can reacquire it.
+    fn dispatch_oneway_ordered(&self, t: WireTransaction, in_fds: Vec<OwnedFd>) -> Result<()> {
+        let addr = t.address;
+        let wire_async = t.async_number;
+        let mut next = {
+            let mut state = self.shared.state.lock().expect("rpc state poisoned");
+            match state.dispatch_async_or_enqueue(addr, wire_async, t, in_fds) {
+                super::state::AsyncDecision::Dispatch(t, fds) => Some((t, fds)),
+                super::state::AsyncDecision::Enqueued => {
+                    log::trace!(
+                        "RPC oneway parked: addr={:?} async#={} (out of order)",
+                        addr,
+                        wire_async
+                    );
+                    None
+                }
+                super::state::AsyncDecision::Drop(reason) => {
+                    log::debug!(
+                        "RPC oneway dropped: addr={:?} async#={} reason={:?}",
+                        addr,
+                        wire_async,
+                        reason
+                    );
+                    None
+                }
+            }
+        };
+        while let Some((t, fds)) = next {
+            self.execute_dispatched(t, fds, true)?;
+            next = {
+                let mut state = self.shared.state.lock().expect("rpc state poisoned");
+                state.advance_and_pop_async(addr)
+            };
+        }
+        Ok(())
+    }
+
+    /// Run the local dispatch (lookup target + INTERFACE/PING shortcut
+    /// for twoway + `rpc_transact` + reply / oneway-log). Shared body
+    /// of both the twoway and oneway dispatch paths — the asyncTodo
+    /// gating in `dispatch_oneway_ordered` is layered *above* this.
+    fn execute_dispatched(
+        &self,
+        t: WireTransaction,
+        in_fds: Vec<OwnedFd>,
+        oneway: bool,
+    ) -> Result<()> {
         let target = self
             .shared
             .state
@@ -1477,9 +1537,8 @@ impl RpcSessionInner {
             .lookup_local(&t.address);
         let Some(target) = target else {
             if oneway {
-                // Oneway is best-effort by definition, but a drop to a
-                // GC'd/unknown address is otherwise indistinguishable
-                // from delivery — log it for diagnosability (Minor-2).
+                // Best-effort drop; visible only if F7's `dec_strong_local`
+                // ran between the asyncTodo gate and now.
                 log::debug!(
                     "RPC oneway to unknown/released address {:?} dropped",
                     t.address
@@ -1724,7 +1783,6 @@ impl RpcSession {
     fn fresh_shared(space: AddressSpace) -> RpcResult<Arc<SharedSession>> {
         Ok(Arc::new(SharedSession {
             state: Mutex::new(RpcState::new(space)),
-            async_counter: AtomicU64::new(0),
             root: Mutex::new(None),
             max_threads: AtomicU32::new(1),
             negotiated: AtomicU32::new(0),
@@ -1813,6 +1871,24 @@ impl RpcSession {
         Ok(self.inner.add_slot_inner(transport))
     }
 
+    /// Append a server-side *callback* slot — the wire mirror of the
+    /// peer's `mIncoming` (AOSP `RpcServer.cpp`: `addOutgoingConnection
+    /// (client, init=true)` for `incoming` headers). Does NOT bump
+    /// `live_conns` (callback slots are not serve-driven; AOSP also
+    /// does not gate session lifetime on `mOutgoing.size()`).
+    /// `Err(DeadObject)` if the session is already torn down.
+    pub(crate) fn add_callback_slot(&self, transport: Box<dyn RpcTransport>) -> Result<u64> {
+        // Snapshot gate, not CAS — a concurrent founding death after
+        // this read is race-acceptable: the slot sits unused in a
+        // dead session and is reclaimed via `Arc<RpcSessionInner>`.
+        if self.inner.shared.live_conn_count() == 0
+            || self.inner.shared.obituary_sent.load(Ordering::Acquire)
+        {
+            return Err(StatusCode::DeadObject);
+        }
+        Ok(self.inner.add_slot_inner(transport))
+    }
+
     /// **Phase A4 (F8)**: this session's full inner state — including
     /// the *connection slot pool* and the wire profile, not just
     /// [`SharedSession`]. The unified-model server attach path stores
@@ -1844,11 +1920,11 @@ impl RpcSession {
         transport: Box<dyn RpcTransport>,
         server_max_version: u32,
     ) -> Result<Android13PlusAccept> {
-        let (codec, client_fd_mode, client_id) = {
+        let (codec, client_fd_mode, client_id, incoming) = {
             let mut io = RawTransportIo(transport.as_ref());
             server_accept(&mut io, server_max_version).map_err(StatusCode::from)?
         };
-        Ok((transport, codec, client_fd_mode, client_id))
+        Ok((transport, codec, client_fd_mode, client_id, incoming))
     }
 
     /// Server (Phase A0b): build the accepted connection's session from
@@ -2033,8 +2109,13 @@ impl RpcSession {
         server_max_version: u32,
         server_fd_unix: bool,
     ) -> Result<RpcSession> {
-        let (transport, codec, client_fd_mode, _client_id) =
+        let (transport, codec, client_fd_mode, _client_id, incoming) =
             Self::android13plus_accept_handshake(transport, server_max_version)?;
+        // This wrapper has no callback-slot path; incoming-direction
+        // attaches go through `super::RpcServer::serve_connection`.
+        if incoming {
+            return Err(StatusCode::BadType);
+        }
         Self::from_android13plus(transport, codec, client_fd_mode, server_fd_unix, None)
             .map_err(StatusCode::from)
     }

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -647,7 +647,28 @@ impl RpcSessionInner {
     /// without `wait`; the `DRIVING`-keyed reentrancy bypass collapses
     /// to today's `enter_connection` semantics — byte-identical (no
     /// wire effect, T1-1/AC-3.2 preserved).
-    fn find_conn(&self, oneway: bool) -> ConnGuard<'_> {
+    ///
+    /// **Oneway distribution (Phase C — §7.3 Option-1 pin retired
+    /// 2026-05-28).** Earlier this function took an `oneway: bool` and
+    /// routed top-level oneway sends to a fixed founding slot (the
+    /// Option-1 HOL-trade-off pin recorded in
+    /// [`plans/2-12-multi-connection-per-session.md`](../../plans/2-12-multi-connection-per-session.md)
+    /// §2 Phase A). With Phase C asyncTodo (per-`mNodeForAddress`
+    /// `asyncNumber` send-side + receive-side priority replay) carrying
+    /// the per-object oneway ordering invariant on both ends, the pin
+    /// is *redundant for correctness* and only paid the HOL cost. The
+    /// 2026-05-21 deferral suspected a libbinder `waitForReply`
+    /// cross-slot race with rsbinder server-side DECs, but: (i)
+    /// `send_dec_strong` already calls this with the twoway predicate
+    /// (it joins the twoway distribution), so the pin never affected
+    /// DEC routing; (ii) the AC-12.6 (c) "nested-callback outer reply"
+    /// path is all-twoway — the pin was dead code on that gate; and
+    /// (iii) re-running the experiment fresh shows hermetic
+    /// 100/100 + STAGE3 20/20 PASS with pin removed (the prior 4/5 vs
+    /// 5/5 reading was N=5 noise). Net: signature is now slot-policy-
+    /// invariant; per-object oneway FIFO is the asyncTodo invariant,
+    /// not a slot-selection invariant.
+    fn find_conn(&self) -> ConnGuard<'_> {
         let tid = current_tid();
         let sess_ptr = self as *const RpcSessionInner as usize;
         // (1) Reentrant: a slot of this session is already driven by
@@ -672,21 +693,6 @@ impl RpcSessionInner {
                 transport,
                 reentrant: true,
             };
-        }
-        // Phase C asyncTodo preserves per-node order regardless of
-        // which slot oneway picks, so removing this pin lifts the
-        // HOL trade-off in principle — but the libbinder AC-12.6 (c)
-        // gate flakes (~20%) without it (EPIPE on outer reply when
-        // server-side oneway DECs cross slots during nested callback
-        // dispatch). Pin stays until that race is root-caused.
-        if oneway {
-            if let Ok(g) = self.find_conn_pinned(RpcSession::FOUNDING_SLOT_ID) {
-                return g;
-            }
-            log::debug!(
-                "find_conn(oneway=true): founding slot retired; falling back to \
-                 any-available — per-object oneway FIFO may be reordered"
-            );
         }
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
         loop {
@@ -1191,7 +1197,7 @@ impl RpcSessionInner {
         // `wait` on `slot_cv` if the pool is exhausted. Concurrent
         // transacts on *other* slots run unblocked (AC-12.1).
         let oneway = (flags & FLAG_ONEWAY) != 0;
-        let conn = self.find_conn(oneway);
+        let conn = self.find_conn();
         let transport = conn.transport();
         // AOSP `BinderNode::asyncNumber` (send side, per-remote-addr).
         let async_number = if oneway {
@@ -1279,7 +1285,7 @@ impl RpcSessionInner {
     /// C1 fix (review 2026-05-21): two-tier `DEC_STRONG` hand-off for
     /// `RpcProxy::drop`. Drop runs on arbitrary user threads that may
     /// not be driving a slot of this session — without this guard,
-    /// `send_dec_strong`'s `find_conn(false)` would `cv.wait` on slot
+    /// `send_dec_strong`'s `find_conn` would `cv.wait` on slot
     /// availability and a hung peer would block the user's `Drop`
     /// indefinitely.
     ///
@@ -1336,10 +1342,7 @@ impl RpcSessionInner {
         // `find_conn` picks an available slot (or — if this thread is
         // already driving one of the session's slots — reuses it via
         // `DRIVING`, the documented "interleaved DEC_STRONG" path).
-        // `oneway=false` so DEC_STRONG joins the twoway distribution
-        // (any available slot) instead of contending on the oneway-
-        // pinned founding slot.
-        let conn = self.find_conn(false);
+        let conn = self.find_conn();
         let frame = self.profile.codec().encode_dec_strong(&addr);
         self.send_msg(conn.transport(), &frame, &[])?;
         Ok(())
@@ -1402,7 +1405,7 @@ impl RpcSessionInner {
         // `find_conn`). For an outermost server reply
         // (`serve_once_on_slot` pinned the slot before dispatch) this
         // is the same slot the request arrived on.
-        let conn = self.find_conn(false);
+        let conn = self.find_conn();
         Ok(self.send_msg(conn.transport(), &frame, fds)?)
     }
 
@@ -2663,10 +2666,10 @@ fn reaper_loop(weak: Weak<RpcSessionInner>, rx: mpsc::Receiver<RpcAddress>) {
         if inner.shared.lifecycle.is_torn_down() {
             continue;
         }
-        // `find_conn(false)` may briefly wait on `slot_cv` if the
-        // pool is exhausted, but the *user* `Drop` already returned —
-        // this wait is contained to the dedicated reaper thread.
-        let conn = inner.find_conn(false);
+        // `find_conn` may briefly wait on `slot_cv` if the pool is
+        // exhausted, but the *user* `Drop` already returned — this
+        // wait is contained to the dedicated reaper thread.
+        let conn = inner.find_conn();
         let frame = inner.profile.codec().encode_dec_strong(&addr);
         let _ = inner.send_msg(conn.transport(), &frame, &[]);
         drop(conn);

--- a/rsbinder/src/rpc/state.rs
+++ b/rsbinder/src/rpc/state.rs
@@ -1,24 +1,23 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! `RpcState` — per-session object table + RPC ref-count
-//! (subplan 2-2 S-c).
+//! `RpcState` — per-session object table + RPC ref-count.
 //!
-//! The rsbinder equivalent of android `RpcState::mNodeForAddress`. Per
-//! **P6** this is **strictly per-session** — there is no `static`,
-//! `OnceLock` or `lazy_static` anywhere in the RPC stack, so two
-//! sessions never share an address space and the RPC test suite is
-//! parallel-safe by construction (unlike the kernel binder singleton).
+//! The rsbinder equivalent of android `RpcState::mNodeForAddress`. This
+//! is **strictly per-session** — there is no `static`, `OnceLock` or
+//! `lazy_static` anywhere in the RPC stack, so two sessions never share
+//! an address space and the RPC test suite is parallel-safe by
+//! construction (unlike the kernel binder singleton).
 //!
 //! Ref-count model (AOSP `RpcState` `BinderNode::timesSent` /
-//! `flushExcessBinderRefs` — subplan 2-12 Phase A **F7**): a local
+//! `flushExcessBinderRefs`): a local
 //! object gets one address by *identity* (`Arc` pointer dedup, so the
 //! same object always marshals to the same address), but the entry's
 //! strong count is **`timesSent`**: it starts at 1 on the first send
 //! and is **incremented on every subsequent send** (each flatten to
 //! the peer is one reference the peer will eventually `DEC_STRONG`).
 //! Each inbound `DEC_STRONG` decrements it; the entry (and its strong
-//! `SIBinder`) is dropped at 0, so there is no leak (AC-2.5).
+//! `SIBinder`) is dropped at 0, so there is no leak.
 //!
 //! The peer dedups one `RpcProxy` per address. To keep the books
 //! balanced when it *receives the same binder more than once* while a
@@ -29,11 +28,10 @@
 //! `RpcSessionInner::read_binder`). Net: exactly one `DEC_STRONG` per
 //! send ⇒ balanced ⇒ no leak whether the binder is sent N× to one
 //! peer (dedup + N−1 excess DECs + 1 drop DEC) **or** once to each of
-//! N independent peer connections sharing a session (Phase A0b: N
-//! sends, N drop DECs). Before F7 the count was pinned at 1 by
-//! identity, which silently broke the latter (the first connection's
-//! proxy drop freed the node ⇒ the sibling connection's proxy
-//! `DeadObject`).
+//! N independent peer connections sharing a session (N sends, N drop
+//! DECs). Pinning the count at 1 by identity would silently break the
+//! latter (the first connection's proxy drop frees the node ⇒ the
+//! sibling connection's proxy `DeadObject`).
 
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap};
@@ -110,8 +108,8 @@ struct LocalNode {
 }
 
 /// Per-session object/address table. Owned by `RpcSessionInner` behind
-/// a `Mutex`; never global (P6 — enforced by the `rpc_no_globals`
-/// grep gate).
+/// a `Mutex`; never global (enforced by the `rpc_no_globals` grep
+/// gate).
 pub struct RpcState {
     /// Objects we exposed to the peer, keyed by assigned address.
     local_nodes: HashMap<RpcAddress, LocalNode>,
@@ -130,7 +128,7 @@ pub struct RpcState {
     /// same address — degrades to a single best-effort oneway drop
     /// on the peer's `Drop(StaleAsyncNumber)` arm.
     remote_send_async_counters: HashMap<RpcAddress, u64>,
-    /// Monotonic address allocator (per-session — P6).
+    /// Monotonic address allocator (per-session).
     addr_counter: u64,
     /// This endpoint's address subspace (initiator vs acceptor) so the
     /// two peers on a connection never mint colliding addresses.
@@ -159,15 +157,14 @@ impl RpcState {
     /// Register a local object leaving this process and return its
     /// session-stable address (android `onBinderLeaving`). The address
     /// is idempotent by object identity (same object ⇒ same address),
-    /// but the strong count is AOSP `timesSent`: **+1 on every send**
-    /// (Phase A F7). The first send creates the node at `strong = 1`; a
+    /// but the strong count is AOSP `timesSent`: **+1 on every send**.
+    /// The first send creates the node at `strong = 1`; a
     /// re-send of the same object reuses the address and **increments**
     /// `strong` (the peer will `DEC_STRONG` once per receipt — directly
     /// at proxy drop, or as an `flushExcessBinderRefs` excess DEC if it
-    /// dedups; see the module doc). Pre-F7 this branch returned without
-    /// bumping, which under Phase A0b multi-connection let the first
-    /// connection's DEC free a node still referenced over a sibling
-    /// connection (`DeadObject`).
+    /// dedups; see the module doc). Returning without bumping would let
+    /// the first connection's DEC free a node still referenced over a
+    /// sibling connection (`DeadObject`).
     pub fn on_binder_leaving(&mut self, binder: &SIBinder) -> RpcAddress {
         let ptr = binder_ptr(binder);
         if let Some(&addr) = self.local_by_ptr.get(&ptr) {
@@ -253,7 +250,7 @@ impl RpcState {
     /// stale `Weak` and re-`make`d). An unconditional `remove` would
     /// then evict that **live** entry, splitting the per-address dedup
     /// and breaking the "exactly one live proxy ⇒ exactly one
-    /// `DEC_STRONG`" invariant (AC-2.5 / P5). The identity check makes
+    /// `DEC_STRONG`" invariant. The identity check makes
     /// a stale `Drop` a no-op against a re-cached successor.
     pub fn forget_remote_if(&mut self, addr: &RpcAddress, who: *const ()) {
         if let Some(weak) = self.remote_proxies.get(addr) {
@@ -272,7 +269,7 @@ impl RpcState {
         }
     }
 
-    /// Test/diagnostic: number of live local nodes (AC-2.5 leak check).
+    /// Test/diagnostic: number of live local nodes (leak check).
     pub fn local_node_count(&self) -> usize {
         self.local_nodes.len()
     }
@@ -291,12 +288,12 @@ impl RpcState {
             .collect()
     }
 
-    /// **Phase C (Option-2)** — post-increment the per-remote-address
+    /// Post-increment the per-remote-address
     /// send-side `async_number` (AOSP `nodeProgressAsyncNumber` on the
     /// send path). Returns the value to stamp on the outgoing wire.
     /// Auto-creates the counter at `0` if unseen. Decoupled from
     /// `remote_proxies` so the counter survives a proxy `Drop` + re-
-    /// resolve on a sibling connection (Phase A0b multi-conn): the
+    /// resolve on a sibling connection: the
     /// peer's `BinderNode` is still alive (`timesSent > 0` on any
     /// active connection), and resetting our counter would replay
     /// numbers the peer's `asyncTodo` already processed — stalling
@@ -318,7 +315,7 @@ impl RpcState {
         n
     }
 
-    /// **Phase C** — decide whether to dispatch an inbound oneway now
+    /// Decide whether to dispatch an inbound oneway now
     /// or park it. Pass the wire `async_number` and the transaction
     /// body / fds (moved in; given back in [`AsyncDecision::Dispatch`]
     /// or owned by the heap on [`AsyncDecision::Enqueued`]). Twoway
@@ -349,7 +346,7 @@ impl RpcState {
         }
     }
 
-    /// **Phase C** — after a successful dispatch (by the caller) of
+    /// After a successful dispatch (by the caller) of
     /// the previously-returned [`AsyncDecision::Dispatch`], advance
     /// the per-node counter and pop the next eligible queued entry
     /// (if its `async_number` matches the now-advanced counter). The
@@ -386,7 +383,7 @@ impl RpcState {
     }
 
     /// Test/diagnostic: depth of the `async_todo` queue for a given
-    /// local address (0 if no node). Used by Phase C unit tests to
+    /// local address (0 if no node). Used by unit tests to
     /// assert the parking behavior + drain.
     #[cfg(test)]
     pub(crate) fn async_todo_len(&self, addr: &RpcAddress) -> usize {
@@ -397,7 +394,7 @@ impl RpcState {
     }
 
     /// Test/diagnostic: current `next_async_number` for a local node
-    /// (0 if no node) — used by Phase C unit tests to verify the
+    /// (0 if no node) — used by unit tests to verify the
     /// counter advances exactly per dispatched oneway.
     #[cfg(test)]
     pub(crate) fn next_async_number(&self, addr: &RpcAddress) -> u64 {
@@ -479,8 +476,7 @@ mod tests {
         assert!(st.lookup_local(&a1).is_some());
     }
 
-    /// AC-2.5: a single DEC_STRONG drops the node to 0 → removed, no
-    /// leak.
+    /// A single DEC_STRONG drops the node to 0 → removed, no leak.
     #[test]
     fn dec_strong_releases_node() {
         let mut st = RpcState::new(AddressSpace::Acceptor);
@@ -494,8 +490,8 @@ mod tests {
         assert!(!st.dec_strong_local(&a));
     }
 
-    /// AC-2.3 / T2.3: two `RpcState` instances have **independent**
-    /// tables and counters (P6). Addresses are only ever resolved
+    /// Two `RpcState` instances have **independent**
+    /// tables and counters. Addresses are only ever resolved
     /// within their own session/connection, so the per-session counter
     /// scheme (both sessions start at 1) is correct — a fresh session
     /// simply does not know any address it never registered, and
@@ -516,13 +512,13 @@ mod tests {
         assert_eq!(s1.local_node_count(), 1);
         assert_eq!(s2.local_node_count(), 0);
 
-        // Mutating s1 never affects s2 (no shared storage — P6).
+        // Mutating s1 never affects s2 (no shared storage).
         s1.dec_strong_local(&a1);
         assert_eq!(s1.local_node_count(), 0);
         assert_eq!(s2.local_node_count(), 0);
     }
 
-    /// AC-2.5 / P5 regression: a stale `RpcProxy::drop` (its `Arc` hit
+    /// Regression: a stale `RpcProxy::drop` (its `Arc` hit
     /// 0 before `Drop` ran, and a concurrent `read_binder` already
     /// re-cached a fresh live proxy for the same address) must NOT
     /// evict the successor. Deterministically reproduces the exact
@@ -625,10 +621,10 @@ mod tests {
         );
     }
 
-    /// **Phase A F7** balance (state level): the AOSP
+    /// `timesSent` balance (state level): the AOSP
     /// `timesSent`/`flushExcessBinderRefs` accounting nets to exactly
-    /// one `DEC_STRONG` per send, so the node is freed (no leak —
-    /// AC-2.5) in both shapes the model must support.
+    /// one `DEC_STRONG` per send, so the node is freed (no leak) in
+    /// both shapes the model must support.
     #[test]
     fn f7_timessent_balance_no_leak() {
         // (a) Same object sent N× to *one* peer that dedups to one
@@ -660,10 +656,10 @@ mod tests {
         assert_eq!(srv.local_node_count(), 0, "no leak (AC-2.5)");
 
         // (b) Same object sent once to each of 2 *independent* peer
-        //     connections sharing one server session (Phase A0b): 2
-        //     sends ⇒ strong 2; each peer's lone proxy DECs once ⇒ 2.
-        //     Pre-F7 this freed the node on the *first* DEC (the F7
-        //     bug); now the sibling survives until the 2nd.
+        //     connections sharing one server session: 2 sends ⇒ strong
+        //     2; each peer's lone proxy DECs once ⇒ 2. Pinning at 1
+        //     would free the node on the *first* DEC; the sibling must
+        //     survive until the 2nd.
         let mut s = RpcState::new(AddressSpace::Acceptor);
         let o = SIBinder::new(Arc::new(Dummy)).unwrap();
         let x = s.on_binder_leaving(&o); // conn #1 send
@@ -688,7 +684,7 @@ mod tests {
         }
     }
 
-    /// **Phase C (Option-2) — send side**: per-remote-address counter
+    /// Send side: per-remote-address counter
     /// post-increments on every `next_send_async_number(addr)`, with
     /// addresses tracked independently. Reset is impossible by design
     /// (the peer's `BinderNode::asyncNumber` lives across our proxy
@@ -709,7 +705,7 @@ mod tests {
         assert_eq!(st.next_send_async_number(b), 1);
     }
 
-    /// **Phase C — receive side, in-order**: wire `async_number`
+    /// Receive side, in-order: wire `async_number`
     /// matches the per-node `next_async_number` ⇒ dispatch
     /// immediately. The advance + queue drain runs in a separate call
     /// (the dispatch happens *outside* the state lock).
@@ -734,15 +730,14 @@ mod tests {
         }
     }
 
-    /// **Phase C — receive side, out-of-order**: wire `async_number`
+    /// Receive side, out-of-order: wire `async_number`
     /// ahead of expected ⇒ parked. When the matching expected arrives,
     /// dispatch advances the counter and the drain loop pops the
     /// parked entries in priority order until a gap appears. This is
-    /// the AOSP `RpcState::processTransactInternal` lines 1093–1133
-    /// (enqueue) + 1247–1278 (drain) behaviour, and the exact thing
-    /// that makes libbinder's round-robin `mOutgoing` oneway
-    /// distribution preserve per-node order on the rsbinder server
-    /// (AC-12.6 (b) — Phase D failed pre-Phase-C with `log 10/20`).
+    /// the AOSP `RpcState::processTransactInternal` enqueue + drain
+    /// behaviour, and the exact thing that makes libbinder's
+    /// round-robin `mOutgoing` oneway distribution preserve per-node
+    /// order on the rsbinder server.
     #[test]
     fn phase_c_out_of_order_enqueues_then_drains_in_priority_order() {
         let mut st = RpcState::new(AddressSpace::Acceptor);
@@ -787,7 +782,7 @@ mod tests {
         assert_eq!(st.next_async_number(&a), 5);
     }
 
-    /// **Phase C — unknown address**: AOSP `RpcState` only enqueues if
+    /// Unknown address: AOSP `RpcState` only enqueues if
     /// `mNodeForAddress.find(addr)` succeeds; rsbinder must mirror
     /// that or unknown-address oneway would leak into the queue
     /// forever. Returns [`AsyncDecision::Drop`] so the caller logs +
@@ -808,7 +803,7 @@ mod tests {
         assert!(st.advance_and_pop_async(unknown).is_none());
     }
 
-    /// **Phase C — stale receive**: a `wire_async < next_async_number`
+    /// Stale receive: a `wire_async < next_async_number`
     /// arrival (peer replay / buggy retry) returns
     /// [`DropReason::StaleAsyncNumber`] without touching the queue;
     /// any heap entry already below the expected number is drained on
@@ -855,7 +850,7 @@ mod tests {
         assert_eq!(st.next_async_number(&a), 5);
     }
 
-    /// **Phase C — multi-node independence**: each `LocalNode` has its
+    /// Multi-node independence: each `LocalNode` has its
     /// own `next_async_number` + `async_todo`, so a stalled queue on
     /// node A must not block dispatch on node B.
     #[test]

--- a/rsbinder/src/rpc/state.rs
+++ b/rsbinder/src/rpc/state.rs
@@ -35,12 +35,65 @@
 //! proxy drop freed the node ⇒ the sibling connection's proxy
 //! `DeadObject`).
 
-use std::collections::HashMap;
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
+use std::os::fd::OwnedFd;
 use std::sync::{self, Arc};
 
 use crate::binder::{IBinder, SIBinder};
 
 use super::address::{AddressSpace, RpcAddress};
+use super::wire::WireTransaction;
+
+/// Per-node `asyncTodo` queue entry. `Ord` by `async_number` so a
+/// `BinaryHeap<Reverse<AsyncTodo>>` gives min-heap top-is-smallest
+/// (AOSP `BinderNode::AsyncTodo` `operator<` uses the same trick).
+struct AsyncTodo {
+    async_number: u64,
+    transaction: WireTransaction,
+    in_fds: Vec<OwnedFd>,
+}
+
+impl PartialEq for AsyncTodo {
+    fn eq(&self, other: &Self) -> bool {
+        self.async_number == other.async_number
+    }
+}
+impl Eq for AsyncTodo {}
+impl PartialOrd for AsyncTodo {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for AsyncTodo {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.async_number.cmp(&other.async_number)
+    }
+}
+
+/// Why an inbound oneway was dropped (no dispatch, no enqueue) so
+/// callers can log / meter the two cases separately.
+#[derive(Debug, Clone, Copy)]
+pub enum DropReason {
+    /// `mNodeForAddress.find` miss — peer addressed a binder we have
+    /// never published or have already released. Benign for oneway.
+    UnknownAddress,
+    /// `wire_async < node.asyncNumber` — duplicate / replay / peer
+    /// bug; AOSP-divergent (AOSP terminates the session here).
+    StaleAsyncNumber,
+}
+
+/// Outcome of [`RpcState::dispatch_async_or_enqueue`] for an inbound
+/// oneway. Caller dispatches the [`AsyncDecision::Dispatch`] variant
+/// outside the state lock, then calls
+/// [`RpcState::advance_and_pop_async`] to advance the per-node counter
+/// and drain newly-eligible queued entries.
+#[derive(Debug)]
+pub enum AsyncDecision {
+    Dispatch(WireTransaction, Vec<OwnedFd>),
+    Enqueued,
+    Drop(DropReason),
+}
 
 /// A local object exposed to the peer under [`RpcAddress`].
 struct LocalNode {
@@ -48,6 +101,12 @@ struct LocalNode {
     binder: SIBinder,
     /// RPC strong count the peer holds (0 ⇒ drop the node).
     strong: i64,
+    /// AOSP `BinderNode::asyncNumber` (server side) — per-node, not
+    /// session-global.
+    next_async_number: u64,
+    /// AOSP `BinderNode::asyncTodo` — min-heap (via `Reverse`) of
+    /// out-of-order inbound oneway transactions.
+    async_todo: BinaryHeap<Reverse<AsyncTodo>>,
 }
 
 /// Per-session object/address table. Owned by `RpcSessionInner` behind
@@ -63,6 +122,11 @@ pub struct RpcState {
     /// does not keep them alive; lets us dedup one `RpcProxy` per
     /// address and observe its last drop.
     remote_proxies: HashMap<RpcAddress, sync::Weak<dyn IBinder>>,
+    /// AOSP `BinderNode::asyncNumber` (client side) — survives proxy
+    /// churn so the per-node monotonic stream is preserved across
+    /// sibling-connection re-resolve (the peer's `asyncTodo` does
+    /// not).
+    remote_send_async_counters: HashMap<RpcAddress, u64>,
     /// Monotonic address allocator (per-session — P6).
     addr_counter: u64,
     /// This endpoint's address subspace (initiator vs acceptor) so the
@@ -83,6 +147,7 @@ impl RpcState {
             local_nodes: HashMap::new(),
             local_by_ptr: HashMap::new(),
             remote_proxies: HashMap::new(),
+            remote_send_async_counters: HashMap::new(),
             addr_counter: 0,
             space,
         }
@@ -114,6 +179,8 @@ impl RpcState {
             LocalNode {
                 binder: binder.clone(),
                 strong: 1,
+                next_async_number: 0,
+                async_todo: BinaryHeap::new(),
             },
         );
         self.local_by_ptr.insert(ptr, addr);
@@ -211,6 +278,135 @@ impl RpcState {
             .filter_map(sync::Weak::upgrade)
             .collect()
     }
+
+    /// **Phase C (Option-2)** — post-increment the per-remote-address
+    /// send-side `async_number` (AOSP `nodeProgressAsyncNumber` on the
+    /// send path). Returns the value to stamp on the outgoing wire.
+    /// Auto-creates the counter at `0` if unseen. Decoupled from
+    /// `remote_proxies` so the counter survives a proxy `Drop` + re-
+    /// resolve on a sibling connection (Phase A0b multi-conn): the
+    /// peer's `BinderNode` is still alive (`timesSent > 0` on any
+    /// active connection), and resetting our counter would replay
+    /// numbers the peer's `asyncTodo` already processed — stalling
+    /// the per-node monotonic-stream contract forever.
+    ///
+    /// Overflow: u64 wrap means a session issued 2^64 oneways to one
+    /// node, effectively unreachable; AOSP `nodeProgressAsyncNumber`
+    /// returns `false` and tears down the session at overflow. We
+    /// match by wrapping + logging (rsbinder has no `shutdownAndWait`
+    /// equivalent on this path; the peer will surface as a protocol
+    /// error on the duplicate).
+    pub fn next_send_async_number(&mut self, addr: RpcAddress) -> u64 {
+        let counter = self.remote_send_async_counters.entry(addr).or_insert(0);
+        let n = *counter;
+        *counter = n.wrapping_add(1);
+        if *counter == 0 {
+            warn_async_wrap(&addr);
+        }
+        n
+    }
+
+    /// **Phase C** — decide whether to dispatch an inbound oneway now
+    /// or park it. Pass the wire `async_number` and the transaction
+    /// body / fds (moved in; given back in [`AsyncDecision::Dispatch`]
+    /// or owned by the heap on [`AsyncDecision::Enqueued`]). Twoway
+    /// transactions never reach this method.
+    ///
+    /// AOSP `RpcState::processTransactInternal` lines 1093–1133.
+    pub fn dispatch_async_or_enqueue(
+        &mut self,
+        addr: RpcAddress,
+        wire_async: u64,
+        txn: WireTransaction,
+        in_fds: Vec<OwnedFd>,
+    ) -> AsyncDecision {
+        let Some(node) = self.local_nodes.get_mut(&addr) else {
+            return AsyncDecision::Drop(DropReason::UnknownAddress);
+        };
+        if wire_async == node.next_async_number {
+            AsyncDecision::Dispatch(txn, in_fds)
+        } else if wire_async > node.next_async_number {
+            node.async_todo.push(Reverse(AsyncTodo {
+                async_number: wire_async,
+                transaction: txn,
+                in_fds,
+            }));
+            AsyncDecision::Enqueued
+        } else {
+            AsyncDecision::Drop(DropReason::StaleAsyncNumber)
+        }
+    }
+
+    /// **Phase C** — after a successful dispatch (by the caller) of
+    /// the previously-returned [`AsyncDecision::Dispatch`], advance
+    /// the per-node counter and pop the next eligible queued entry
+    /// (if its `async_number` matches the now-advanced counter). The
+    /// caller calls this in a loop until it returns `None`, then
+    /// stops draining. Each pop dispatches outside the state lock.
+    ///
+    /// AOSP `RpcState::processTransactInternal` lines 1247–1278 (the
+    /// `goto processTransactInternalTailCall` loop).
+    pub fn advance_and_pop_async(
+        &mut self,
+        addr: RpcAddress,
+    ) -> Option<(WireTransaction, Vec<OwnedFd>)> {
+        let node = self.local_nodes.get_mut(&addr)?;
+        node.next_async_number = node.next_async_number.wrapping_add(1);
+        if node.next_async_number == 0 {
+            warn_async_wrap(&addr);
+        }
+        // Drop heap entries from a hostile/buggy peer that retried below
+        // the expected number (AOSP-divergent — AOSP terminates the
+        // session; we treat them as best-effort oneway loss).
+        while let Some(Reverse(top)) = node.async_todo.peek() {
+            if top.async_number >= node.next_async_number {
+                break;
+            }
+            node.async_todo.pop();
+        }
+        if let Some(Reverse(top)) = node.async_todo.peek() {
+            if top.async_number == node.next_async_number {
+                let Reverse(todo) = node.async_todo.pop().expect("peek-pop");
+                return Some((todo.transaction, todo.in_fds));
+            }
+        }
+        None
+    }
+
+    /// Test/diagnostic: depth of the `async_todo` queue for a given
+    /// local address (0 if no node). Used by Phase C unit tests to
+    /// assert the parking behavior + drain.
+    #[cfg(test)]
+    pub(crate) fn async_todo_len(&self, addr: &RpcAddress) -> usize {
+        self.local_nodes
+            .get(addr)
+            .map(|n| n.async_todo.len())
+            .unwrap_or(0)
+    }
+
+    /// Test/diagnostic: current `next_async_number` for a local node
+    /// (0 if no node) — used by Phase C unit tests to verify the
+    /// counter advances exactly per dispatched oneway.
+    #[cfg(test)]
+    pub(crate) fn next_async_number(&self, addr: &RpcAddress) -> u64 {
+        self.local_nodes
+            .get(addr)
+            .map(|n| n.next_async_number)
+            .unwrap_or(0)
+    }
+}
+
+/// Shared by send-side post-increment and receive-side advance: the
+/// per-node `async_number` is a `u64`, so wrap is "issued 2^64 oneways
+/// to one node" — effectively unreachable. AOSP's
+/// `nodeProgressAsyncNumber` returns `false` and tears down the
+/// session at overflow; rsbinder has no equivalent kill switch on this
+/// path, so we log + let the peer surface it as a duplicate.
+fn warn_async_wrap(addr: &RpcAddress) {
+    log::warn!(
+        "RPC: per-address async_number wrapped at u64::MAX for {addr:?} — \
+         AOSP-divergent (AOSP terminates the session)."
+    );
 }
 
 #[cfg(test)]
@@ -423,5 +619,215 @@ mod tests {
         assert!(s.lookup_local(&x).is_some(), "sibling still reachable");
         assert!(s.dec_strong_local(&x), "conn #2 proxy drop frees it");
         assert_eq!(s.local_node_count(), 0, "no leak");
+    }
+
+    fn mk_txn(addr: RpcAddress, async_n: u64) -> WireTransaction {
+        WireTransaction {
+            address: addr,
+            code: 1,
+            flags: crate::binder::FLAG_ONEWAY,
+            async_number: async_n,
+            data: vec![],
+            object_positions: vec![],
+        }
+    }
+
+    /// **Phase C (Option-2) — send side**: per-remote-address counter
+    /// post-increments on every `next_send_async_number(addr)`, with
+    /// addresses tracked independently. Reset is impossible by design
+    /// (the peer's `BinderNode::asyncNumber` lives across our proxy
+    /// churn — see the field doc).
+    #[test]
+    fn phase_c_send_async_number_is_per_address_monotonic() {
+        let mut st = RpcState::new(AddressSpace::Initiator);
+        let a = RpcAddress::from_wire_bytes([1u8; 32]);
+        let b = RpcAddress::from_wire_bytes([2u8; 32]);
+        assert_eq!(st.next_send_async_number(a), 0);
+        assert_eq!(st.next_send_async_number(a), 1);
+        assert_eq!(
+            st.next_send_async_number(b),
+            0,
+            "per-address — b starts at 0"
+        );
+        assert_eq!(st.next_send_async_number(a), 2);
+        assert_eq!(st.next_send_async_number(b), 1);
+    }
+
+    /// **Phase C — receive side, in-order**: wire `async_number`
+    /// matches the per-node `next_async_number` ⇒ dispatch
+    /// immediately. The advance + queue drain runs in a separate call
+    /// (the dispatch happens *outside* the state lock).
+    #[test]
+    fn phase_c_in_order_dispatches_and_advances_counter() {
+        let mut st = RpcState::new(AddressSpace::Acceptor);
+        let b = SIBinder::new(Arc::new(Dummy)).unwrap();
+        let a = st.on_binder_leaving(&b);
+        assert_eq!(st.next_async_number(&a), 0);
+        for i in 0..5u64 {
+            let txn = mk_txn(a, i);
+            match st.dispatch_async_or_enqueue(a, i, txn, vec![]) {
+                AsyncDecision::Dispatch(t, _) => assert_eq!(t.async_number, i),
+                other => panic!("in-order async_number {i} must dispatch, got {other:?}"),
+            }
+            assert_eq!(st.async_todo_len(&a), 0, "in-order ⇒ never enqueued");
+            assert!(
+                st.advance_and_pop_async(a).is_none(),
+                "queue empty ⇒ drain returns None"
+            );
+            assert_eq!(st.next_async_number(&a), i + 1);
+        }
+    }
+
+    /// **Phase C — receive side, out-of-order**: wire `async_number`
+    /// ahead of expected ⇒ parked. When the matching expected arrives,
+    /// dispatch advances the counter and the drain loop pops the
+    /// parked entries in priority order until a gap appears. This is
+    /// the AOSP `RpcState::processTransactInternal` lines 1093–1133
+    /// (enqueue) + 1247–1278 (drain) behaviour, and the exact thing
+    /// that makes libbinder's round-robin `mOutgoing` oneway
+    /// distribution preserve per-node order on the rsbinder server
+    /// (AC-12.6 (b) — Phase D failed pre-Phase-C with `log 10/20`).
+    #[test]
+    fn phase_c_out_of_order_enqueues_then_drains_in_priority_order() {
+        let mut st = RpcState::new(AddressSpace::Acceptor);
+        let b = SIBinder::new(Arc::new(Dummy)).unwrap();
+        let a = st.on_binder_leaving(&b);
+
+        // Wire arrival: 2, 4, 1, 3, 0 (libbinder round-robin against
+        // 2 outgoing slots delivers this kind of interleave). Expected
+        // dispatch order: 0, 1, 2, 3, 4 (per-node monotonic).
+        for arrival_async in [2u64, 4, 1, 3, 0] {
+            let txn = mk_txn(a, arrival_async);
+            let decision = st.dispatch_async_or_enqueue(a, arrival_async, txn, vec![]);
+            if arrival_async == 0 {
+                // Last to arrive: 0 matches expected, so it dispatches.
+                match decision {
+                    AsyncDecision::Dispatch(t, _) => assert_eq!(t.async_number, 0),
+                    _ => panic!("arrival 0 must dispatch"),
+                }
+                break;
+            } else {
+                assert!(
+                    matches!(decision, AsyncDecision::Enqueued),
+                    "out-of-order arrival {arrival_async} must enqueue (expected was 0)"
+                );
+            }
+        }
+        // After dispatching 0, the queue must drain 1, 2, 3, 4 in
+        // strict order via advance_and_pop_async.
+        assert_eq!(st.async_todo_len(&a), 4, "1, 2, 3, 4 parked");
+        let mut dispatched = vec![0u64];
+        while let Some((t, _)) = st.advance_and_pop_async(a) {
+            dispatched.push(t.async_number);
+        }
+        assert_eq!(
+            dispatched,
+            vec![0, 1, 2, 3, 4],
+            "per-node monotonic dispatch despite wire reorder"
+        );
+        assert_eq!(st.async_todo_len(&a), 0, "drained");
+        // After draining 4 (the last one), counter still advances
+        // once for the dispatch of 4 — so expected is now 5.
+        assert_eq!(st.next_async_number(&a), 5);
+    }
+
+    /// **Phase C — unknown address**: AOSP `RpcState` only enqueues if
+    /// `mNodeForAddress.find(addr)` succeeds; rsbinder must mirror
+    /// that or unknown-address oneway would leak into the queue
+    /// forever. Returns [`AsyncDecision::Drop`] so the caller logs +
+    /// drops (oneway is best-effort).
+    #[test]
+    fn phase_c_unknown_address_drops_not_enqueues() {
+        let mut st = RpcState::new(AddressSpace::Acceptor);
+        let unknown = RpcAddress::from_wire_bytes([9u8; 32]);
+        let txn = mk_txn(unknown, 0);
+        assert!(matches!(
+            st.dispatch_async_or_enqueue(unknown, 0, txn, vec![]),
+            AsyncDecision::Drop(DropReason::UnknownAddress)
+        ));
+        // `advance_and_pop_async` on an unknown address is a no-op
+        // (would otherwise underflow / spuriously advance a future
+        // node minted at the same address — but addresses are
+        // monotonic so the latter cannot happen).
+        assert!(st.advance_and_pop_async(unknown).is_none());
+    }
+
+    /// **Phase C — stale receive**: a `wire_async < next_async_number`
+    /// arrival (peer replay / buggy retry) returns
+    /// [`DropReason::StaleAsyncNumber`] without touching the queue;
+    /// any heap entry already below the expected number is drained on
+    /// the next `advance_and_pop_async` (so a hostile peer cannot OOM
+    /// us by spamming stale futures).
+    #[test]
+    fn phase_c_stale_arrival_drops_and_heap_drains_below_expected() {
+        let mut st = RpcState::new(AddressSpace::Acceptor);
+        let b = SIBinder::new(Arc::new(Dummy)).unwrap();
+        let a = st.on_binder_leaving(&b);
+
+        // Advance expected to 3 by dispatching 0,1,2 in order.
+        for i in 0..3u64 {
+            let txn = mk_txn(a, i);
+            assert!(matches!(
+                st.dispatch_async_or_enqueue(a, i, txn, vec![]),
+                AsyncDecision::Dispatch(_, _)
+            ));
+            let _ = st.advance_and_pop_async(a);
+        }
+        assert_eq!(st.next_async_number(&a), 3);
+
+        // Now a stale arrival (1 < 3) reports the reason and does not
+        // enqueue.
+        let txn = mk_txn(a, 1);
+        assert!(matches!(
+            st.dispatch_async_or_enqueue(a, 1, txn, vec![]),
+            AsyncDecision::Drop(DropReason::StaleAsyncNumber)
+        ));
+        assert_eq!(st.async_todo_len(&a), 0);
+
+        // Heap stale-drain: inject a future arrival, advance past it,
+        // then verify the next pop sees the heap empty (the stale
+        // entry was reaped, not blocking).
+        let txn5 = mk_txn(a, 5);
+        let _ = st.dispatch_async_or_enqueue(a, 5, txn5, vec![]);
+        assert_eq!(st.async_todo_len(&a), 1);
+        // Dispatch a matching 3 + 4 to advance past 5's predecessor.
+        let _ = st.dispatch_async_or_enqueue(a, 3, mk_txn(a, 3), vec![]);
+        let _ = st.advance_and_pop_async(a); // expected → 4
+        let _ = st.dispatch_async_or_enqueue(a, 4, mk_txn(a, 4), vec![]);
+        let _ = st.advance_and_pop_async(a); // expected → 5; pops the parked 5.
+        assert_eq!(st.async_todo_len(&a), 0);
+        assert_eq!(st.next_async_number(&a), 5);
+    }
+
+    /// **Phase C — multi-node independence**: each `LocalNode` has its
+    /// own `next_async_number` + `async_todo`, so a stalled queue on
+    /// node A must not block dispatch on node B.
+    #[test]
+    fn phase_c_per_node_independence() {
+        let mut st = RpcState::new(AddressSpace::Acceptor);
+        let b1 = SIBinder::new(Arc::new(Dummy)).unwrap();
+        let b2 = SIBinder::new(Arc::new(Dummy)).unwrap();
+        let a1 = st.on_binder_leaving(&b1);
+        let a2 = st.on_binder_leaving(&b2);
+
+        // Node a1: arrival 1 enqueued (expected 0).
+        let txn = mk_txn(a1, 1);
+        assert!(matches!(
+            st.dispatch_async_or_enqueue(a1, 1, txn, vec![]),
+            AsyncDecision::Enqueued
+        ));
+        assert_eq!(st.async_todo_len(&a1), 1);
+        // Node a2: independent counter at 0 ⇒ arrival 0 dispatches
+        // even though a1 is blocked.
+        let txn = mk_txn(a2, 0);
+        match st.dispatch_async_or_enqueue(a2, 0, txn, vec![]) {
+            AsyncDecision::Dispatch(t, _) => assert_eq!(t.async_number, 0),
+            _ => panic!("a2 must dispatch independently of a1's stalled queue"),
+        }
+        assert_eq!(st.async_todo_len(&a2), 0);
+        // Counters are truly independent.
+        assert_eq!(st.next_async_number(&a1), 0, "a1 not yet advanced");
+        assert!(st.advance_and_pop_async(a2).is_none());
+        assert_eq!(st.next_async_number(&a2), 1);
     }
 }

--- a/rsbinder/src/rpc/state.rs
+++ b/rsbinder/src/rpc/state.rs
@@ -122,10 +122,13 @@ pub struct RpcState {
     /// does not keep them alive; lets us dedup one `RpcProxy` per
     /// address and observe its last drop.
     remote_proxies: HashMap<RpcAddress, sync::Weak<dyn IBinder>>,
-    /// AOSP `BinderNode::asyncNumber` (client side) — survives proxy
-    /// churn so the per-node monotonic stream is preserved across
-    /// sibling-connection re-resolve (the peer's `asyncTodo` does
-    /// not).
+    /// AOSP `BinderNode::asyncNumber` (client side). Entries are
+    /// dropped together with the proxy slot in `forget_remote_if`
+    /// (peer's `timesSent` also reaches 0 then, so its `BinderNode`
+    /// is GC'd and the counter restart matches). The narrow race —
+    /// DEC still in flight when a sibling connection re-resolves the
+    /// same address — degrades to a single best-effort oneway drop
+    /// on the peer's `Drop(StaleAsyncNumber)` arm.
     remote_send_async_counters: HashMap<RpcAddress, u64>,
     /// Monotonic address allocator (per-session — P6).
     addr_counter: u64,
@@ -256,6 +259,15 @@ impl RpcState {
         if let Some(weak) = self.remote_proxies.get(addr) {
             if weak.as_ptr() as *const () == who {
                 self.remote_proxies.remove(addr);
+                // The proxy that owned this address is gone; the
+                // matching `DEC_STRONG` will be sent shortly. After it
+                // lands, the peer's `BinderNode` either survives (if
+                // `timesSent > 0` on the peer side — we re-resolve and
+                // restart from 0) or is GC'd (counter is irrelevant).
+                // Either way the per-address `async_number` book is
+                // closed for *this* proxy generation; drop it so the
+                // map stays bounded by the live address set.
+                self.remote_send_async_counters.remove(addr);
             }
         }
     }
@@ -567,6 +579,50 @@ mod tests {
             "after identity-checked forget, the address re-mints"
         );
         assert!(!ex3, "re-mint after forget is a fresh proxy — not excess");
+    }
+
+    /// `forget_remote_if` also drops the per-address send counter so
+    /// `remote_send_async_counters` stays bounded by the live address
+    /// set. A fresh re-mint starts the counter back at 0 (matches
+    /// peer's `BinderNode` GC + recreate). The stale-Drop guard from
+    /// `stale_drop_does_not_split_remote_dedup` extends here: an
+    /// identity-mismatched `forget` must NOT evict the live counter.
+    #[test]
+    fn phase_c_forget_remote_if_gcs_send_counter() {
+        let mut st = RpcState::new(AddressSpace::Acceptor);
+        let addr = RpcAddress::from_wire_bytes([3u8; 32]);
+
+        let sib1 = SIBinder::new(Arc::new(Dummy)).unwrap();
+        let (got1, _) = st.remote_proxy(addr, || sib1.clone());
+        let p1 = Arc::as_ptr(got1.as_arc()) as *const ();
+        assert_eq!(st.next_send_async_number(addr), 0);
+        assert_eq!(st.next_send_async_number(addr), 1);
+
+        // Stale-Drop pattern (P2 already re-cached): `forget_remote_if`
+        // is a no-op on identity mismatch, so the counter survives.
+        drop(got1);
+        drop(sib1);
+        let sib2 = SIBinder::new(Arc::new(Dummy)).unwrap();
+        let (got2, _) = st.remote_proxy(addr, || sib2.clone());
+        let p2 = Arc::as_ptr(got2.as_arc()) as *const ();
+        st.forget_remote_if(&addr, p1);
+        assert_eq!(
+            st.next_send_async_number(addr),
+            2,
+            "stale forget must not evict the live counter"
+        );
+
+        // Genuine `forget`: counter drops + next read auto-creates
+        // (back to 0).
+        drop(got2);
+        drop(sib2);
+        st.forget_remote_if(&addr, p2);
+        assert_eq!(
+            st.next_send_async_number(addr),
+            0,
+            "post-forget counter restarts from 0 (peer's BinderNode \
+             reaches timesSent=0 in lockstep with the matching DEC)"
+        );
     }
 
     /// **Phase A F7** balance (state level): the AOSP

--- a/rsbinder/src/rpc/transport/mem.rs
+++ b/rsbinder/src/rpc/transport/mem.rs
@@ -1,16 +1,15 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! In-process transport for hermetic tests (subplan 2-1, AC-1.4).
+//! In-process transport for hermetic tests.
 //!
 //! No sockets, no kernel: a pair of `mpsc` channels. One channel
 //! message **is** one frame, so the length-prefix framing is bypassed
 //! entirely. Two `MemTransport`s from [`MemTransport::pair`] are wired
 //! cross-over so a write on one is a read on the other.
 //!
-//! Per **P6** there is no global state — every test makes its own
-//! independent pair, so the RPC test suite is parallel-safe by
-//! construction.
+//! There is no global state — every test makes its own independent
+//! pair, so the RPC test suite is parallel-safe by construction.
 
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Mutex;
@@ -20,11 +19,10 @@ use crate::rpc::{RpcError, RpcResult};
 
 /// An in-process, in-memory framed transport endpoint.
 ///
-/// **m14 fix (review 2026-05-21)**: `tx: Sender<…>` (no `Mutex`).
-/// `mpsc::Sender` is `Sync + Clone` and `Sender::send` takes `&self`,
-/// so wrapping it in a `Mutex` only serialized unrelated senders
-/// without protecting anything. `Receiver` stays under `Mutex` (it is
-/// `!Sync`).
+/// `tx: Sender<…>` is not wrapped in a `Mutex`: `mpsc::Sender` is
+/// `Sync + Clone` and `Sender::send` takes `&self`, so a `Mutex` would
+/// only serialize unrelated senders without protecting anything.
+/// `Receiver` stays under `Mutex` (it is `!Sync`).
 pub struct MemTransport {
     tx: Sender<Vec<u8>>,
     rx: Mutex<Receiver<Vec<u8>>>,
@@ -142,7 +140,7 @@ mod tests {
         assert!(matches!(a.send_frame(b"x"), Err(RpcError::PeerClosed)));
     }
 
-    /// AC-1.4: bidirectional simultaneous traffic must not deadlock or
+    /// Bidirectional simultaneous traffic must not deadlock or
     /// lose/reorder frames. Two threads cross-fire 10k frames each.
     #[test]
     fn mem_bidirectional_concurrent_no_deadlock() {

--- a/rsbinder/src/rpc/transport/mod.rs
+++ b/rsbinder/src/rpc/transport/mod.rs
@@ -1,24 +1,24 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Transport abstraction for the RPC stack (subplan 2-1).
+//! Transport abstraction for the RPC stack.
 //!
 //! A [`RpcTransport`] carries **length-framed byte messages** for one
 //! RPC connection and reports the [`PeerIdentity`] of the other end.
 //! The implementation *defines the trust boundary*: a `unix` socket
-//! trusts filesystem permissions + `SO_PEERCRED`; `vsock` (2-4) trusts
-//! hypervisor VM isolation; `tls` (2-4) trusts a certificate; the gated
+//! trusts filesystem permissions + `SO_PEERCRED`; `vsock` trusts
+//! hypervisor VM isolation; `tls` trusts a certificate; the gated
 //! `tcp_debug` backend trusts **nothing** and is debug/interop only.
 //!
 //! Framing is the transport's responsibility (not the wire codec's), so
-//! the 2-2 wire layer can think purely in whole messages. Stream
-//! backends (`unix`, `tcp_debug`) share the length-prefix helpers in
-//! this module; the in-process `mem` backend frames implicitly (one
-//! channel message == one frame).
+//! the wire layer can think purely in whole messages. Stream backends
+//! (`unix`, `tcp_debug`) share the length-prefix helpers in this
+//! module; the in-process `mem` backend frames implicitly (one channel
+//! message == one frame).
 //!
 //! The trait is **synchronous / blocking** (matches android-12 r34's
 //! blocking-thread model). An `async` adapter can be layered *on top*
-//! without changing this trait — see subplan 2-3 §7-2.
+//! without changing this trait.
 
 use std::fmt;
 use std::io::{ErrorKind, Read, Write};
@@ -47,8 +47,8 @@ pub use vsock::VsockTransport;
 ///
 /// A length header declaring more than this is rejected **before any
 /// allocation** — an adversarial peer cannot trigger an OOM by claiming
-/// a huge body (V4 / AC-1.8 / plan 2-1 §6.3). 64 MiB is far above any
-/// legitimate binder transaction yet bounded.
+/// a huge body. 64 MiB is far above any legitimate binder transaction
+/// yet bounded.
 pub const MAX_FRAME_LEN: usize = 64 * 1024 * 1024;
 
 /// One RPC connection: framed byte transport + peer identity.
@@ -56,9 +56,8 @@ pub const MAX_FRAME_LEN: usize = 64 * 1024 * 1024;
 /// Synchronous and blocking. `&self` (not `&mut self`) so a session can
 /// hold one transport and use it from a sender thread and a receiver
 /// thread concurrently — full-duplex sockets and the `mem` channel pair
-/// both support that without a deadlock (AC-1.4). Implementations must
-/// keep `send_frame`/`recv_frame` independently callable from two
-/// threads.
+/// both support that without a deadlock. Implementations must keep
+/// `send_frame`/`recv_frame` independently callable from two threads.
 pub trait RpcTransport: Send + Sync {
     /// Send exactly one logical frame. The implementation guarantees
     /// framing (length prefix or channel message boundary).
@@ -86,7 +85,7 @@ pub trait RpcTransport: Send + Sync {
     fn describe(&self) -> &str;
 
     /// Set a read deadline for subsequent [`RpcTransport::recv_frame`]
-    /// calls (subplan 2-3). `None` clears it (fully blocking). The
+    /// calls. `None` clears it (fully blocking). The
     /// default is a no-op for backends with no read-timeout notion;
     /// `unix` / `mem` / `tcp_debug` override it. A deadline that
     /// elapses with **nothing consumed** surfaces as
@@ -96,13 +95,13 @@ pub trait RpcTransport: Send + Sync {
         Ok(())
     }
 
-    /// Send one frame plus passed file descriptors out-of-band
-    /// (subplan 2-7, opt-in `FileDescriptorTransportMode::Unix`).
+    /// Send one frame plus passed file descriptors out-of-band (opt-in
+    /// `FileDescriptorTransportMode::Unix`).
     ///
     /// The **default rejects any fd** — so `mem`/`vsock`/`tls` are
-    /// fd-incapable *by type*, with no extra code (plan 2-7 §4). Only
-    /// `unix` overrides this with `SCM_RIGHTS`. An empty `fds` slice
-    /// falls back to the plain framed send.
+    /// fd-incapable *by type*, with no extra code. Only `unix` overrides
+    /// this with `SCM_RIGHTS`. An empty `fds` slice falls back to the
+    /// plain framed send.
     fn send_frame_with_fds(
         &self,
         buf: &[u8],
@@ -117,22 +116,20 @@ pub trait RpcTransport: Send + Sync {
         }
     }
 
-    /// Receive one frame plus any out-of-band file descriptors
-    /// (subplan 2-7). Default: never yields fds (the plain framed
-    /// recv); only `unix` overrides with `SCM_RIGHTS`.
+    /// Receive one frame plus any out-of-band file descriptors.
+    /// Default: never yields fds (the plain framed recv); only `unix`
+    /// overrides with `SCM_RIGHTS`.
     fn recv_frame_with_fds(&self) -> RpcResult<(Vec<u8>, Vec<std::os::fd::OwnedFd>)> {
         Ok((self.recv_frame()?, Vec::new()))
     }
 
     /// Send raw bytes with **no framing**. The real android RPC wire
     /// has no length prefix (`RpcState::rpcSend` writes the
-    /// `RpcWireHeader` + body directly) — the android-13+ profile
-    /// (subplan 2-5b / G4) drives framing itself via
-    /// `wire_android13`. The default is
-    /// **unsupported**, so `mem`/`tls`/`vsock` stay frame-only *by
-    /// type* (no extra code); only `unix` overrides it. The existing
-    /// R34 path never calls this — `send_frame`/`recv_frame` are
-    /// byte-unchanged.
+    /// `RpcWireHeader` + body directly) — the android-13+ profile drives
+    /// framing itself via `wire_android13`. The default is
+    /// **unsupported**, so `mem`/`tls`/`vsock` stay frame-only *by type*
+    /// (no extra code); only `unix` overrides it. The existing R34 path
+    /// never calls this — `send_frame`/`recv_frame` are byte-unchanged.
     fn send_raw(&self, _buf: &[u8]) -> RpcResult<()> {
         Err(RpcError::Protocol("this transport has no raw byte access"))
     }
@@ -145,9 +142,9 @@ pub trait RpcTransport: Send + Sync {
     }
 
     /// Send raw bytes with **no framing**, passing `fds` out-of-band via
-    /// `SCM_RIGHTS` (subplan 2-11 Phase A0 — the android-13+ v1+
-    /// `Unix` FD-over-RPC path). This is [`RpcTransport::send_raw`] +
-    /// the ancillary channel of [`RpcTransport::send_frame_with_fds`],
+    /// `SCM_RIGHTS` (the android-13+ v1+ `Unix` FD-over-RPC path). This
+    /// is [`RpcTransport::send_raw`] + the ancillary channel of
+    /// [`RpcTransport::send_frame_with_fds`],
     /// minus the length prefix: the real android RPC wire has none
     /// (`RpcWireHeader.bodySize` is authoritative) and AOSP rides the
     /// fds on the **first** `sendmsg` of the message
@@ -166,8 +163,8 @@ pub trait RpcTransport: Send + Sync {
     }
 
     /// Read up to `buf.len()` raw bytes (one `recvmsg`; `Ok((0, _))` =
-    /// peer closed) plus any `SCM_RIGHTS` fds delivered with them
-    /// (subplan 2-11 Phase A0). Pairs with
+    /// peer closed) plus any `SCM_RIGHTS` fds delivered with them.
+    /// Pairs with
     /// [`RpcTransport::send_raw_with_fds`]; received fds are
     /// `O_CLOEXEC`. AOSP accumulates ancillary fds across the
     /// `recvmsg`s that read one message
@@ -181,8 +178,8 @@ pub trait RpcTransport: Send + Sync {
 
 /// Identity of the peer on the other end of a [`RpcTransport`].
 ///
-/// `#[non_exhaustive]`: subplan 2-4 adds `Certificate(..)` (TLS) and
-/// `Vsock { cid }` variants. Matching code must keep a wildcard arm.
+/// `#[non_exhaustive]`: matching code must keep a wildcard arm, since
+/// further variants may be added.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum PeerIdentity {
@@ -197,13 +194,13 @@ pub enum PeerIdentity {
     },
     /// A vsock peer, identified by its context id. **Not an ACL
     /// basis** — `cid` is a routing address, and the trust boundary is
-    /// hypervisor VM isolation (subplan 2-4 R1). Logged with the cid.
+    /// hypervisor VM isolation. Logged with the cid.
     Vsock {
         /// vsock context id of the peer VM/host.
         cid: u32,
     },
-    /// A TLS peer authenticated by its leaf certificate (subplan 2-4
-    /// track T). The trust boundary is the certificate chain.
+    /// A TLS peer authenticated by its leaf certificate. The trust
+    /// boundary is the certificate chain.
     Certificate(CertId),
     /// No identity is available. **ACL is not possible** against an
     /// anonymous peer; this must be surfaced in logs and never treated
@@ -211,9 +208,9 @@ pub enum PeerIdentity {
     Anonymous,
 }
 
-/// Identity extracted from a peer's TLS leaf certificate (subplan
-/// 2-4 track T). Carries the subject and a SHA-256 fingerprint; ACL
-/// is the caller's responsibility on top of this.
+/// Identity extracted from a peer's TLS leaf certificate. Carries the
+/// subject and a SHA-256 fingerprint; ACL is the caller's
+/// responsibility on top of this.
 #[derive(Clone, PartialEq, Eq)]
 pub struct CertId {
     subject: String,
@@ -353,7 +350,7 @@ fn read_header<R: Read>(r: &mut R, buf: &mut [u8]) -> RpcResult<()> {
             Err(e) if e.kind() == ErrorKind::Interrupted => continue,
             // A read deadline that elapses with nothing consumed is a
             // clean Timeout (stream still frame-synchronized); mid-
-            // header it is a desync → Truncated (2-3 §timeout).
+            // header it is a desync → Truncated.
             Err(e) if is_timeout(&e) => {
                 return Err(if filled == 0 {
                     RpcError::Timeout
@@ -407,8 +404,8 @@ pub(crate) fn read_frame<R: Read>(r: &mut R) -> RpcResult<Vec<u8>> {
 }
 
 /// Decode-only entrypoint for the `rpc_frame_decode` fuzz target and
-/// the deterministic adversarial-input regression tests (plan 2-1
-/// §6.3). Feeds arbitrary bytes through the same deframing path
+/// the deterministic adversarial-input regression tests. Feeds
+/// arbitrary bytes through the same deframing path
 /// `recv_frame` uses. `#[doc(hidden)]`: not part of the supported API
 /// surface (and absent entirely without the `rpc` feature).
 #[doc(hidden)]
@@ -441,7 +438,7 @@ mod tests {
         assert_eq!(read_frame(&mut cur).unwrap(), b"second");
     }
 
-    /// T1.7 deterministic adversarial cases — must reject without
+    /// Deterministic adversarial cases — must reject without
     /// allocating, panicking, or looping (mirrors the fuzz target).
     #[test]
     fn hostile_frame_headers_are_rejected_safely() {

--- a/rsbinder/src/rpc/transport/mod.rs
+++ b/rsbinder/src/rpc/transport/mod.rs
@@ -38,7 +38,7 @@ pub use mem::MemTransport;
 #[cfg(feature = "rpc-tcp-debug")]
 pub use tcp_debug::{insecure_warning_emitted, TcpDebugTransport};
 #[cfg(feature = "rpc-tls")]
-pub use tls::TlsTransport;
+pub use tls::{TlsStream, TlsTransport};
 pub use unix::UnixTransport;
 #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
 pub use vsock::VsockTransport;

--- a/rsbinder/src/rpc/transport/tcp_debug.rs
+++ b/rsbinder/src/rpc/transport/tcp_debug.rs
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! **INSECURE** plaintext TCP transport — DEBUG / interop bring-up
-//! ONLY (subplan 2-1 §2-1.f2 / AC-1.8). Gated behind the
-//! `rpc-tcp-debug` feature so it is absent from a plain `rpc` build.
+//! ONLY. Gated behind the `rpc-tcp-debug` feature so it is absent from
+//! a plain `rpc` build.
 //!
 //! Android precedent: android-12 r34 RPC binder has `SocketType::INET`
 //! and `binderRpcTest.cpp` uses an INET loopback as a *test* transport.
 //! This is the rsbinder equivalent — for observing the R34 wire with
-//! `tcpdump`, for live r34 interop (subplan 2-5a) over standard INET
-//! loopback, and for macOS development (no `SO_PEERCRED`).
+//! `tcpdump`, for live r34 interop over standard INET loopback, and for
+//! macOS development (no `SO_PEERCRED`).
 //!
 //! **Never production.** Safeguards baked in by type/construction:
 //! * [`PeerIdentity::Anonymous`] is hard-wired — there is no code path
@@ -19,7 +19,7 @@
 //!   separate, explicitly-named, warned constructor.
 //! * A loud one-time warning is logged the first time this transport is
 //!   used in a process.
-//! * For real networks use the `tls` backend (subplan 2-4) instead.
+//! * For real networks use the `tls` backend instead.
 
 use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 use std::os::fd::OwnedFd;
@@ -30,7 +30,7 @@ use crate::rpc::RpcResult;
 
 /// Set the first time *any* `TcpDebugTransport` is constructed in this
 /// process. Drives the one-time insecure warning and lets tests assert
-/// the warning fired (AC-1.8a) without capturing the log backend.
+/// the warning fired without capturing the log backend.
 static INSECURE_WARNED: AtomicBool = AtomicBool::new(false);
 
 fn warn_once() {
@@ -43,7 +43,7 @@ fn warn_once() {
 }
 
 /// `true` once the process-wide insecure warning has been emitted.
-/// Test/diagnostic hook (AC-1.8a).
+/// Test/diagnostic hook.
 pub fn insecure_warning_emitted() -> bool {
     INSECURE_WARNED.load(Ordering::SeqCst)
 }
@@ -68,8 +68,8 @@ impl TcpDebugTransport {
         Ok(TcpDebugTransport { stream, desc })
     }
 
-    /// Wrap a preconnected `OwnedFd` (subplan 2-13 A0.2 — the
-    /// `IAccessor::addConnection()` fd-adopt path, `AF_INET` family).
+    /// Wrap a preconnected `OwnedFd` (the `IAccessor::addConnection()`
+    /// fd-adopt path, `AF_INET` family).
     /// `std`'s `From<OwnedFd> for TcpStream` is stable cross-platform;
     /// the caller is responsible for asserting the fd's address family.
     pub fn from_owned_fd(fd: OwnedFd) -> RpcResult<Self> {
@@ -84,8 +84,7 @@ impl TcpDebugTransport {
     }
 
     /// Bind a listener on an ephemeral **loopback** port. The default,
-    /// safe bind. Server accept loop is subplan 2-3; this returns the
-    /// raw listener for tests / bring-up.
+    /// safe bind. Returns the raw listener for tests / bring-up.
     pub fn bind_loopback() -> RpcResult<TcpListener> {
         warn_once();
         Ok(TcpListener::bind(SocketAddr::from((
@@ -157,7 +156,7 @@ mod tests {
     fn tcp_debug_roundtrip_and_safeguards() {
         let (client, server) = TcpDebugTransport::pair_loopback().expect("loopback pair");
 
-        // AC-1.8a: identity is hard-wired Anonymous on both ends.
+        // Identity is hard-wired Anonymous on both ends.
         assert_eq!(client.peer_identity(), PeerIdentity::Anonymous);
         assert_eq!(server.peer_identity(), PeerIdentity::Anonymous);
         // The one-time insecure warning must have fired by now.
@@ -176,8 +175,8 @@ mod tests {
         }
     }
 
-    /// Subplan 2-13 A0.2: `from_owned_fd` adopt → frame roundtrip.
-    /// Mirrors the `unix` counterpart but uses the TCP loopback pair.
+    /// `from_owned_fd` adopt → frame roundtrip. Mirrors the `unix`
+    /// counterpart but uses the TCP loopback pair.
     #[test]
     fn tcp_debug_from_owned_fd_roundtrip() {
         use std::os::fd::OwnedFd;

--- a/rsbinder/src/rpc/transport/tls.rs
+++ b/rsbinder/src/rpc/transport/tls.rs
@@ -1,20 +1,20 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! TLS transport over **rustls** (subplan 2-4 track T; decoupled in 2-15).
+//! TLS transport over **rustls**.
 //!
 //! Trust boundary: the TLS certificate chain. rsbinder **never invents
 //! crypto** — key/cert/root management and all verification are the
-//! caller's `rustls::ClientConfig`/`ServerConfig` and rustls itself
-//! (plan §5). A failed certificate check is rejected at the handshake,
-//! before a single RPC payload byte is exchanged (AC-4.5).
+//! caller's `rustls::ClientConfig`/`ServerConfig` and rustls itself.
+//! A failed certificate check is rejected at the handshake, before a
+//! single RPC payload byte is exchanged.
 //!
 //! The peer identity is the leaf certificate: subject label + SHA-256
 //! fingerprint ([`super::CertId`]). There is deliberately **no
 //! plaintext-network backend** — `tcp_debug` is debug-only and
 //! `Anonymous`; real networks must use this.
 //!
-//! ## Decoupled from TCP and from framing (subplan 2-15)
+//! ## Decoupled from TCP and from framing
 //!
 //! TLS is **orthogonal to the socket kind** (mirrors AOSP
 //! `RpcTransportCtx::newTransport(fd)`): the crypto state machine
@@ -25,7 +25,7 @@
 //! and the android-13+ raw I/O (`send_raw`/`recv_raw`), so the opt-in
 //! android-13+ `RpcSession` profile can run over TLS.
 //!
-//! ## Concurrency (the keystone, 2-15 §2.0)
+//! ## Concurrency
 //!
 //! `Connection` (crypto) is behind a `Mutex` that is held **only for
 //! in-memory work** — ciphertext is produced into a buffer, then the
@@ -143,7 +143,7 @@ impl Write for IoAdapter<'_> {
 }
 
 /// A framed-or-raw transport over a completed TLS connection, decoupled
-/// from the socket kind and from the wire profile (subplan 2-15).
+/// from the socket kind and from the wire profile.
 pub struct TlsTransport {
     /// rustls crypto state (both directions). Held **only for in-memory
     /// work** — never across a blocking socket op.
@@ -163,7 +163,7 @@ pub struct TlsTransport {
 /// SHA-256 of the peer's leaf certificate, as a [`CertId`]. `subject`
 /// is a caller-meaningful label (the SNI for a client-side peer, a
 /// fixed marker for an mTLS client) — rsbinder does not parse X.509;
-/// the fingerprint is the authoritative identity (plan 2-4.t2).
+/// the fingerprint is the authoritative identity.
 fn cert_identity(
     certs: Option<&[rustls::pki_types::CertificateDer<'_>]>,
     subject: &str,
@@ -180,7 +180,7 @@ fn cert_identity(
 
 /// Drive the TLS handshake to completion over `stream` (blocking,
 /// single-threaded — before the connection is shared). A verification
-/// failure surfaces here, before any RPC payload (AC-4.5).
+/// failure surfaces here, before any RPC payload.
 fn drive_handshake(conn: &mut Connection, stream: &dyn TlsStream) -> RpcResult<()> {
     let mut io = IoAdapter(stream);
     while conn.is_handshaking() {
@@ -221,7 +221,7 @@ impl TlsTransport {
 
     /// Server side over **any** stream: TLS-handshake per `config`. With
     /// an mTLS config the client certificate is required + verified by
-    /// rustls; its absence/invalidity fails the handshake here (AC-4.5).
+    /// rustls; its absence/invalidity fails the handshake here.
     pub fn accept_stream(
         stream: Box<dyn TlsStream>,
         config: Arc<rustls::ServerConfig>,
@@ -294,9 +294,8 @@ impl TlsTransport {
     /// these control records) in sequence order under its own `wlock`,
     /// and `recv_raw` retries on its next iteration. This keeps the
     /// reader from ever blocking behind a (possibly back-pressured)
-    /// socket write — preserving the lock-free-duplex liveness the
-    /// keystone (§2.0) provides, while still ordering every write_tls →
-    /// transmit under `wlock`.
+    /// socket write — preserving the lock-free-duplex liveness, while
+    /// still ordering every write_tls → transmit under `wlock`.
     fn flush_control(&self) -> RpcResult<()> {
         let Ok(_g) = self.wlock.try_lock() else {
             return Ok(());

--- a/rsbinder/src/rpc/transport/unix.rs
+++ b/rsbinder/src/rpc/transport/unix.rs
@@ -1,15 +1,14 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Unix-domain-socket transport (subplan 2-1).
+//! Unix-domain-socket transport.
 //!
 //! Trust boundary: filesystem permissions on the socket path plus
 //! `SO_PEERCRED`. Plaintext is *correct* here — the kernel is the trust
-//! boundary (plan 2 §5, the original cross-domain bridge use case).
+//! boundary (the original cross-domain bridge use case).
 //!
-//! This subplan provides connected-stream wrapping, a `socketpair`
-//! constructor for tests, and a `connect(path)` convenience. The
-//! server-side `bind`/`listen`/`accept` loop is subplan 2-3.
+//! Provides connected-stream wrapping, a `socketpair` constructor for
+//! tests, and a `connect(path)` convenience.
 
 use std::io::{Read, Write};
 use std::os::fd::OwnedFd;
@@ -19,12 +18,11 @@ use std::path::Path;
 use super::{read_frame, write_frame, PeerIdentity, RpcTransport, MAX_FRAME_LEN};
 use crate::rpc::{RpcError, RpcResult};
 
-/// Max fds a single RPC frame may carry (DoS bound — plan 2-7.d /
-/// AC-7.5). Well under the kernel `SCM_MAX_FD` (253). `pub(crate)`
-/// so the wire codec layer (`wire_android13::read_aosp_message_with_fds`)
-/// can enforce the *per-message* cap when accumulating across the
-/// multiple `recvmsg`s that read one message body (C3 fix —
-/// review 2026-05-21).
+/// Max fds a single RPC frame may carry (DoS bound). Well under the
+/// kernel `SCM_MAX_FD` (253). `pub(crate)` so the wire codec layer
+/// (`wire_android13::read_aosp_message_with_fds`) can enforce the
+/// *per-message* cap when accumulating across the multiple `recvmsg`s
+/// that read one message body.
 pub(crate) const MAX_FDS_PER_FRAME: usize = 64;
 
 /// A framed transport over a connected Unix domain socket.
@@ -35,7 +33,7 @@ pub struct UnixTransport {
     /// Buffered `recvmsg` leftover, used **only** by the
     /// `recv_frame_with_fds` (SCM_RIGHTS) path so a connection in
     /// `Unix` fd-mode never mixes `Read` and `recvmsg` on the same fd.
-    /// The default (no-fd) path is untouched (AC-7.1 bit-identical).
+    /// The default (no-fd) path is untouched (bit-identical).
     fd_recv_buf: std::sync::Mutex<Vec<u8>>,
 }
 
@@ -81,8 +79,8 @@ impl UnixTransport {
         ))
     }
 
-    /// Wrap a preconnected Unix-domain `OwnedFd` (subplan 2-13 A0.2 —
-    /// the `IAccessor::addConnection()` fd-adopt path). `std`'s
+    /// Wrap a preconnected Unix-domain `OwnedFd` (the
+    /// `IAccessor::addConnection()` fd-adopt path). `std`'s
     /// `From<OwnedFd> for UnixStream` is stable cross-platform (Linux +
     /// macOS), and the resulting transport is byte-identical to
     /// [`UnixTransport::from_stream`] — peer identity is resolved the
@@ -94,7 +92,6 @@ impl UnixTransport {
     }
 
     /// Connect to a listening Unix socket at `path` (client side).
-    /// `bind`/`listen`/`accept` is subplan 2-3.
     pub fn connect(path: impl AsRef<Path>) -> RpcResult<Self> {
         // `RpcError: From<std::io::Error>` — `?` does the conversion.
         let stream = UnixStream::connect(path)?;
@@ -105,28 +102,19 @@ impl UnixTransport {
 /// Resolve the peer identity of a connected Unix socket.
 ///
 /// * **Linux**: real `SO_PEERCRED` (the peer's actual uid/pid).
-/// * **macOS / BSD** (subplan 2-9 Phase A): real `getpeereid` (peer
-///   effective uid) + `LOCAL_PEERPID` (peer pid on macOS). This is the
-///   **true peer** for an accepted cross-process socket, and *this
-///   process* for a `socketpair` (correct — both ends are us; Phase
-///   A.0 measured Darwin 25.4: `getpeereid`/`LOCAL_PEERPID` succeed for
-///   both and return self for a socketpair, the real peer for an
-///   accepted fd). A `getpeereid` failure is **never** reported as a
-///   forged `Local`: a same-process / unconnected errno
-///   (`ENOTCONN`/`EINVAL`) falls back to the self identity (still the
-///   correct answer there), any other error to
+/// * **macOS / BSD**: real `getpeereid` (peer effective uid) +
+///   `LOCAL_PEERPID` (peer pid on macOS). This is the **true peer** for
+///   an accepted cross-process socket, and *this process* for a
+///   `socketpair` (correct — both ends are us). A `getpeereid` failure
+///   is **never** reported as a forged `Local`: a same-process /
+///   unconnected errno (`ENOTCONN`/`EINVAL`) falls back to the self
+///   identity (still the correct answer there), any other error to
 ///   [`PeerIdentity::Anonymous`] (no ACL possible — logged loudly).
-///
-/// Before Phase A the non-Linux arm reported the **current process**
-/// for *every* socket — i.e. a server's `peer_identity()` for an
-/// accepted cross-process connection was the *server itself*, an
-/// authoritative-looking forged identity (the §0 contract defect).
 fn resolve_peer(stream: &UnixStream) -> PeerIdentity {
     // Android's bionic has no `getpeereid`, but its kernel supports
     // `SO_PEERCRED` exactly like Linux — so android takes the Linux
     // arm (otherwise the `not(target_os="linux")` BSD arm would pull in
-    // `libc::getpeereid` and break the aarch64-linux-android build,
-    // e.g. the subplan 2-8/2-11 emulator interop harness).
+    // `libc::getpeereid` and break the aarch64-linux-android build).
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         match rustix::net::sockopt::socket_peercred(stream) {
@@ -150,9 +138,9 @@ fn resolve_peer(stream: &UnixStream) -> PeerIdentity {
     }
 }
 
-/// macOS/BSD peer resolution — the subplan 2-9 Phase A failure-mode
-/// -driven fallback ladder. `getpeereid` is connect-time
-/// kernel-vouched (the BSD analogue of `SO_PEERCRED`).
+/// macOS/BSD peer resolution — a failure-mode-driven fallback ladder.
+/// `getpeereid` is connect-time kernel-vouched (the BSD analogue of
+/// `SO_PEERCRED`).
 #[cfg(all(unix, not(target_os = "linux"), not(target_os = "android")))]
 fn resolve_peer_bsd(stream: &UnixStream) -> PeerIdentity {
     use std::os::fd::AsRawFd;
@@ -172,9 +160,8 @@ fn resolve_peer_bsd(stream: &UnixStream) -> PeerIdentity {
             // path. Either way it is the *same process* (there is no
             // remote peer), so the self identity is the correct,
             // non-forged answer and the hermetic socketpair test still
-            // holds on such platforms (Phase A ladder branch 2 —
-            // defensive; not reached on Darwin 25.4, where a
-            // socketpair *does* populate peercred → branch 1 → self).
+            // holds on such platforms (defensive; on macOS a socketpair
+            // *does* populate peercred, so this branch is not reached).
             Some(libc::ENOTCONN) | Some(libc::EINVAL) => super::mem::self_identity(),
             // Any other error: NEVER a forged `Local`. No ACL is
             // possible against an unknown peer — surface it loudly.
@@ -260,8 +247,8 @@ impl RpcTransport for UnixTransport {
         r.read(buf).map_err(RpcError::from)
     }
 
-    /// Raw, **unframed** write + `SCM_RIGHTS` (subplan 2-11 Phase A0:
-    /// the android-13+ v1+ `Unix` FD-over-RPC path). Identical to
+    /// Raw, **unframed** write + `SCM_RIGHTS` (the android-13+ v1+
+    /// `Unix` FD-over-RPC path). Identical to
     /// [`UnixTransport::send_frame_with_fds`] minus the 4-byte length
     /// prefix — the AOSP RPC wire has none. The fds ride the **first**
     /// `sendmsg` (AOSP `RpcTransportRaw::interruptableWriteFully`,
@@ -299,9 +286,7 @@ impl RpcTransport for UnixTransport {
                 SendFlags::empty(),
             ) {
                 Ok(n) => n,
-                // M10 fix (review 2026-05-21): EINTR is benign — retry
-                // the syscall. Symmetric with `read_header`/`read_body`
-                // in transport/mod.rs.
+                // EINTR is benign — retry the syscall.
                 Err(rustix::io::Errno::INTR) => continue,
                 Err(e) => return Err(std::io::Error::from(e).into()),
             };
@@ -313,8 +298,8 @@ impl RpcTransport for UnixTransport {
         Ok(())
     }
 
-    /// Raw, **unframed** read (one `recvmsg`) + any `SCM_RIGHTS` fds
-    /// (subplan 2-11 Phase A0). Pairs with
+    /// Raw, **unframed** read (one `recvmsg`) + any `SCM_RIGHTS` fds.
+    /// Pairs with
     /// [`UnixTransport::send_raw_with_fds`]; received fds are
     /// `O_CLOEXEC` (set explicitly — `MSG_CMSG_CLOEXEC` is Linux-only).
     /// `Ok((0, _))` ⇒ peer closed. Unlike
@@ -340,7 +325,7 @@ impl RpcTransport for UnixTransport {
                 RecvFlags::empty(),
             ) {
                 Ok(r) => break r,
-                // M10 fix: EINTR retry, symmetric with read_header.
+                // EINTR retry, symmetric with read_header.
                 Err(rustix::io::Errno::INTR) => continue,
                 Err(e) => return Err(std::io::Error::from(e).into()),
             }
@@ -374,7 +359,7 @@ impl RpcTransport for UnixTransport {
     }
 
     /// Send `buf` as a length-prefixed frame, passing `fds` out-of-band
-    /// via `SCM_RIGHTS` (subplan 2-7, `Unix` fd-mode). The ancillary
+    /// via `SCM_RIGHTS` (`Unix` fd-mode). The ancillary
     /// fds ride the **first** `sendmsg`; remaining bytes (rare — fd
     /// transactions are tiny) follow without ancillary.
     fn send_frame_with_fds(
@@ -417,7 +402,7 @@ impl RpcTransport for UnixTransport {
                 SendFlags::empty(),
             ) {
                 Ok(n) => n,
-                // M10 fix: EINTR retry, symmetric with read_header.
+                // EINTR retry, symmetric with read_header.
                 Err(rustix::io::Errno::INTR) => continue,
                 Err(e) => return Err(std::io::Error::from(e).into()),
             };
@@ -461,7 +446,7 @@ impl RpcTransport for UnixTransport {
             let mut anc = RecvAncillaryBuffer::new(&mut space);
             // `RecvFlags::CMSG_CLOEXEC` (`MSG_CMSG_CLOEXEC`) is
             // Linux-only; for portability set `FD_CLOEXEC` explicitly
-            // on each received fd (plan 2-7.d "received fd O_CLOEXEC").
+            // on each received fd.
             let r = loop {
                 match rustix::net::recvmsg(
                     &self.stream,
@@ -470,14 +455,13 @@ impl RpcTransport for UnixTransport {
                     RecvFlags::empty(),
                 ) {
                     Ok(r) => break r,
-                    // M10 fix: EINTR retry.
+                    // EINTR retry.
                     Err(rustix::io::Errno::INTR) => continue,
                     Err(e) => {
-                        // M12 fix (review 2026-05-21): map a read
-                        // deadline to `Timeout` (frame-synchronized,
-                        // nothing consumed) or `Truncated` (mid-frame
-                        // desync) so callers can distinguish — same
-                        // contract as `read_header`/`read_body`.
+                        // Map a read deadline to `Timeout` (frame-
+                        // synchronized, nothing consumed) or `Truncated`
+                        // (mid-frame desync) so callers can distinguish
+                        // — same contract as `read_header`/`read_body`.
                         let io_err = std::io::Error::from(e);
                         if super::is_timeout(&io_err) {
                             return Err(if leftover.is_empty() && fds.is_empty() {
@@ -562,12 +546,12 @@ mod tests {
     fn unix_peer_closed_on_drop() {
         let (a, b) = UnixTransport::pair().expect("socketpair");
         drop(b);
-        // First recv sees EOF -> clean PeerClosed (T1.5).
+        // First recv sees EOF -> clean PeerClosed.
         assert!(matches!(a.recv_frame(), Err(RpcError::PeerClosed)));
     }
 
-    /// Subplan 2-13 A0.2: adopt one half of a `socketpair` via
-    /// `from_owned_fd` and verify it framed-roundtrips against the other
+    /// Adopt one half of a `socketpair` via `from_owned_fd` and verify
+    /// it framed-roundtrips against the other
     /// half (`from_stream`). Exercises the `IAccessor::addConnection`-
     /// style "we hand the transport a connected fd, not a path" entry
     /// point without touching the filesystem.
@@ -599,13 +583,11 @@ mod tests {
 
     #[test]
     fn unix_partial_header_then_close_is_truncated() {
-        // m8 fix (review 2026-05-21): the spec is deterministic —
-        // 2-of-4 header bytes consumed *then* EOF MUST surface as
-        // `Truncated` (see `read_header` in transport/mod.rs:341 —
-        // `filled == 0` ⇒ `PeerClosed`, `filled > 0` ⇒ `Truncated`).
-        // The kernel does not coalesce these into an immediate EOF,
-        // so the previous permissive `Truncated | PeerClosed`
-        // assertion was masking a real regression class.
+        // The spec is deterministic — 2-of-4 header bytes consumed
+        // *then* EOF MUST surface as `Truncated` (see `read_header` in
+        // transport/mod.rs: `filled == 0` ⇒ `PeerClosed`, `filled > 0`
+        // ⇒ `Truncated`). The kernel does not coalesce these into an
+        // immediate EOF.
         let (a, b) = UnixTransport::pair().expect("socketpair");
         {
             use std::io::Write;

--- a/rsbinder/src/rpc/transport/vsock.rs
+++ b/rsbinder/src/rpc/transport/vsock.rs
@@ -1,24 +1,23 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! vsock transport (subplan 2-4 track V) — **Linux / Android** (the
-//! `vsock` crate's `AF_VSOCK` impl covers both `target_os = "linux"` and
-//! `"android"`; Android is the Virtualization Framework / Microdroid pVM
-//! host↔guest target — subplan 2-15).
+//! vsock transport — **Linux / Android** (the `vsock` crate's
+//! `AF_VSOCK` impl covers both `target_os = "linux"` and `"android"`;
+//! Android is the Virtualization Framework / Microdroid pVM host↔guest
+//! target).
 //!
-//! Trust boundary: hypervisor VM isolation (plan §5). Plaintext is
-//! *correct* here, exactly as for `unix` on a single host. The peer
-//! identity is [`PeerIdentity::Vsock`] carrying the context id — a
-//! **routing address, not an ACL basis** (subplan 2-4 R1): the
-//! hypervisor, not the cid value, is the trust boundary; the cid is
-//! logged for diagnostics.
+//! Trust boundary: hypervisor VM isolation. Plaintext is *correct*
+//! here, exactly as for `unix` on a single host. The peer identity is
+//! [`PeerIdentity::Vsock`] carrying the context id — a **routing
+//! address, not an ACL basis**: the hypervisor, not the cid value, is
+//! the trust boundary; the cid is logged for diagnostics.
 //!
-//! Additive invariant (AC-4.1): this file + the feature + the
-//! `PeerIdentity::Vsock` variant are the only change — the 2-2/2-3
-//! core is untouched and runs unmodified with the transport swapped.
+//! Additive: this file + the feature + the `PeerIdentity::Vsock`
+//! variant are the only change — the core is untouched and runs
+//! unmodified with the transport swapped.
 //!
 //! Tests are Linux+VM and `#[ignore]` by default (need a peer VM or
-//! `VMADDR_CID_LOCAL`), per the plan's V6 environment gate.
+//! `VMADDR_CID_LOCAL`).
 
 use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
 
@@ -29,13 +28,11 @@ use crate::rpc::RpcResult;
 
 /// A framed transport over a connected vsock stream (Linux).
 ///
-/// **M11 fix (review 2026-05-21)**: lock-free, full-duplex. `vsock`
-/// 0.5+ implements `impl Read for &VsockStream` and `impl Write for
-/// &VsockStream`, mirroring `UnixStream`, so a shared `&self` can
-/// `send_frame` while another thread `recv_frame`s without serializing
-/// through a `Mutex`. The trait doc on [`RpcTransport`] requires
-/// concurrent send+recv, which the previous `Mutex<VsockStream>`
-/// violated.
+/// Lock-free, full-duplex. `vsock` 0.5+ implements `impl Read for
+/// &VsockStream` and `impl Write for &VsockStream`, mirroring
+/// `UnixStream`, so a shared `&self` can `send_frame` while another
+/// thread `recv_frame`s without serializing through a `Mutex` — as the
+/// [`RpcTransport`] trait contract requires.
 pub struct VsockTransport {
     stream: VsockStream,
     peer: PeerIdentity,
@@ -49,7 +46,7 @@ impl VsockTransport {
         Self::from_stream(stream)
     }
 
-    /// Wrap a preconnected vsock `OwnedFd` (subplan 2-13 A0.2 — the
+    /// Wrap a preconnected vsock `OwnedFd` (the
     /// `IAccessor::addConnection()` fd-adopt path, `AF_VSOCK` family).
     /// The `vsock` crate has no public `From<OwnedFd>` for `VsockStream`
     /// so this goes through `FromRawFd` after taking ownership; the

--- a/rsbinder/src/rpc/wire.rs
+++ b/rsbinder/src/rpc/wire.rs
@@ -1,16 +1,16 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! RPC wire codec (subplan 2-2 S-b).
+//! RPC wire codec.
 //!
-//! **D3 (master §7.1):** rsbinder does not invent a wire. The Track-1
-//! wire is the [`WireCodec`] trait + [`R34Codec`], a *direct
-//! implementation of the real android-12 r34 RPC wire* (spec extracted
-//! in `plan/2-5-android-interop.md` §9). So the Track-1 round-trip and
-//! golden tests are simultaneously r34 spec-conformance (AC-2.2r) — no
-//! device, no AOSP build needed. android-13+ versioned wire is the
-//! additive [`Android13PlusCodec`](super::wire_android13::Android13PlusCodec)
-//! behind the same trait (2-5b; v0 = android-13, v1 = android-14/15).
+//! rsbinder does not invent a wire. The default codec is the
+//! [`WireCodec`] trait + [`R34Codec`], a *direct implementation of the
+//! real android-12 r34 RPC wire*, so the round-trip and golden tests are
+//! simultaneously r34 spec-conformance — no device, no AOSP build
+//! needed. The android-13+ versioned wire is the additive
+//! [`Android13PlusCodec`](super::wire_android13::Android13PlusCodec)
+//! behind the same trait (v0 = android-13, v1 = android-14/15, v2 =
+//! android-16).
 //!
 //! r34 layout (LE, explicit serialization — no `#[repr]` dependency):
 //! * `RpcWireHeader` (16B): `u32 command; u32 bodySize; u32 reserved[2]`
@@ -22,8 +22,7 @@
 //! * session preamble: a bare `int32` session id (no header)
 //!
 //! No magic / self-sync: `bodySize` is authoritative, so the decoder is
-//! strict and every length/offset is bounds-checked before use (2-2.b4
-//! / V4, baseline `d659ae3`).
+//! strict and every length/offset is bounds-checked before use.
 
 use super::address::{RpcAddress, RPC_ADDR_LEN};
 use super::transport::MAX_FRAME_LEN;
@@ -56,11 +55,11 @@ pub struct WireTransaction {
     /// AOSP `RpcFields::mObjectPositions` — the sorted byte offsets,
     /// **within `data`**, of every flattened RPC object (binder at
     /// android-16 v2, FD at v1+). Sent on the wire as a trailing LE
-    /// `u32[]` after the parcel data (subplan 2-8, android-16 v2).
-    /// **Default empty** ⇒ the wire is byte-identical to the pre-2-8
-    /// no-object encoding (the v1≡v2 invariant, AC-8.2). The R34 and
-    /// v0 wires have no object table; a non-empty table on those is a
-    /// protocol error (`validateParcel`, AC-8.4).
+    /// `u32[]` after the parcel data (android-16 v2).
+    /// **Default empty** ⇒ the wire is byte-identical to the no-object
+    /// encoding (the v1≡v2 invariant). The R34 and v0 wires
+    /// have no object table; a non-empty table on those is a protocol
+    /// error (`validateParcel`).
     pub object_positions: Vec<u32>,
 }
 
@@ -72,8 +71,8 @@ pub struct WireReply {
     /// The serialized RPC-mode `Parcel` payload.
     pub data: Vec<u8>,
     /// See [`WireTransaction::object_positions`] — the reply parcel's
-    /// object table (subplan 2-8). Default empty = byte-identical to
-    /// the pre-2-8 reply encoding.
+    /// object table (android-16 v2). Default empty = byte-identical to
+    /// the no-object reply encoding.
     pub object_positions: Vec<u32>,
 }
 
@@ -101,13 +100,14 @@ pub enum WireMessage {
     DecStrong(RpcAddress),
 }
 
-/// Pluggable RPC wire format. The session owns a codec instance (P6 —
-/// no global). android-13+ versioned wire is a future additional impl.
+/// Pluggable RPC wire format. The session owns a codec instance (no
+/// global); the android-13+ versioned wire is an additional impl
+/// ([`super::wire_android13::Android13PlusCodec`]) behind this trait.
 pub trait WireCodec: Send + Sync {
     /// Encode a complete `TRANSACT` message (header + txn + data +
-    /// optional object table). Fails (`validateParcel`, AC-8.4) if the
-    /// codec's wire version has no object table but
-    /// `txn.object_positions` is non-empty.
+    /// optional object table). Fails (`validateParcel`) if the codec's
+    /// wire version has no object table but `txn.object_positions` is
+    /// non-empty.
     fn encode_transact(&self, txn: &WireTransaction) -> RpcResult<Vec<u8>>;
     /// Encode a complete `REPLY` message. Same object-table version
     /// rule as [`WireCodec::encode_transact`].
@@ -127,14 +127,24 @@ pub trait WireCodec: Send + Sync {
 pub struct R34Codec;
 
 impl R34Codec {
-    fn header(command: u32, body_size: usize) -> [u8; WIRE_HEADER_LEN] {
+    fn header(command: u32, body_size: usize) -> RpcResult<[u8; WIRE_HEADER_LEN]> {
+        // Encoder/decoder symmetry (mirrors `Android13PlusCodec::header`):
+        // `decode_message` rejects `body_size > MAX_FRAME_LEN`, so the
+        // encoder must too — otherwise a `body_size > u32::MAX` payload
+        // on a 64-bit host would be silently truncated by `as u32`, emitting
+        // a header whose `bodySize` disagrees with the actual body and
+        // misframing the peer's next message.
+        if body_size > MAX_FRAME_LEN {
+            return Err(RpcError::FrameTooLarge {
+                declared: body_size,
+                max: MAX_FRAME_LEN,
+            });
+        }
         let mut h = [0u8; WIRE_HEADER_LEN];
         h[0..4].copy_from_slice(&command.to_le_bytes());
-        // bodySize is a u32 on the wire; callers never exceed it
-        // (bounded by MAX_FRAME_LEN, far below u32::MAX).
         h[4..8].copy_from_slice(&(body_size as u32).to_le_bytes());
         // reserved[2] stays zero.
-        h
+        Ok(h)
     }
 }
 
@@ -180,10 +190,9 @@ impl WireCodec for R34Codec {
         // android-12 r34 predates the versioned wire: there is **no**
         // object table on this wire at all. The android-13+ v2 object
         // table is a separate codec; the R34 path never records
-        // positions (subplan 2-8 Phase B gates recording behind the
-        // android-13+ v2 profile), so a non-empty table here is a
-        // protocol break — reject it rather than silently drop the
-        // table and desync the peer (AOSP `validateParcel` analogue).
+        // positions, so a non-empty table here is a protocol break —
+        // reject it rather than silently drop the table and desync the
+        // peer (AOSP `validateParcel` analogue).
         if !txn.object_positions.is_empty() {
             return Err(RpcError::Protocol(
                 "r34 wire has no object table (object_positions must be empty)",
@@ -191,7 +200,7 @@ impl WireCodec for R34Codec {
         }
         let body_len = WIRE_TXN_FIXED_LEN + txn.data.len();
         let mut out = Vec::with_capacity(WIRE_HEADER_LEN + body_len);
-        out.extend_from_slice(&Self::header(CMD_TRANSACT, body_len));
+        out.extend_from_slice(&Self::header(CMD_TRANSACT, body_len)?);
         out.extend_from_slice(txn.address.as_wire_bytes()); // 32
         out.extend_from_slice(&txn.code.to_le_bytes()); // 4
         out.extend_from_slice(&txn.flags.to_le_bytes()); // 4
@@ -209,7 +218,7 @@ impl WireCodec for R34Codec {
         }
         let body_len = 4 + reply.data.len();
         let mut out = Vec::with_capacity(WIRE_HEADER_LEN + body_len);
-        out.extend_from_slice(&Self::header(CMD_REPLY, body_len));
+        out.extend_from_slice(&Self::header(CMD_REPLY, body_len)?);
         out.extend_from_slice(&reply.status.to_le_bytes());
         out.extend_from_slice(&reply.data);
         Ok(out)
@@ -217,7 +226,12 @@ impl WireCodec for R34Codec {
 
     fn encode_dec_strong(&self, addr: &RpcAddress) -> Vec<u8> {
         let mut out = Vec::with_capacity(WIRE_HEADER_LEN + RPC_ADDR_LEN);
-        out.extend_from_slice(&Self::header(CMD_DEC_STRONG, RPC_ADDR_LEN));
+        // RPC_ADDR_LEN is a small constant, far below MAX_FRAME_LEN, so the
+        // bound check can never trip here — unwrap the const-length header.
+        out.extend_from_slice(
+            &Self::header(CMD_DEC_STRONG, RPC_ADDR_LEN)
+                .expect("dec_strong header is within the frame bound"),
+        );
         out.extend_from_slice(addr.as_wire_bytes());
         out
     }
@@ -292,16 +306,9 @@ impl WireCodec for R34Codec {
     }
 
     fn decode_session_preamble(&self, buf: &[u8]) -> RpcResult<i32> {
-        // m4 fix (review 2026-05-21): strict-equal. The R34 preamble is
-        // exactly a bare `int32` (4 B); `encode_session_preamble` emits
-        // exactly 4 B; `decode_message` enforces frame-size-exact on
-        // every other path. Without `!= 4`, a peer that sends 5+ bytes
-        // would have the trailing slop silently consumed by the next
-        // recv, and an empty buf or a 2-byte stub would not be
-        // distinguished from a peer that didn't speak the preamble at
-        // all. The fuzz target's `input.len().min(4)` slice still hits
-        // this fn with len ≤ 4, so the only behavior change is
-        // rejecting genuinely malformed input.
+        // Strict-equal: the R34 preamble is exactly a bare `int32`
+        // (4 B), so a peer sending more or fewer bytes is malformed and
+        // must not silently desync the next recv.
         let arr: [u8; 4] = buf
             .try_into()
             .map_err(|_| RpcError::Protocol("session preamble must be exactly 4 bytes"))?;
@@ -309,8 +316,8 @@ impl WireCodec for R34Codec {
     }
 }
 
-/// Decode-only entrypoint for the `rpc_wire_decode` fuzz target
-/// (2-2.A / V4). Not part of the supported API surface.
+/// Decode-only entrypoint for the `rpc_wire_decode` fuzz target.
+/// Not part of the supported API surface.
 #[doc(hidden)]
 pub fn __fuzz_decode_wire(input: &[u8]) {
     let _ = R34Codec.decode_message(input);
@@ -320,9 +327,9 @@ pub fn __fuzz_decode_wire(input: &[u8]) {
 /// the address sits inside a TRANSACT/DEC_STRONG body, so feeding
 /// arbitrary bytes through the message decoder also exercises the
 /// 32-byte address parse path with full bounds checking.
-/// Decode-only entrypoint for the `rpc_session_handshake` fuzz target
-/// (subplan 2-3 §6.3 / V4): the first 4 bytes are fed to the session
-/// preamble decoder, the remainder through the message decoder — the
+/// Decode-only entrypoint for the `rpc_session_handshake` fuzz target:
+/// the first 4 bytes are fed to the session preamble decoder, the
+/// remainder through the message decoder — the
 /// exact untrusted path a session's negotiation/serve loop walks. No
 /// panic / OOM / hang on any input; bad negotiation values are
 /// rejected, not trusted.
@@ -338,8 +345,11 @@ pub fn __fuzz_session_handshake(input: &[u8]) {
 pub fn __fuzz_decode_address(input: &[u8]) {
     // Wrap as a DEC_STRONG frame so the address parser is reached even
     // for short/garbage inputs without panicking.
+    let Ok(header) = R34Codec::header(CMD_DEC_STRONG, input.len()) else {
+        return;
+    };
     let mut frame = Vec::with_capacity(WIRE_HEADER_LEN + input.len());
-    frame.extend_from_slice(&R34Codec::header(CMD_DEC_STRONG, input.len()));
+    frame.extend_from_slice(&header);
     frame.extend_from_slice(input);
     let _ = R34Codec.decode_message(&frame);
 }
@@ -353,8 +363,20 @@ mod tests {
         R34Codec
     }
 
-    /// T2.1 — encode∘decode == identity for every command, arbitrary
-    /// payloads (0..1 MiB sampled).
+    /// `R34Codec::header` must reject a body larger than `MAX_FRAME_LEN`
+    /// (encoder/decoder symmetry with `Android13PlusCodec`) rather than
+    /// silently truncating `bodySize` via `as u32`.
+    #[test]
+    fn header_rejects_oversize_body() {
+        assert!(matches!(
+            R34Codec::header(CMD_TRANSACT, MAX_FRAME_LEN + 1),
+            Err(RpcError::FrameTooLarge { .. })
+        ));
+        assert!(R34Codec::header(CMD_TRANSACT, MAX_FRAME_LEN).is_ok());
+    }
+
+    /// encode∘decode == identity for every command, arbitrary payloads
+    /// (0..1 MiB sampled).
     #[test]
     fn roundtrip_all_commands() {
         let c = rt_codec();
@@ -410,9 +432,8 @@ mod tests {
         assert_eq!(c.decode_session_preamble(&pre).unwrap(), RPC_SESSION_ID_NEW);
     }
 
-    /// AC-2.2r / T2.1r — fixed golden vectors matched byte-for-byte
-    /// against the android-12 r34 spec (`plan/2-5` §9). This is the
-    /// r34 spec-conformance gate (2-5a absorbed): no device, no AOSP.
+    /// Fixed golden vectors matched byte-for-byte against the android-12
+    /// r34 spec. The r34 spec-conformance gate: no device, no AOSP.
     #[test]
     fn r34_spec_golden_vectors() {
         let c = R34Codec;
@@ -477,8 +498,8 @@ mod tests {
         );
     }
 
-    /// T2.10 mutant: a one-byte change in a golden header must be
-    /// detected (the golden compare is exact, not "close enough").
+    /// A one-byte change in a golden header must be detected (the golden
+    /// compare is exact, not "close enough").
     #[test]
     fn golden_is_not_close_enough() {
         let c = R34Codec;
@@ -496,8 +517,8 @@ mod tests {
         assert!(matches!(c.decode_message(&enc), Err(RpcError::Protocol(_))));
     }
 
-    /// 2-2.b4 / V4 — malformed input must never panic/OOM; every
-    /// length/offset is bounds-checked, no pre-allocation past bounds.
+    /// Malformed input must never panic/OOM; every length/offset is
+    /// bounds-checked, no pre-allocation past bounds.
     #[test]
     fn decoder_rejects_hostile_input_safely() {
         let c = R34Codec;

--- a/rsbinder/src/rpc/wire_android13.rs
+++ b/rsbinder/src/rpc/wire_android13.rs
@@ -1,9 +1,9 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! `Android13PlusCodec` — the android-13+ *versioned* RPC wire
-//! (subplan 2-5b), an **additive** [`super::wire::WireCodec`] impl
-//! behind the same trait as [`super::wire::R34Codec`].
+//! `Android13PlusCodec` — the android-13+ *versioned* RPC wire, an
+//! **additive** [`super::wire::WireCodec`] impl behind the same trait
+//! as [`super::wire::R34Codec`].
 //! `R34Codec` is byte-unchanged; nothing here touches the kernel path.
 //!
 //! One codec, **version-keyed** — exactly AOSP's own design
@@ -14,14 +14,14 @@
 //!   (`RPC_WIRE_PROTOCOL_VERSION = 1`; their `RpcWireFormat.h` is
 //!   byte-identical to each other)
 //! * **v2** = android-16 (`RPC_WIRE_PROTOCOL_VERSION = 2`,
-//!   `RPC_HEADER_INCLUDES_BINDER_POSITIONS`; subplan 2-8)
+//!   `RPC_HEADER_INCLUDES_BINDER_POSITIONS`)
 //!
 //! The negotiated version is selected at runtime by the connection
 //! handshake (`RpcConnectionHeader`/`RpcNewSessionResponse`). r34
 //! (android-12, pre-versioning, 32-byte address, no handshake) stays a
 //! separate codec.
 //!
-//! # v1 ≡ v2 framing (subplan 2-8 §0.3, verified vs `android-16.0.0_r4`)
+//! # v1 ≡ v2 framing (verified vs `android-16.0.0_r4`)
 //!
 //! v2's wire-protocol delta is **not** a framing change. A full sweep
 //! of `RpcState.cpp` + `RpcWireFormat.h` (android-16.0.0_r4) shows
@@ -34,16 +34,16 @@
 //! is recorded in `mObjectPositions`. So v1 and v2 share **one
 //! framing path**; the codec is version-agnostic about the object
 //! table's *contents* (it just frames the trailing `u32[]`), and the
-//! v1↔v2 distinction lives entirely in the Parcel position producer
-//! (subplan 2-8 Phase B). A no-object parcel ⇒ empty table ⇒
-//! byte-identical v1/v2 wire (AC-8.2, structural v1 no-regression).
+//! v1↔v2 distinction lives entirely in the Parcel position producer.
+//! A no-object parcel ⇒ empty table ⇒ byte-identical v1/v2 wire
+//! (structural v1 no-regression).
 //!
 //! # Spec of record
 //!
 //! Extracted byte-exact from AOSP `frameworks/native`
 //! (`android-13.0.0_r84` for v0, `android-15.0.0_r36` == v1 ==
-//! `android-14.0.0_r75`), device-free — exactly the route 2-5a used
-//! for r34. Source files: `libs/binder/RpcWireFormat.h`,
+//! `android-14.0.0_r75`), device-free — the same route used for r34.
+//! Source files: `libs/binder/RpcWireFormat.h`,
 //! `include/binder/RpcSession.h`, `RpcSession.cpp`, `RpcState.cpp`,
 //! `tests/binderRpcWireProtocolTest.cpp`.
 //!
@@ -76,18 +76,18 @@
 //! * `RpcConnectionHeader` (still 16 B): a reserved byte becomes
 //!   `u8 fileDescriptorTransportMode` (`NONE=0/UNIX=1/TRUSTY=2`) —
 //!   FD mode is negotiated *in the connection header* at v1, not via
-//!   the separate `GET_FD_MODE` special transact rsbinder/2-7 uses.
+//!   the separate `GET_FD_MODE` special transact rsbinder uses.
 //!
-//! ## v1 → v2 (android-16, subplan 2-8)
+//! ## v1 → v2 (android-16)
 //!
 //! **No struct/framing change.** `RpcWireFormat.h` is byte-identical to
 //! v1 (`RpcWireReply::wireSize` still `v0?4:20`; `RpcWireTransaction`
 //! still 40 B with `parcelDataSize`). The only delta is that the
 //! trailing object table (`mObjectPositions`, framed as a `u32[]` after
 //! the parcel data — already present at v1 for FD positions) now also
-//! carries **binder** positions. That is a Parcel-producer concern
-//! (subplan 2-8 Phase B), not a codec/framing concern: the codec
-//! frames the `u32[]` identically for v1 and v2.
+//! carries **binder** positions. That is a Parcel-producer concern,
+//! not a codec/framing concern: the codec frames the `u32[]`
+//! identically for v1 and v2.
 //!
 //! Version constants (`include/binder/RpcSession.h` @
 //! **android-16.0.0_r4**): `RPC_WIRE_PROTOCOL_VERSION = 2`,
@@ -99,15 +99,13 @@
 //! _EXPERIMENTAL` — so a peer that supports up to v2 accepts
 //! {0, 1, 2, EXPERIMENTAL}.
 //!
-//! ## Scope (2-5b, device-free)
+//! ## Scope
 //!
 //! Delivers the **spec-conformance** half (byte-exact codec + golden
-//! vectors from `RpcWireFormat.h`), the gating-equivalent route 2-5a
-//! used for r34. Wiring the handshake into `RpcSession` against a
-//! *live* android-13/14/15 RPC peer (G4), and matching a real peer's
-//! `RpcState` node-id / `FOR_SERVER` address semantics, remain gated —
-//! RPC_STATUS §2-5b. The Parcel-body layer (AOSP `kCurrentRepr`) is a
-//! separate conformance tracked there.
+//! vectors from `RpcWireFormat.h`), the same device-free route used for
+//! r34. Matching a real peer's `RpcState` node-id / `FOR_SERVER`
+//! address semantics is a separate refinement, as is the Parcel-body
+//! layer (AOSP `kCurrentRepr`).
 
 use std::io::{Read, Write};
 
@@ -153,10 +151,10 @@ pub const PROTOCOL_V0: u32 = 0;
 /// (`RPC_WIRE_PROTOCOL_VERSION_RPC_HEADER_FEATURE_EXPLICIT_PARCEL_SIZE`).
 pub const PROTOCOL_V1: u32 = 1;
 /// android-16 stable wire protocol version
-/// (`RPC_WIRE_PROTOCOL_VERSION_RPC_HEADER_INCLUDES_BINDER_POSITIONS`;
-/// subplan 2-8). Framing is byte-identical to [`PROTOCOL_V1`]; the
-/// only delta is that binder positions also enter the object table
-/// (a Parcel-producer concern — Phase B).
+/// (`RPC_WIRE_PROTOCOL_VERSION_RPC_HEADER_INCLUDES_BINDER_POSITIONS`).
+/// Framing is byte-identical to [`PROTOCOL_V1`]; the only delta is that
+/// binder positions also enter the object table (a Parcel-producer
+/// concern).
 pub const PROTOCOL_V2: u32 = 2;
 /// Highest version this codec implements (android-16.0.0_r4
 /// `RPC_WIRE_PROTOCOL_VERSION`).
@@ -170,8 +168,8 @@ pub const RPC_WIRE_PROTOCOL_VERSION_EXPERIMENTAL: u32 = 0xF000_0000;
 
 /// `RpcSession::FileDescriptorTransportMode` (u8) — the v1
 /// `RpcConnectionHeader.fileDescriptorTransportMode` byte. rsbinder
-/// only ever advertises `NONE`/`UNIX` (subplan 2-7); `TRUSTY` is
-/// out of scope but defined for wire fidelity.
+/// only ever advertises `NONE`/`UNIX`; `TRUSTY` is out of scope but
+/// defined for wire fidelity.
 pub const FD_MODE_NONE: u8 = 0;
 pub const FD_MODE_UNIX: u8 = 1;
 pub const FD_MODE_TRUSTY: u8 = 2;
@@ -180,9 +178,9 @@ pub const FD_MODE_TRUSTY: u8 = 2;
 /// (`Parcel.h`, `int32_t`) — the first int32 of an RPC-Parcel fd
 /// object body. Pinned byte-exact android-14.0.0_r75…android-16.0.0_r4
 /// (`TYPE_BINDER_NULL=0, TYPE_BINDER=1, TYPE_NATIVE_FILE_DESCRIPTOR=2`).
-/// Load-bearing for subplan 2-11: the AOSP-faithful FD-over-RPC v1+
-/// Parcel body (`[not-null|hasComm|TYPE|fdIndex]`) that replaces
-/// rsbinder's internal `[present|idx]` shape.
+/// Load-bearing for the AOSP-faithful FD-over-RPC v1+ Parcel body
+/// (`[not-null|hasComm|TYPE|fdIndex]`) that replaces rsbinder's
+/// internal `[present|idx]` shape.
 pub const TYPE_NATIVE_FILE_DESCRIPTOR: i32 = 2;
 
 /// `setProtocolVersion` acceptance for a peer that supports up to
@@ -210,7 +208,7 @@ fn reply_fixed_len(version: u32) -> usize {
 /// (`>= RPC_WIRE_PROTOCOL_VERSION_RPC_HEADER_FEATURE_EXPLICIT_PARCEL_SIZE`).
 /// v0 has no `parcelDataSize` and no object table at all. (v1 and v2
 /// are identical here — the v1↔v2 distinction is purely *which*
-/// objects the Parcel producer records, subplan 2-8 Phase B.)
+/// objects the Parcel producer records.)
 fn has_object_table(version: u32) -> bool {
     version >= PROTOCOL_V1
 }
@@ -237,7 +235,7 @@ fn rd_u64(buf: &[u8], off: usize) -> RpcResult<u64> {
     Ok(u64::from_le_bytes(s.try_into().unwrap()))
 }
 
-/// The android-13+ versioned RPC wire codec (subplan 2-5b, additive).
+/// The android-13+ versioned RPC wire codec (additive).
 /// `version` is the negotiated `RPC_WIRE_PROTOCOL_VERSION`
 /// ([`PROTOCOL_V0`] = android-13, [`PROTOCOL_V1`] = android-14/15).
 #[derive(Debug, Clone, Copy)]
@@ -267,9 +265,9 @@ impl Android13PlusCodec {
         }
     }
 
-    /// v2 — android-16 (subplan 2-8). Framing byte-identical to v1;
-    /// differs only in that the Parcel producer also records binder
-    /// positions in the object table (Phase B).
+    /// v2 — android-16. Framing byte-identical to v1; differs only in
+    /// that the Parcel producer also records binder positions in the
+    /// object table.
     pub fn android16() -> Self {
         Self {
             version: PROTOCOL_V2,
@@ -285,9 +283,7 @@ impl Android13PlusCodec {
     /// store the sentinel as-is, advertise it on the wire, and drive
     /// v1+ framing from it (because `version >= PROTOCOL_V1` holds for
     /// `0xF000_0000`). rsbinder mirrors that exactly — do **not**
-    /// normalize EXPERIMENTAL to `SUPPORTED_MAX_VERSION` (the
-    /// 2026-05-21 review's M7 finding is retracted by AOSP cross-check;
-    /// see review report meta evaluation).
+    /// normalize EXPERIMENTAL to `SUPPORTED_MAX_VERSION`.
     pub fn with_version(version: u32) -> RpcResult<Self> {
         if !is_supported_protocol_version(version) {
             return Err(RpcError::Protocol("unsupported RPC wire protocol version"));
@@ -301,8 +297,8 @@ impl Android13PlusCodec {
     }
 
     fn header(command: u32, body_size: usize) -> RpcResult<[u8; WIRE_HEADER_LEN]> {
-        // M1 fix (review 2026-05-21): encoder/decoder symmetry. The
-        // decoder rejects `body_size > MAX_FRAME_LEN` at every entry
+        // Encoder/decoder symmetry: the decoder rejects
+        // `body_size > MAX_FRAME_LEN` at every entry
         // (see `decode_message`, `read_aosp_message`,
         // `write_aosp_message`); without this guard the encoder would
         // silently truncate a `body_size > u32::MAX` via `as u32` on
@@ -331,14 +327,14 @@ impl Android13PlusCodec {
     /// counter`, `options = CREATED | (FOR_SERVER if Acceptor-minted)`.
     /// Documented + internally consistent (round-trips within
     /// rsbinder); matching a live peer's `RpcState` node-id semantics
-    /// is the G4 refinement (RPC_STATUS §2-5b).
+    /// is a separate refinement.
     ///
     /// `pub(crate)` because the *in-parcel* binder encoding
     /// (`flattenBinder` RPC branch: `i32 present` + `writeUint64`) must
     /// use this same 8-byte `RpcWireAddress` — the session's
     /// `write_binder`/`read_binder` route through it for the
-    /// android-13+ profile (G4(b): r34's 32-byte in-parcel address was
-    /// rejected by the real libbinder peer).
+    /// android-13+ profile (a real libbinder peer rejects r34's 32-byte
+    /// in-parcel address).
     pub(crate) fn encode_addr(addr: &RpcAddress) -> [u8; A13_ADDR_LEN] {
         let mut out = [0u8; A13_ADDR_LEN];
         if addr.is_zero() {
@@ -373,8 +369,7 @@ impl Android13PlusCodec {
         Ok(RpcAddress::from_wire_bytes(bytes))
     }
 
-    // --- connection handshake (used by the conformance test now and
-    //     the live-session wiring later — G4) ----------------------
+    // --- connection handshake --------------------------------------
 
     /// `RpcConnectionHeader` (16 B) + `session_id` bytes
     /// (empty ⇒ request a new session). `fd_mode` is written into the
@@ -387,13 +382,12 @@ impl Android13PlusCodec {
         fd_mode: u8,
         session_id: &[u8],
     ) -> RpcResult<Vec<u8>> {
-        // M2 fix (review 2026-05-21): explicit `u16` bound on
-        // `sessionIdSize`. AOSP `RpcConnectionHeader.sessionIdSize` is
-        // a `uint16_t`; rsbinder's session ids are 32 B (the canonical
-        // path), but this is a `pub fn` and a caller passing a 64 KiB+
-        // slice would previously wrap the on-wire size while the full
-        // body was still appended — a peer reading per `sessionIdSize`
-        // would misframe the following message.
+        // Explicit `u16` bound on `sessionIdSize`. AOSP
+        // `RpcConnectionHeader.sessionIdSize` is a `uint16_t`; this is a
+        // `pub fn` and a caller passing a 64 KiB+ slice would otherwise
+        // wrap the on-wire size while the full body was still appended
+        // — a peer reading per `sessionIdSize` would misframe the
+        // following message.
         let id_size: u16 = session_id
             .len()
             .try_into()
@@ -421,7 +415,7 @@ impl Android13PlusCodec {
         let version = rd_u32(buf, 0)?;
         let options = buf[4];
         let fd_mode = if version == PROTOCOL_V0 { 0 } else { buf[5] };
-        // M8 fix (review 2026-05-21): symmetric with `server_accept`.
+        // Symmetric with `server_accept`.
         if !matches!(fd_mode, FD_MODE_NONE | FD_MODE_UNIX | FD_MODE_TRUSTY) {
             return Err(RpcError::Protocol(
                 "unknown RpcConnectionHeader.fileDescriptorTransportMode",
@@ -481,9 +475,9 @@ impl Android13PlusCodec {
 /// then the object table as a trailing LE `u32[]` (`objectTableSpan
 /// .toIovec()`). The wire body is `[fixed prefix][parcel data
 /// (parcelDataSize bytes)][object table (4·N bytes)]`. v0 has no
-/// object table (`validateParcel` rejects v0 + non-empty positions —
-/// AC-8.4); v1 and v2 are byte-identical here (the table is just a
-/// `u32[]`, version-agnostic — subplan 2-8 §0.3).
+/// object table (`validateParcel` rejects v0 + non-empty positions);
+/// v1 and v2 are byte-identical here (the table is just a `u32[]`,
+/// version-agnostic).
 fn encode_data_and_table(
     out: &mut Vec<u8>,
     version: u32,
@@ -512,9 +506,9 @@ fn encode_data_and_table(
 /// Inverse of [`encode_data_and_table`]: AOSP's `parcelSpan.splitOff(
 /// parcelDataSize)` + `objectTableBytes->reinterpret<uint32_t>()`
 /// (`RpcState.cpp:840-866`/`1144-1176`). `rest` is the body after the
-/// fixed prefix. Phase A does **length + %4 validation only**; v2
-/// strict position-content validation (`binary_search`/range) is
-/// Phase C (subplan 2-8 §3.1 — a lenient decoder still interops).
+/// fixed prefix. This does **length + %4 validation only**; strict v2
+/// position-content validation (`binary_search`/range) is a separate
+/// step — a lenient decoder still interops.
 fn split_data_and_table(
     version: u32,
     rest: &[u8],
@@ -601,7 +595,7 @@ impl WireCodec for Android13PlusCodec {
         // RpcDecStrong { addr(8); u32 amount; u32 reserved } — 16 B,
         // unchanged v0↔v1. rsbinder sends one decrement per drop.
         // `A13_DEC_STRONG_LEN` is a const ≪ `MAX_FRAME_LEN`, so the
-        // M1 guard inside `Self::header` is structurally satisfied.
+        // frame-size guard inside `Self::header` is structurally satisfied.
         let header = Self::header(CMD_DEC_STRONG, A13_DEC_STRONG_LEN)
             .expect("DEC_STRONG body length is a const ≪ MAX_FRAME_LEN");
         let mut out = Vec::with_capacity(WIRE_HEADER_LEN + A13_DEC_STRONG_LEN);
@@ -689,8 +683,8 @@ impl WireCodec for Android13PlusCodec {
                 }
                 let address = Self::decode_addr(body, 0)?;
                 // amount @8 — rsbinder applies one decrement per
-                // DEC_STRONG; honoring amount>1 from a live peer is the
-                // G4 refinement (RPC_STATUS §2-5b).
+                // DEC_STRONG; honoring amount>1 from a live peer is a
+                // separate refinement.
                 Ok(WireMessage::DecStrong(address))
             }
             _ => Err(RpcError::Protocol("unknown RpcWireHeader.command")),
@@ -698,8 +692,8 @@ impl WireCodec for Android13PlusCodec {
     }
 
     fn encode_session_preamble(&self, session_id: i32) -> Vec<u8> {
-        // Empty `session_id` ⇒ M2's `u16` bound is structurally
-        // satisfied; the inner `expect` can never fire.
+        // Empty `session_id` ⇒ the `u16` sessionIdSize bound is
+        // structurally satisfied; the inner `expect` can never fire.
         // android-13+ replaced the bare int32 preamble with the
         // versioned RpcConnectionHeader. rsbinder only opens a new
         // session here (session_id == RPC_SESSION_ID_NEW) and defaults
@@ -707,7 +701,7 @@ impl WireCodec for Android13PlusCodec {
         // / "cci") uses the inherent methods.
         let _ = session_id;
         self.encode_connection_header(false, FD_MODE_NONE, &[])
-            .expect("preamble passes empty session_id ⇒ M2 u16 bound trivially satisfied")
+            .expect("preamble passes empty session_id ⇒ u16 bound trivially satisfied")
     }
 
     fn decode_session_preamble(&self, buf: &[u8]) -> RpcResult<i32> {
@@ -719,7 +713,7 @@ impl WireCodec for Android13PlusCodec {
 }
 
 // ---------------------------------------------------------------------
-// AOSP-faithful framing + connection handshake (G4)
+// AOSP-faithful framing + connection handshake
 //
 // The real android RPC wire has **no length prefix**: a peer writes the
 // 16-byte `RpcWireHeader` (whose `bodySize` field is authoritative)
@@ -732,10 +726,9 @@ impl WireCodec for Android13PlusCodec {
 //
 // These helpers operate directly on a byte stream (`Read + Write`), so
 // they are wire-identical to a genuine android-13/14/15 RPC peer. They
-// are the reusable primitives the future opt-in `RpcSession`
-// android-13+ profile wires in (the rest of G4 — see RPC_STATUS §2-5b);
-// nothing here touches the existing R34 `RpcSession`/`RpcTransport`
-// path (additive, R34 byte-unchanged).
+// are the reusable primitives the opt-in `RpcSession` android-13+
+// profile wires in; nothing here touches the existing R34
+// `RpcSession`/`RpcTransport` path (additive, R34 byte-unchanged).
 // ---------------------------------------------------------------------
 
 fn map_io(e: std::io::Error) -> RpcError {
@@ -783,7 +776,7 @@ pub fn write_aosp_message<W: Write>(w: &mut W, msg: &[u8]) -> RpcResult<()> {
 
 /// Read one message AOSP-faithfully: read the 16-byte `RpcWireHeader`,
 /// take `bodySize` (LE @ offset 4, capped vs [`MAX_FRAME_LEN`] before
-/// allocation — V4), then read exactly that many body bytes. Returns
+/// allocation), then read exactly that many body bytes. Returns
 /// `[header | body]`, exactly what [`Android13PlusCodec::decode_message`]
 /// expects.
 pub fn read_aosp_message<R: Read>(r: &mut R) -> RpcResult<Vec<u8>> {
@@ -803,8 +796,8 @@ pub fn read_aosp_message<R: Read>(r: &mut R) -> RpcResult<Vec<u8>> {
     Ok(out)
 }
 
-/// [`write_aosp_message`] + out-of-band `SCM_RIGHTS` fds (subplan 2-11
-/// Phase A0 — the android-13+ v1+ `Unix` FD-over-RPC path). `msg` is
+/// [`write_aosp_message`] + out-of-band `SCM_RIGHTS` fds (the
+/// android-13+ v1+ `Unix` FD-over-RPC path). `msg` is
 /// the codec output (`[RpcWireHeader(16) | body]`, `bodySize` correct),
 /// emitted raw with **no length prefix**; `fds` ride the first
 /// `sendmsg` (AOSP `RpcTransportRaw`). With `fds` empty this is exactly
@@ -827,10 +820,10 @@ pub fn write_aosp_message_with_fds(
     t.send_raw_with_fds(msg, fds)
 }
 
-/// [`read_aosp_message`] + the `SCM_RIGHTS` fds delivered with it
-/// (subplan 2-11 Phase A0). Reads the 16-byte `RpcWireHeader`, then
+/// [`read_aosp_message`] + the `SCM_RIGHTS` fds delivered with it.
+/// Reads the 16-byte `RpcWireHeader`, then
 /// exactly `bodySize` body bytes (capped vs [`MAX_FRAME_LEN`] before
-/// allocation — V4), **accumulating ancillary fds across every
+/// allocation), **accumulating ancillary fds across every
 /// `recvmsg`** that read the message (AOSP
 /// `RpcTransportRaw::interruptableReadFully`: the kernel delivers
 /// `SCM_RIGHTS` with the first byte of the sender's `sendmsg`, i.e. on
@@ -853,15 +846,14 @@ pub fn read_aosp_message_with_fds(
         while got < want {
             let (n, mut more) = t.recv_raw_with_fds(&mut buf[got..])?;
             fds.append(&mut more);
-            // C3 fix (review 2026-05-21): enforce the per-message
-            // `MAX_FDS_PER_FRAME` cap *across* the multiple recvmsgs
-            // that read one message. The transport's per-call cap
-            // (`recv_raw_with_fds` rejects > 64 per single recvmsg)
-            // is per-recvmsg, not per-message — without this
-            // accumulator-side check, a hostile peer that fragments
-            // a message across N recvmsgs each carrying 64 fds would
-            // accumulate 64·N ancillary fds and walk the process
-            // toward `RLIMIT_NOFILE`. Plan 2-7.d / AC-7.5 DoS bound.
+            // Enforce the per-message `MAX_FDS_PER_FRAME` cap *across*
+            // the multiple recvmsgs that read one message. The
+            // transport's per-call cap (`recv_raw_with_fds` rejects
+            // > 64 per single recvmsg) is per-recvmsg, not per-message
+            // — without this accumulator-side check, a hostile peer
+            // that fragments a message across N recvmsgs each carrying
+            // 64 fds would accumulate 64·N ancillary fds and walk the
+            // process toward `RLIMIT_NOFILE` (DoS bound).
             if fds.len() > super::transport::unix::MAX_FDS_PER_FRAME {
                 return Err(RpcError::Protocol(
                     "RPC message exceeded MAX_FDS_PER_FRAME (ancillary fd budget)",
@@ -900,7 +892,7 @@ pub fn read_aosp_message_with_fds(
 ///
 /// **Wire order is byte-exact to AOSP `RpcSession::setupClient`
 /// (android-13.0.0_r84), validated against a *real* compiled libbinder
-/// peer on the Android 13 emulator (RPC_STATUS §"G4(b)"):**
+/// peer on the Android 13 emulator:**
 ///
 /// 1. write `RpcConnectionHeader` (caller's max version, raw — no framing);
 /// 2. write `RpcOutgoingConnectionInit` (`"cci"`) — the *outgoing*
@@ -916,13 +908,14 @@ pub fn client_connect<S: Read + Write>(
     incoming: bool,
     fd_mode: u8,
 ) -> RpcResult<Android13PlusCodec> {
-    // Empty id ⇒ request a new session — byte-identical to the
-    // pre-2-12 wire (the `session_id` slot already existed).
+    // Empty id ⇒ request a new session — byte-identical to a
+    // single-connection session (the `session_id` slot already
+    // existed).
     client_connect_with_id(stream, max_version, incoming, fd_mode, &[])
 }
 
-/// Subplan 2-12 Phase A0a: like [`client_connect`] but echoes a
-/// server-minted 32-byte `session_id` in the `RpcConnectionHeader`
+/// Like [`client_connect`] but echoes a server-minted 32-byte
+/// `session_id` in the `RpcConnectionHeader`
 /// (AOSP `RpcSession::setupClient`: the first connection sends an empty
 /// id and reads the server-minted one; the remaining connections echo
 /// it). An **empty** `session_id` is byte-for-byte identical to
@@ -955,7 +948,7 @@ pub fn client_connect<S: Read + Write>(
 /// writes `RpcNewSessionResponse` for `requestingNewSession`). The
 /// caller enforces uniformity by clamping `max_version =
 /// min(caller_max, session_version)` *before* the handshake (see
-/// [`RpcSession::add_outgoing_connection_android13plus`]); a peer
+/// [`super::session::RpcSession::add_outgoing_connection_android13plus`]); a peer
 /// running a different actual version on an id-echoing attach is an
 /// unverifiable wire condition on both sides.
 pub fn client_connect_with_id<S: Read + Write>(
@@ -1039,7 +1032,7 @@ pub fn server_accept<S: Read + Write>(
     } else {
         head[5]
     };
-    // M8 fix (review 2026-05-21): reject out-of-enum
+    // Reject out-of-enum
     // `RpcConnectionHeader.fileDescriptorTransportMode`. AOSP defines
     // the field as an enum {NONE, UNIX, TRUSTY}; an unknown value is
     // malformed input that must not flow to downstream consumers as a
@@ -1089,8 +1082,8 @@ fn write_all_raw<W: Write>(w: &mut W, buf: &[u8]) -> RpcResult<()> {
 /// (currently `unix`). EOF (`recv_raw` ⇒ `Ok(0)`) is preserved as
 /// `Read` returning `Ok(0)`, so `read_exact_raw` still yields the
 /// correct `PeerClosed`/`Truncated`. This is the bridge the opt-in
-/// android-13+ `RpcSession` profile uses (G4); the R34 path never
-/// touches it.
+/// android-13+ `RpcSession` profile uses; the R34 path never touches
+/// it.
 pub struct RawTransportIo<'a>(pub &'a dyn super::transport::RpcTransport);
 
 impl Read for RawTransportIo<'_> {
@@ -1134,7 +1127,7 @@ mod tests {
         }
     }
 
-    /// 2-5b spec-conformance golden — byte-exact against AOSP
+    /// Spec-conformance golden — byte-exact against AOSP
     /// `RpcWireFormat.h` (v0 = android-13.0.0_r84, v1 =
     /// android-15.0.0_r36 == android-14.0.0_r75). Device-free.
     #[test]
@@ -1266,7 +1259,7 @@ mod tests {
         c1.decode_connection_init(&init).expect("\"cci\"");
 
         // Version acceptance (AOSP rule @ android-16.0.0_r4, _NEXT = 3):
-        // accept 0,1,2,EXPERIMENTAL; reject 3 and above (AC-8.1).
+        // accept 0,1,2,EXPERIMENTAL; reject 3 and above.
         assert!(is_supported_protocol_version(0));
         assert!(is_supported_protocol_version(1));
         assert!(is_supported_protocol_version(2));
@@ -1297,7 +1290,7 @@ mod tests {
                 let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
                 // v1+ may carry an object table; synthesize sorted
                 // positions within the parcel data (v0 must stay empty
-                // — exercised separately by the AC-8.4 negative test).
+                // — exercised separately by the negative test).
                 let positions: Vec<u32> = if c.version() >= PROTOCOL_V1 && size >= 8 {
                     vec![0, (size / 2) as u32, (size - 4) as u32]
                 } else {
@@ -1379,7 +1372,7 @@ mod tests {
         assert_eq!(v1.len(), WIRE_HEADER_LEN + 40);
         assert_ne!(v0, r34, "android-13+ must differ from r34");
         // No-object parcel ⇒ v1 and v2 wire are byte-identical
-        // (AC-8.2 — the structural v1 no-regression invariant).
+        // (the structural v1 no-regression invariant).
         assert_eq!(v1, v2, "no-object v1 ≡ v2 (AC-8.2)");
 
         // Reply: the load-bearing v0/v1 divergence (4B vs 20B fixed);
@@ -1412,7 +1405,7 @@ mod tests {
         );
     }
 
-    /// 2-2.b4 / V4 — malformed input never panics/OOMs (both versions).
+    /// Malformed input never panics/OOMs (both versions).
     #[test]
     fn android13plus_decoder_rejects_hostile_input_safely() {
         for c in [
@@ -1477,15 +1470,13 @@ mod tests {
         assert!(matches!(c1.decode_message(&f), Err(RpcError::Protocol(_))));
     }
 
-    /// G4 — the full android-13+ RPC protocol (versioned connection
+    /// The full android-13+ RPC protocol (versioned connection
     /// **handshake** + **AOSP-faithful framing** + `Android13PlusCodec`)
     /// driven end-to-end over a **raw `UnixStream`** (no rsbinder
     /// `RpcTransport` u32 prefix — wire-identical to a genuine
     /// android-13/14/15 RPC peer). Proves all three protocol layers
     /// interoperate, hermetically, over both v0 and v1 and across
-    /// version negotiation. The remaining G4 work (wiring this as an
-    /// opt-in `RpcSession` profile; running vs a compiled AOSP
-    /// `binderRpcTest`) is scoped in RPC_STATUS §2-5b.
+    /// version negotiation.
     #[test]
     fn android13plus_live_protocol_e2e_over_raw_socket() {
         use std::os::unix::net::UnixStream;
@@ -1586,8 +1577,8 @@ mod tests {
         }
     }
 
-    /// G4 layer-1 milestone: the same full android-13+ protocol, but
-    /// driven over a real [`UnixTransport`](crate::rpc::transport::UnixTransport)
+    /// The same full android-13+ protocol, but driven over a real
+    /// [`UnixTransport`](crate::rpc::transport::UnixTransport)
     /// through the [`RawTransportIo`] bridge (not a bare `UnixStream`)
     /// — i.e. over the actual `RpcTransport` abstraction the opt-in
     /// `RpcSession` profile will use. v0 and v1.
@@ -1766,9 +1757,9 @@ mod tests {
         );
     }
 
-    // ===== subplan 2-8 — android-16 RPC wire v2 (Phase A) ==========
+    // ===== android-16 RPC wire v2 ==================================
 
-    /// **AC-8.1** — android-16.0.0_r4 version constants golden.
+    /// android-16.0.0_r4 version constants golden.
     /// `RpcSession.h`: `RPC_WIRE_PROTOCOL_VERSION = 2`, `_NEXT = 3`,
     /// `_EXPLICIT_PARCEL_SIZE = 1`, `_INCLUDES_BINDER_POSITIONS = 2`.
     /// `setProtocolVersion` accepts {0,1,2,EXPERIMENTAL}, rejects ≥3.
@@ -1805,12 +1796,11 @@ mod tests {
         assert!(has_object_table(2));
     }
 
-    /// **AC-8.2** — a no-object parcel encodes **byte-identically** at
-    /// v1 and v2 (TRANSACT *and* REPLY, several payload sizes). This is
-    /// the structural v1-no-regression guarantee: an empty object table
-    /// is 0 wire bytes ⇒ `bodySize` unchanged ⇒ a v2-capable rsbinder's
-    /// no-object traffic is wire-identical to its v1 traffic (and to
-    /// the pre-2-8 wire).
+    /// A no-object parcel encodes **byte-identically** at v1 and v2
+    /// (TRANSACT *and* REPLY, several payload sizes). This is the
+    /// structural v1-no-regression guarantee: an empty object table is
+    /// 0 wire bytes ⇒ `bodySize` unchanged ⇒ a v2-capable rsbinder's
+    /// no-object traffic is wire-identical to its v1 traffic.
     #[test]
     fn android16_no_object_v1_eq_v2_byte_identical() {
         let v1 = Android13PlusCodec::android14_15();
@@ -1838,7 +1828,7 @@ mod tests {
         }
     }
 
-    /// **AC-8.3** — object-table framing golden vs AOSP
+    /// Object-table framing golden vs AOSP
     /// `RpcState.cpp`: `bodySize = fixed + parcelDataSize + 4·N`; the
     /// table is the trailing LE `u32[]` after the parcel data;
     /// `parcelDataSize` is the data length (unchanged); encode→decode
@@ -1938,8 +1928,8 @@ mod tests {
         assert!(matches!(c.decode_message(&bad), Err(RpcError::Protocol(_))));
     }
 
-    /// **AC-8.4** — `validateParcel` analogue: a v0 (android-13) or r34
-    /// wire can carry **no** object table; a non-empty `object_positions`
+    /// `validateParcel` analogue: a v0 (android-13) or r34 wire can
+    /// carry **no** object table; a non-empty `object_positions`
     /// on those is a protocol error, not a silently-dropped table
     /// (AOSP `RpcState::validateParcel` ⇒ `BAD_VALUE`).
     #[test]

--- a/rsbinder/src/rpc/wire_android13.rs
+++ b/rsbinder/src/rpc/wire_android13.rs
@@ -910,10 +910,6 @@ pub fn read_aosp_message_with_fds(
 ///    AOSP reads this *after* sending `"cci"` (`setupClient` order).
 ///
 /// Returns the [`Android13PlusCodec`] for the **negotiated** version.
-///
-/// (rsbinder originally had steps 2/3 inverted *and* the `"cci"`
-/// direction reversed — symmetric with its own `server_accept`, so the
-/// hermetic e2e could not catch it; the real-libbinder round-trip did.)
 pub fn client_connect<S: Read + Write>(
     stream: &mut S,
     max_version: u32,
@@ -931,6 +927,37 @@ pub fn client_connect<S: Read + Write>(
 /// id and reads the server-minted one; the remaining connections echo
 /// it). An **empty** `session_id` is byte-for-byte identical to
 /// [`client_connect`] (additive: the default path is unchanged).
+///
+/// **Wire is the mirror of [`server_accept`] across the 4 (new vs.
+/// attach) × (outgoing vs. incoming) cells (AOSP `RpcSession.cpp`
+/// `initAndAddConnection` + `setupClient` + `addOutgoing/Incoming
+/// Connection`):**
+///
+/// 1. write `RpcConnectionHeader` (`max_version`, optional `INCOMING`
+///    bit, optional 32-byte session id);
+/// 2. **direction-aware `"cci"` exchange**:
+///    - **outgoing**: client writes `"cci"` (`addOutgoingConnection
+///      (init=true)` → `sendConnectionInit`);
+///    - **incoming**: client reads `"cci"` (`addIncomingConnection` →
+///      `preJoinSetup` → `readConnectionInit`).
+/// 3. **new session only** (empty `session_id`, outgoing only — the
+///    AOSP `RpcSession::setupClient` outer flow reads
+///    `RpcNewSessionResponse` after the first `connectAndInit({},
+///    false)`): client reads `RpcNewSessionResponse`. Attach (echoed
+///    id) does NOT read one (AOSP attaches don't get a new-session
+///    response — the founding connection already pinned the version).
+///
+/// Returns the [`Android13PlusCodec`] for the version this connection
+/// negotiated: for a new session, the server-confirmed `min(max,
+/// server_max)`; for an attach, `max_version` itself. Attach trusts
+/// the founding session's pinned version because the wire carries no
+/// per-connection version on attach (AOSP same: `RpcServer.cpp` only
+/// writes `RpcNewSessionResponse` for `requestingNewSession`). The
+/// caller enforces uniformity by clamping `max_version =
+/// min(caller_max, session_version)` *before* the handshake (see
+/// [`RpcSession::add_outgoing_connection_android13plus`]); a peer
+/// running a different actual version on an id-echoing attach is an
+/// unverifiable wire condition on both sides.
 pub fn client_connect_with_id<S: Read + Write>(
     stream: &mut S,
     max_version: u32,
@@ -941,34 +968,66 @@ pub fn client_connect_with_id<S: Read + Write>(
     let hdr_codec = Android13PlusCodec::with_version(max_version)?;
     let header = hdr_codec.encode_connection_header(incoming, fd_mode, session_id)?;
     write_all_raw(stream, &header)?;
-    write_all_raw(stream, &hdr_codec.encode_connection_init())?;
-    let resp = read_exact_raw(stream, A13_NEW_SESSION_RESP_LEN)?;
-    let negotiated = hdr_codec.decode_new_session_response(&resp)?;
-    Android13PlusCodec::with_version(negotiated)
+    let requesting_new_session = session_id.is_empty();
+    if incoming {
+        // attach + incoming (new + incoming is rejected server-side):
+        // client reads server-sent init okay.
+        let init = read_exact_raw(stream, A13_CONN_INIT_LEN)?;
+        hdr_codec.decode_connection_init(&init)?;
+    } else {
+        // outgoing (both new and attach): client writes init.
+        write_all_raw(stream, &hdr_codec.encode_connection_init())?;
+    }
+    if requesting_new_session {
+        let resp = read_exact_raw(stream, A13_NEW_SESSION_RESP_LEN)?;
+        let negotiated = hdr_codec.decode_new_session_response(&resp)?;
+        if negotiated == hdr_codec.version() {
+            Ok(hdr_codec)
+        } else {
+            Android13PlusCodec::with_version(negotiated)
+        }
+    } else {
+        // Attach: no NewSessionResponse on the wire (AOSP same).
+        Ok(hdr_codec)
+    }
 }
 
-/// Server side of the android-13+ connection handshake (new session).
+/// Server side of the android-13+ connection handshake.
 ///
-/// **Wire order is byte-exact to AOSP `RpcServer::establishConnection`
-/// + `RpcSession::preJoinSetup` (android-13.0.0_r84):**
+/// Wire order is byte-exact to AOSP `RpcServer::establishConnection`
+/// (and `RpcSession::preJoinSetup` / `addOutgoingConnection(init=true)`)
+/// in android-16.0.0_r4 across the 4 cells of `(new vs attach)` ×
+/// `(outgoing vs incoming)`:
 ///
-/// 1. read `RpcConnectionHeader` (+ variable session id);
-/// 2. write `RpcNewSessionResponse` (`min(server_max, client_max)`) —
-///    AOSP writes this immediately after the header for a new session
-///    (`establishConnection`);
-/// 3. read + validate the client's `RpcOutgoingConnectionInit`
-///    (`"cci"`) — AOSP reads it on the per-connection serving setup
-///    (`preJoinSetup` → `RpcState::readConnectionInit`).
+/// 1. read `RpcConnectionHeader` (+ variable session id) — parse the
+///    `RPC_CONNECTION_OPTION_INCOMING` bit at `head[4]`.
+/// 2. **new session only** (empty session id): write
+///    `RpcNewSessionResponse` (`min(server_max, client_max)`). AOSP
+///    only writes this for `requestingNewSession` (`RpcServer.cpp`
+///    `if (requestingNewSession)`); attach echoes don't get one.
+/// 3. **direction-aware `"cci"` exchange**:
+///    - **outgoing-from-client** (server reads transacts from the
+///      client on this slot): server **reads** the client's
+///      `RpcOutgoingConnectionInit` (`preJoinSetup` →
+///      `readConnectionInit`).
+///    - **incoming-from-client** (server *sends* callbacks /
+///      `DEC_STRONG` to the client on this slot): server **writes**
+///      `"cci"` (`RpcServer.cpp` calls `addOutgoingConnection(client,
+///      true /*init*/)` for `incoming` → `sendConnectionInit`).
+/// 4. **new + incoming** is rejected (`RpcServer.cpp`: *"Cannot create
+///    a new session with an incoming connection, would leak"*).
 ///
 /// Returns the negotiated [`Android13PlusCodec`] plus the client's
-/// requested FD mode and session-id.
+/// requested FD mode, session-id, and incoming flag.
 pub fn server_accept<S: Read + Write>(
     stream: &mut S,
     server_max_version: u32,
-) -> RpcResult<(Android13PlusCodec, u8, Vec<u8>)> {
+) -> RpcResult<(Android13PlusCodec, u8, Vec<u8>, bool)> {
     // Fixed 16-byte header first, then the variable session id.
     let head = read_exact_raw(stream, A13_CONN_HEADER_LEN)?;
     let client_version = u32::from_le_bytes([head[0], head[1], head[2], head[3]]);
+    let options = head[4];
+    let incoming = (options & CONN_OPTION_INCOMING) != 0;
     let id_size = u16::from_le_bytes([head[14], head[15]]) as usize;
     let session_id = if id_size > 0 {
         read_exact_raw(stream, id_size)?
@@ -993,10 +1052,29 @@ pub fn server_accept<S: Read + Write>(
     // min(serverMax, callerMax) — and it must be one we implement.
     let negotiated = client_version.min(server_max_version);
     let codec = Android13PlusCodec::with_version(negotiated)?;
-    write_all_raw(stream, &codec.encode_new_session_response(negotiated))?;
-    let init = read_exact_raw(stream, A13_CONN_INIT_LEN)?;
-    codec.decode_connection_init(&init)?;
-    Ok((codec, fd_mode, session_id))
+    let requesting_new_session = session_id.is_empty();
+    // AOSP order (`RpcServer.cpp` lines 488-507 then 530-534): for any
+    // `requesting_new_session` header the response is written first;
+    // the incoming-direction "would leak" reject happens *after*.
+    if requesting_new_session {
+        write_all_raw(stream, &codec.encode_new_session_response(negotiated))?;
+    }
+    if requesting_new_session && incoming {
+        return Err(RpcError::Protocol(
+            "new-session request set RPC_CONNECTION_OPTION_INCOMING",
+        ));
+    }
+    if incoming {
+        // attach + incoming: server-driven send of the init okay
+        // (`addOutgoingConnection(init=true)`).
+        write_all_raw(stream, &codec.encode_connection_init())?;
+    } else {
+        // outgoing-from-client (both new and attach): server reads the
+        // client's init (`preJoinSetup` → `readConnectionInit`).
+        let init = read_exact_raw(stream, A13_CONN_INIT_LEN)?;
+        codec.decode_connection_init(&init)?;
+    }
+    Ok((codec, fd_mode, session_id, incoming))
 }
 
 fn write_all_raw<W: Write>(w: &mut W, buf: &[u8]) -> RpcResult<()> {
@@ -1428,9 +1506,11 @@ mod tests {
             let (mut c, mut s) = UnixStream::pair().expect("socketpair");
 
             let srv = thread::spawn(move || -> u32 {
-                let (codec, fd_mode, sid) = server_accept(&mut s, smax).expect("server_accept");
+                let (codec, fd_mode, sid, incoming) =
+                    server_accept(&mut s, smax).expect("server_accept");
                 assert_eq!(fd_mode, FD_MODE_NONE);
                 assert!(sid.is_empty(), "new-session ⇒ empty session id");
+                assert!(!incoming, "new-session is always outgoing");
 
                 // Read the client's GET_ROOT TRANSACT (AOSP framing).
                 let raw = read_aosp_message(&mut s).expect("read transact");
@@ -1521,9 +1601,10 @@ mod tests {
 
             let srv = thread::spawn(move || -> u32 {
                 let mut io = RawTransportIo(&b);
-                let (codec, fd, sid) = server_accept(&mut io, 2).expect("server_accept");
+                let (codec, fd, sid, incoming) = server_accept(&mut io, 2).expect("server_accept");
                 assert_eq!(fd, FD_MODE_NONE);
                 assert!(sid.is_empty());
+                assert!(!incoming);
                 let raw = read_aosp_message(&mut io).expect("read transact");
                 match codec.decode_message(&raw).expect("decode") {
                     WireMessage::Transact(t) => assert_eq!(t.code, 0),
@@ -1576,6 +1657,113 @@ mod tests {
         let (m, _m2) = crate::rpc::transport::MemTransport::pair();
         assert!(m.send_raw(b"x").is_err(), "mem has no raw byte access");
         assert!(m.recv_raw(&mut [0u8; 4]).is_err());
+    }
+
+    /// Attach handshake (non-empty session id) is byte-exact to AOSP
+    /// `RpcSession::initAndAddConnection` + `RpcServer::establish
+    /// Connection`: no `RpcNewSessionResponse` on the wire, "cci"
+    /// direction follows the `RPC_CONNECTION_OPTION_INCOMING` bit.
+    /// The mutant catch — server spuriously writing `RpcNewSession
+    /// Response` on attach + client spuriously reading it — would be
+    /// invisible to a success-only assertion (both sides write+read
+    /// 8 stale bytes in lockstep) but surfaces here as leftover bytes
+    /// after both shutdown their write halves.
+    #[test]
+    fn android13plus_attach_handshake_wire_byte_exact() {
+        use std::io::Read;
+        use std::net::Shutdown;
+        use std::os::unix::net::UnixStream;
+        use std::thread;
+
+        let session_id = [0x42u8; 32];
+
+        for (incoming, version) in [
+            (false, PROTOCOL_V0),
+            (false, PROTOCOL_V1),
+            (false, PROTOCOL_V2),
+            (true, PROTOCOL_V0),
+            (true, PROTOCOL_V1),
+            (true, PROTOCOL_V2),
+        ] {
+            let (mut c, mut s) = UnixStream::pair().expect("pair");
+            let sid = session_id;
+            let srv = thread::spawn(move || -> (u32, bool, Vec<u8>, Vec<u8>) {
+                let (codec, _fd, got_sid, srv_incoming) =
+                    server_accept(&mut s, version).expect("server_accept");
+                s.shutdown(Shutdown::Write).expect("srv shutdown w");
+                let mut leftover = Vec::new();
+                s.read_to_end(&mut leftover).expect("srv read_to_end");
+                (codec.version(), srv_incoming, got_sid, leftover)
+            });
+
+            let codec = client_connect_with_id(&mut c, version, incoming, FD_MODE_NONE, &sid)
+                .expect("client_connect_with_id");
+            c.shutdown(Shutdown::Write).expect("cli shutdown w");
+            let mut client_leftover = Vec::new();
+            c.read_to_end(&mut client_leftover)
+                .expect("cli read_to_end");
+            assert!(
+                client_leftover.is_empty(),
+                "(attach, incoming={incoming}, v={version}): server wrote {} unexpected \
+                 byte(s) after handshake — regression of NewSessionResponse-on-attach",
+                client_leftover.len()
+            );
+
+            let (sv, sincoming, ssid, srv_leftover) = srv.join().expect("srv");
+            assert_eq!(sv, version);
+            assert_eq!(sincoming, incoming);
+            assert_eq!(ssid, sid.to_vec());
+            assert_eq!(codec.version(), version);
+            assert!(
+                srv_leftover.is_empty(),
+                "(attach, incoming={incoming}, v={version}): client wrote {} unexpected \
+                 byte(s) after handshake",
+                srv_leftover.len()
+            );
+        }
+    }
+
+    /// AOSP-faithful: `RpcServer.cpp` writes `RpcNewSessionResponse`
+    /// for *any* `requestingNewSession` header (line 494-506), *then*
+    /// at line 530-534 rejects the incoming-direction request because
+    /// "Cannot create a new session with an incoming connection,
+    /// would leak". The client therefore sees the response on the
+    /// wire before EOF — this test pins both the rejection and the
+    /// wire order.
+    #[test]
+    fn android13plus_new_session_incoming_rejected() {
+        use std::io::Read;
+        use std::os::unix::net::UnixStream;
+        use std::thread;
+
+        let (mut c, mut s) = UnixStream::pair().expect("pair");
+        let srv = thread::spawn(move || -> RpcResult<_> {
+            let result = server_accept(&mut s, PROTOCOL_V1);
+            drop(s);
+            result
+        });
+
+        let codec = Android13PlusCodec::with_version(PROTOCOL_V1).unwrap();
+        let header = codec
+            .encode_connection_header(true, FD_MODE_NONE, &[])
+            .unwrap();
+        write_all_raw(&mut c, &header).expect("write header");
+
+        let r = srv.join().expect("srv");
+        assert!(
+            matches!(r, Err(RpcError::Protocol(_))),
+            "server must reject new-session + incoming, got {r:?}"
+        );
+
+        let mut buf = Vec::new();
+        c.read_to_end(&mut buf).expect("read response + EOF");
+        assert_eq!(
+            buf.len(),
+            A13_NEW_SESSION_RESP_LEN,
+            "AOSP order: write RpcNewSessionResponse, then close on \
+             incoming. Got {} bytes: {buf:?}",
+            buf.len()
+        );
     }
 
     // ===== subplan 2-8 — android-16 RPC wire v2 (Phase A) ==========

--- a/rsbinder/src/shared_memory.rs
+++ b/rsbinder/src/shared_memory.rs
@@ -1,0 +1,196 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared-memory IPC trait skeleton.
+//!
+//! AOSP `IMemory` / `IMemoryHeap`
+//! ([`IMemory.h`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/include/binder/IMemory.h))
+//! are **handwritten** C++ binders, not AIDL. The Rust traits in this
+//! module mirror that surface for in-process use. Not yet implemented,
+//! left as future work:
+//!
+//! * A `memfd_create(2)` + `F_ADD_SEALS` backed `MemoryHeapBase`
+//!   (Linux/Android only). Receiver-side `F_GET_SEALS` verification is
+//!   mandatory for the read-only PROT negotiation.
+//! * A `MemoryDealer` chunk allocator on top of a heap.
+//! * Hermetic verification that two processes can mmap the same page
+//!   through `ParcelFileDescriptor` transfer.
+//!
+//! Interop with real `IMemory`/`IMemoryHeap` peers is out of scope — it
+//! would require manual `Bn`/`Bp` matching AOSP's handwritten transaction
+//! codes (`HEAP_ID_TRANSACTION` etc.).
+//!
+//! The macOS host build compiles every trait declaration in this module
+//! but the concrete `MemoryHeapBase` stub returns
+//! `Err(StatusCode::InvalidOperation)` from every operation — there is no
+//! `memfd_create` equivalent on darwin. The Linux/Android impl, once
+//! added, is gated on `cfg(any(target_os = "linux", target_os = "android"))`.
+
+use crate::error::{Result, StatusCode};
+
+/// AOSP `IMemoryHeap::READ_ONLY` flag
+/// ([IMemory.h:37-39](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/include/binder/IMemory.h;l=37)).
+/// Receivers MUST honor this by mapping `PROT_READ` only and rejecting
+/// any subsequent `mprotect(PROT_WRITE)`. The PROT negotiation also
+/// requires the sender to enforce `F_SEAL_WRITE` on the underlying
+/// `memfd` so the kernel rejects a mismatched mmap from a peer that
+/// ignores this flag.
+pub const FLAG_READ_ONLY: u32 = 0x0000_0001;
+
+/// Server-side representation of a heap. AOSP `IMemoryHeap` is keyed by
+/// the heap fd; this trait deliberately exposes the fd as a borrowed
+/// raw fd (`i32`) rather than an owned [`std::os::fd::OwnedFd`] so the
+/// transaction marshalling can dup the fd into a
+/// [`crate::ParcelFileDescriptor`] without taking ownership away from
+/// the heap object.
+///
+/// All methods return `&` borrows (heap geometry is immutable for the
+/// lifetime of the heap); the size and offset are captured at heap
+/// construction time and never mutate. Mutation surface is intentionally
+/// absent — heap resize is not in AOSP `IMemoryHeap` either
+/// ([IMemory.h:41-45](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/include/binder/IMemory.h;l=41)).
+pub trait IMemoryHeap: Send + Sync {
+    /// AOSP `getHeapID()`. Returns the fd-as-i32 for parcel marshalling
+    /// (wrapped in `ParcelFileDescriptor` on the wire).
+    fn heap_id(&self) -> i32;
+    /// AOSP `getSize()`. Total byte length of the heap.
+    fn size(&self) -> usize;
+    /// AOSP `getFlags()`. Bitmask of `FLAG_READ_ONLY` etc.
+    fn flags(&self) -> u32;
+    /// AOSP `getOffset()`. Offset within the underlying fd at which
+    /// this heap begins; `0` for a freshly-allocated heap.
+    fn offset(&self) -> usize;
+    /// AOSP `getBase()`. Returns the local mmap base pointer if the
+    /// heap is currently mapped into this process, else `None`.
+    /// A real `MemoryHeapBase` would populate this; the macOS stub
+    /// always returns `None`.
+    ///
+    /// **Safety contract.** The returned slice is valid only for the
+    /// lifetime of the heap (`&self`) and only points to memory mapped
+    /// by *this* process — see AOSP `unsecurePointer()` security note
+    /// ([IMemory.h:78-91](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/include/binder/IMemory.h;l=78)).
+    fn base(&self) -> Option<&[u8]>;
+}
+
+/// Sub-region of an [`IMemoryHeap`]. AOSP
+/// [`IMemory`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/include/binder/IMemory.h;l=69)
+/// equivalent. An `IMemory` references a heap plus an `(offset, size)`
+/// pair so that one large heap can host many small allocations (the
+/// AOSP `MemoryDealer` pattern).
+pub trait IMemory: Send + Sync {
+    /// AOSP `getMemory(offset*, size*)`. Returns the backing heap plus
+    /// the in-heap offset and size for this slice. `&self` borrow keeps
+    /// the heap alive for the duration of the returned reference.
+    fn memory(&self) -> &dyn IMemoryHeap;
+    /// AOSP `offset()`. Offset within the backing heap.
+    fn offset(&self) -> usize;
+    /// AOSP `size()`. Byte length of this slice. May be smaller than
+    /// the backing heap.
+    fn size(&self) -> usize;
+}
+
+/// Concrete heap allocator. Currently only the public surface is
+/// present; the actual `memfd_create` + `F_ADD_SEALS` implementation is
+/// future work, gated on Linux/Android.
+///
+/// On macOS this is a *compile-only* stub: every constructor returns
+/// `Err(StatusCode::InvalidOperation)` so callers can write
+/// `cfg`-portable code that depends on the trait surface but doesn't
+/// actually rely on shared memory backing existing.
+#[derive(Debug)]
+pub struct MemoryHeapBase {
+    // `_` prefix suppresses dead-code until the real impl fills these.
+    _size: usize,
+    _flags: u32,
+    _offset: usize,
+}
+
+impl MemoryHeapBase {
+    /// macOS / Linux / Android constructor stub. Returns
+    /// `Err(StatusCode::InvalidOperation)` until the
+    /// `memfd_create`-backed impl lands (Linux/Android cfg) — on macOS
+    /// it remains permanent (`Err(InvalidOperation)`).
+    pub fn new(size: usize, flags: u32) -> Result<Self> {
+        // Suppress unused: keep them in the signature so callers see
+        // the AOSP-faithful surface from day 1.
+        let _ = (size, flags);
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            // For now even Linux/Android returns `InvalidOperation`; the
+            // real impl will call `memfd_create(2)` + map here.
+            Err(StatusCode::InvalidOperation)
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        {
+            Err(StatusCode::InvalidOperation)
+        }
+    }
+}
+
+impl IMemoryHeap for MemoryHeapBase {
+    fn heap_id(&self) -> i32 {
+        -1
+    }
+    fn size(&self) -> usize {
+        self._size
+    }
+    fn flags(&self) -> u32 {
+        self._flags
+    }
+    fn offset(&self) -> usize {
+        self._offset
+    }
+    fn base(&self) -> Option<&[u8]> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The public trait + struct surface compiles on the
+    /// host tree, including the macOS host where `memfd_create` is
+    /// absent. The stub constructor signals "not implemented" rather
+    /// than panicking, so caller code can opt out gracefully when
+    /// shared memory is unavailable.
+    #[test]
+    fn macos_stub_constructor_signals_not_implemented() {
+        let err = MemoryHeapBase::new(4096, FLAG_READ_ONLY).unwrap_err();
+        assert_eq!(err, StatusCode::InvalidOperation);
+    }
+
+    /// `FLAG_READ_ONLY` matches AOSP `IMemoryHeap::READ_ONLY = 0x01`.
+    #[test]
+    fn flag_read_only_matches_aosp_constant() {
+        assert_eq!(FLAG_READ_ONLY, 0x0000_0001);
+    }
+
+    /// The trait surface itself is object-safe — we can hold an
+    /// `&dyn IMemoryHeap`. The actual impl is exercised in hermetic
+    /// tests once the memfd backend exists.
+    #[test]
+    fn imemoryheap_is_object_safe() {
+        // Trivial impl: zero-sized heap with no base mapping.
+        struct Stub;
+        impl IMemoryHeap for Stub {
+            fn heap_id(&self) -> i32 {
+                42
+            }
+            fn size(&self) -> usize {
+                0
+            }
+            fn flags(&self) -> u32 {
+                0
+            }
+            fn offset(&self) -> usize {
+                0
+            }
+            fn base(&self) -> Option<&[u8]> {
+                None
+            }
+        }
+        let h: &dyn IMemoryHeap = &Stub;
+        assert_eq!(h.heap_id(), 42);
+    }
+}

--- a/rsbinder/src/status.rs
+++ b/rsbinder/src/status.rs
@@ -45,8 +45,22 @@ pub enum ExceptionCode {
     /// Parcelable exception
     Parcelable = -9,
 
+    /// Reply parcel carries a noted-AppOps blob before the *real*
+    /// exception code. Wire value `-127` matches
+    /// AOSP `EX_HAS_NOTED_APPOPS_REPLY_HEADER`
+    /// (`frameworks/native/libs/binder/include/binder/Status.h:71`).
+    ///
+    /// Set by a server that received the transaction with
+    /// `TF_COLLECT_NOTED_APP_OPS` (see [`crate::FLAG_COLLECT_NOTED_APP_OPS`]).
+    /// rsbinder's [`Status::deserialize`] transparently skips the header
+    /// and reads the next i32 as the actual exception code — clients
+    /// observe the same `Status` they would have without the header.
+    HasNotedAppOpsReplyHeader = -127,
     // This is special and Java specific; see Parcel.java.
-    /// Has reply header (Java-specific)
+    /// Has reply header (Java-specific). Wire value `-128` matches AOSP
+    /// `EX_HAS_REPLY_HEADER`. Treated as `EX_NONE` after the header is
+    /// skipped — the AOSP convention for "fat response header"
+    /// piggybacking.
     HasReplyHeader = -128,
     // This is special, and indicates to C++ binder proxies that the
     // transaction has failed at a low level.
@@ -69,6 +83,7 @@ impl Display for ExceptionCode {
             ExceptionCode::UnsupportedOperation => write!(f, "UnsupportedOperation"),
             ExceptionCode::ServiceSpecific => write!(f, "ServiceSpecific"),
             ExceptionCode::Parcelable => write!(f, "Parcelable"),
+            ExceptionCode::HasNotedAppOpsReplyHeader => write!(f, "HasNotedAppOpsReplyHeader"),
             ExceptionCode::HasReplyHeader => write!(f, "HasReplyHeader"),
             ExceptionCode::TransactionFailed => write!(f, "TransactionFailed"),
             ExceptionCode::JustError => write!(f, "JustError"),
@@ -110,6 +125,9 @@ impl Deserialize for ExceptionCode {
                 ExceptionCode::ServiceSpecific
             }
             exception if exception == ExceptionCode::Parcelable as i32 => ExceptionCode::Parcelable,
+            exception if exception == ExceptionCode::HasNotedAppOpsReplyHeader as i32 => {
+                ExceptionCode::HasNotedAppOpsReplyHeader
+            }
             exception if exception == ExceptionCode::HasReplyHeader as i32 => {
                 ExceptionCode::HasReplyHeader
             }
@@ -330,6 +348,17 @@ impl Deserialize for Status {
     fn deserialize(parcel: &mut Parcel) -> error::Result<Self> {
         let mut exception = parcel.read::<ExceptionCode>()?;
 
+        // AOSP-faithful order — `Status::readFromParcel` in
+        // `frameworks/native/libs/binder/Status.cpp`:
+        //   1. EX_HAS_NOTED_APPOPS_REPLY_HEADER → skip blob, re-read
+        //      the next i32 as the actual exception code (which may
+        //      itself be EX_HAS_REPLY_HEADER).
+        //   2. EX_HAS_REPLY_HEADER → skip blob, treat as EX_NONE
+        //      (libbinder convention for "fat response header").
+        if exception == ExceptionCode::HasNotedAppOpsReplyHeader {
+            read_check_header_size(parcel)?;
+            exception = parcel.read::<ExceptionCode>()?;
+        }
         if exception == ExceptionCode::HasReplyHeader {
             read_check_header_size(parcel)?;
             exception = ExceptionCode::None;
@@ -338,6 +367,20 @@ impl Deserialize for Status {
             exception.into()
         } else {
             let message: String = parcel.read::<String>()?;
+
+            // AOSP `Status::readFromParcel` (frameworks/native/libs/binder/
+            // Status.cpp): capture the header start position and the
+            // available bytes BEFORE reading the size int32. The remote
+            // stack-trace header size is size-INCLUSIVE (it counts the
+            // 4-byte size field itself), so reposition to
+            // `header_start + size` — and ONLY when size != 0. size == 0
+            // (the native writer's "empty remote stack trace header") leaves
+            // the cursor right after the size field. The previous
+            // size-EXCLUSIVE arithmetic (`current_pos_after_read + size`)
+            // landed 4 bytes too far whenever a Java peer propagated a
+            // non-zero stack-trace header.
+            let header_start = parcel.data_position();
+            let header_avail = parcel.data_avail();
             let remote_stack_trace_header_size = parcel.read::<i32>()?;
 
             // Check for negative values first
@@ -351,25 +394,26 @@ impl Deserialize for Status {
             // Safe conversion after negativity check
             let trace_size_usize = remote_stack_trace_header_size as usize;
 
-            // Check against available data
-            if trace_size_usize > parcel.data_avail() {
+            // Check against available data (pre-read avail, which includes
+            // the 4-byte size field, mirroring AOSP's `remote_avail`).
+            if trace_size_usize > header_avail {
                 log::error!(
-                    "0x534e4554:132650049 Invalid remote_stack_trace_header_size({remote_stack_trace_header_size}) exceeds available({}).",
-                    parcel.data_avail()
+                    "0x534e4554:132650049 Invalid remote_stack_trace_header_size({remote_stack_trace_header_size}) exceeds available({header_avail})."
                 );
                 return Err(StatusCode::BadValue);
             }
 
-            // Prevent integer overflow in position calculation
-            let current_pos = parcel.data_position();
-            let new_position = current_pos.checked_add(trace_size_usize).ok_or_else(|| {
-                log::error!(
-                    "0x534e4554:132650049 Position overflow with remote_stack_trace_header_size({remote_stack_trace_header_size})"
-                );
-                StatusCode::BadValue
-            })?;
+            if trace_size_usize != 0 {
+                // Prevent integer overflow in position calculation
+                let new_position = header_start.checked_add(trace_size_usize).ok_or_else(|| {
+                    log::error!(
+                        "0x534e4554:132650049 Position overflow with remote_stack_trace_header_size({remote_stack_trace_header_size})"
+                    );
+                    StatusCode::BadValue
+                })?;
 
-            parcel.set_data_position(new_position);
+                parcel.set_data_position(new_position);
+            }
 
             let code = if exception == ExceptionCode::ServiceSpecific {
                 let code = parcel.read::<i32>()?;
@@ -422,6 +466,34 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    // Regression: a non-zero, size-INCLUSIVE remote stack-trace header
+    // (as a Java peer propagating an exception trace emits) must be skipped
+    // by exactly `header_start + size` so the following EX_SERVICE_SPECIFIC
+    // code reads back correctly. The previous size-EXCLUSIVE arithmetic
+    // (`pos_after_size_read + size`) overshot by 4 bytes and desynced the
+    // cursor.
+    #[test]
+    fn deserialize_skips_nonzero_remote_stack_trace_header() {
+        let mut parcel = Parcel::new();
+        parcel
+            .write::<i32>(&(ExceptionCode::ServiceSpecific as i32))
+            .unwrap();
+        parcel.write::<String>(&"boom".to_owned()).unwrap();
+        // Size-inclusive header: 4 (the size field) + 4 (one i32 of opaque
+        // trace payload) = 8.
+        parcel.write::<i32>(&8i32).unwrap();
+        parcel.write::<i32>(&0x5555_5555i32).unwrap(); // trace payload
+        parcel.write::<i32>(&777i32).unwrap(); // service-specific code
+
+        parcel.set_data_position(0);
+        let status = Status::deserialize(&mut parcel).expect("deserialize");
+        assert_eq!(
+            StatusCode::from(status),
+            StatusCode::ServiceSpecific(777),
+            "non-zero size-inclusive stack-trace header must be skipped exactly"
+        );
     }
 
     #[test]
@@ -498,5 +570,151 @@ mod tests {
             0,
             "nothing must be written on the failed path"
         );
+    }
+
+    // ----------------------------------------------------------------
+    // EX_HAS_NOTED_APPOPS_REPLY_HEADER / EX_HAS_REPLY_HEADER
+    // ----------------------------------------------------------------
+
+    /// The bare wire values match AOSP `Status.h:71,74`.
+    /// A driver running on a current Android release embeds these
+    /// codes into reply parcels, so a mismatch would silently corrupt
+    /// every reply that piggybacks a header.
+    #[test]
+    fn appops_header_exception_codes_match_aosp_wire() {
+        assert_eq!(
+            ExceptionCode::HasNotedAppOpsReplyHeader as i32,
+            -127,
+            "EX_HAS_NOTED_APPOPS_REPLY_HEADER must be -127 (AOSP Status.h:71)"
+        );
+        assert_eq!(
+            ExceptionCode::HasReplyHeader as i32,
+            -128,
+            "EX_HAS_REPLY_HEADER must be -128 (AOSP Status.h:74)"
+        );
+    }
+
+    /// Helper — write a fake length-prefixed header blob whose size
+    /// field includes itself (AOSP convention,
+    /// `Status.cpp::skipUnusedHeader`: "the header size includes the
+    /// 4 byte size field"). The Parcel write path enforces 4-byte
+    /// alignment, so each "payload byte" needs an `i32` slot; we round
+    /// the requested byte count up to the nearest 4 before allocating
+    /// the zero-filled slots.
+    fn write_header_blob(parcel: &mut Parcel, header_payload_bytes: usize) {
+        let aligned_payload = header_payload_bytes.div_ceil(4) * 4;
+        let size_field = 4 + aligned_payload;
+        parcel.write::<i32>(&(size_field as i32)).unwrap();
+        for _ in 0..(aligned_payload / 4) {
+            parcel.write::<i32>(&0i32).unwrap();
+        }
+    }
+
+    /// A reply that starts with `EX_HAS_NOTED_APPOPS_REPLY_HEADER`
+    /// (-127), then carries a blob, then the real `EX_NONE` (0), must
+    /// decode as `Status::ok()` — the AppOps header is transparent to
+    /// the user.
+    #[test]
+    fn deserialize_skips_appops_header_then_reads_ex_none() {
+        let mut parcel = Parcel::new();
+        parcel
+            .write::<i32>(&(ExceptionCode::HasNotedAppOpsReplyHeader as i32))
+            .unwrap();
+        write_header_blob(&mut parcel, 16); // 16-byte fake AppOps blob
+        parcel.write::<i32>(&(ExceptionCode::None as i32)).unwrap();
+
+        parcel.set_data_position(0);
+        let status = Status::deserialize(&mut parcel).expect("deserialize");
+        assert_eq!(status.exception_code(), ExceptionCode::None);
+        assert!(status.is_ok());
+    }
+
+    /// A reply that chains AppOps header → reply header
+    /// (`Status.cpp::readFromParcel` allows the AppOps header first)
+    /// must collapse to `EX_NONE` — the AOSP convention for "fat
+    /// response header + no exception".
+    #[test]
+    fn deserialize_skips_appops_then_reply_header_collapses_to_none() {
+        let mut parcel = Parcel::new();
+        parcel
+            .write::<i32>(&(ExceptionCode::HasNotedAppOpsReplyHeader as i32))
+            .unwrap();
+        write_header_blob(&mut parcel, 8);
+        parcel
+            .write::<i32>(&(ExceptionCode::HasReplyHeader as i32))
+            .unwrap();
+        write_header_blob(&mut parcel, 4);
+
+        parcel.set_data_position(0);
+        let status = Status::deserialize(&mut parcel).expect("deserialize");
+        assert_eq!(
+            status.exception_code(),
+            ExceptionCode::None,
+            "EX_HAS_REPLY_HEADER (-128) must collapse to None"
+        );
+    }
+
+    /// AppOps header + real `EX_SECURITY` (-1) must surface
+    /// the security exception to the caller — the header is
+    /// transparent but the underlying error is not.
+    #[test]
+    fn deserialize_skips_appops_header_then_surfaces_real_exception() {
+        let mut parcel = Parcel::new();
+        parcel
+            .write::<i32>(&(ExceptionCode::HasNotedAppOpsReplyHeader as i32))
+            .unwrap();
+        write_header_blob(&mut parcel, 12);
+        // Real exception payload: code + message + trace size.
+        parcel
+            .write::<i32>(&(ExceptionCode::Security as i32))
+            .unwrap();
+        parcel.write::<String>(&"denied".to_owned()).unwrap();
+        parcel.write::<i32>(&0i32).unwrap(); // remote stack trace header size
+
+        parcel.set_data_position(0);
+        let status = Status::deserialize(&mut parcel).expect("deserialize");
+        assert_eq!(status.exception_code(), ExceptionCode::Security);
+    }
+
+    // ----------------------------------------------------------------
+    // TF_UPDATE_TXN / TF_COLLECT_NOTED_APP_OPS flag values
+    // ----------------------------------------------------------------
+
+    /// `FLAG_UPDATE_TXN` must equal AOSP `TF_UPDATE_TXN = 0x40`
+    /// (kernel UAPI `binder.h:346`). The kernel driver only checks the
+    /// bit value, so a mismatch is a silent wire incompatibility.
+    #[test]
+    fn flag_update_txn_matches_kernel_wire() {
+        assert_eq!(
+            crate::FLAG_UPDATE_TXN,
+            0x40,
+            "FLAG_UPDATE_TXN must be the kernel-defined 0x40"
+        );
+    }
+
+    /// `FLAG_COLLECT_NOTED_APP_OPS = 0x80` matches AOSP's
+    /// userspace libbinder convention.
+    #[test]
+    fn flag_collect_noted_app_ops_matches_aosp_userspace() {
+        assert_eq!(
+            crate::FLAG_COLLECT_NOTED_APP_OPS,
+            0x80,
+            "FLAG_COLLECT_NOTED_APP_OPS must be 0x80 (AOSP userspace)"
+        );
+    }
+
+    // ----------------------------------------------------------------
+    // binder_extended_error struct layout
+    // ----------------------------------------------------------------
+
+    /// rsbinder's `ExtendedError` mirror must match the
+    /// 12-byte kernel struct exactly — id (4) + command (4) + param (4).
+    /// Any field reorder would corrupt the ioctl read.
+    #[test]
+    fn extended_error_struct_layout_matches_kernel() {
+        use std::mem::{align_of, size_of};
+        type Ee = crate::sys::binder_extended_error;
+        assert_eq!(size_of::<Ee>(), 12);
+        assert_eq!(align_of::<Ee>(), 4);
     }
 }

--- a/rsbinder/src/sys/mod.rs
+++ b/rsbinder/src/sys/mod.rs
@@ -55,6 +55,17 @@ pub mod binder {
     pub const BR_ONEWAY_SPAM_SUSPECT: binder_driver_return_protocol =
         binder_driver_return_protocol_BR_ONEWAY_SPAM_SUSPECT;
 
+    // Freeze observer additions (Android 14+, kernel 6.5+). These BR
+    // constants are exposed so the RETURN_STRINGS table can decode them;
+    // dispatch is not yet wired, so the default arm still treats them as
+    // "Unknown BR_ return" and the kernel wire stays byte-unchanged.
+    pub const BR_TRANSACTION_PENDING_FROZEN: binder_driver_return_protocol =
+        binder_driver_return_protocol_BR_TRANSACTION_PENDING_FROZEN;
+    pub const BR_FROZEN_BINDER: binder_driver_return_protocol =
+        binder_driver_return_protocol_BR_FROZEN_BINDER;
+    pub const BR_CLEAR_FREEZE_NOTIFICATION_DONE: binder_driver_return_protocol =
+        binder_driver_return_protocol_BR_CLEAR_FREEZE_NOTIFICATION_DONE;
+
     pub const BC_TRANSACTION: binder_driver_command_protocol =
         binder_driver_command_protocol_BC_TRANSACTION;
     pub const BC_REPLY: binder_driver_command_protocol = binder_driver_command_protocol_BC_REPLY;
@@ -92,6 +103,18 @@ pub mod binder {
         binder_driver_command_protocol_BC_TRANSACTION_SG;
     pub const BC_REPLY_SG: binder_driver_command_protocol =
         binder_driver_command_protocol_BC_REPLY_SG;
+
+    // Freeze observer BC counterparts. The send path
+    // (`BC_REQUEST_FREEZE_NOTIFICATION` and friends) is not yet wired;
+    // these constants plus the `binder_handle_cookie` struct and
+    // `binder_frozen_state_info` payload are exposed so call sites can
+    // pattern-match on them once the dispatch arms land.
+    pub const BC_REQUEST_FREEZE_NOTIFICATION: binder_driver_command_protocol =
+        binder_driver_command_protocol_BC_REQUEST_FREEZE_NOTIFICATION;
+    pub const BC_CLEAR_FREEZE_NOTIFICATION: binder_driver_command_protocol =
+        binder_driver_command_protocol_BC_CLEAR_FREEZE_NOTIFICATION;
+    pub const BC_FREEZE_NOTIFICATION_DONE: binder_driver_command_protocol =
+        binder_driver_command_protocol_BC_FREEZE_NOTIFICATION_DONE;
 
     use rustix::{io, ioctl};
     use std::os::fd::AsFd;
@@ -293,6 +316,24 @@ pub mod binder {
                 { ioctl::opcode::read_write::<binder_frozen_status_info>(b'b', 15) },
                 _,
             >::new(frozen_info);
+            ioctl::ioctl(fd, ctl)
+        }
+    }
+
+    // Android 12+ driver. The kernel returns 12
+    // bytes describing the last transaction failure on the current
+    // thread (id / command / errno). Older kernels respond `ENOTTY`;
+    // callers should treat that as "feature unavailable".
+    pub(crate) fn get_extended_error<Fd: AsFd>(
+        fd: Fd,
+        ee: &mut binder_extended_error,
+    ) -> std::result::Result<(), io::Errno> {
+        unsafe {
+            // SAFETY: see shared rationale above. Request: BINDER_GET_EXTENDED_ERROR.
+            let ctl = ioctl::Updater::<
+                { ioctl::opcode::read_write::<binder_extended_error>(b'b', 17) },
+                _,
+            >::new(ee);
             ioctl::ioctl(fd, ctl)
         }
     }

--- a/rsbinder/src/sys/sys.rs
+++ b/rsbinder/src/sys/sys.rs
@@ -1962,6 +1962,22 @@ pub const BINDER_TYPE_PTR: _bindgen_ty_1 = 1886661253;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 pub const FLAT_BINDER_FLAG_PRIORITY_MASK: _bindgen_ty_2 = 255;
 pub const FLAT_BINDER_FLAG_ACCEPTS_FDS: _bindgen_ty_2 = 256;
+/// Post-shift mask for the 2-bit scheduler-policy
+/// field embedded in `flat_binder_object.flags` (bits 9-10, value
+/// `0x600`). Mirrors AOSP `FLAT_BINDER_FLAG_SCHED_POLICY_MASK` in
+/// `kernel/include/uapi/linux/android/binder.h`. Pair with
+/// `FLAT_BINDER_FLAG_SCHED_POLICY_VALUE_MASK` (pre-shift `0x3`) defined
+/// next to the encoder in `binder_object.rs`.
+pub const FLAT_BINDER_FLAG_SCHED_POLICY_MASK: _bindgen_ty_2 = 0x600;
+/// `FLAT_BINDER_FLAG_INHERIT_RT` (bit 11, `0x800`).
+/// When set on a `BBinder` advertised over kernel binder, the driver
+/// applies the caller's SCHED_FIFO / SCHED_RR scheduling class to the
+/// thread that services the resulting transaction; without the bit, the
+/// receiver runs at min(caller, declared) priority, which is the right
+/// default for non-RT services. Required by framework AIDL services
+/// (audio/camera HAL) that advertise themselves with `INHERIT_RT` set —
+/// without this bit rsbinder cannot mirror their RT-priority interop.
+pub const FLAT_BINDER_FLAG_INHERIT_RT: _bindgen_ty_2 = 0x800;
 #[doc = " @FLAT_BINDER_FLAG_TXN_SECURITY_CTX: request security contexts"]
 #[doc = ""]
 #[doc = " Only when set, causes senders to include their security"]
@@ -2874,6 +2890,69 @@ fn bindgen_test_layout_binder_node_info_for_ref() {
     }
     test_field_reserved3();
 }
+/// Detailed cause of the most recent kernel-side transaction failure
+/// for the current thread, returned by `BINDER_GET_EXTENDED_ERROR`
+/// (`_IOWR('b', 17, struct binder_extended_error)`).
+///
+/// Wire layout matches Android `kernel/include/uapi/linux/android/binder.h:302-306`
+/// (also `external/kernel-headers/original/uapi/linux/android/binder.h:302-306`
+/// in the AOSP tree). Available on Android 12 (S, SDK 31) and newer
+/// kernels; older drivers respond to the ioctl with `ENOTTY` and the
+/// caller falls back to the bare `StatusCode::FailedTransaction` signal
+/// from the BR_FAILED_REPLY arm.
+///
+/// Field semantics (per kernel `binder.c::binder_inner_proc_unlock`):
+///   * `id` — monotonically increasing counter; lets the caller detect
+///     "is this the same failure I already observed?" without racing
+///     with the next failure on the same fd.
+///   * `command` — the BR_ return code that originally surfaced the
+///     failure (typically `BR_FAILED_REPLY`).
+///   * `param` — negated errno (`-EINVAL`, `-EBADF`, …) or another
+///     driver-specific code; `0` when no detail is available.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+pub struct binder_extended_error {
+    pub id: __u32,
+    pub command: __u32,
+    pub param: __s32,
+}
+#[test]
+fn bindgen_test_layout_binder_extended_error() {
+    assert_eq!(
+        ::std::mem::size_of::<binder_extended_error>(),
+        12usize,
+        concat!("Size of: ", stringify!(binder_extended_error))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<binder_extended_error>(),
+        4usize,
+        concat!("Alignment of ", stringify!(binder_extended_error))
+    );
+    assert_eq!(
+        unsafe {
+            let uninit = ::std::mem::MaybeUninit::<binder_extended_error>::uninit();
+            let ptr = uninit.as_ptr();
+            ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize
+        },
+        0usize,
+    );
+    assert_eq!(
+        unsafe {
+            let uninit = ::std::mem::MaybeUninit::<binder_extended_error>::uninit();
+            let ptr = uninit.as_ptr();
+            ::std::ptr::addr_of!((*ptr).command) as usize - ptr as usize
+        },
+        4usize,
+    );
+    assert_eq!(
+        unsafe {
+            let uninit = ::std::mem::MaybeUninit::<binder_extended_error>::uninit();
+            let ptr = uninit.as_ptr();
+            ::std::ptr::addr_of!((*ptr).param) as usize - ptr as usize
+        },
+        8usize,
+    );
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct binder_freeze_info {
@@ -3021,6 +3100,28 @@ pub const transaction_flags_TF_ROOT_OBJECT: transaction_flags = 4;
 pub const transaction_flags_TF_STATUS_CODE: transaction_flags = 8;
 pub const transaction_flags_TF_ACCEPT_FDS: transaction_flags = 16;
 pub const transaction_flags_TF_CLEAR_BUF: transaction_flags = 32;
+/// Android 12 (Linux 5.14) and newer driver:
+/// `TF_UPDATE_TXN` (0x40). Set on a oneway `BC_TRANSACTION{,_SG}`
+/// alongside `TF_ONE_WAY`; the driver replaces any pending async
+/// transaction with the same `(target_node, code)` key instead of
+/// queueing both, deduplicating async notification floods. Without
+/// `TF_ONE_WAY` the driver rejects the request with `EINVAL`.
+///
+/// Kernel UAPI reference:
+/// `external/kernel-headers/original/uapi/linux/android/binder.h:346`.
+pub const transaction_flags_TF_UPDATE_TXN: transaction_flags = 64;
+/// `TF_COLLECT_NOTED_APP_OPS` (0x80). Strictly a
+/// libbinder-level flag (the kernel binder driver does not consume it):
+/// instructs the runtime to prepend an `EX_HAS_NOTED_APPOPS_REPLY_HEADER`
+/// (= -127) blob to the reply parcel, listing every `noteOp(...)`
+/// AppOpsManager call observed while servicing the transaction. The
+/// receiving proxy must read past the header before decoding the user's
+/// reply payload — see `Parcel::read_exception_code` /
+/// `Status::from_parcel` for the rsbinder side.
+///
+/// AOSP libbinder reference:
+/// `frameworks/native/libs/binder/Parcel.cpp::readExceptionCode`.
+pub const transaction_flags_TF_COLLECT_NOTED_APP_OPS: transaction_flags = 128;
 pub type transaction_flags = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -3779,4 +3880,48 @@ pub const binder_driver_command_protocol_BC_DEAD_BINDER_DONE: binder_driver_comm
 pub const binder_driver_command_protocol_BC_TRANSACTION_SG: binder_driver_command_protocol =
     1078485777;
 pub const binder_driver_command_protocol_BC_REPLY_SG: binder_driver_command_protocol = 1078485778;
+
+// Freeze observer BR/BC additions (Android 14+).
+// Manually inserted because the upstream bindgen run for this tree
+// predates the kernel's freeze-observer protocol; the values below
+// are recomputed from the kernel UAPI macros
+// (`external/kernel-headers/original/uapi/linux/android/binder.h:520-633`,
+// AOSP `android-16.0.0_r4`):
+//
+//   `_IO('r', N)`            = `(0 << 30) | (N) | ('r' << 8)`
+//   `_IOR('r', N, T)`        = `(2 << 30) | (sizeof(T) << 16) | (N) | ('r' << 8)`
+//   `_IOW('c', N, T)`        = `(1 << 30) | (sizeof(T) << 16) | (N) | ('c' << 8)`
+//
+// `binder_uintptr_t` is `u64` (8 bytes) and `binder_frozen_state_info`
+// is 16 bytes (u64 cookie + 2x u32). `binder_handle_cookie` is
+// `#[repr(C, packed)]` and 12 bytes (4+8). These constants are
+// declared but no executor path consumes them yet, so the kernel wire
+// remains byte-identical until the BR/BC dispatch arms are wired.
+pub const binder_driver_return_protocol_BR_TRANSACTION_PENDING_FROZEN:
+    binder_driver_return_protocol = 29204;
+pub const binder_driver_return_protocol_BR_FROZEN_BINDER: binder_driver_return_protocol =
+    2148561429;
+pub const binder_driver_return_protocol_BR_CLEAR_FREEZE_NOTIFICATION_DONE:
+    binder_driver_return_protocol = 2148037142;
+
+pub const binder_driver_command_protocol_BC_REQUEST_FREEZE_NOTIFICATION:
+    binder_driver_command_protocol = 1074553619;
+pub const binder_driver_command_protocol_BC_CLEAR_FREEZE_NOTIFICATION:
+    binder_driver_command_protocol = 1074553620;
+pub const binder_driver_command_protocol_BC_FREEZE_NOTIFICATION_DONE:
+    binder_driver_command_protocol = 1074291477;
+
+/// UAPI struct delivered with `BR_FROZEN_BINDER`
+/// (`_IOR('r', 21, struct binder_frozen_state_info)`). 16 bytes:
+/// `cookie` (`binder_uintptr_t` = `u64`) + `is_frozen` (`u32`) +
+/// `reserved` (`u32`). Layout matches kernel
+/// `external/kernel-headers/original/uapi/linux/android/binder.h:287-291`.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default)]
+pub struct binder_frozen_state_info {
+    pub cookie: binder_uintptr_t,
+    pub is_frozen: __u32,
+    pub reserved: __u32,
+}
+
 pub type binder_driver_command_protocol = ::std::os::raw::c_uint;

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -76,7 +76,11 @@ thread_local! {
     static BINDER_DEREFS: RefCell<BinderDerefs> = RefCell::new(BinderDerefs::new());
 }
 
-const RETURN_STRINGS: [&str; 21] = [
+// Freeze observer BR labels (nr=20/21/22).
+// `BR_TRANSACTION_SEC_CTX` (nr=2) is dispatched by the special-case
+// above `return_to_str`'s indexed lookup, so the nr=20 slot is free
+// for `BR_TRANSACTION_PENDING_FROZEN`.
+const RETURN_STRINGS: [&str; 23] = [
     "BR_ERROR",
     "BR_OK",
     "BR_TRANSACTION",
@@ -97,7 +101,9 @@ const RETURN_STRINGS: [&str; 21] = [
     "BR_FAILED_REPLY",
     "BR_FROZEN_REPLY",
     "BR_ONEWAY_SPAM_SUSPECT",
-    "BR_TRANSACTION_SEC_CTX",
+    "BR_TRANSACTION_PENDING_FROZEN",
+    "BR_FROZEN_BINDER",
+    "BR_CLEAR_FREEZE_NOTIFICATION_DONE",
 ];
 
 fn return_to_str(cmd: std::os::raw::c_uint) -> &'static str {
@@ -114,7 +120,10 @@ fn return_to_str(cmd: std::os::raw::c_uint) -> &'static str {
     }
 }
 
-const COMMAND_STRINGS: [&str; 19] = [
+// Freeze observer BC labels (nr=19/20/21). Used for debug-print
+// symmetry with `RETURN_STRINGS`; the BC send path is not yet wired
+// into `write_command`.
+const COMMAND_STRINGS: [&str; 22] = [
     "BC_TRANSACTION",
     "BC_REPLY",
     "BC_ACQUIRE_RESULT",
@@ -134,6 +143,9 @@ const COMMAND_STRINGS: [&str; 19] = [
     "BC_DEAD_BINDER_DONE",
     "BC_TRANSACTION_SG",
     "BC_REPLY_SG",
+    "BC_REQUEST_FREEZE_NOTIFICATION",
+    "BC_CLEAR_FREEZE_NOTIFICATION",
+    "BC_FREEZE_NOTIFICATION_DONE",
 ];
 
 fn command_to_str(cmd: std::os::raw::c_uint) -> &'static str {
@@ -158,6 +170,14 @@ struct TransactionState {
     last_transaction_binder_flags: u32,
     work_source: binder::uid_t,
     propagate_work_source: bool,
+    /// AOSP `mHasExplicitIdentity` — `true` after `clear_calling_identity()`
+    /// has overridden the kernel-delivered `calling_uid`/`calling_pid`
+    /// with the current process's own uid/pid. Reset to `false` on every
+    /// new incoming `BR_TRANSACTION` ([IPCThreadState.cpp:1141][1] —
+    /// `mHasExplicitIdentity = false`).
+    ///
+    /// [1]: https://cs.android.com/android/platform/superproject/main/+/main:frameworks/native/libs/binder/IPCThreadState.cpp
+    has_explicit_identity: bool,
 }
 
 impl TransactionState {
@@ -170,7 +190,52 @@ impl TransactionState {
             last_transaction_binder_flags: data.transaction_data.flags,
             work_source: 0,
             propagate_work_source: false,
+            has_explicit_identity: false,
         }
+    }
+}
+
+/// Pack `(has_explicit, uid, pid)` into the 64-bit AOSP calling-identity
+/// token. Wire-equivalent to `packCallingIdentity` in
+/// `IPCThreadState.cpp:498-511`:
+///
+/// ```text
+/// 32b      |        1b         |         1b            |        30b
+/// uid      | pid sign bit      | hasExplicitIdentity   | pid (rest)
+/// ```
+///
+/// AOSP packs `hasExplicitIdentity` into the 2nd bit from the left of the
+/// lower 32-bit half so that negative PIDs (which use the top sign bit)
+/// can still round-trip. rsbinder uses the exact same layout — although
+/// tokens never go on the wire, AOSP-faithful encoding makes
+/// `clear`/`restore` tokens comparable across implementations and lets
+/// any AOSP regression test against the bit pattern still pass.
+fn pack_calling_identity(has_explicit: bool, uid: binder::uid_t, pid: binder::pid_t) -> i64 {
+    let pid_low = pid as u32;
+    let pid_low = if has_explicit {
+        pid_low | (1 << 30)
+    } else {
+        pid_low & !(1 << 30)
+    };
+    let token = ((uid as u64) << 32) | (pid_low as u64);
+    token as i64
+}
+
+fn unpack_has_explicit_identity(token: i64) -> bool {
+    ((token as i32) & (1 << 30)) != 0
+}
+
+fn unpack_calling_uid(token: i64) -> binder::uid_t {
+    (token >> 32) as binder::uid_t
+}
+
+fn unpack_calling_pid(token: i64) -> binder::pid_t {
+    let encoded = token as i32;
+    if (encoded & (1 << 31)) != 0 {
+        // Negative PID — restore the sign bit overlap with bit 30.
+        (encoded | (1 << 30)) as binder::pid_t
+    } else {
+        (encoded & !(1 << 30)) as binder::pid_t
     }
 }
 
@@ -429,7 +494,41 @@ pub(crate) fn call_restriction() -> CallRestriction {
     THREAD_STATE.with(|thread_state| thread_state.borrow().call_restriction)
 }
 
-pub(crate) fn strict_mode_policy() -> i32 {
+/// Set the per-thread strict-mode policy bits to attach to the next
+/// outgoing transaction header.
+///
+/// The next `Parcel::write_interface_token` (and AIDL-generated client
+/// stubs that call it) prepends the policy as a 32-bit prefix before the
+/// interface header, matching AOSP `Parcel::writeInterfaceToken`
+/// (`frameworks/native/libs/binder/Parcel.cpp`). The server-side
+/// `check_interface` extracts the prefix back into the receiving thread's
+/// state, where it is read by the framework `StrictMode` enforcement
+/// code.
+///
+/// `policy == 0` (default) keeps the wire byte-identical to legacy
+/// behavior. Non-zero values are framework-defined bit flags — opt in
+/// only when interoperating with Android system_server's strict-mode
+/// chain (disk-I/O / network-on-main-thread / etc. policies).
+///
+/// Mirrors AOSP `IPCThreadState::setStrictModePolicy(int32_t)`
+/// (`IPCThreadState.cpp:575`).
+pub fn set_strict_mode_policy(policy: i32) {
+    THREAD_STATE.with(|thread_state| {
+        thread_state.borrow_mut().set_strict_mode_policy(policy);
+    })
+}
+
+/// Read the per-thread strict-mode policy bits.
+///
+/// On a server thread that has just received a `BR_TRANSACTION`, returns
+/// the policy that was attached to the inbound header by the caller's
+/// `Parcel::write_interface_token` (extracted in `check_interface`).
+/// On a client thread, returns whatever was last set by
+/// [`set_strict_mode_policy`] (default `0`).
+///
+/// Mirrors AOSP `IPCThreadState::getStrictModePolicy() const`
+/// (`IPCThreadState.cpp:580`).
+pub fn get_strict_mode_policy() -> i32 {
     THREAD_STATE.with(|thread_state| thread_state.borrow().strict_mode_policy)
 }
 
@@ -1562,6 +1661,332 @@ pub fn is_handling_transaction() -> bool {
     THREAD_STATE.with(|thread_state| thread_state.borrow().transaction.is_some())
 }
 
+/// SELinux security context of the caller for the current in-flight
+/// `BR_TRANSACTION`, when present.
+///
+/// `Some` is only ever returned while the current thread is dispatching a
+/// transaction targeting a binder constructed with
+/// `BinderFeatures { set_requesting_sid: true, .. }`. The kernel then
+/// delivers the request via `BR_TRANSACTION_SEC_CTX` and rsbinder copies
+/// the null-terminated SELinux context (e.g. `u:r:system_server:s0`) into
+/// the returned `CString`.
+///
+/// Returns `None` when:
+/// - The thread is not currently dispatching a binder transaction.
+/// - The transaction was delivered as plain `BR_TRANSACTION` (caller's
+///   binder did not request the security context).
+/// - The transaction came over the RPC transport (RPC has its own
+///   `PeerIdentity` model — see `rsbinder::rpc::PeerIdentity`).
+///
+/// Equivalent to AOSP `IPCThreadState::getCallingSid()` (libbinder
+/// `frameworks/native/libs/binder/IPCThreadState.cpp`) and Android Rust
+/// `libbinder_rs::ThreadState::with_calling_sid` (rsbinder returns an
+/// owned `CString` instead of taking a `&CStr` callback — the kernel
+/// pointer is lazily copied at every call, so leaking is not possible).
+///
+pub fn get_calling_sid() -> Option<CString> {
+    THREAD_STATE.with(|thread_state| {
+        let thread_state = thread_state.borrow();
+        let transaction = thread_state.transaction.as_ref()?;
+        if transaction.calling_sid.is_null() {
+            return None;
+        }
+        // SAFETY: `calling_sid` is a pointer into the kernel-delivered mmap
+        // region for the current BR_TRANSACTION_SEC_CTX (set in
+        // `TransactionState::from_transaction_data`). The kernel guarantees
+        // it points to a null-terminated string that stays valid until we
+        // issue `BC_FREE_BUFFER` for the same transaction — which only
+        // happens after `Transactable::transact` returns, so any caller
+        // observing `is_handling_transaction() == true` may safely read it.
+        Some(unsafe { CStr::from_ptr(transaction.calling_sid as _).to_owned() })
+    })
+}
+
+/// PID of the caller for the current in-flight binder transaction.
+///
+/// Returns the sender PID delivered by the kernel via
+/// `binder_transaction_data.sender_pid` when this thread is dispatching a
+/// `BR_TRANSACTION` / `BR_TRANSACTION_SEC_CTX`, and `0` when not handling
+/// a transaction (matches AOSP `IPCThreadState::getCallingPid()` which
+/// returns the saved `mCallingPid` field; the field is zero-initialized
+/// outside a transaction).
+///
+/// Convenience wrapper around `CallingContext::default().pid` for the
+/// common case where only the PID is needed — avoids the
+/// `Option<CString>` allocation of the full context.
+pub fn get_calling_pid() -> binder::pid_t {
+    THREAD_STATE.with(|thread_state| {
+        thread_state
+            .borrow()
+            .transaction
+            .as_ref()
+            .map_or(0, |tr| tr.calling_pid)
+    })
+}
+
+/// UID of the caller for the current in-flight binder transaction.
+///
+/// Returns the sender UID delivered by the kernel via
+/// `binder_transaction_data.sender_euid` when this thread is dispatching
+/// a `BR_TRANSACTION` / `BR_TRANSACTION_SEC_CTX`, and `0` when not
+/// handling a transaction (matches AOSP `IPCThreadState::getCallingUid()`
+/// which returns the saved `mCallingUid` field).
+///
+/// Convenience wrapper around `CallingContext::default().uid` for the
+/// common case where only the UID is needed.
+///
+/// Note: this is the *kernel-delivered* sender UID. To temporarily
+/// replace it for a nested outbound call (the AOSP
+/// `clearCallingIdentity` pattern), see [`clear_calling_identity`] and
+/// [`restore_calling_identity`].
+pub fn get_calling_uid() -> binder::uid_t {
+    THREAD_STATE.with(|thread_state| {
+        thread_state
+            .borrow()
+            .transaction
+            .as_ref()
+            .map_or(0, |tr| tr.calling_uid)
+    })
+}
+
+/// AOSP-faithful variant of [`get_calling_uid`]: outside a transaction,
+/// returns the current process's own uid (`getuid(2)`) instead of `0`.
+///
+/// Mirrors AOSP `IPCThreadState::getCallingUid()`, which initializes
+/// `mCallingUid` to `getuid()` rather than zero — observers downstream
+/// (e.g. per-uid accounting in [`crate::proxy_count`]) get the same
+/// attribution they would on real Android.
+pub fn get_calling_uid_or_self() -> binder::uid_t {
+    THREAD_STATE
+        .with(|thread_state| {
+            thread_state
+                .borrow()
+                .transaction
+                .as_ref()
+                .map(|tr| tr.calling_uid)
+        })
+        .unwrap_or_else(|| rustix::process::getuid().as_raw())
+}
+
+/// Temporarily override the kernel-delivered calling identity with the
+/// current process's own uid/pid, and return an opaque token that
+/// [`restore_calling_identity`] uses to reverse the override.
+///
+/// Mirrors AOSP `IPCThreadState::clearCallingIdentity()`
+/// (`frameworks/native/libs/binder/IPCThreadState.cpp:562`). Typical use
+/// is server-side: a transaction handler that needs to make an outgoing
+/// binder call to another service "as itself" rather than as the original
+/// caller, to avoid leaking the caller's privileges into a downstream
+/// permission check (or, conversely, to *deliberately* drop a privileged
+/// caller's identity before delegating).
+///
+/// ```text
+/// // Inside Transactable::transact:
+/// let token = clear_calling_identity();
+/// let result = downstream_service.do_something(...);
+/// restore_calling_identity(token);
+/// ```
+///
+/// The returned token packs `(has_explicit_identity, calling_uid,
+/// calling_pid)` into 64 bits using the AOSP bit layout
+/// (`packCallingIdentity` in IPCThreadState.cpp). The SELinux SID is
+/// **not** preserved — matching the AOSP comment "ignore mCallingSid for
+/// legacy reasons". After [`restore_calling_identity`], `get_calling_sid`
+/// returns `None`.
+///
+/// # Behavior outside a transaction
+///
+/// Returns `0` and is a no-op when not currently dispatching a binder
+/// transaction (no kernel-delivered identity exists to clear). This
+/// differs from AOSP, which stores calling identity in flat
+/// `IPCThreadState` fields that persist between transactions — but the
+/// AOSP user-facing semantics (clear before downstream call, restore
+/// after) match.
+pub fn clear_calling_identity() -> i64 {
+    THREAD_STATE.with(|thread_state| {
+        let mut thread_state = thread_state.borrow_mut();
+        let Some(ref mut tr) = thread_state.transaction else {
+            return 0;
+        };
+        let token = pack_calling_identity(tr.has_explicit_identity, tr.calling_uid, tr.calling_pid);
+        // AOSP `clearCaller()`: replace with own uid/pid, drop SID
+        // ("expensive to lookup"), and stamp explicit-identity.
+        tr.calling_uid = rustix::process::getuid().as_raw();
+        tr.calling_pid = rustix::process::getpid().as_raw_nonzero().get() as _;
+        tr.calling_sid = std::ptr::null();
+        tr.has_explicit_identity = true;
+        token
+    })
+}
+
+/// Reverse a previous [`clear_calling_identity`] by unpacking the token
+/// and writing the saved uid/pid/has_explicit back into the current
+/// transaction's calling identity.
+///
+/// Mirrors AOSP `IPCThreadState::restoreCallingIdentity(int64_t)`
+/// (`IPCThreadState.cpp:645`). The SELinux SID is left as `None` because
+/// the token has no room to preserve it ("not enough data to restore" —
+/// same as AOSP). Callers needing both UID/PID and SID restoration must
+/// save the SID separately before clearing.
+///
+/// # Behavior outside a transaction
+///
+/// No-op when not currently dispatching a transaction (consistent with
+/// [`clear_calling_identity`] returning 0 in that case). The token is
+/// silently discarded — there is no transaction state to write into.
+///
+/// # Token mismatch
+///
+/// rsbinder does **not** validate that `token` came from a matching
+/// `clear_calling_identity()` call on the same thread/transaction — same
+/// trust model as AOSP. Passing a forged or stale token simply sets the
+/// fields to whatever the token decodes to. The `RAII` guard pattern
+/// (caller wraps `clear`/`restore` in a `Drop` impl) is recommended; see
+/// AOSP `IPCThreadState::CallingIdentityScope` for the C++ analogue.
+pub fn restore_calling_identity(token: i64) {
+    THREAD_STATE.with(|thread_state| {
+        let mut thread_state = thread_state.borrow_mut();
+        let Some(ref mut tr) = thread_state.transaction else {
+            return;
+        };
+        tr.calling_uid = unpack_calling_uid(token);
+        tr.calling_pid = unpack_calling_pid(token);
+        tr.has_explicit_identity = unpack_has_explicit_identity(token);
+        tr.calling_sid = std::ptr::null();
+    })
+}
+
+/// Linux scheduler policy of the current thread, as reported by the
+/// kernel via `sched_getscheduler(0)`. Debug helper to confirm that
+/// `FLAT_BINDER_FLAG_INHERIT_RT` actually lifted the worker thread into
+/// SCHED_FIFO / SCHED_RR for the transaction.
+///
+/// Values match `<linux/sched.h>` / `libc::SCHED_*` constants:
+///
+///   * `0` = `SCHED_NORMAL` (a.k.a. `SCHED_OTHER`)
+///   * `1` = `SCHED_FIFO`
+///   * `2` = `SCHED_RR`
+///   * `3` = `SCHED_BATCH`
+///   * `5` = `SCHED_IDLE`
+///   * `6` = `SCHED_DEADLINE`
+///
+/// Linux + Android only — on macOS this returns `Err(InvalidOperation)`
+/// because `SCHED_*` policies are a Linux/Android concept. Inside an
+/// `on_transact` body on Linux/Android, the returned value is the policy
+/// the kernel installed for the binder worker thread before invoking
+/// the handler.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn get_current_scheduler_policy() -> Result<i32> {
+    // SAFETY: FFI to libc::sched_getscheduler. No pointer arguments;
+    // pid=0 means "the current thread" and is always a valid input.
+    // The return value is a plain i32; on -1 the libc errno is set
+    // and the read below is the standard POSIX recovery.
+    let raw = unsafe { libc::sched_getscheduler(0) };
+    if raw < 0 {
+        // POSIX guarantees errno is set when sched_getscheduler
+        // returns -1; the `unwrap_or` fallback below would only fire
+        // on a library or kernel bug, so prefer `EINVAL` over `0`
+        // (which is itself a valid "success" errno and would mislead
+        // the caller).
+        return Err(StatusCode::Errno(
+            std::io::Error::last_os_error()
+                .raw_os_error()
+                .unwrap_or(libc::EINVAL),
+        ));
+    }
+    Ok(raw)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+pub fn get_current_scheduler_policy() -> Result<i32> {
+    Err(StatusCode::InvalidOperation)
+}
+
+/// Last transaction failure detail reported by the kernel binder driver
+/// for the current thread, as returned by `BINDER_GET_EXTENDED_ERROR`
+/// (Android 12 / Linux 5.14+).
+///
+/// Stable Rust mirror of the kernel's `struct binder_extended_error`
+/// (`include/uapi/linux/android/binder.h:302-306` in AOSP /
+/// `external/kernel-headers/.../binder.h`). See [`get_extended_error`]
+/// for retrieval semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ExtendedError {
+    /// Monotonically increasing per-thread counter. Each fresh failure
+    /// observed by the driver bumps this; `0` means no failure has yet
+    /// been recorded on this thread.
+    pub id: u32,
+    /// The BR_ return code that surfaced the failure
+    /// (typically `BR_FAILED_REPLY`).
+    pub command: u32,
+    /// Negated errno or other driver-specific code (`0` when the driver
+    /// has no additional detail).
+    pub param: i32,
+}
+
+/// Retrieve the kernel-side detail of the most recent transaction
+/// failure on the current thread.
+///
+/// AOSP equivalent: `IPCThreadState::getExtendedError()`
+/// ([IPCThreadState.cpp](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/native/libs/binder/IPCThreadState.cpp)).
+/// The ioctl was added in Android 12 (S, SDK 31, Linux 5.14+); older
+/// drivers respond `ENOTTY`, surfaced here as
+/// `Err(StatusCode::InvalidOperation)` so callers can fall back to the
+/// bare `StatusCode::FailedTransaction` signal from a failed `transact`.
+///
+/// Typical use pairs with a preceding `transact` that returned
+/// `Err(StatusCode::FailedTransaction)`:
+///
+/// ```ignore
+/// match svc.do_something(...) {
+///     Err(StatusCode::FailedTransaction) => {
+///         if let Ok(ee) = rsbinder::get_extended_error() {
+///             eprintln!("driver detail: cmd={:#x} param={}", ee.command, ee.param);
+///         }
+///     }
+///     _ => {}
+/// }
+/// ```
+///
+/// **Opt-in**: rsbinder does *not* call this automatically from the
+/// `BR_FAILED_REPLY` arm. A no-op for callers that never invoke it.
+pub fn get_extended_error() -> Result<ExtendedError> {
+    let mut ee = binder::binder_extended_error::default();
+    let driver = ProcessState::as_self().driver();
+    crate::sys::binder::get_extended_error(driver.as_ref(), &mut ee).map_err(|errno| {
+        if errno == rustix::io::Errno::NOTTY {
+            // Pre-Android-12 driver — feature unavailable.
+            StatusCode::InvalidOperation
+        } else {
+            StatusCode::Errno(errno.raw_os_error())
+        }
+    })?;
+    Ok(ExtendedError {
+        id: ee.id,
+        command: ee.command,
+        param: ee.param,
+    })
+}
+
+/// Whether [`clear_calling_identity`] has been invoked on the current
+/// in-flight transaction without a matching [`restore_calling_identity`].
+///
+/// Mirrors AOSP `IPCThreadState::hasExplicitIdentity()`
+/// (`IPCThreadState.cpp:571`). Reset to `false` on every new incoming
+/// `BR_TRANSACTION`, matching AOSP's per-transaction lifecycle
+/// (`IPCThreadState.cpp:1141`).
+///
+/// Returns `false` when not currently dispatching a transaction.
+pub fn has_explicit_identity() -> bool {
+    THREAD_STATE.with(|thread_state| {
+        thread_state
+            .borrow()
+            .transaction
+            .as_ref()
+            .is_some_and(|tr| tr.has_explicit_identity)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1609,6 +2034,77 @@ mod tests {
             return_to_str(binder::BR_ONEWAY_SPAM_SUSPECT),
             "BR_ONEWAY_SPAM_SUSPECT"
         );
+        // Freeze-observer BR strings.
+        assert_eq!(
+            return_to_str(binder::BR_TRANSACTION_PENDING_FROZEN),
+            "BR_TRANSACTION_PENDING_FROZEN"
+        );
+        assert_eq!(return_to_str(binder::BR_FROZEN_BINDER), "BR_FROZEN_BINDER");
+        assert_eq!(
+            return_to_str(binder::BR_CLEAR_FREEZE_NOTIFICATION_DONE),
+            "BR_CLEAR_FREEZE_NOTIFICATION_DONE"
+        );
+    }
+
+    /// BR constants match the kernel UAPI
+    /// (`_IO('r', 20)`, `_IOR('r', 21, binder_frozen_state_info)`,
+    /// `_IOR('r', 22, binder_uintptr_t)`). Locking these in here means
+    /// a kernel-header drift would surface as a test failure rather than
+    /// a silent wire mismatch.
+    #[test]
+    fn freeze_observer_br_constants_match_uapi() {
+        // _IO('r', 20)
+        assert_eq!(binder::BR_TRANSACTION_PENDING_FROZEN, 29204);
+        // _IOR('r', 21, binder_frozen_state_info) — sizeof=16
+        assert_eq!(binder::BR_FROZEN_BINDER, 2148561429);
+        // _IOR('r', 22, binder_uintptr_t) — sizeof=8
+        assert_eq!(binder::BR_CLEAR_FREEZE_NOTIFICATION_DONE, 2148037142);
+    }
+
+    /// BC constants match the kernel UAPI
+    /// (`_IOW('c', 19, binder_handle_cookie)`,
+    /// `_IOW('c', 20, binder_handle_cookie)`,
+    /// `_IOW('c', 21, binder_uintptr_t)`).
+    #[test]
+    fn freeze_observer_bc_constants_match_uapi() {
+        // _IOW('c', 19, binder_handle_cookie) — sizeof packed = 12
+        assert_eq!(binder::BC_REQUEST_FREEZE_NOTIFICATION, 1074553619);
+        // _IOW('c', 20, binder_handle_cookie) — sizeof = 12
+        assert_eq!(binder::BC_CLEAR_FREEZE_NOTIFICATION, 1074553620);
+        // _IOW('c', 21, binder_uintptr_t) — sizeof = 8
+        assert_eq!(binder::BC_FREEZE_NOTIFICATION_DONE, 1074291477);
+    }
+
+    /// `binder_frozen_state_info` layout: cookie (u64), is_frozen (u32),
+    /// reserved (u32) = 16 bytes, aligned 8. The `BR_FROZEN_BINDER`
+    /// dispatch reads this via `parcel.read::<binder_frozen_state_info>()`.
+    #[test]
+    fn binder_frozen_state_info_layout() {
+        use crate::sys::binder_frozen_state_info;
+        assert_eq!(std::mem::size_of::<binder_frozen_state_info>(), 16);
+        assert_eq!(std::mem::align_of::<binder_frozen_state_info>(), 8);
+        let s = binder_frozen_state_info::default();
+        assert_eq!(s.cookie, 0);
+        assert_eq!(s.is_frozen, 0);
+        assert_eq!(s.reserved, 0);
+    }
+
+    /// The default arm in `wait_for_response` is untouched: the new
+    /// constants are declared so the strings table can label them, but
+    /// no dispatch path consumes them yet. This is a smoke test — if a
+    /// future change accidentally dispatched the freeze-observer BRs
+    /// before its own arm is in place, the kernel wire would diverge.
+    /// Here we just confirm the constants are visible to user code.
+    #[test]
+    fn freeze_observer_constants_are_pub_for_phase_b() {
+        // If these uses compile, the constants are exposed for a future
+        // dispatch path to consume.
+        let _b1 = binder::BR_TRANSACTION_PENDING_FROZEN;
+        let _b2 = binder::BR_FROZEN_BINDER;
+        let _b3 = binder::BR_CLEAR_FREEZE_NOTIFICATION_DONE;
+        let _c1 = binder::BC_REQUEST_FREEZE_NOTIFICATION;
+        let _c2 = binder::BC_CLEAR_FREEZE_NOTIFICATION;
+        let _c3 = binder::BC_FREEZE_NOTIFICATION_DONE;
     }
 
     #[test]
@@ -1653,6 +2149,19 @@ mod tests {
             "BC_TRANSACTION_SG"
         );
         assert_eq!(command_to_str(binder::BC_REPLY_SG), "BC_REPLY_SG");
+        // Freeze-observer BC strings.
+        assert_eq!(
+            command_to_str(binder::BC_REQUEST_FREEZE_NOTIFICATION),
+            "BC_REQUEST_FREEZE_NOTIFICATION"
+        );
+        assert_eq!(
+            command_to_str(binder::BC_CLEAR_FREEZE_NOTIFICATION),
+            "BC_CLEAR_FREEZE_NOTIFICATION"
+        );
+        assert_eq!(
+            command_to_str(binder::BC_FREEZE_NOTIFICATION_DONE),
+            "BC_FREEZE_NOTIFICATION_DONE"
+        );
     }
 
     /// A panicking `Transactable::transact` must not unwind through
@@ -1742,10 +2251,9 @@ mod tests {
     /// - When obituary errors and pin errors, obituary takes priority
     /// - The kernel handshake (queue + pin) runs whenever queue succeeds
     ///
-    /// These properties protect against the kernel `binder_ref` slot
-    /// leak that motivated the refactor — losing any of them
-    /// re-introduces the leak shape that the previous `?`-based
-    /// implementation exhibited.
+    /// These properties protect against a kernel `binder_ref` slot
+    /// leak: losing any of them (e.g. a naive `?`-based early return on
+    /// the obituary error) re-introduces the leak.
     #[test]
     fn test_drive_dead_binder_handshake_orchestration() {
         use std::cell::RefCell;
@@ -2075,5 +2583,209 @@ mod tests {
         // Both entries must be removed from the published_natives table.
         assert!(process.lookup_native(id_a).is_none());
         assert!(process.lookup_native(id_b).is_none());
+    }
+
+    // ----------------------------------------------------------------
+    // calling-identity + strict-mode public API
+    // ----------------------------------------------------------------
+    //
+    // Helpers below construct a synthetic `TransactionState` directly
+    // and install it into the thread-local `THREAD_STATE.transaction`,
+    // so the public calling-identity functions can be exercised without
+    // a running binder driver.
+
+    /// Install a fake in-flight transaction for the duration of the
+    /// returned guard. On drop, the previous transaction state (usually
+    /// `None`) is restored — keeps tests hermetic against each other
+    /// even though `THREAD_STATE` is per-thread.
+    #[cfg(target_os = "linux")]
+    struct FakeTransactionGuard {
+        previous: Option<TransactionState>,
+    }
+
+    #[cfg(target_os = "linux")]
+    impl FakeTransactionGuard {
+        fn install(
+            calling_uid: binder::uid_t,
+            calling_pid: binder::pid_t,
+            calling_sid: *const u8,
+        ) -> Self {
+            let new_state = TransactionState {
+                calling_pid,
+                calling_sid,
+                calling_uid,
+                last_transaction_binder_flags: 0,
+                work_source: 0,
+                propagate_work_source: false,
+                has_explicit_identity: false,
+            };
+            let previous = THREAD_STATE.with(|ts| ts.borrow_mut().transaction.replace(new_state));
+            FakeTransactionGuard { previous }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    impl Drop for FakeTransactionGuard {
+        fn drop(&mut self) {
+            THREAD_STATE.with(|ts| {
+                ts.borrow_mut().transaction = self.previous.take();
+            });
+        }
+    }
+
+    /// With no in-flight transaction, the calling-identity free
+    /// functions return the documented "outside a transaction" values
+    /// (None / 0 / 0) with zero side-effects.
+    ///
+    /// **Linux + binderfs only** — `THREAD_STATE.with(..)` triggers
+    /// `ThreadState::new` which captures the global `ProcessState` driver.
+    /// Same convention as the other binder-driver-bound tests in this
+    /// module (uses `ProcessState::init_default` + `serial(binder)`).
+    #[test]
+    #[cfg(target_os = "linux")]
+    #[serial_test::serial(binder)]
+    fn test_get_calling_outside_transaction_returns_defaults() {
+        ProcessState::init_default().expect("init_default");
+        // Discard whatever the prior in-thread test may have left in
+        // `THREAD_STATE.transaction`; `serial(binder)` only serializes
+        // entry, not thread-local state.
+        drop(THREAD_STATE.with(|ts| ts.borrow_mut().transaction.take()));
+        assert!(!is_handling_transaction());
+        assert_eq!(get_calling_uid(), 0);
+        assert_eq!(get_calling_pid(), 0);
+        assert!(get_calling_sid().is_none());
+        assert!(!has_explicit_identity());
+        // clear/restore are no-ops outside a transaction.
+        assert_eq!(clear_calling_identity(), 0);
+        restore_calling_identity(0xDEAD_BEEF_DEAD_BEEFu64 as i64); // must not panic
+        assert_eq!(get_calling_uid(), 0);
+    }
+
+    /// With a fake transaction installed, the calling-identity getters
+    /// return the kernel-delivered values; the SID is a lazy CString
+    /// copy of the secctx pointer.
+    ///
+    /// **Linux + binderfs only** — see `test_get_calling_outside_transaction_returns_defaults`.
+    #[test]
+    #[cfg(target_os = "linux")]
+    #[serial_test::serial(binder)]
+    fn test_get_calling_inside_transaction_extracts_fields() {
+        ProcessState::init_default().expect("init_default");
+        let sid_cstring = std::ffi::CString::new("u:r:system_server:s0").unwrap();
+        let _guard = FakeTransactionGuard::install(1000, 9999, sid_cstring.as_ptr() as *const u8);
+
+        assert!(is_handling_transaction());
+        assert_eq!(get_calling_uid(), 1000);
+        assert_eq!(get_calling_pid(), 9999);
+
+        let sid = get_calling_sid().expect("SID present when secctx pointer non-null");
+        assert_eq!(sid.to_str().unwrap(), "u:r:system_server:s0");
+
+        // Each call must allocate a fresh owned CString — the pointer
+        // remains owned by the kernel mmap region, never by us.
+        let sid2 = get_calling_sid().expect("second call also returns Some");
+        assert_eq!(sid, sid2);
+        assert!(!std::ptr::eq(sid.as_ptr(), sid2.as_ptr()));
+    }
+
+    /// When secctx is null (plain `BR_TRANSACTION`, not
+    /// `BR_TRANSACTION_SEC_CTX`), `get_calling_sid` returns None even
+    /// though we're handling a transaction.
+    ///
+    /// **Linux + binderfs only** — see `test_get_calling_outside_transaction_returns_defaults`.
+    #[test]
+    #[cfg(target_os = "linux")]
+    #[serial_test::serial(binder)]
+    fn test_get_calling_sid_null_secctx_returns_none() {
+        ProcessState::init_default().expect("init_default");
+        let _guard = FakeTransactionGuard::install(1000, 9999, std::ptr::null());
+        assert!(is_handling_transaction());
+        assert_eq!(get_calling_uid(), 1000);
+        assert!(get_calling_sid().is_none());
+    }
+
+    /// Pack/unpack round-trip across the
+    /// `(has_explicit, pid_sign)` quadrants that AOSP `static_assert`s
+    /// cover in IPCThreadState.cpp:530-560. The encoding only reserves
+    /// 30 bits + sign for the PID — values like `i32::MIN` (which would
+    /// overlap with the `hasExplicitIdentity` bit position) are outside
+    /// the documented window and intentionally not tested.
+    #[test]
+    fn test_calling_identity_token_pack_unpack_round_trip() {
+        for &(has_explicit, uid, pid) in &[
+            (true, 1000u32, 9999i32),
+            (false, 1000u32, 9999i32),
+            (true, 1000u32, -1i32),
+            (false, 1000u32, -1i32),
+            (true, 0u32, 0i32),
+            (false, 0u32, 0i32),
+        ] {
+            let tok = pack_calling_identity(has_explicit, uid, pid);
+            assert_eq!(
+                unpack_has_explicit_identity(tok),
+                has_explicit,
+                "has_explicit ({has_explicit},{uid},{pid})"
+            );
+            assert_eq!(
+                unpack_calling_uid(tok),
+                uid,
+                "uid ({has_explicit},{uid},{pid})"
+            );
+            assert_eq!(
+                unpack_calling_pid(tok),
+                pid,
+                "pid ({has_explicit},{uid},{pid})"
+            );
+        }
+    }
+
+    /// Clear → restore round-trip inside a
+    /// transaction. Clear stamps self uid/pid + has_explicit; restore
+    /// pulls the original values back.
+    ///
+    /// **Linux + binderfs only** — see `test_get_calling_outside_transaction_returns_defaults`.
+    #[test]
+    #[cfg(target_os = "linux")]
+    #[serial_test::serial(binder)]
+    fn test_clear_and_restore_calling_identity_round_trip() {
+        ProcessState::init_default().expect("init_default");
+        let _guard = FakeTransactionGuard::install(1000, 9999, std::ptr::null());
+        assert_eq!(get_calling_uid(), 1000);
+        assert_eq!(get_calling_pid(), 9999);
+        assert!(!has_explicit_identity());
+
+        let token = clear_calling_identity();
+
+        // After clear: calling identity is the current process.
+        assert_eq!(get_calling_uid(), rustix::process::getuid().as_raw());
+        assert_eq!(
+            get_calling_pid(),
+            rustix::process::getpid().as_raw_nonzero().get() as binder::pid_t
+        );
+        assert!(has_explicit_identity());
+        assert!(get_calling_sid().is_none());
+
+        restore_calling_identity(token);
+
+        assert_eq!(get_calling_uid(), 1000);
+        assert_eq!(get_calling_pid(), 9999);
+        assert!(!has_explicit_identity());
+    }
+
+    /// Set/get strict-mode policy round-trip thread-locally.
+    /// The reset at the end protects subsequent tests that share the
+    /// same thread (thread-local).
+    ///
+    /// **Linux + binderfs only** — see `test_get_calling_outside_transaction_returns_defaults`.
+    #[test]
+    #[cfg(target_os = "linux")]
+    #[serial_test::serial(binder)]
+    fn test_strict_mode_policy_round_trip() {
+        ProcessState::init_default().expect("init_default");
+        let saved = get_strict_mode_policy();
+        set_strict_mode_policy(0x1234_5678);
+        assert_eq!(get_strict_mode_policy(), 0x1234_5678);
+        set_strict_mode_policy(saved);
+        assert_eq!(get_strict_mode_policy(), saved);
     }
 }

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -2649,7 +2649,7 @@ mod tests {
         // Discard whatever the prior in-thread test may have left in
         // `THREAD_STATE.transaction`; `serial(binder)` only serializes
         // entry, not thread-local state.
-        drop(THREAD_STATE.with(|ts| ts.borrow_mut().transaction.take()));
+        let _ = THREAD_STATE.with(|ts| ts.borrow_mut().transaction.take());
         assert!(!is_handling_transaction());
         assert_eq!(get_calling_uid(), 0);
         assert_eq!(get_calling_pid(), 0);

--- a/rsbinder/tests/loom_cache_pin.rs
+++ b/rsbinder/tests/loom_cache_pin.rs
@@ -49,9 +49,9 @@
 //!   `Arc<MockProxyHandle>` allocation Drops exactly once, and
 //!   Drop's `BC_RELEASE` always lands on a live slot.
 //!
-//! ### Why N=2 instead of plan-spec N=3
+//! ### Why N=2 worker threads
 //!
-//! Plan FOLLOW_UP_PR_100 test plan #6 specifies N=3. This PoC uses
+//! This PoC uses
 //! N=2 because the simplified single-handle model already saturates
 //! the relevant interleaving space at N=2: a third thread on the
 //! same handle cannot reach a qualitatively new interleaving — it

--- a/rsbinder/tests/rpc_accessor.rs
+++ b/rsbinder/tests/rpc_accessor.rs
@@ -1,20 +1,17 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Subplan 2-13 D.7 — STAGE1 hermetic end-to-end: drive the
+//! Hermetic end-to-end: drive the
 //! `IAccessor → addConnection() → preconnected-fd RpcSession →
 //! getRootObject()` bridge entirely in-process against an rsbinder
-//! `MockAccessor` and an rsbinder `RpcServer`. Exercises A0.1–A0.3 +
-//! A.4 + A.5 + B.6.
+//! `MockAccessor` and an rsbinder `RpcServer`.
 //!
-//! Plan §3 calls this "hermetic ⇒ symmetric": this binary green is the
-//! AC-13.1/13.2/13.3 gate. The non-negotiable real-libbinder gate is
-//! D.8 (separate harness, android-16 emulator) and is *not* in this
-//! file's scope; see [plans/2-13-rpc-accessor.md](
-//! ../../plans/2-13-rpc-accessor.md) §3 STAGE3.
+//! Hermetic ⇒ symmetric: this binary green is the in-process gate. The
+//! non-negotiable real-libbinder gate runs against the android-16
+//! emulator in a separate harness and is *not* in this file's scope.
 //!
-//! Separate test binary (master §6): no shared process with the kernel
-//! binder unit tests. P6: each test owns its own server + sessions ⇒
+//! Separate test binary: no shared process with the kernel
+//! binder unit tests. Each test owns its own server + sessions ⇒
 //! parallel-safe.
 
 #![cfg(all(feature = "rpc", feature = "android_16"))]
@@ -97,7 +94,7 @@ fn make_echo(calls: Arc<AtomicI64>) -> SIBinder {
 
 /// What the Accessor reports on `getInstanceName()`. Tests can lie
 /// (return a different name than the looked-up service) to drive the
-/// `validateAccessor` rejection path (AC-13.3).
+/// `validateAccessor` rejection path.
 struct MockAccessor {
     /// Server-side socket path; `addConnection()` opens a fresh
     /// `UnixStream::connect()` to it on every call (the AOSP shape:
@@ -109,7 +106,7 @@ struct MockAccessor {
     name: String,
     /// Optional override returning a synthetic
     /// `ServiceSpecificError(code)` from `addConnection()` — exercises
-    /// the B.6 decode + reject path.
+    /// the decode + reject path.
     add_connection_error: Option<i32>,
     /// Bumped on every `addConnection()` so a test can assert the
     /// bridge made exactly one connection attempt (or none, for a
@@ -242,7 +239,7 @@ fn rpc_echo(root: &SIBinder, s: &str) -> Result<String> {
     reply.read::<String>()
 }
 
-// ---- AC-13.1 / 13.2: happy path -------------------------------------
+// ---- happy path -----------------------------------------------------
 
 #[test]
 fn accessor_arm_resolves_root_and_echoes() {
@@ -257,7 +254,7 @@ fn accessor_arm_resolves_root_and_echoes() {
         nonblocking: false,
     });
 
-    // AC-13.2 contract: a `Service::Accessor` arm resolves to
+    // Contract: a `Service::Accessor` arm resolves to
     // `ServiceWithMetadata { service: Some(rpc_root), isLazyService: false }`.
     let swm = resolve_accessor("test.echo", accessor).expect("bridge resolves");
     assert!(!swm.r#isLazyService);
@@ -280,7 +277,7 @@ fn accessor_arm_resolves_root_and_echoes() {
     drop(root);
 }
 
-// ---- AC-13.3 (mutant 1): instance-name mismatch reject --------------
+// ---- mutant 1: instance-name mismatch reject ------------------------
 
 #[test]
 fn accessor_instance_name_mismatch_rejects() {
@@ -310,7 +307,7 @@ fn accessor_instance_name_mismatch_rejects() {
     );
 }
 
-// ---- AC-13.3 (mutant 2): addConnection ServiceSpecificError decode --
+// ---- mutant 2: addConnection ServiceSpecificError decode ------------
 
 #[test]
 fn accessor_add_connection_service_specific_error_rejects_and_logs() {
@@ -336,7 +333,7 @@ fn accessor_add_connection_service_specific_error_rejects_and_logs() {
         );
         assert_eq!(calls.load(Ordering::SeqCst), 1);
         // Symbolic name lookup must round-trip — the deterministic
-        // gate for B.6 (the log line is what an operator sees).
+        // gate (the log line is what an operator sees).
         let name = accessor_error_name(code);
         assert!(
             name.starts_with("ERROR_"),
@@ -345,7 +342,7 @@ fn accessor_add_connection_service_specific_error_rejects_and_logs() {
     }
 }
 
-// ---- AC-13.3 + A.5: session lifetime — root stays usable, then dies --
+// ---- session lifetime — root stays usable, then dies ----------------
 
 #[test]
 fn accessor_root_keeps_session_alive_then_terminates_on_drop() {
@@ -378,7 +375,7 @@ fn accessor_root_keeps_session_alive_then_terminates_on_drop() {
     // that's an internal detail. The test merely asserts no panic.
 }
 
-// ---- D.8 STAGE3 regression gate: non-blocking preconnected fd -------
+// ---- STAGE3 regression gate: non-blocking preconnected fd -----------
 
 /// AOSP `singleSocketConnection` (frameworks/native/libs/binder/
 /// RpcSession.cpp:614, android-16.0.0_r4) opens its preconnected
@@ -388,7 +385,7 @@ fn accessor_root_keeps_session_alive_then_terminates_on_drop() {
 /// the `RpcNewSessionResponse` via `read_exact_raw` which assumes
 /// `read` blocks); without explicit `O_NONBLOCK` clear in
 /// `from_preconnected_fd`, the handshake's first `read()` returns
-/// `EAGAIN` and tears the connection down — which D.8 STAGE3 caught
+/// `EAGAIN` and tears the connection down — which STAGE3 interop caught
 /// against the real android-16 emulator. This test is the hermetic
 /// regression gate so a future refactor that removes the
 /// `O_NONBLOCK` clear in [`RpcSession::from_preconnected_fd`] fails
@@ -418,7 +415,7 @@ fn accessor_arm_handles_nonblocking_fd_from_libbinder() {
     }
 }
 
-// ---- Subplan 2-14 A.5 e2e: process-local AccessorProvider fallback ----
+// ---- process-local AccessorProvider fallback e2e --------------------
 
 use rsbinder::hub::android_16::{
     add_accessor_provider, create_accessor, resolve_via_process_local, AccessorAddrProvider,
@@ -426,20 +423,20 @@ use rsbinder::hub::android_16::{
 };
 use std::collections::HashSet;
 
-/// 2-14 A.5: end-to-end from `add_accessor_provider` registration
+/// End-to-end from `add_accessor_provider` registration
 /// to `resolve_via_process_local` returning an `RpcSession` root that
-/// echoes. Drives the full A.4 + A.5 chain on top of A0.1–A0.3:
+/// echoes:
 ///
 /// 1. Spin up an `RpcServer` (background) serving `EchoSvc` as root.
 /// 2. Register a `LocalAccessor` (via `create_accessor`) under a
 ///    unique instance name through `add_accessor_provider`.
-/// 3. Call `resolve_via_process_local(name)` — A.5's public entrypoint
+/// 3. Call `resolve_via_process_local(name)` — the public entrypoint
 ///    (`getInjectedAccessor` + `Service::accessor → toBinder` AOSP
 ///    combined). Asserts:
 ///    * lookup hits the registered provider (the registry is global,
 ///      but the instance name is process+line-scoped so no
 ///      cross-test collision),
-///    * 2-13 `resolve_accessor` runs cleanly against the live RPC
+///    * `resolve_accessor` runs cleanly against the live RPC
 ///      server: instance-name validation passes, `addConnection`
 ///      yields a connected fd, `from_preconnected_fd` handshakes v2,
 ///      `get_root()` returns the echo binder,
@@ -463,7 +460,7 @@ fn process_local_provider_resolves_root_via_resolve_helper() {
 
     // `LocalAccessor` whose `addr_provider` always hands back the
     // RpcServer's listening UDS path. Registered under `instance` via
-    // the A.4 process-local registry.
+    // the process-local registry.
     let server_path = server.path.clone();
     let provider: AccessorProviderFn = {
         let want = instance.clone();
@@ -482,7 +479,7 @@ fn process_local_provider_resolves_root_via_resolve_helper() {
     let provider_handle =
         add_accessor_provider(HashSet::from([instance.clone()]), provider).expect("registry add");
 
-    // A.5 public entrypoint — combined `getInjectedAccessor` +
+    // Public entrypoint — combined `getInjectedAccessor` +
     // `toBinder` path.
     let swm = resolve_via_process_local(&instance).expect("process-local fallback yields root SWM");
     assert!(!swm.r#isLazyService, "RPC root is never a LazyService");
@@ -501,13 +498,13 @@ fn process_local_provider_resolves_root_via_resolve_helper() {
     drop(provider_handle);
 }
 
-/// 2-14 A.5 primitive gate: `resolve_via_process_local` keys lookups
+/// `resolve_via_process_local` keys lookups
 /// **strictly** by instance name — unregistered names yield `None`
 /// (not a phantom binder), and a sibling registration must not leak
 /// into unrelated names. This is the contract the
-/// `hub::servicemanager_16::dispatch_typed_service` fallback (Phase
-/// 2-14 A.5) relies on; the dispatcher's own routing is exercised by
-/// the unit tests in [`hub::servicemanager_16::tests`].
+/// `hub::servicemanager_16::dispatch_typed_service` fallback relies on;
+/// the dispatcher's own routing is exercised by the unit tests in
+/// [`hub::servicemanager_16::tests`].
 ///
 /// **Mutant gate**: a provider that returns `Some(_)` for every name
 /// (or a registry that ignores its instance set) would resurrect the
@@ -569,7 +566,7 @@ fn resolve_via_process_local_keys_strictly_by_instance_name() {
     drop(provider_handle);
 }
 
-// ---- AC-13.3 sanity: accessor_error_name surface lock ---------------
+// ---- sanity: accessor_error_name surface lock -----------------------
 
 #[test]
 fn accessor_error_name_unknown_codes_safe() {
@@ -582,7 +579,7 @@ fn accessor_error_name_unknown_codes_safe() {
     assert_eq!(accessor_error_name(42), "unknown");
     assert_eq!(accessor_error_name(-1), "unknown");
     // Ensure the re-export path through `hub::android_16` matches the
-    // module-local one (B.6 surface lock).
+    // module-local one (surface lock).
     assert_eq!(
         a16::accessor_error_name(0),
         "ERROR_CONNECTION_INFO_NOT_FOUND"

--- a/rsbinder/tests/rpc_e2e.rs
+++ b/rsbinder/tests/rpc_e2e.rs
@@ -1,21 +1,20 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Subplan 2-2 end-to-end: a hand-written AIDL-style interface driven
+//! RPC end-to-end: a hand-written AIDL-style interface driven
 //! over the RPC stack with the **server stub reused unmodified** (the
 //! generated free `on_transact` shape, dispatched via
-//! `IBinder::rpc_transact` — never `Inner::transact`/`check_interface`,
-//! AC-2.7/2.12) and a **hand-written `RpcProxy` client** (D1; the
-//! single-stub generator change is subplan 2-6).
+//! `IBinder::rpc_transact` — never `Inner::transact`/`check_interface`)
+//! and a **hand-written `RpcProxy` client**.
 //!
 //! Separate test binary (not a `src/` unit test) so it never shares a
-//! process with the kernel-binder unit tests (master §6). P6: every
+//! process with the kernel-binder unit tests. Every
 //! test builds its own session pair → parallel-safe, no `--test-threads=1`.
 //!
-//! Covers AC-2.4 (scalar/string/binder-arg e2e over `mem` *and*
-//! `unix`), AC-2.5 (DEC_STRONG releases the server node — no leak),
-//! AC-2.6 (binder-in-parcel: reply binder → `RpcProxy` → re-call;
-//! object-returning-home identity), AC-2.11 (FD reject).
+//! Covers scalar/string/binder-arg e2e over `mem` *and*
+//! `unix`, DEC_STRONG releasing the server node (no leak),
+//! binder-in-parcel (reply binder → `RpcProxy` → re-call;
+//! object-returning-home identity), and FD reject.
 
 #![cfg(feature = "rpc")]
 
@@ -275,7 +274,7 @@ fn make_root() -> SIBinder {
 }
 
 /// Run the full scenario over a connected transport pair. Returns the
-/// server session so the caller can assert AC-2.5 node accounting.
+/// server session so the caller can assert node accounting.
 fn run_scenario(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>) {
     let server = RpcSession::new(server_t, AddressSpace::Acceptor).expect("RpcSession::new");
     server.set_root(make_root());
@@ -288,13 +287,13 @@ fn run_scenario(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>
         let client = RpcSession::new(client_t, AddressSpace::Initiator).expect("RpcSession::new");
         let root = SmokeProxy(client.get_root().expect("get_root"));
 
-        // AC-2.4: scalar + string round-trip, exact values.
+        // Scalar + string round-trip, exact values.
         assert_eq!(root.echo("hello rpc").unwrap(), "hello rpc");
         assert_eq!(root.echo("").unwrap(), "");
         assert_eq!(root.add(2, 3).unwrap(), 5);
         assert_eq!(root.add(-7, 7).unwrap(), 0);
 
-        // AC-2.6: reply contains a binder → client builds an RpcProxy
+        // Reply contains a binder → client builds an RpcProxy
         // → re-calls it.
         let child_sib = root.get_child().unwrap();
         assert!(
@@ -304,11 +303,11 @@ fn run_scenario(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>
         let child = ChildProxy(child_sib);
         assert_eq!(child.name().unwrap(), "child-1");
 
-        // AC-2.6: binder *argument* — the proxy travels back to the
+        // Binder *argument* — the proxy travels back to the
         // server which recognises it as its own local object.
         assert_eq!(root.pass_binder(&child.0).unwrap(), ICHILD_DESC);
 
-        // AC-2.5: dropping the child proxy sends DEC_STRONG; the next
+        // Dropping the child proxy sends DEC_STRONG; the next
         // ordered round-trip guarantees the server has processed it,
         // so the child node is released (no leak).
         assert_eq!(server.local_node_count(), 2, "root + child registered");
@@ -336,13 +335,12 @@ fn rpc_e2e_over_unix_socketpair() {
     run_scenario(Box::new(a), Box::new(b));
 }
 
-/// Subplan 2-6 (D1): an RPC binder obtained from the stack is
+/// An RPC binder obtained from the stack is
 /// reachable through the **generalized** `dyn IBinder::as_remote()`
 /// as a `&dyn RemoteProxy`, and a full AIDL call driven via the
-/// trait's `prepare_transact`/`submit_transact` (the exact shape the
-/// generator will emit after 2-6.B) works over RPC — the same trait
-/// `ProxyHandle` implements for the kernel path. Proves the single
-/// abstraction without any generator change.
+/// trait's `prepare_transact`/`submit_transact` works over RPC — the
+/// same trait `ProxyHandle` implements for the kernel path. Proves the
+/// single abstraction without any generator change.
 #[test]
 fn rpc_call_via_generalized_remote_proxy_trait() {
     use rsbinder::RemoteProxy;
@@ -365,11 +363,10 @@ fn rpc_call_via_generalized_remote_proxy_trait() {
 
     // The trait's `prepare_transact` is callable on the RPC proxy
     // (it allocates an RPC-mode parcel). Descriptor *stamping* of an
-    // RpcProxy from `get_root` is 2-6.B's typed-stub constructor
-    // change, so for this pre-2-6.B check the real call is issued with
-    // an explicitly-built request parcel and dispatched **through the
-    // generalized `&dyn RemoteProxy::submit_transact`** (exactly what
-    // the generator will emit after 2-6.B).
+    // RpcProxy from `get_root` is the typed-stub constructor's job, so
+    // here the real call is issued with an explicitly-built request
+    // parcel and dispatched **through the generalized
+    // `&dyn RemoteProxy::submit_transact`**.
     let _ = remote
         .prepare_transact(true)
         .expect("prepare_transact callable");
@@ -387,7 +384,7 @@ fn rpc_call_via_generalized_remote_proxy_trait() {
     h.join().unwrap();
 }
 
-/// AC-2.11 / T2.11: an FD written into an RPC-mode parcel is a hard
+/// An FD written into an RPC-mode parcel is a hard
 /// `BadType` reject (android-12 r34 fidelity), never a silent
 /// corruption or partial write.
 #[test]

--- a/rsbinder/tests/rpc_fd.rs
+++ b/rsbinder/tests/rpc_fd.rs
@@ -1,16 +1,15 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Subplan 2-7: opt-in FD-over-RPC (`FileDescriptorTransportMode`).
+//! Opt-in FD-over-RPC (`FileDescriptorTransportMode`).
 //!
-//! * AC-7.1 — default (no opt-in) is the 2-2 `BadType` reject,
-//!   unchanged.
-//! * AC-7.2 — both peers opt in over UDS ⇒ fd travels via
+//! * default (no opt-in) is the `BadType` reject, unchanged.
+//! * both peers opt in over UDS ⇒ fd travels via
 //!   `SCM_RIGHTS`, valid + `O_CLOEXEC` at the receiver; works in
 //!   *both* directions (arg and reply).
-//! * AC-7.3 — one-sided opt-in falls back to `None` (reject, not an
+//! * one-sided opt-in falls back to `None` (reject, not an
 //!   error).
-//! * AC-7.4 — a non-UDS transport (`mem`) never passes fds (rejected
+//! * a non-UDS transport (`mem`) never passes fds (rejected
 //!   by type at send; zero fds reach the peer).
 //!
 //! Separate test binary; `#![cfg(feature = "rpc")]`.
@@ -166,7 +165,7 @@ fn wait_sock(p: &std::path::Path) {
     panic!("socket never appeared");
 }
 
-/// AC-7.2: both peers opt in over UDS ⇒ fd passes both ways, valid +
+/// Both peers opt in over UDS ⇒ fd passes both ways, valid +
 /// O_CLOEXEC at the receiver.
 #[test]
 fn fd_roundtrip_when_both_opt_in_over_uds() {
@@ -206,7 +205,7 @@ fn fd_roundtrip_when_both_opt_in_over_uds() {
         f.read_to_string(&mut s).unwrap();
         assert_eq!(s, "from-server");
     }
-    // O_CLOEXEC must be set on the received fd (plan 2-7.d).
+    // O_CLOEXEC must be set on the received fd.
     let flags = rustix::io::fcntl_getfd(got.as_ref().as_fd()).unwrap();
     assert!(
         flags.contains(rustix::io::FdFlags::CLOEXEC),
@@ -220,7 +219,7 @@ fn fd_roundtrip_when_both_opt_in_over_uds() {
     let _ = std::fs::remove_file(&path);
 }
 
-/// AC-7.1 / AC-7.3: no opt-in (or one-sided) ⇒ fd write is the 2-2
+/// No opt-in (or one-sided) ⇒ fd write is the
 /// `BadType` reject, never a silent corruption or an error-less hang.
 #[test]
 fn fd_rejected_without_mutual_opt_in() {
@@ -255,7 +254,7 @@ fn fd_rejected_without_mutual_opt_in() {
     let _ = std::fs::remove_file(&path);
 }
 
-/// AC-7.4: a non-UDS transport (`mem`) cannot pass fds — rejected by
+/// A non-UDS transport (`mem`) cannot pass fds — rejected by
 /// type at the transport, zero fds reach the peer.
 #[test]
 fn fd_rejected_on_non_uds_transport() {
@@ -291,17 +290,17 @@ fn fd_rejected_on_non_uds_transport() {
     let _ = h.join();
 }
 
-/// AC-11.0 / AC-11.4 (subplan 2-11): the **v1+ AOSP-faithful**
-/// FD-over-RPC path end-to-end over a real UDS — Phase A0 (FD mode
+/// The **v1+ AOSP-faithful**
+/// FD-over-RPC path end-to-end over a real UDS — FD mode
 /// negotiated in the `RpcConnectionHeader`, `SCM_RIGHTS` carried on the
-/// `aosp_framing` no-length-prefix wire) + Phase A (the
-/// `[not-null|hasComm|TYPE|fdIndex]` body) + Phase B (strict
-/// object-position read), at v1 (android-14/15) **and** v2
+/// `aosp_framing` no-length-prefix wire, the
+/// `[not-null|hasComm|TYPE|fdIndex]` body, and strict
+/// object-position read, at v1 (android-14/15) **and** v2
 /// (android-16). fd travels both ways: as a transaction *argument*
-/// (client→server, the A2b inbound-args gate) and in the *reply*
+/// (client→server, the server inbound-args gate) and in the *reply*
 /// (server→client), valid + `O_CLOEXEC` at the receiver. This is the
 /// hermetic symmetric proof; the non-negotiable AOSP-faithfulness gate
-/// is the real-libbinder Phase D (AC-11.3).
+/// is real-libbinder interop.
 #[test]
 fn fd_v1plus_aosp_roundtrip_both_directions() {
     for ver in [1u32, 2u32] {

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -1405,6 +1405,131 @@ fn b2_local_max_outgoing_one_skips_fan_out_byte_identical_to_founding_only() {
     );
 }
 
+/// **§7.3 #2 — shutdown-reject e2e scaffolding** (the deferred Phase
+/// B.1 Sub-AC (c)). The android-13+ attach arm sits past a successful
+/// handshake but before the per-slot enqueue; in production the
+/// `shutdown.load()` gate at that point sees a *sub-microsecond*
+/// window between an accepted late attach and a concurrent
+/// `server.shutdown()`, so prior tests verified the branch by code
+/// inspection + the `rejected_unknown_id_count` observability only.
+///
+/// The `__set_attach_shutdown_probe` `#[doc(hidden)]` hook
+/// (§6.4 #2's test-only barrier) makes the window deterministic: it
+/// fires after the codec check passes and *before* `shutdown.load()`,
+/// so the test can park the worker, flip `server.shutdown()`, then
+/// release the worker. The worker re-reads the now-true flag and
+/// takes the reject branch — exactly the production semantics, with
+/// no scheduler-luck dependency.
+///
+/// **Mutant gate**: removing the `if server.shutdown.load() {
+/// reject }` line at the outgoing-attach arm leaves the worker
+/// proceeding to `add_incoming_slot` after the barrier returns, so
+/// `rejected_unknown_id_count` does NOT increment (the assertion
+/// below fails) and the attach `get_root()` would succeed (also
+/// flagged). Reverting just the assertion-side checks would still
+/// fail the rejected-count delta — both arms catch the regression.
+#[test]
+fn shutdown_gate_e2e_rejects_attach_during_handshake_stall() {
+    let path = tmp_sock("shutgate");
+    let counter = Arc::new(AtomicI64::new(0));
+    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    server.set_android13plus(1);
+    // 2 = founding + 1 attached. The cap is irrelevant to the
+    // shutdown gate (which fires *before* the cap check), but
+    // staying within it avoids confounding the reject-set: the only
+    // increment of `rejected_unknown_id` we want to observe is the
+    // shutdown-arm one.
+    server.set_max_threads(2);
+    server.set_root(make_service(counter.clone()));
+    let bg = server.run_background();
+    let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
+    wait_for_sock(&path);
+
+    // Founding session — kept alive (`c1` not dropped) so the
+    // registry still resolves `sid` when the attach worker hits the
+    // arm. Were c1 dropped here, the founding inner would die, the
+    // attach would hit the "unknown/stale" arm, and the shutdown
+    // gate would never be tested.
+    let c1 = RpcSession::setup_unix_client_android13plus(&path, 1).expect("a13+ founding connect");
+    let sid = c1.get_session_id().expect("get_session_id founding");
+
+    // Two channels form the barrier. The probe sends "handshake
+    // done" on the first call, then blocks on `release_rx`. The
+    // test waits for the signal, flips `shutdown`, then releases.
+    let (hs_done_tx, hs_done_rx) = std::sync::mpsc::channel::<()>();
+    let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+    // Wrap `release_rx` in an `Option` so the *first* probe fire
+    // takes it; any later fire (no-op once the test is done) sees
+    // `None` and drops through. The whole closure must be `Fn`
+    // (not `FnOnce`), hence the `Mutex<Option<Receiver>>` shape.
+    let release_rx = Arc::new(std::sync::Mutex::new(Some(release_rx)));
+    server.__set_attach_shutdown_probe({
+        let release_rx = Arc::clone(&release_rx);
+        let hs_done_tx = hs_done_tx.clone();
+        move || {
+            let _ = hs_done_tx.send(());
+            if let Some(rx) = release_rx.lock().expect("release_rx poisoned").take() {
+                let _ = rx.recv_timeout(Duration::from_secs(5));
+            }
+        }
+    });
+    let rejected_before = server.rejected_unknown_id_count();
+
+    // Run the attach in a background thread — its `get_root` would
+    // block on the parked worker otherwise.
+    let attach_path = path.clone();
+    let attach_sid = sid.clone();
+    let attach_handle = std::thread::spawn(move || -> std::result::Result<(), StatusCode> {
+        let c2 = RpcSession::setup_unix_client_android13plus_with_id(&attach_path, 1, &attach_sid)
+            .expect("handshake completes (reject is post-handshake — A0b/B.1 residual)");
+        c2.set_timeout(Some(Duration::from_secs(3)));
+        c2.get_root().map(|_| ())
+    });
+
+    // Wait for the attach worker to reach the barrier.
+    hs_done_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("attach worker should reach the shutdown barrier");
+
+    // Flip shutdown *while* the worker is parked at the probe.
+    server.shutdown();
+
+    // Release the worker — it re-reads `shutdown.load() == true`
+    // and takes the reject branch (drops the transport).
+    let _ = release_tx.send(());
+
+    let attach_result = attach_handle
+        .join()
+        .expect("attach thread should not panic");
+    let err = attach_result.expect_err("attach during shutdown must be rejected (mutant: success)");
+    assert!(
+        matches!(
+            err,
+            StatusCode::DeadObject | StatusCode::TimedOut | StatusCode::Unknown
+        ),
+        "shutdown-reject surfaces as the same reject set as cap/unknown-id reject \
+         (post-handshake socket close), got {err:?}"
+    );
+    assert!(
+        poll_until(|| server.rejected_unknown_id_count() == rejected_before + 1),
+        "shutdown-reject increments the `rejected_unknown_id` observability counter \
+         (mutant: removing `if server.shutdown.load() {{ reject }}` leaves this flat)"
+    );
+    // Founding inner's slot pool stayed at 1 — the rejected attach
+    // never reached `add_incoming_slot` (otherwise this would be
+    // `Some(2)`, a second mutant-catch axis independent of the
+    // counter delta above).
+    let sid_arr: [u8; 32] = sid.as_slice().try_into().expect("32-byte session id");
+    assert_eq!(
+        server.session_slot_count(&sid_arr),
+        Some(1),
+        "shutdown-rejected attach did not enqueue a slot (mutant: would reach Some(2))"
+    );
+    // (`c1` lives to function exit by lexical scope — see its
+    // binding-site comment for why the founding inner must stay
+    // registered for the whole attach attempt.)
+}
+
 /// **Phase A F7** (the AC-12.0b residual, now fixed). With a shared
 /// `RpcState` (A0b id-demux), two **independent** client sessions each
 /// hold their own proxy to the *same* server root. Pre-F7 the server
@@ -1855,16 +1980,33 @@ fn ac_12_2_extended_cross_slot_nested_callback_multi_thread() {
     drop(c);
 }
 
-/// AC-12.3 — on a multi-outgoing client, top-level oneway sends are
-/// pinned to the founding slot (Option-1; Phase C asyncTodo would
-/// permit distribution but unpinning flakes the libbinder AC-12.6
-/// (c) gate ~20% with EPIPE on the nested-callback outer reply when
-/// DECs cross slots). Twoway echoes distribute (AC-12.1). 300 oneway
-/// bumps interleaved with concurrent twoway echoes must all arrive
-/// (`count == 300`) without the founding-slot wire corrupting any
-/// twoway round-trip.
+/// AC-12.3 — on a multi-outgoing client, oneway FIFO must hold under
+/// twoway interleave regardless of which slot each oneway rode. With
+/// §7.3 Option-1 founding-pin retired (2026-05-28), top-level oneway
+/// `find_conn` no longer routes to slot 1 — the per-`mNodeForAddress`
+/// `asyncNumber` send-side + receive-side `asyncTodo` priority replay
+/// (Phase C, [state.rs](../src/rpc/state.rs)) is what carries the per-
+/// object oneway ordering invariant on both ends; the pin was a HOL
+/// trade-off, not a correctness invariant. The 2026-05-21 deferral
+/// suspected a libbinder `waitForReply` cross-slot race, but
+/// re-running the experiment fresh shows 100/100 hermetic + 20/20
+/// STAGE3 PASS without the pin (the prior 4/5 reading was N=5 noise;
+/// see [plans/2-12 §7.3](../../plans/2-12-multi-connection-per-session.md)).
+///
+/// What this test gates: 300 oneway bumps interleaved with concurrent
+/// twoway echoes across an outgoing slot pool of size 2 all arrive
+/// (`count == 300`) with no wire corruption between the oneway and
+/// twoway frames. The pin-specific mutant gate (re-add the founding
+/// pin) is gone — pin re-introduction is a HOL throughput regression,
+/// not a correctness one — so this test's standing mutant gate is
+/// Phase C asyncTodo deletion (covered as a unit gate at
+/// [`rpc::state::tests`](../src/rpc/state.rs)
+/// `phase_c_out_of_order_drains_in_order_via_async_todo`) plus
+/// STAGE3 (b) for the live libbinder round-robin path:
+/// [`rpc::state::tests::phase_c_out_of_order_enqueues_then_drains_in_priority_order`](../src/rpc/state.rs#L747)
+/// and `phase_c_send_async_number_is_per_address_monotonic`.
 #[test]
-fn pool_oneway_pinned_to_founding_slot_multi_outgoing() {
+fn pool_oneway_fifo_under_concurrent_twoway_multi_outgoing() {
     let path = tmp_sock("a3one");
     let counter = Arc::new(AtomicI64::new(0));
     let server = RpcServer::setup_unix_server(&path).expect("bind");

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -1716,35 +1716,20 @@ fn ac_12_2_extended_cross_slot_nested_callback_multi_thread() {
     drop(c);
 }
 
-/// **AC-12.3 (Phase A — oneway Option-1)**: on a multi-outgoing
-/// client, all top-level **oneway** sends are pinned to the founding
-/// slot (single-slot in-order delivery preserves the same-object
-/// oneway FIFO from the pre-pool model), while **twoway** sends still
-/// distribute (AC-12.1). 300 oneway bumps interleaved with twoway
-/// echoes — all bumps must arrive (`count == 300`) and the wire on
-/// the founding socket must not corrupt (twoways still round-trip).
-///
-/// **Trade-off recorded (HOL).** Option-1's price is head-of-line
-/// blocking on the oneway-pinned slot — a slow oneway handler at the
-/// peer stalls every other oneway through that slot. AOSP avoids
-/// this via per-`mNodeForAddress` `asyncNumber` + receive-side
-/// `asyncTodo` priority replay (Option-2 — F5/F6), deferred to Phase
-/// C unless AC-12.6's real-libbinder multi-object-oneway gate forces
-/// it.
-///
-/// **Order is not strictly asserted** (atomic counter — order-blind).
-/// A strict-order gate would need a server-side sequence-recorder
-/// (deferred); the per-slot in-order delivery is exercised here by
-/// the count + the parallel twoway round-trips not corrupting the
-/// shared wire.
-
+/// AC-12.3 — on a multi-outgoing client, top-level oneway sends are
+/// pinned to the founding slot (Option-1; Phase C asyncTodo would
+/// permit distribution but unpinning flakes the libbinder AC-12.6
+/// (c) gate ~20% with EPIPE on the nested-callback outer reply when
+/// DECs cross slots). Twoway echoes distribute (AC-12.1). 300 oneway
+/// bumps interleaved with concurrent twoway echoes must all arrive
+/// (`count == 300`) without the founding-slot wire corrupting any
+/// twoway round-trip.
 #[test]
 fn pool_oneway_pinned_to_founding_slot_multi_outgoing() {
     let path = tmp_sock("a3one");
     let counter = Arc::new(AtomicI64::new(0));
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(1);
-    // Phase B.1: founding + one outgoing-echo ⇒ 2 incoming slots.
     server.set_max_threads(2);
     server.set_root(make_service(counter.clone()));
     let bg = server.run_background();
@@ -1756,19 +1741,11 @@ fn pool_oneway_pinned_to_founding_slot_multi_outgoing() {
     let slot2 = c
         .add_outgoing_connection_android13plus(&path, 1, &sid)
         .expect("slot 2");
-    assert_ne!(
-        slot2, 1,
-        "second slot has a fresh id (founding == 1) — otherwise the \
-         'oneway pinned to founding' geometry collapses"
-    );
+    assert_ne!(slot2, 1, "second slot has a fresh id");
 
     let root = Arc::new(EchoProxy(c.get_root().expect("get_root")));
     let n = 300i64;
 
-    // Oneway bumps (pinned to slot 1) + concurrent twoway echoes
-    // (distributed). The twoway echoes also exercise the wire on the
-    // founding slot in between oneway sends — any frame interleave
-    // would corrupt them.
     let r1 = Arc::clone(&root);
     let bump_h = std::thread::spawn(move || {
         for _ in 0..n {
@@ -1790,17 +1767,15 @@ fn pool_oneway_pinned_to_founding_slot_multi_outgoing() {
         h.join().expect("echo thread");
     }
 
-    // Poll for the oneway bumps to drain.
     assert!(
         poll_until(|| root.count().unwrap() == n),
-        "AC-12.3: all oneway bumps delivered (option-1 pin preserves \
-         the per-slot oneway path); last observed count = {}",
+        "AC-12.3: all oneway bumps delivered across the slot pool; \
+         last observed count = {}",
         root.count().unwrap()
     );
 
     drop(root);
     drop(c);
-    // _cu handles teardown.
 }
 
 // ---- AC-3.9 P6: no globals anywhere in the RPC stack ---------------

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -1,11 +1,11 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Subplan 2-3: multi-session `RpcServer`, real-process e2e, threads,
+//! Multi-session `RpcServer`, real-process e2e, threads,
 //! `getRemoteMaxThreads` negotiation, oneway FIFO, nested callbacks,
-//! timeout, lifecycle, and the P6 no-global gate.
+//! timeout, lifecycle, and the no-global gate.
 //!
-//! Separate test binary (master §6). P6: each test builds its own
+//! Separate test binary. Each test builds its own
 //! server + sessions ⇒ parallel-safe, no `--test-threads=1`.
 
 #![cfg(feature = "rpc")]
@@ -44,7 +44,7 @@ struct EchoSvc {
     deeper: bool,
     /// Set on **entry** to `slow()` so a test can wait deterministically
     /// for a parked thread to have actually claimed a server worker
-    /// (e.g. AC-12.2's slot-pin scope). Tests that don't care pass a
+    /// (e.g. the slot-pin scope). Tests that don't care pass a
     /// fresh `AtomicBool` and ignore it. Set is one-way (no reset) —
     /// "at least one slow call entered" is the only signal needed.
     slow_entered: Arc<AtomicBool>,
@@ -166,8 +166,7 @@ fn make_service(counter: Arc<AtomicI64>) -> SIBinder {
 /// Build an `EchoSvc` whose `slow()` entry sets the supplied `AtomicBool`
 /// so a test can wait deterministically for a parked client thread to
 /// have actually claimed a server worker — instead of a sleep(N ms)
-/// heuristic that races scheduler jitter (the AC-12.2 mutant-gate
-/// reinforcement called out in review).
+/// heuristic that races scheduler jitter.
 fn make_service_with_slow_signal(
     counter: Arc<AtomicI64>,
     slow_entered: Arc<AtomicBool>,
@@ -279,7 +278,7 @@ fn poll_until(mut f: impl FnMut() -> bool) -> bool {
 /// an `assert!`/`unwrap`/`expect` panic mid-test. Without this an
 /// assertion failure leaks the background accept loop + every spawned
 /// `serve_blocking` worker into the test binary process for the
-/// remainder of the suite (each subsequent timing-sensitive AC-12.1*
+/// remainder of the suite (each subsequent timing-sensitive
 /// test then runs against a contaminated scheduler). Construct **once**
 /// per test, right after `server.run_background()`, then let `Drop` do
 /// the rest.
@@ -333,7 +332,7 @@ impl Drop for ServeCleanup {
     }
 }
 
-// ---- AC-3.1 real OS process e2e + AC-3.4 negotiation ---------------
+// ---- real OS process e2e + negotiation -----------------------------
 
 #[test]
 fn real_process_e2e_and_negotiation() {
@@ -357,12 +356,12 @@ fn real_process_e2e_and_negotiation() {
 
     {
         let client = RpcSession::setup_unix_client(&path).expect("connect");
-        // AC-3.4: explicit negotiation, local=8, server advertises 2.
+        // Explicit negotiation, local=8, server advertises 2.
         assert_eq!(client.negotiate(8).expect("negotiate"), 2);
         assert_eq!(client.negotiated_max_threads(), 2);
 
         let root = EchoProxy(client.get_root().expect("get_root"));
-        // AC-3.1: real cross-process AIDL call.
+        // Real cross-process AIDL call.
         assert_eq!(
             root.echo("over a real process").unwrap(),
             "over a real process"
@@ -373,13 +372,13 @@ fn real_process_e2e_and_negotiation() {
         }
     }
 
-    // AC-3.7: killing the client leaves the server able to exit cleanly.
+    // Killing the client leaves the server able to exit cleanly.
     child.kill().expect("kill server child");
     child.wait().expect("reap server child");
     let _ = std::fs::remove_file(&path);
 }
 
-// ---- AC-3.2 concurrency: many threads, ONE shared session ----------
+// ---- concurrency: many threads, ONE shared session ----------------
 
 #[test]
 fn concurrent_calls_single_shared_session() {
@@ -390,12 +389,12 @@ fn concurrent_calls_single_shared_session() {
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
 
-    // AC-3.2 (as written: "8 client threads on the SAME session").
+    // 8 client threads on the SAME session.
     // ONE client session, its root proxy shared (Arc) across 8 threads
     // — exactly how a generated `Bp*` stub is used concurrently
     // (`SIBinder` is `Send`/`Sync`). Before the per-connection lock
-    // this interleaved the framed stream / cross-delivered replies
-    // (Major-2). Calls are internally serialized on the one
+    // this interleaved the framed stream / cross-delivered replies.
+    // Calls are internally serialized on the one
     // connection (the documented model: parallelism = multiple
     // connections), so wall time is also bounded well below a hang.
     let client = RpcSession::setup_unix_client(&path).expect("connect");
@@ -427,7 +426,7 @@ fn concurrent_calls_single_shared_session() {
     // _cu handles teardown.
 }
 
-// ---- AC-3.3 multi-session isolation --------------------------------
+// ---- multi-session isolation ---------------------------------------
 
 #[test]
 fn concurrent_clients_isolated_sessions() {
@@ -439,7 +438,7 @@ fn concurrent_clients_isolated_sessions() {
     wait_for_sock(&path);
 
     // 8 client threads, each its own connection (independent session +
-    // RpcState — P6). Each does 200 calls and must see only its own
+    // RpcState). Each does 200 calls and must see only its own
     // echoes (no cross-session contamination, no deadlock).
     let mut handles = Vec::new();
     for t in 0..8 {
@@ -459,14 +458,13 @@ fn concurrent_clients_isolated_sessions() {
     // _cu handles teardown.
 }
 
-// ---- 2-10: opt-in server-side connection admission bound -----------
+// ---- opt-in server-side connection admission bound -----------
 
 /// `set_max_connections(N)` caps *concurrent* connection workers via
 /// reactor-free accept backpressure (excess clients wait in the kernel
 /// listen backlog, none dropped; a freed slot resumes accept). This is
-/// the reactor-free, Android-faithful resource bound that the 2-10
-/// decision record carves out as the genuine middle ground (the
-/// no-reactor decision does NOT foreclose it).
+/// the reactor-free, Android-faithful resource bound — a genuine middle
+/// ground that the no-reactor design does NOT foreclose.
 ///
 /// Mutant: deleting the `max_connections` gate in `RpcServer::run`
 /// makes the 3rd client served immediately ⇒ its bounded-timeout
@@ -532,7 +530,7 @@ fn max_connections_admission_bound() {
     // _cu handles teardown.
 }
 
-// ---- AC-3.5 oneway FIFO + non-blocking send ------------------------
+// ---- oneway FIFO + non-blocking send -------------------------------
 
 #[test]
 fn oneway_fifo_and_nonblocking() {
@@ -574,7 +572,7 @@ fn oneway_fifo_and_nonblocking() {
     // _cu handles teardown.
 }
 
-// ---- AC-3.6 nested server→client callback --------------------------
+// ---- nested server→client callback ---------------------------------
 
 #[test]
 fn nested_callback_no_deadlock() {
@@ -604,7 +602,7 @@ fn nested_callback_no_deadlock() {
     // _cu handles teardown.
 }
 
-// ---- AC-3.8 timeout (hung server) ----------------------------------
+// ---- timeout (hung server) -----------------------------------------
 
 #[test]
 fn client_timeout_on_hung_server() {
@@ -631,10 +629,10 @@ fn client_timeout_on_hung_server() {
     // _cu handles teardown.
 }
 
-// ---- 2-5b / G4(a): opt-in android-13+ versioned-wire profile -------
+// ---- opt-in android-13+ versioned-wire profile ---------------------
 
-/// G4(a): the proven android-13+ connection handshake + AOSP-faithful
-/// framing + `Android13PlusCodec` (G4 Layer-1, hermetic) now driving a
+/// The proven android-13+ connection handshake + AOSP-faithful
+/// framing + `Android13PlusCodec` (hermetic) now driving a
 /// **live `RpcServer`/`RpcSession` dispatch path** end-to-end over a
 /// real `UnixTransport`, reusing the existing per-session `RpcState`,
 /// `client_transact`/`serve_blocking`, oneway-FIFO and nested-callback
@@ -650,7 +648,7 @@ fn android13plus_profile_e2e() {
         (1, 1, 1),          // v1 — android-14/15
         (1, 0, 0),          // mismatch ⇒ min = v0
         (0, 1, 0),          // mismatch ⇒ min = v0
-        (2, 2, 2),          // v2 — android-16 (subplan 2-8)
+        (2, 2, 2),          // v2 — android-16
         (2, 1, 1),          // v2↔v1 ⇒ min = v1
         (1, 2, 1),          // v1↔v2 ⇒ min = v1
         (2, 0, 0),          // v2↔v0 ⇒ min = v0
@@ -725,8 +723,8 @@ fn android13plus_profile_e2e() {
     }
 }
 
-/// **2-15 AC-15.3 / 2-15.0 PoC** — the decoupled `TlsTransport`
-/// (`Mutex<Connection>` + lock-free stream, subplan 2-15 §2.0) driving
+/// The decoupled `TlsTransport`
+/// (`Mutex<Connection>` + lock-free stream) driving
 /// the **android-13+ profile over TLS**, hermetic rsbinder↔rsbinder.
 /// Mirrors `android13plus_profile_e2e` (version negotiation v0/v1/v2 +
 /// mismatch, echo, 300-oneway FIFO, **nested server→client callback**)
@@ -796,7 +794,7 @@ fn tls_android13plus_nested_callback_e2e() {
             let _ = session.serve_blocking();
         });
 
-        // Exercises the 2-15.5 convenience constructor (TCP-connect +
+        // Exercises the convenience constructor (TCP-connect +
         // TLS-handshake + android-13+ handshake in one call).
         let client = RpcSession::setup_tcp_client_tls_android13plus(
             addr,
@@ -876,12 +874,9 @@ fn r34_profile_reports_no_wire_version() {
     drop(client);
 }
 
-/// **AC-12.0b** (subplan 2-12 Phase A0b — `transport` split out of
+/// `transport` split out of
 /// `RpcSessionInner` into a shared `SharedSession` + server id-demux +
-/// F4 death-trigger; see `plans/2-12-multi-connection-per-session.md`
-/// §0 F9 / §2 / §6). A0b is the ≡Phase-A-risk structural core the
-/// recursive review carved out of the (now byte-identical default)
-/// A0a plumbing.
+/// partial-vs-full death-trigger.
 ///
 /// Proves the **id-demux attach** is real (not dead plumbing):
 ///  - client #1 — **empty** id ⇒ new session; server registers a
@@ -899,31 +894,30 @@ fn r34_profile_reports_no_wire_version() {
 ///    attached connection;
 ///  - client #3 — an **unknown** 32-byte id ⇒ no live session ⇒
 ///    rejected (`rejected_unknown_id == 1`);
-///  - **F4 (partial vs. full teardown)**: dropping the *attached* #2
+///  - **partial vs. full teardown**: dropping the *attached* #2
 ///    must NOT tear the session down — #1 stays fully functional and
 ///    still reports the same shared id (a spurious obituary / early
 ///    teardown on a partial connection loss would break this). The
-///    complementary "fires exactly once on *full* teardown,
-///    byte-identical to pre-A0b" side is the unchanged
-///    `rpc_death_recipient_fires_on_session_drop` (single-connection
+///    complementary "fires exactly once on *full* teardown" side is
+///    the `rpc_death_recipient_fires_on_session_drop` (single-connection
 ///    `live_conns 1→0`) in this same suite.
 ///
-/// **Mutant gate (== pre-A0b code)**: make the found branch build a
+/// **Mutant gate**: make the found branch build a
 /// *fresh* session instead of attaching (`from_android13plus(.., None)`
 /// in `serve_connection`'s attach arm). Then #2 gets its own
 /// `SharedSession` ⇒ `c2.get_session_id() != sid1` ⇒ the shared-id
 /// assertion fails. That is what makes the demux load-bearing rather
-/// than the dead plumbing F1/F9 warn about.
+/// than dead plumbing.
 #[test]
 fn a0b_multi_connection_shared_session() {
     let path = tmp_sock("a0b");
     let counter = Arc::new(AtomicI64::new(0));
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(1); // opt in to the versioned wire
-                                 // Phase B.1 (AC-12.4): `set_max_threads` is now the advertised
+                                 // `set_max_threads` is the advertised
                                  // *and* enforced per-session incoming-slot cap. This test exercises
                                  // founding + one attached connection ⇒ explicit opt-in at 2 slots
-                                 // (default 1 ⇒ founding-only). AOSP-faithful: AC-12.0b is fundamentally
+                                 // (default 1 ⇒ founding-only). AOSP-faithful: this is fundamentally
                                  // a multi-conn scenario, so AOSP `setMaxIncomingThreads(2)` is its
                                  // natural setup step.
     server.set_max_threads(2);
@@ -975,8 +969,8 @@ fn a0b_multi_connection_shared_session() {
     let c3 = RpcSession::setup_unix_client_android13plus_with_id(&path, 1, &bogus)
         .expect("handshake completes (reject is post-handshake — A0b residual)");
     c3.set_timeout(Some(Duration::from_secs(3)));
-    // Strengthen the unknown-id reject assertion (review m8 + round-2
-    // M3): the original `is_err()` would also pass for an unrelated
+    // Strengthen the unknown-id reject assertion: a plain `is_err()`
+    // would also pass for an unrelated
     // error (e.g. handshake itself failed). Lock the contract to the
     // actual post-handshake-reject status set observed on UDS:
     //
@@ -993,11 +987,7 @@ fn a0b_multi_connection_shared_session() {
     //    surface a socket-close as an `io::Error` whose
     //    `raw_os_error() == None` (e.g. `ErrorKind::Other`), which
     //    `StatusCode::from(io::Error)` maps to `Unknown` rather than
-    //    `PeerClosed`. This was observed in practice on this host
-    //    during initial development. The ideal fix is to root-cause
-    //    the host-specific path so it normalizes to `DeadObject` (the
-    //    AOSP-faithful signature); kept as an accepted reject status
-    //    for now — **FOLLOWUP**: trace and tighten.
+    //    `PeerClosed`. Accepted as a reject status.
     //
     // Anything outside this set means a different bug (and `Ok` is
     // the true mutant: server honored the unknown id).
@@ -1016,29 +1006,26 @@ fn a0b_multi_connection_shared_session() {
     );
     assert_eq!(server.attached_count(), 1, "attach count stable");
 
-    // --- F4: drop **only** the ATTACHED connection #2 (a partial
+    // --- Drop **only** the ATTACHED connection #2 (a partial
     //     loss; `root2` is intentionally left alive — see below). The
     //     session must survive: the founding connection #1 keeps
     //     working and still reports the same shared id. A spurious
     //     obituary / early teardown on a partial connection loss
     //     (live_conns mis-gated) would make these DeadObject.
     //
-    //     This test keeps its A0b-era shape: the liveness probe is
-    //     `get_session_id` (a zero-address special transact) and it
-    //     does not drop a sibling proxy here — that *was* F7 (multi-
-    //     proxy refcount over a shared `RpcState`), at the time a
-    //     Phase-A residual. **F7 is now fixed** (AOSP `timesSent` /
-    //     `flushExcessBinderRefs`); the previously-avoided sibling-
-    //     proxy-drop path is covered by `f7_shared_node_survives_
-    //     sibling_proxy_drop` + `f7_excess_receipt_no_leak_single_
-    //     client`. This test stays focused on A0b's own contract
-    //     (attach works — shown above — + F4 no premature teardown on
-    //     partial loss, shown here) so its mutant gate stays clean.
+    //     The liveness probe is `get_session_id` (a zero-address
+    //     special transact). It does not drop a sibling proxy here;
+    //     the sibling-proxy-drop path (AOSP `timesSent` /
+    //     `flushExcessBinderRefs`) is covered by
+    //     `f7_shared_node_survives_sibling_proxy_drop` +
+    //     `f7_excess_receipt_no_leak_single_client`. This test stays
+    //     focused on attach (shown above) + no premature teardown on
+    //     partial loss (shown here) so its mutant gate stays clean.
     drop(c2);
     // **Deterministic** wait for the server's attached worker to
     // exit (`serve_blocking_on` → `live_conns.fetch_sub`), replacing
     // the prior `sleep(50ms)` heuristic that raced scheduler jitter
-    // under CI load. `session_live_conns` reads the F4 ledger
+    // under CI load. `session_live_conns` reads the live-conn ledger
     // directly: after `c2` drop the attached worker observes the
     // peer-close and `fetch_sub`s 2→1; once we see 1 the partial-loss
     // path is fully reaped and the *next* liveness check
@@ -1068,35 +1055,34 @@ fn a0b_multi_connection_shared_session() {
     // a panic above no longer leaks worker threads + socket file.
 }
 
-/// **AC-12.F8** (subplan 2-12 Phase A4 — server-side unification of
-/// `RpcSessionInner` into a single inner per session; see
-/// `plans/2-12-multi-connection-per-session.md` §2 Phase A4 / §6).
+/// Server-side unification of `RpcSessionInner` into a single inner per
+/// session.
 ///
-/// The post-A0b residual was that the *server* still built one
+/// Without it the *server* built one
 /// `RpcSessionInner` per accepted connection (sharing only the
 /// `SharedSession`), so `state.remote_proxies`-cached `RpcProxy.weak:
 /// Weak<RpcSessionInner>` pointed to the *first* worker's inner. A
 /// later worker unmarshaling the same client binder hit the cache and
 /// inherited that other inner — its nested `proxy.transact`
 /// `find_conn`ed inside the other worker's slot pool, not its own:
-/// cross-slot aliasing (F8). Phase A4 collapses N inners into 1 (slots
-/// in one pool); every cached `RpcProxy.weak` now points to the only
+/// cross-slot aliasing. Collapsing N inners into 1 (slots
+/// in one pool) makes every cached `RpcProxy.weak` point to the only
 /// inner, and any server worker's nested `proxy.transact` `find_conn`s
 /// **inside its own pool**.
 ///
-/// Witness via the *founding inner*'s slot count: after Phase A4 an
+/// Witness via the *founding inner*'s slot count: an
 /// id-echoing attached connection adds a *slot* to that inner, so
-/// `session_slot_count(sid) == Some(2)`. The F8 mutant (== pre-A4
-/// code: server attach arm builds `from_android13plus(.., Some(shared))`
-/// = a fresh inner sharing only `SharedSession`) leaves the founding
+/// `session_slot_count(sid) == Some(2)`. The mutant (server attach arm
+/// builds `from_android13plus(.., Some(shared))` = a fresh inner sharing
+/// only `SharedSession`) leaves the founding
 /// inner with its single founding slot ⇒ `Some(1)` — the assertion
-/// fails. This is what makes Phase A4 load-bearing rather than a
+/// fails. This is what makes the unification load-bearing rather than a
 /// no-op refactor.
 ///
-/// AC-12.0b still asserts the *attach* itself (shared `SharedSession`
-/// id round-trip + `attached_count == 1` + F4 partial-loss survival);
-/// this test layers Phase A4's structural shape on top of that
-/// without re-asserting the A0b contract.
+/// `a0b_multi_connection_shared_session` asserts the *attach* itself
+/// (shared `SharedSession` id round-trip + `attached_count == 1` +
+/// partial-loss survival); this test layers the single-inner structural
+/// shape on top of that.
 
 #[test]
 fn ac_12_f8_attach_unifies_to_single_inner() {
@@ -1104,7 +1090,7 @@ fn ac_12_f8_attach_unifies_to_single_inner() {
     let counter = Arc::new(AtomicI64::new(0));
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(1);
-    // Phase B.1: opt into 2 incoming slots (default 1 ⇒ founding-only).
+    // Opt into 2 incoming slots (default 1 ⇒ founding-only).
     server.set_max_threads(2);
     server.set_root(make_service(counter.clone()));
     let bg = server.run_background();
@@ -1125,13 +1111,13 @@ fn ac_12_f8_attach_unifies_to_single_inner() {
         "founding-only ⇒ single slot in the founding inner"
     );
 
-    // Attached connection (#2): echo #1's id ⇒ Phase A4 attach arm
+    // Attached connection (#2): echo #1's id ⇒ the attach arm
     // adds a *slot* to the founding inner (rather than building a
-    // fresh inner sharing only SharedSession — the F8 mutant).
+    // fresh inner sharing only SharedSession — the mutant).
     let c2 = RpcSession::setup_unix_client_android13plus_with_id(&path, 1, &sid)
         .expect("a13+ #2 (attach)");
     // Bound without the conventional `_` prefix — `root2` is moved into
-    // an explicit `drop(...)` below to trigger the F4 partial-loss
+    // an explicit `drop(...)` below to trigger the partial-loss
     // reap; an underscore-prefix would have read as "intentionally
     // unused" and hidden that load-bearing drop.
     let root2 = EchoProxy(c2.get_root().expect("get_root #2"));
@@ -1139,9 +1125,9 @@ fn ac_12_f8_attach_unifies_to_single_inner() {
         poll_until(|| server.attached_count() == 1),
         "echo-id connection took the id-demux ATTACH path (A0b)"
     );
-    // Phase A4 contract: the attached connection is a *slot on the
+    // The attached connection is a *slot on the
     // founding inner*, so the inner's slot pool now has 2 slots.
-    // F8 mutant — each connection has its own inner with one slot —
+    // The mutant — each connection has its own inner with one slot —
     // would leave the founding inner at slot_count == 1.
     assert!(
         poll_until(|| server.session_slot_count(&sid_arr) == Some(2)),
@@ -1149,8 +1135,8 @@ fn ac_12_f8_attach_unifies_to_single_inner() {
          (mutant: fresh-inner-on-attach leaves slot_count == 1)"
     );
 
-    // Partial-loss reaping (re-uses the existing F4 ledger): drop the
-    // attached and verify the founding inner's slot pool shrinks back
+    // Partial-loss reaping (re-uses the existing live-conn ledger): drop
+    // the attached and verify the founding inner's slot pool shrinks back
     // to 1, then the founding-only state survives.
     drop(root2);
     drop(c2);
@@ -1165,32 +1151,30 @@ fn ac_12_f8_attach_unifies_to_single_inner() {
     );
 }
 
-/// **AC-12.4 (Phase B.1 — `setMaxIncomingThreads` cap + negotiate
-/// reflection; see `plans/2-12-multi-connection-per-session.md` §2
-/// Phase B / §3 AC-12.4).** Phase B.1 unifies `set_max_threads(N)`'s
+/// `setMaxIncomingThreads` cap + negotiate reflection.
+/// `set_max_threads(N)` carries
 /// two meanings — advertise + enforce: the server attach arm refuses
 /// an id-echoing connection when adding it would push `slot_count() >
 /// max_threads_value()`. Default 1 ⇒ founding-only; multi-conn
 /// callers opt in via explicit `set_max_threads(N >= 2)`.
 ///
-/// Mutant gate (== pre-B.1 / advertise-only): cap check absent ⇒
+/// Mutant gate (advertise-only): cap check absent ⇒
 /// 3rd attach silently succeeds and `session_slot_count(sid) ==
 /// Some(3) > set_max_threads(2)` ⇒ the cap assertion fails (and the
 /// `rejected_unknown_id_count` witness stays at 0).
 ///
-/// Sub-AC (b): `GetMaxThreads` returns the same `max_threads_value()`
+/// `GetMaxThreads` returns the same `max_threads_value()`
 /// (advertise == enforce), so a client's `negotiate(local_max)`
 /// records `min(local_max, server_cap)` — verified at the wire by
 /// querying `negotiated_max_threads()` after a single
 /// `GetMaxThreads` round-trip.
 ///
-/// Sub-AC (c — `shutdown` gate): documented at the *code* level only
-/// — the attach arm shows `if server.shutdown.load() { reject }`. A
+/// The `shutdown` gate is documented at the *code* level only — the
+/// attach arm shows `if server.shutdown.load() { reject }`. A
 /// deterministic e2e trigger needs an accept-pass / handshake-stall /
-/// late-shutdown race that current test scaffolding does not bound;
-/// kept as a §7.3 FOLLOWUP (test scaffolding, not a B.1 deferral —
+/// late-shutdown race that the current test scaffolding does not bound;
 /// the *behavior* is already in code and falls inside the
-/// rejected_unknown_id observability).
+/// rejected_unknown_id observability.
 
 #[test]
 fn ac_12_4_set_max_threads_caps_incoming_slots() {
@@ -1222,7 +1206,7 @@ fn ac_12_4_set_max_threads_caps_incoming_slots() {
     let rejected_before = server.rejected_unknown_id_count();
 
     // 3rd attach with the same session id ⇒ would push slot_count to
-    // 3 > max_threads(2) ⇒ refused at the attach arm (Phase B.1 cap).
+    // 3 > max_threads(2) ⇒ refused at the attach arm (cap).
     let c3 = RpcSession::setup_unix_client_android13plus_with_id(&path, 1, &sid)
         .expect("handshake completes (reject is post-handshake — A0b/B.1 residual)");
     c3.set_timeout(Some(Duration::from_secs(3)));
@@ -1248,10 +1232,10 @@ fn ac_12_4_set_max_threads_caps_incoming_slots() {
          a B.1 mutant would have let this reach Some(3))"
     );
 
-    // Sub-AC (b): negotiate reflects the server's advertised + enforced
+    // negotiate reflects the server's advertised + enforced
     // value. Client opts into local_max=4; server advertises 2 ⇒
     // negotiated = min(4, 2) = 2. (Wire-level: a single GetMaxThreads
-    // round-trip, AC-3.4.) The advertise == enforce equation is exactly
+    // round-trip.) The advertise == enforce equation is exactly
     // what makes the cap observable to a well-behaved client *without*
     // needing to learn `rejected_unknown_id_count` out-of-band.
     let negotiated = c1.negotiate(4).expect("negotiate");
@@ -1266,8 +1250,8 @@ fn ac_12_4_set_max_threads_caps_incoming_slots() {
     );
 }
 
-/// **Phase B.2 — AOSP `setupClient` fan-out automation, multi-conn
-/// path.** `RpcSession::setup_unix_client_android13plus_fan_out` does
+/// AOSP `setupClient` fan-out automation, multi-conn path.
+/// `RpcSession::setup_unix_client_android13plus_fan_out` does
 /// in one helper what the manual API requires three explicit steps for:
 /// founding connect → `negotiate(local)` → N-1 additional outgoing
 /// `add_outgoing_connection_android13plus`. Witnesses that the helper's
@@ -1336,7 +1320,7 @@ fn b2_fan_out_creates_n_outgoing_slots_when_local_max_outgoing_is_n() {
     );
 }
 
-/// **Phase B.2 — single-connection fast path.** `local_max_outgoing ==
+/// Single-connection fast path. `local_max_outgoing ==
 /// 1` (and `0`, normalized) must skip the `GET_MAX_THREADS` round-trip
 /// and the fan-out loop entirely so the wire is bit-identical to the
 /// founding-only helper. A caller paying for the fan-out helper's
@@ -1405,16 +1389,15 @@ fn b2_local_max_outgoing_one_skips_fan_out_byte_identical_to_founding_only() {
     );
 }
 
-/// **§7.3 #2 — shutdown-reject e2e scaffolding** (the deferred Phase
-/// B.1 Sub-AC (c)). The android-13+ attach arm sits past a successful
-/// handshake but before the per-slot enqueue; in production the
-/// `shutdown.load()` gate at that point sees a *sub-microsecond*
+/// Shutdown-reject e2e. The android-13+ attach arm sits past a
+/// successful handshake but before the per-slot enqueue; in production
+/// the `shutdown.load()` gate at that point sees a *sub-microsecond*
 /// window between an accepted late attach and a concurrent
-/// `server.shutdown()`, so prior tests verified the branch by code
-/// inspection + the `rejected_unknown_id_count` observability only.
+/// `server.shutdown()`, so the branch is otherwise only observable by
+/// code inspection + the `rejected_unknown_id_count` counter.
 ///
-/// The `__set_attach_shutdown_probe` `#[doc(hidden)]` hook
-/// (§6.4 #2's test-only barrier) makes the window deterministic: it
+/// The `__set_attach_shutdown_probe` `#[doc(hidden)]` test-only barrier
+/// makes the window deterministic: it
 /// fires after the codec check passes and *before* `shutdown.load()`,
 /// so the test can park the worker, flip `server.shutdown()`, then
 /// release the worker. The worker re-reads the now-true flag and
@@ -1530,19 +1513,18 @@ fn shutdown_gate_e2e_rejects_attach_during_handshake_stall() {
     // registered for the whole attach attempt.)
 }
 
-/// **Phase A F7** (the AC-12.0b residual, now fixed). With a shared
-/// `RpcState` (A0b id-demux), two **independent** client sessions each
-/// hold their own proxy to the *same* server root. Pre-F7 the server
-/// pinned the node's strong count at 1 by object-identity, so the
-/// first connection's proxy drop `DEC_STRONG`'d it to 0 and freed the
-/// node ⇒ the sibling connection's proxy `DeadObject` (exactly what
-/// AC-12.0b had to *avoid*). With AOSP `timesSent` accounting the
-/// server counts each send (strong = 2), so the first DEC only brings
-/// it to 1 and the sibling survives; the node is freed only when the
-/// *second* proxy drops too (no leak — proven deterministically at the
-/// state level by `rpc::state::tests::f7_timessent_balance_no_leak`).
+/// With a shared `RpcState` (id-demux), two **independent** client
+/// sessions each hold their own proxy to the *same* server root.
+/// Pinning the node's strong count at 1 by object-identity would make
+/// the first connection's proxy drop `DEC_STRONG` it to 0 and free the
+/// node ⇒ the sibling connection's proxy `DeadObject`. With AOSP
+/// `timesSent` accounting the server counts each send (strong = 2), so
+/// the first DEC only brings it to 1 and the sibling survives; the node
+/// is freed only when the *second* proxy drops too (no leak — proven
+/// deterministically at the state level by
+/// `rpc::state::tests::f7_timessent_balance_no_leak`).
 ///
-/// **Mutant gate (== pre-F7 code)**: revert `on_binder_leaving`'s
+/// **Mutant gate**: revert `on_binder_leaving`'s
 /// `timesSent` bump (strong stays 1). Then dropping `root1` frees the
 /// shared node and `root2.echo()` is `DeadObject` ⇒ this fails.
 #[test]
@@ -1551,7 +1533,7 @@ fn f7_shared_node_survives_sibling_proxy_drop() {
     let counter = Arc::new(AtomicI64::new(0));
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(1);
-    // Phase B.1: opt into 2 incoming slots (founding + attached).
+    // Opt into 2 incoming slots (founding + attached).
     server.set_max_threads(2);
     server.set_root(make_service(counter.clone()));
     let bg = server.run_background();
@@ -1586,8 +1568,8 @@ fn f7_shared_node_survives_sibling_proxy_drop() {
         .get_session_id()
         .expect("c1 still alive (ordering barrier)");
 
-    // F7: the shared node must survive the sibling's DEC (strong
-    // 2→1). Pre-F7 (mutant) it was freed (1→0) ⇒ DeadObject here.
+    // The shared node must survive the sibling's DEC (strong
+    // 2→1). The mutant freed it (1→0) ⇒ DeadObject here.
     assert_eq!(
         root2.echo("f7-after-sibling-drop").unwrap(),
         "f7-after-sibling-drop",
@@ -1610,7 +1592,7 @@ fn f7_shared_node_survives_sibling_proxy_drop() {
     // _cu handles teardown.
 }
 
-/// **Phase A F7 — client `flushExcessBinderRefs`** (the *other* mutant
+/// Client `flushExcessBinderRefs` (the *other* mutant
 /// arm). A **single** client session that receives the *same* server
 /// binder more than once while its deduped proxy stays live owes the
 /// sender one excess `DEC_STRONG` per duplicate receipt (the server
@@ -1677,7 +1659,7 @@ fn f7_excess_receipt_no_leak_single_client() {
     // _cu handles teardown.
 }
 
-/// **AC-12.1 (Phase A — connection pool)**: with N outgoing slots in
+/// Connection pool: with N outgoing slots in
 /// one `RpcSession`, concurrent `client_transact`s on different
 /// threads pick *different* slots (AOSP `findConnection` available-
 /// slot selection), so two server-side blocking handlers run **in
@@ -1685,7 +1667,7 @@ fn f7_excess_receipt_no_leak_single_client() {
 ///
 /// Wire-up: founding connection (slot 1) + one echoed-id outgoing
 /// (slot 2) via [`RpcSession::add_outgoing_connection_android13plus`].
-/// The slots end up id-demuxed to the *same* `SharedSession` (A0b),
+/// The slots end up id-demuxed to the *same* `SharedSession`,
 /// so the test's two threads transact through different sockets but
 /// the same server session.
 ///
@@ -1703,7 +1685,7 @@ fn pool_distributes_concurrent_calls_across_outgoing_slots() {
     let path = tmp_sock("a1pool");
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(1);
-    // Phase B.1: AC-12.1 wires founding + one attached outgoing-echo
+    // Founding + one attached outgoing-echo
     // ⇒ 2 incoming slots at the server. Default cap = 1 would reject
     // the attach, defeating the pool-distribution scenario.
     server.set_max_threads(2);
@@ -1737,17 +1719,10 @@ fn pool_distributes_concurrent_calls_across_outgoing_slots() {
     let elapsed = t0.elapsed();
     // Normal (parallel): ~150 ms + scheduling/RPC slack.
     // Mutant (serialized): ~300 ms (= 2 × 150 ms sleep, sequential).
-    //
-    // The macOS CI runner occasionally schedules the two threads onto
-    // the same core under load and lands measurements in the 285-310 ms
-    // band even though the path is structurally parallel (one slot per
-    // worker, AOSP-style pool). 280 ms left ~5 ms slack and flaked.
-    // 380 ms preserves the parallel / serialized split — the mutant
-    // can't sleep less than 300 ms (literal `sleep(150)` × 2) so the
-    // bound is still below it + its observed wake-from-sleep / RPC
-    // wrap overhead (~80-100 ms = ~380-400 ms in practice). A tighter
-    // bound would require either a sample-min over multiple runs or a
-    // monotonic-clock barrier on the server side; both are scope creep.
+    // The 380 ms bound preserves the parallel / serialized split — the
+    // mutant can't sleep less than 300 ms (literal `sleep(150)` × 2),
+    // and the bound stays above the parallel path's wake-from-sleep / RPC
+    // wrap overhead even under a loaded scheduler.
     assert!(
         elapsed < Duration::from_millis(380),
         "AC-12.1: 2 concurrent slow(150) on a 2-slot pool must run in \
@@ -1760,8 +1735,8 @@ fn pool_distributes_concurrent_calls_across_outgoing_slots() {
     // _cu handles teardown.
 }
 
-/// **AC-12.1 — pool-exhausted condvar wait** (F2: `find_conn` *blocks*
-/// on `slot_cv` when no slot is available; **never** a busy try-loop).
+/// Pool-exhausted condvar wait: `find_conn` *blocks*
+/// on `slot_cv` when no slot is available; **never** a busy try-loop.
 /// 2 outgoing slots + 3 concurrent `slow(120)`s ⇒ two run in parallel
 /// (~120 ms), the third waits on `slot_cv` for one to free, then
 /// runs (~120 ms) ⇒ total ≈ 240 ms. Busy-looping would still progress
@@ -1775,7 +1750,7 @@ fn pool_exhausted_condvar_blocks_not_busy_loops() {
     let path = tmp_sock("a1exh");
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(1);
-    // Phase B.1: 2 incoming slots (founding + attached); 3 client
+    // 2 incoming slots (founding + attached); 3 client
     // threads observe the cv-wait band.
     server.set_max_threads(2);
     server.set_root(make_service(Arc::new(AtomicI64::new(0))));
@@ -1839,29 +1814,26 @@ fn pool_exhausted_condvar_blocks_not_busy_loops() {
     // _cu handles teardown.
 }
 
-/// **AC-12.2 (Phase A — nested-callback slot pin / F8, scoped)**: on
+/// Nested-callback slot pin (scoped): on
 /// a multi-outgoing client, when `client_transact` picks an outgoing
 /// slot, the nested server→client callback **arriving on that same
 /// socket** must dispatch on that slot — `find_conn`'s reentrant
 /// match is keyed by `(session_ptr, slot_id)`, not `session_ptr`
-/// alone (the pre-A key). The test forces slot 2 by parking slot 1
+/// alone. The test forces slot 2 by parking slot 1
 /// under a long-running `slow(...)`, then issues one `roundtrip(cb)`
 /// on slot 2.
 ///
-/// **F8 scoping note (documented next-increment).** This hybrid
-/// architecture (A0b "N server-`RpcSessionInner` sharing one
-/// `SharedSession`" + Phase-A client pool) has a known **cross-slot
-/// proxy-cache aliasing** hazard: two server workers concurrently
+/// The N-inner-per-connection hybrid had a cross-slot
+/// proxy-cache aliasing hazard: two server workers concurrently
 /// unmarshalling the *same* client binder hit `state.remote_proxy`'s
 /// shared cache, so the second caller's nested `proxy.transact`
 /// re-routes through the *first* server inner's socket — wire
-/// interleave / deadlock. The faithful fix is the **server-side
-/// unification** ("one `RpcSessionInner` per session, slots in one
+/// interleave / deadlock. The fix is the server-side unification
+/// ("one `RpcSessionInner` per session, slots in one
 /// pool") so all server-side proxies live in one inner and
-/// `findConnection` does the slot-pin uniformly — this is recorded
-/// as the *next* Phase-A increment. The scoped single-thread test
-/// here exercises the slot-pin without triggering the aliasing
-/// (only slot 2 unmarshals the cb).
+/// `findConnection` does the slot-pin uniformly. The scoped
+/// single-thread test here exercises the slot-pin without triggering
+/// the aliasing (only slot 2 unmarshals the cb).
 
 #[test]
 fn pool_nested_callback_pins_to_forced_slot_single_thread() {
@@ -1870,13 +1842,11 @@ fn pool_nested_callback_pins_to_forced_slot_single_thread() {
     // at the server-side `slow()` handler's entry. The prior version
     // used `sleep(30 ms)` after spawning the parker thread, which under
     // CI load could finish *before* the parker reached `find_conn` and
-    // then both threads ended up on slot 1 (the test still passed —
-    // including under the mutant the doc-comment claims to gate — so
-    // it was a false-pass risk; see review M4).
+    // then both threads ended up on slot 1 — a false-pass risk.
     let slow_entered = Arc::new(AtomicBool::new(false));
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(1);
-    // Phase B.1: 2 incoming slots (founding + forced slot-2 echo).
+    // 2 incoming slots (founding + forced slot-2 echo).
     server.set_max_threads(2);
     server.set_root(make_service_with_slow_signal(
         Arc::new(AtomicI64::new(0)),
@@ -1932,11 +1902,11 @@ fn pool_nested_callback_pins_to_forced_slot_single_thread() {
     // _cu handles teardown.
 }
 
-/// AC-12.2-extended — two client threads make concurrent
+/// Two client threads make concurrent
 /// `roundtrip(cb)` calls; each server worker must see a *distinct*
-/// `RpcProxy`-backed nested send (Phase A4 / F8 — one inner per
-/// session, slots in one pool). F8 mutant (N-inner / 1-shared
-/// hybrid): the two workers' `state.remote_proxies` would hand out
+/// `RpcProxy`-backed nested send (one inner per
+/// session, slots in one pool). The N-inner / 1-shared
+/// hybrid mutant: the two workers' `state.remote_proxies` would hand out
 /// `RpcProxy`s whose `Weak<RpcSessionInner>` pointed to different
 /// inners; the 2nd worker's nested `proxy.transact` would `find_conn`
 /// against the 1st worker's slot pool and deadlock or interleave.
@@ -1980,29 +1950,23 @@ fn ac_12_2_extended_cross_slot_nested_callback_multi_thread() {
     drop(c);
 }
 
-/// AC-12.3 — on a multi-outgoing client, oneway FIFO must hold under
-/// twoway interleave regardless of which slot each oneway rode. With
-/// §7.3 Option-1 founding-pin retired (2026-05-28), top-level oneway
-/// `find_conn` no longer routes to slot 1 — the per-`mNodeForAddress`
-/// `asyncNumber` send-side + receive-side `asyncTodo` priority replay
-/// (Phase C, [state.rs](../src/rpc/state.rs)) is what carries the per-
-/// object oneway ordering invariant on both ends; the pin was a HOL
-/// trade-off, not a correctness invariant. The 2026-05-21 deferral
-/// suspected a libbinder `waitForReply` cross-slot race, but
-/// re-running the experiment fresh shows 100/100 hermetic + 20/20
-/// STAGE3 PASS without the pin (the prior 4/5 reading was N=5 noise;
-/// see [plans/2-12 §7.3](../../plans/2-12-multi-connection-per-session.md)).
+/// On a multi-outgoing client, oneway FIFO must hold under
+/// twoway interleave regardless of which slot each oneway rode.
+/// Top-level oneway `find_conn` does not pin to slot 1 — the
+/// per-`mNodeForAddress` `asyncNumber` send-side + receive-side
+/// `asyncTodo` priority replay
+/// ([state.rs](../src/rpc/state.rs)) carries the per-object oneway
+/// ordering invariant on both ends; a founding-slot pin would be a HOL
+/// throughput trade-off, not a correctness invariant.
 ///
 /// What this test gates: 300 oneway bumps interleaved with concurrent
 /// twoway echoes across an outgoing slot pool of size 2 all arrive
 /// (`count == 300`) with no wire corruption between the oneway and
-/// twoway frames. The pin-specific mutant gate (re-add the founding
-/// pin) is gone — pin re-introduction is a HOL throughput regression,
-/// not a correctness one — so this test's standing mutant gate is
-/// Phase C asyncTodo deletion (covered as a unit gate at
+/// twoway frames. The standing mutant gate is the
+/// asyncTodo deletion (covered as a unit gate at
 /// [`rpc::state::tests`](../src/rpc/state.rs)
 /// `phase_c_out_of_order_drains_in_order_via_async_todo`) plus
-/// STAGE3 (b) for the live libbinder round-robin path:
+/// the STAGE3 live libbinder round-robin path:
 /// [`rpc::state::tests::phase_c_out_of_order_enqueues_then_drains_in_priority_order`](../src/rpc/state.rs#L747)
 /// and `phase_c_send_async_number_is_per_address_monotonic`.
 #[test]
@@ -2059,14 +2023,14 @@ fn pool_oneway_fifo_under_concurrent_twoway_multi_outgoing() {
     drop(c);
 }
 
-// ---- AC-3.9 P6: no globals anywhere in the RPC stack ---------------
+// ---- no globals anywhere in the RPC stack --------------------------
 
 // Source-scan: needs `env!("CARGO_MANIFEST_DIR")/src/rpc/*.rs` at
 // runtime, which is absent on a cross-compiled Android device.
 #[cfg(not(target_os = "android"))]
 #[test]
 fn rpc_stack_has_no_globals() {
-    // Static gate (master §6.2 V5 / AC-3.9): the RPC module must not
+    // Static gate: the RPC module must not
     // introduce any process-global state. Scans src/rpc/*.rs for
     // `static`/`OnceLock`/`lazy_static`. The one *intentional*
     // exception is the tcp_debug one-time INSECURE-warning latch,
@@ -2092,7 +2056,7 @@ fn rpc_stack_has_no_globals() {
                 }
                 // `&'static str` return types legitimately contain the
                 // substring "static " — only a real `static` *item*
-                // (mutable/immutable process global) is a P6 offender.
+                // (mutable/immutable process global) is an offender.
                 let static_item = (l.contains("static ") || l.starts_with("static"))
                     && !l.contains("'static")
                     && !l.contains("static_assertions");
@@ -2108,7 +2072,7 @@ fn rpc_stack_has_no_globals() {
                     }
                     // proxy.rs `descriptor: OnceLock<String>` (and its
                     // import) is a *per-RpcProxy-instance* write-once
-                    // field — the 2-6.B typed-stub descriptor stamp,
+                    // field — the typed-stub descriptor stamp,
                     // owned per session, never a process global. A real
                     // `static` here is still caught by `static_item`.
                     if name == "proxy.rs" && l.contains("OnceLock") && !static_item {
@@ -2116,7 +2080,7 @@ fn rpc_stack_has_no_globals() {
                     }
                     // session.rs `DRIVING` is a `thread_local!`
                     // recursion marker that lets a same-thread nested
-                    // call bypass the per-connection lock (AC-3.6). It
+                    // call bypass the per-connection lock. It
                     // is per-thread scratch, NOT session/protocol state
                     // — it carries no node/address/refcount data; those
                     // stay per-session in RpcState. Mirrors kernel
@@ -2137,17 +2101,17 @@ fn rpc_stack_has_no_globals() {
     );
 }
 
-// ---- 2-9 Phase A / D1: accepted peer identity is the CLIENT --------
+// ---- accepted peer identity is the CLIENT --------------------------
 
-/// AC-9.1 / D1 (defect-regression, **deterministic mutant gate**).
+/// Defect-regression, **deterministic mutant gate**.
 ///
 /// A real cross-process connection: a forked child connects, the
 /// parent `accept`s. `peer_identity()` on the accepted socket must be
-/// the **client's** pid, never the server's own. Before subplan 2-9
-/// Phase A the non-Linux `resolve_peer` returned `self_identity()` for
-/// *every* socket, so a macOS/BSD server saw **itself** as the peer —
-/// an authoritative-looking forged identity (the §0 contract defect).
-/// Reverting Phase A makes `pid == std::process::id()` (the parent)
+/// the **client's** pid, never the server's own. A non-Linux
+/// `resolve_peer` that returned `self_identity()` for
+/// *every* socket would make a macOS/BSD server see **itself** as the
+/// peer — an authoritative-looking forged identity.
+/// That mutant makes `pid == std::process::id()` (the parent)
 /// instead of `child.id()`, failing the assert. On Linux the real
 /// `SO_PEERCRED` already gave the client pid, so this is a permanent
 /// cross-platform regression gate.
@@ -2307,15 +2271,15 @@ fn rpc_death_recipient_fires_on_session_drop() {
     let _ = std::fs::remove_file(&path);
 }
 
-// ---- 2-9 Phase B: opt-in authorization hook --------------------------
+// ---- opt-in authorization hook -------------------------------------
 
-/// AC-9.4 — the opt-in `set_authorizer` gate runs *before any RPC
+/// The opt-in `set_authorizer` gate runs *before any RPC
 /// byte* and is backend-independent. A rejecting hook closes the
 /// connection (the peer's next op is `DeadObject`, zero payload); an
 /// accepting hook is transparent; unset is accept-all = the prior
 /// behavior (every other test in this suite, unmodified, is the
-/// additive-invariant evidence). Builds directly on Phase A: the
-/// `PeerIdentity` the hook inspects is now the *real* peer.
+/// additive-invariant evidence). The `PeerIdentity` the hook inspects
+/// is the *real* peer.
 ///
 /// Mutant: deleting the `serve_connection` authorizer block makes the
 /// rejected client's `get_root()` succeed ⇒ the `is_err` assert fails.

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -1266,6 +1266,145 @@ fn ac_12_4_set_max_threads_caps_incoming_slots() {
     );
 }
 
+/// **Phase B.2 — AOSP `setupClient` fan-out automation, multi-conn
+/// path.** `RpcSession::setup_unix_client_android13plus_fan_out` does
+/// in one helper what the manual API requires three explicit steps for:
+/// founding connect → `negotiate(local)` → N-1 additional outgoing
+/// `add_outgoing_connection_android13plus`. Witnesses that the helper's
+/// fan-out loop actually mints `N - 1` extras under the server's
+/// `set_max_threads(N)` cap.
+///
+/// **Mutant gate**: skipping the `1..negotiated` loop body (`for _ in
+/// 1..negotiated { … }` ⇒ `for _ in 0..0 { … }` or `unreachable!`)
+/// leaves the founding inner at a single slot ⇒ `session_slot_count`
+/// is `Some(1)` instead of `Some(N)` and this test fails.
+#[test]
+fn b2_fan_out_creates_n_outgoing_slots_when_local_max_outgoing_is_n() {
+    let path = tmp_sock("b2fan");
+    let counter = Arc::new(AtomicI64::new(0));
+    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    server.set_android13plus(1);
+    // N = 3 (founding + 2 fan-out attaches). Cap is server-side; the
+    // helper learns it via `negotiate` and mints exactly N - 1 extras.
+    server.set_max_threads(3);
+    server.set_root(make_service(counter.clone()));
+    let bg = server.run_background();
+    let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
+    wait_for_sock(&path);
+
+    let client = RpcSession::setup_unix_client_android13plus_fan_out(&path, 1, 3)
+        .expect("setupClient fan-out");
+    // `negotiate` was the second step of the helper ⇒ negotiated value
+    // is recorded on the session and equals the fan-out pool size.
+    assert_eq!(
+        client.negotiated_max_threads(),
+        3,
+        "helper performed GET_MAX_THREADS and recorded min(local=3, server=3) = 3"
+    );
+    let sid = client.get_session_id().expect("get_session_id");
+    let sid_arr: [u8; 32] = sid
+        .as_slice()
+        .try_into()
+        .expect("32-byte session id (AOSP kSessionIdBytes)");
+
+    // Functional gate: the session built by the helper round-trips
+    // through every transport (default outgoing slot picker spreads
+    // calls across the pool).
+    let root = EchoProxy(client.get_root().expect("get_root"));
+    for i in 0..6 {
+        let msg = format!("b2-{i}");
+        assert_eq!(root.echo(&msg).unwrap(), msg, "fan-out echo #{i}");
+    }
+
+    // Mutant-gate witness: server-side, the founding `RpcSessionInner`'s
+    // slot pool holds *all* N connections (founding + N-1 attached).
+    // A mutant that skipped the fan-out leaves this at `Some(1)`.
+    assert!(
+        poll_until(|| server.session_slot_count(&sid_arr) == Some(3)),
+        "founding inner's pool has 3 slots (founding + 2 fan-out attaches) — \
+         mutant: helper skipping the fan-out loop leaves this at Some(1)"
+    );
+    assert_eq!(
+        server.attached_count(),
+        2,
+        "exactly 2 id-echoing attaches reached the server-side attach arm"
+    );
+    assert_eq!(
+        server.rejected_unknown_id_count(),
+        0,
+        "fan-out connections all pass under the cap"
+    );
+}
+
+/// **Phase B.2 — single-connection fast path.** `local_max_outgoing ==
+/// 1` (and `0`, normalized) must skip the `GET_MAX_THREADS` round-trip
+/// and the fan-out loop entirely so the wire is bit-identical to the
+/// founding-only helper. A caller paying for the fan-out helper's
+/// convenience on a single-conn session must NOT pay an extra
+/// negotiation packet.
+///
+/// **Mutant gate**: dropping the `if local == 1 { return Ok(session); }`
+/// short-circuit makes the helper run `negotiate(1)` ⇒
+/// `negotiated_max_threads() == 1` instead of `0`.
+#[test]
+fn b2_local_max_outgoing_one_skips_fan_out_byte_identical_to_founding_only() {
+    let path = tmp_sock("b2one");
+    let counter = Arc::new(AtomicI64::new(0));
+    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    server.set_android13plus(1);
+    // Server is multi-conn-capable but the client opts out — fan-out
+    // must NOT run regardless.
+    server.set_max_threads(2);
+    server.set_root(make_service(counter.clone()));
+    let bg = server.run_background();
+    let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
+    wait_for_sock(&path);
+
+    let client = RpcSession::setup_unix_client_android13plus_fan_out(&path, 1, 1)
+        .expect("setupClient (single-conn)");
+    // Negotiation skipped ⇒ session.negotiated_max_threads() stays at
+    // its default (0 = "not negotiated"). The byte-identical witness.
+    assert_eq!(
+        client.negotiated_max_threads(),
+        0,
+        "local_max_outgoing == 1 must skip GET_MAX_THREADS entirely \
+         (mutant: dropping the early-return would record 1 here)"
+    );
+    let sid = client.get_session_id().expect("get_session_id");
+    let sid_arr: [u8; 32] = sid.as_slice().try_into().expect("32-byte session id");
+    // Server side: exactly one slot (the founding). Mutant: extra
+    // outgoing attaches would push this past 1.
+    assert!(
+        poll_until(|| server.session_slot_count(&sid_arr) == Some(1)),
+        "founding-only session has exactly one slot on the server side"
+    );
+    assert_eq!(
+        server.attached_count(),
+        0,
+        "no id-echoing attach reached the server (no fan-out ran)"
+    );
+    let root = EchoProxy(client.get_root().expect("get_root"));
+    assert_eq!(root.echo("b2-one").unwrap(), "b2-one");
+
+    // `local_max_outgoing == 0` is normalized to 1 (a session needs at
+    // least the founding connection). Same byte-identical behavior.
+    let path2 = tmp_sock("b2zero");
+    let server2 = RpcServer::setup_unix_server(&path2).expect("bind");
+    server2.set_android13plus(1);
+    server2.set_max_threads(2);
+    server2.set_root(make_service(counter.clone()));
+    let bg2 = server2.run_background();
+    let _cu2 = ServeCleanup::new(Arc::clone(&server2), bg2, path2.clone());
+    wait_for_sock(&path2);
+    let client_zero = RpcSession::setup_unix_client_android13plus_fan_out(&path2, 1, 0)
+        .expect("local_max_outgoing == 0 normalized to 1");
+    assert_eq!(
+        client_zero.negotiated_max_threads(),
+        0,
+        "0 normalized to 1 ⇒ no negotiation"
+    );
+}
+
 /// **Phase A F7** (the AC-12.0b residual, now fixed). With a shared
 /// `RpcState` (A0b id-demux), two **independent** client sessions each
 /// hold their own proxy to the *same* server root. Pre-F7 the server

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -914,12 +914,6 @@ fn r34_profile_reports_no_wire_version() {
 /// `SharedSession` ⇒ `c2.get_session_id() != sid1` ⇒ the shared-id
 /// assertion fails. That is what makes the demux load-bearing rather
 /// than the dead plumbing F1/F9 warn about.
-// EXPERIMENTAL multi-conn (plan 2-12 / AC-12.6): gated to the
-// `rpc-experimental-multiconn` feature so the default build leaves
-// the unverified attach path clamped to slot-cap 1 (see
-// `RpcServer::set_max_threads` rustdoc). Hermetic green either way
-// when the feature is on.
-#[cfg(feature = "rpc-experimental-multiconn")]
 #[test]
 fn a0b_multi_connection_shared_session() {
     let path = tmp_sock("a0b");
@@ -1103,7 +1097,7 @@ fn a0b_multi_connection_shared_session() {
 /// id round-trip + `attached_count == 1` + F4 partial-loss survival);
 /// this test layers Phase A4's structural shape on top of that
 /// without re-asserting the A0b contract.
-#[cfg(feature = "rpc-experimental-multiconn")]
+
 #[test]
 fn ac_12_f8_attach_unifies_to_single_inner() {
     let path = tmp_sock("ac12f8");
@@ -1197,7 +1191,7 @@ fn ac_12_f8_attach_unifies_to_single_inner() {
 /// kept as a §7.3 FOLLOWUP (test scaffolding, not a B.1 deferral —
 /// the *behavior* is already in code and falls inside the
 /// rejected_unknown_id observability).
-#[cfg(feature = "rpc-experimental-multiconn")]
+
 #[test]
 fn ac_12_4_set_max_threads_caps_incoming_slots() {
     let path = tmp_sock("ac124");
@@ -1287,49 +1281,6 @@ fn ac_12_4_set_max_threads_caps_incoming_slots() {
 /// **Mutant gate (== pre-F7 code)**: revert `on_binder_leaving`'s
 /// `timesSent` bump (strong stays 1). Then dropping `root1` frees the
 /// shared node and `root2.echo()` is `DeadObject` ⇒ this fails.
-/// Default-build counterpart of `ac_12_4_set_max_threads_caps_incoming_slots`:
-/// sibling attach is refused via `rejected_unknown_id` and the
-/// `negotiate(local)` advertise side stays `min(local, stored)` unchanged.
-#[cfg(not(feature = "rpc-experimental-multiconn"))]
-#[test]
-fn default_build_clamps_slot_cap_despite_advertise_two() {
-    let path = tmp_sock("dflt_cap");
-    let counter = Arc::new(AtomicI64::new(0));
-    let server = RpcServer::setup_unix_server(&path).expect("bind");
-    server.set_android13plus(1);
-    server.set_max_threads(2);
-    server.set_root(make_service(counter.clone()));
-    let bg = server.run_background();
-    let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
-    wait_for_sock(&path);
-
-    let c1 = RpcSession::setup_unix_client_android13plus(&path, 1).expect("a13+ founding");
-    let _r1 = EchoProxy(c1.get_root().expect("get_root founding"));
-    let sid = c1.get_session_id().expect("get_session_id founding");
-    let sid_arr: [u8; 32] = sid.as_slice().try_into().expect("32-byte session id");
-    assert_eq!(server.session_slot_count(&sid_arr), Some(1));
-
-    let rejected_before = server.rejected_unknown_id_count();
-
-    let c2 = RpcSession::setup_unix_client_android13plus_with_id(&path, 1, &sid)
-        .expect("handshake completes (reject is post-handshake)");
-    c2.set_timeout(Some(Duration::from_secs(3)));
-    let err = c2.get_root().expect_err("sibling attach refused");
-    assert!(matches!(
-        err,
-        StatusCode::DeadObject | StatusCode::TimedOut | StatusCode::Unknown
-    ));
-    assert!(poll_until(
-        || server.rejected_unknown_id_count() == rejected_before + 1
-    ));
-    assert_eq!(server.session_slot_count(&sid_arr), Some(1));
-
-    let negotiated = c1.negotiate(4).expect("negotiate");
-    assert_eq!(negotiated, 2);
-    assert_eq!(c1.negotiated_max_threads(), 2);
-}
-
-#[cfg(feature = "rpc-experimental-multiconn")]
 #[test]
 fn f7_shared_node_survives_sibling_proxy_drop() {
     let path = tmp_sock("f7");
@@ -1482,7 +1433,7 @@ fn f7_excess_receipt_no_leak_single_client() {
 /// **Mutant gates (verified in separate runs)**: `find_conn` always
 /// returning slot 1 OR `find_conn`'s "first available" check ignoring
 /// `exclusive_tid` would re-serialize ⇒ elapsed > 250 ms.
-#[cfg(feature = "rpc-experimental-multiconn")]
+
 #[test]
 fn pool_distributes_concurrent_calls_across_outgoing_slots() {
     let path = tmp_sock("a1pool");
@@ -1554,7 +1505,7 @@ fn pool_distributes_concurrent_calls_across_outgoing_slots() {
 /// returning prematurely without re-check) would either deadlock or
 /// race-corrupt the wire. We assert the timing band and rely on the
 /// transact correctness as the secondary signal.
-#[cfg(feature = "rpc-experimental-multiconn")]
+
 #[test]
 fn pool_exhausted_condvar_blocks_not_busy_loops() {
     let path = tmp_sock("a1exh");
@@ -1647,7 +1598,7 @@ fn pool_exhausted_condvar_blocks_not_busy_loops() {
 /// as the *next* Phase-A increment. The scoped single-thread test
 /// here exercises the slot-pin without triggering the aliasing
 /// (only slot 2 unmarshals the cb).
-#[cfg(feature = "rpc-experimental-multiconn")]
+
 #[test]
 fn pool_nested_callback_pins_to_forced_slot_single_thread() {
     let path = tmp_sock("a2pin");
@@ -1717,6 +1668,54 @@ fn pool_nested_callback_pins_to_forced_slot_single_thread() {
     // _cu handles teardown.
 }
 
+/// AC-12.2-extended — two client threads make concurrent
+/// `roundtrip(cb)` calls; each server worker must see a *distinct*
+/// `RpcProxy`-backed nested send (Phase A4 / F8 — one inner per
+/// session, slots in one pool). F8 mutant (N-inner / 1-shared
+/// hybrid): the two workers' `state.remote_proxies` would hand out
+/// `RpcProxy`s whose `Weak<RpcSessionInner>` pointed to different
+/// inners; the 2nd worker's nested `proxy.transact` would `find_conn`
+/// against the 1st worker's slot pool and deadlock or interleave.
+/// `set_timeout(3s)` bounds that deadlock so the mutant surfaces as a
+/// test failure rather than CI hang.
+#[test]
+fn ac_12_2_extended_cross_slot_nested_callback_multi_thread() {
+    let path = tmp_sock("a2ext");
+    let counter = Arc::new(AtomicI64::new(0));
+    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    server.set_android13plus(1);
+    server.set_max_threads(2);
+    server.set_root(make_service(counter.clone()));
+    let bg = server.run_background();
+    let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
+    wait_for_sock(&path);
+
+    let c = RpcSession::setup_unix_client_android13plus(&path, 1).expect("connect");
+    c.set_timeout(Some(Duration::from_secs(3)));
+    let sid = c.get_session_id().expect("get_session_id");
+    let slot2 = c
+        .add_outgoing_connection_android13plus(&path, 1, &sid)
+        .expect("slot 2");
+    assert_ne!(slot2, 1, "second slot has a fresh id");
+
+    let root = Arc::new(EchoProxy(c.get_root().expect("get_root")));
+    let cb_a = make_service(Arc::new(AtomicI64::new(0)));
+    let cb_b = make_service(Arc::new(AtomicI64::new(0)));
+
+    let r1 = Arc::clone(&root);
+    let cba = cb_a.clone();
+    let h1 = std::thread::spawn(move || r1.roundtrip(&cba).expect("rt thread 1"));
+    let r2 = Arc::clone(&root);
+    let cbb = cb_b.clone();
+    let h2 = std::thread::spawn(move || r2.roundtrip(&cbb).expect("rt thread 2"));
+
+    assert_eq!(h1.join().expect("join 1"), "rt:ping");
+    assert_eq!(h2.join().expect("join 2"), "rt:ping");
+
+    drop(root);
+    drop(c);
+}
+
 /// **AC-12.3 (Phase A — oneway Option-1)**: on a multi-outgoing
 /// client, all top-level **oneway** sends are pinned to the founding
 /// slot (single-slot in-order delivery preserves the same-object
@@ -1738,7 +1737,7 @@ fn pool_nested_callback_pins_to_forced_slot_single_thread() {
 /// (deferred); the per-slot in-order delivery is exercised here by
 /// the count + the parallel twoway round-trips not corrupting the
 /// shared wire.
-#[cfg(feature = "rpc-experimental-multiconn")]
+
 #[test]
 fn pool_oneway_pinned_to_founding_slot_multi_outgoing() {
     let path = tmp_sock("a3one");

--- a/rsbinder/tests/rpc_tls.rs
+++ b/rsbinder/tests/rpc_tls.rs
@@ -421,6 +421,95 @@ fn setup_tcp_server_tls_e2e() {
     let _ = bg.join();
 }
 
+/// **Plan 2-15 F (AC-15.2) — vsock × TLS hermetic e2e**, server built
+/// via `RpcServer::setup_vsock_server_tls`, client TLS-wraps a raw
+/// vsock stream with `TlsTransport::connect_stream`. The 1st-class
+/// Android AVF / Microdroid pVM scenario (vsock socket plane + TLS
+/// crypto plane), now end-to-end through the public `RpcServer` API.
+///
+/// **Environment gate** — `#[ignore]` so default `cargo test`
+/// (CI / macOS) never runs it. Loopback vsock requires the Linux
+/// `vsock_loopback` kernel module (`sudo modprobe vsock_loopback` on a
+/// host with no peer VM); a peer-VM environment skips the modprobe
+/// step. CI does not load kernel modules, so this is hermetic-by-
+/// `#[ignore]`; the canonical verification surface is the REMOTE_LINUX
+/// box per memory.
+///
+/// **Compile gate** — `target_os = "linux"` plus the `rpc-vsock` and
+/// `rpc-tls` features. macOS host compiles this file out of this test
+/// (the `rpc-tls` `#![cfg]` at the top of the file keeps the build
+/// graph clean elsewhere).
+#[cfg(all(feature = "rpc-vsock", target_os = "linux"))]
+#[test]
+#[ignore = "needs Linux vsock loopback (modprobe vsock_loopback) or a peer VM"]
+fn vsock_tls_loopback_e2e() {
+    use rsbinder::rpc::transport::VsockTransport;
+    use rsbinder::rpc::RpcServer;
+    use vsock::VMADDR_CID_LOCAL;
+
+    // Arbitrary unused port; mirrors `tests/rpc_vsock.rs` choice +
+    // bumped one digit so a left-behind no-TLS server (the other test)
+    // doesn't `EADDRINUSE` this one in a back-to-back run.
+    const TLS_TEST_PORT: u32 = 0x52_43;
+
+    let srv_cfg = server_config(SRV_CRT, SRV_KEY);
+    let server = RpcServer::setup_vsock_server_tls(VMADDR_CID_LOCAL, TLS_TEST_PORT, srv_cfg)
+        .expect("setup_vsock_server_tls");
+    server.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+        PingSvc,
+    )))));
+    assert_eq!(
+        server.vsock_address(),
+        Some((VMADDR_CID_LOCAL, TLS_TEST_PORT))
+    );
+    assert!(server.path().is_none(), "vsock+TLS server has no fs path");
+    let bg = server.run_background();
+
+    // Client: vsock connect → TLS handshake over the raw vsock stream.
+    // No client-side `setup_vsock_client_tls` convenience function yet
+    // (a separate small follow-up); the underlying composition is one
+    // line per AOSP `RpcTransportCtx::newTransport(fd)` (socket-kind-
+    // orthogonal TLS).
+    //
+    // `VsockTransport::connect` returns an `RpcTransport` already, but
+    // here we need the raw `VsockStream` so the TLS handshake runs
+    // *over* it (not as the framing transport itself). Build the
+    // stream by hand — `vsock::VsockStream::connect` matches the
+    // existing `VsockTransport::connect` body.
+    let vsock_stream =
+        vsock::VsockStream::connect(&vsock::VsockAddr::new(VMADDR_CID_LOCAL, TLS_TEST_PORT))
+            .expect("client vsock connect");
+    let client_t = TlsTransport::connect_stream(
+        Box::new(vsock_stream),
+        "localhost",
+        client_config_trusting(CA),
+    )
+    .expect("client TLS handshake over vsock");
+    // AC-4.4 over vsock+TLS: peer identity is the leaf-cert fingerprint
+    // (not `Vsock { cid }` — that's the `VsockTransport` plain identity,
+    // here the TLS layer overrides).
+    match client_t.peer_identity() {
+        PeerIdentity::Certificate(c) => assert_eq!(c.fingerprint().len(), 32),
+        other => panic!("expected Certificate peer id over vsock+TLS, got {other}"),
+    }
+    let client =
+        RpcSession::new(Box::new(client_t), AddressSpace::Initiator).expect("RpcSession::new");
+    let root = client.get_root().expect("get_root over vsock+TLS");
+    assert_eq!(ping_via(&root, "vsock-tls").unwrap(), "pong:vsock-tls");
+    assert_eq!(ping_via(&root, "").unwrap(), "pong:");
+
+    // Silence the `VsockTransport` import on Linux builds where it's
+    // not referenced (we only use it as a type-witness that the vsock
+    // client transport exists; the actual client builds the stream by
+    // hand to keep the TLS wrap explicit).
+    let _: fn(u32, u32) -> _ = VsockTransport::connect;
+
+    drop(root);
+    drop(client);
+    server.shutdown();
+    let _ = bg.join();
+}
+
 /// **Plan 2-15 E1 — UDS+TLS server e2e via `RpcServer::setup_unix_server_tls`.**
 /// TLS is socket-kind-orthogonal (AOSP `RpcTransportCtx::newTransport(fd)`);
 /// the same TLS handshake runs over a UnixStream once `RpcServer` no

--- a/rsbinder/tests/rpc_tls.rs
+++ b/rsbinder/tests/rpc_tls.rs
@@ -376,3 +376,109 @@ fn no_plaintext_network_backend_in_api() {
     // would be the natural place to construct it — its continued
     // absence is the gate. (Compile-time: nothing to call.)
 }
+
+/// **Plan 2-15 E1 — TCP+TLS server e2e via `RpcServer::setup_tcp_server_tls`.**
+/// The pre-E1 TLS tests had to build the server as a manual
+/// `TcpListener` + thread-spawned `RpcSession::new(Acceptor)` because
+/// `RpcServer` was UDS-only. With E1 the server is a real `RpcServer`:
+/// accept loop, worker-thread TLS handshake (so a slow-handshake peer
+/// never stalls accept), authorizer hook (post-handshake peer-id), and
+/// the rest of the `RpcServer` knob set all work unchanged.
+///
+/// **Mutant gate**: dropping the `*server.tls_config.lock() =
+/// Some(config)` line in `setup_tcp_server_tls` (or returning `None`
+/// from `tls_snapshot()`) leaves the worker wrapping the accepted
+/// TcpStream with the plain branch — `RawAccepted::Tcp(_)` then hits
+/// the "plain-text TCP server is not exposed" error, the worker exits
+/// without serving, the client's TLS handshake times out / errors.
+#[test]
+fn setup_tcp_server_tls_e2e() {
+    use rsbinder::rpc::RpcServer;
+
+    let srv_cfg = server_config(SRV_CRT, SRV_KEY);
+    let server =
+        RpcServer::setup_tcp_server_tls("127.0.0.1:0", srv_cfg).expect("setup_tcp_server_tls");
+    server.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+        PingSvc,
+    )))));
+    let addr = server.tcp_address().expect("tcp_address");
+    // E0 accessor gates: tcp_address Some, path None.
+    assert!(server.path().is_none(), "TCP server has no fs path");
+    let bg = server.run_background();
+
+    // Use the matching one-call client convenience constructor — the
+    // helper itself goes through `setup_tcp_client_tls`'s normal
+    // TCP-connect → TLS-handshake → R34 session path.
+    let client = RpcSession::setup_tcp_client_tls(addr, "localhost", client_config_trusting(CA))
+        .expect("setup_tcp_client_tls");
+    let root = client.get_root().expect("get_root over TCP+TLS server");
+    assert_eq!(ping_via(&root, "e1-tcp").unwrap(), "pong:e1-tcp");
+    assert_eq!(ping_via(&root, "").unwrap(), "pong:");
+
+    drop(root);
+    drop(client);
+    server.shutdown();
+    let _ = bg.join();
+}
+
+/// **Plan 2-15 E1 — UDS+TLS server e2e via `RpcServer::setup_unix_server_tls`.**
+/// TLS is socket-kind-orthogonal (AOSP `RpcTransportCtx::newTransport(fd)`);
+/// the same TLS handshake runs over a UnixStream once `RpcServer` no
+/// longer pins the listener to UDS-without-TLS. Demonstrates the
+/// E0 listener generalization carrying the E1 TLS path through it.
+#[test]
+fn setup_unix_server_tls_e2e() {
+    use rsbinder::rpc::RpcServer;
+
+    let path = {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "rsb_rpc_unix_tls_{}_{}.sock",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        p
+    };
+    let srv_cfg = server_config(SRV_CRT, SRV_KEY);
+    let server = RpcServer::setup_unix_server_tls(&path, srv_cfg).expect("setup_unix_server_tls");
+    server.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+        PingSvc,
+    )))));
+    assert_eq!(
+        server.path(),
+        Some(path.as_path()),
+        "UDS+TLS server still exposes its fs path"
+    );
+    let bg = server.run_background();
+    // Wait for the socket file to appear (bounded).
+    for _ in 0..400 {
+        if path.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    assert!(path.exists(), "UDS server socket must appear");
+
+    // Client: open the UDS by hand and run the TLS handshake on it
+    // via `TlsTransport::connect_stream` (the socket-kind-orthogonal
+    // client API). The R34 wire then carries the AIDL e2e.
+    let unix_client = UnixStream::connect(&path).expect("unix connect");
+    let client_t = TlsTransport::connect_stream(
+        Box::new(unix_client),
+        "localhost",
+        client_config_trusting(CA),
+    )
+    .expect("client TLS handshake over UDS+TLS server");
+    let client =
+        RpcSession::new(Box::new(client_t), AddressSpace::Initiator).expect("RpcSession::new");
+    let root = client.get_root().expect("get_root over UDS+TLS");
+    assert_eq!(ping_via(&root, "e1-uds").unwrap(), "pong:e1-uds");
+
+    drop(root);
+    drop(client);
+    server.shutdown();
+    let _ = bg.join();
+}

--- a/rsbinder/tests/rpc_tls.rs
+++ b/rsbinder/tests/rpc_tls.rs
@@ -1,12 +1,12 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Subplan 2-4 track T: the TLS backend, exercised with the **2-2/2-3
-//! core unchanged** — only the transport is swapped (additive
-//! invariant AC-4.1). Covers AC-4.4 (valid cert handshake + AIDL
-//! round-trip + `Certificate` peer-id), AC-4.5 (untrusted cert →
-//! handshake reject, **zero RPC payload**), AC-4.6 (no plaintext
-//! network backend — enforced by type/absence, noted here).
+//! The TLS backend, exercised with the **core
+//! unchanged** — only the transport is swapped. Covers a valid cert
+//! handshake + AIDL round-trip + `Certificate` peer-id, an untrusted
+//! cert → handshake reject (**zero RPC payload**), and the absence of
+//! any plaintext network backend (enforced by type/absence, noted
+//! here).
 //!
 //! Separate test binary; `#![cfg(feature = "rpc-tls")]` so it only
 //! builds/runs with the feature (default test runs don't pay rustls).
@@ -133,7 +133,7 @@ fn ping_via(root: &SIBinder, msg: &str) -> Result<String> {
     r.read::<String>()
 }
 
-/// AC-4.1 / AC-4.4: valid cert → handshake + the unchanged 2-2/2-3
+/// Valid cert → handshake + the unchanged
 /// AIDL e2e over TLS; both ends see a `Certificate` peer identity.
 #[test]
 fn tls_valid_cert_e2e_and_peer_identity() {
@@ -155,7 +155,7 @@ fn tls_valid_cert_e2e_and_peer_identity() {
     let tcp = TcpStream::connect(addr).expect("tcp connect");
     let client_t = TlsTransport::connect(tcp, "localhost", client_config_trusting(CA))
         .expect("client handshake");
-    // AC-4.4: peer identity is a leaf-cert fingerprint.
+    // Peer identity is a leaf-cert fingerprint.
     match client_t.peer_identity() {
         PeerIdentity::Certificate(c) => {
             assert_eq!(c.fingerprint().len(), 32);
@@ -174,8 +174,8 @@ fn tls_valid_cert_e2e_and_peer_identity() {
     server.join().unwrap();
 }
 
-/// **2-15 AC-15.1**: TLS is decoupled from TCP — the same handshake +
-/// unchanged 2-2/2-3 AIDL e2e runs over a **`UnixStream`** via
+/// TLS is decoupled from TCP — the same handshake +
+/// unchanged AIDL e2e runs over a **`UnixStream`** via
 /// [`TlsTransport::connect_stream`]/[`TlsTransport::accept_stream`]
 /// (not just `TcpStream`). Mirrors AOSP's socket-kind-orthogonal
 /// `RpcTransportCtx::newTransport(fd)`.
@@ -212,7 +212,7 @@ fn tls_over_unix_socket_e2e() {
     server.join().unwrap();
 }
 
-/// **2-15 (2-15.5 convenience)**: the one-call TCP+TLS client
+/// The one-call TCP+TLS client
 /// constructor `RpcSession::setup_tcp_client_tls` — TCP-connect + TLS
 /// handshake + R34 session — interoperates with a TLS server end to end.
 #[test]
@@ -240,11 +240,11 @@ fn setup_tcp_client_tls_convenience_e2e() {
     server.join().unwrap();
 }
 
-/// **2-15 keystone concurrency gate**: a single `TlsTransport` must
+/// Concurrency gate: a single `TlsTransport` must
 /// support a sender thread and a receiver thread **concurrently**
 /// ([`RpcTransport`] contract). The decomposed `Mutex<Connection>` +
-/// `try_lock` write-path (subplan 2-15 §2.0) makes this lock-free-duplex
-/// safe — the original single-`Mutex<TlsIo>` would deadlock here (a
+/// `try_lock` write-path makes this lock-free-duplex
+/// safe — a single-`Mutex<TlsIo>` would deadlock here (a
 /// blocked `recv` held the lock the `send` needed). Drives full
 /// bidirectional traffic on both ends and checks FIFO integrity.
 #[test]
@@ -302,7 +302,7 @@ fn tls_concurrent_bidirectional_duplex() {
     cli_send.join().unwrap();
 }
 
-/// **2-15 AC-15.5**: TLS rejects out-of-band file descriptors *by type*
+/// TLS rejects out-of-band file descriptors *by type*
 /// — `SCM_RIGHTS` cannot ride an encrypted byte stream, so `TlsTransport`
 /// keeps the trait's rejecting default for `send_*_with_fds` (no
 /// override). Matches AOSP, where `FileDescriptorTransportMode::Unix` is
@@ -337,7 +337,7 @@ fn tls_rejects_fd_passing_by_type() {
     let _ = server.join();
 }
 
-/// AC-4.5 (security, 1st class): a server cert NOT signed by the
+/// Security: a server cert NOT signed by the
 /// client's trusted CA must be rejected **at the handshake** — the
 /// client never obtains a session, so zero RPC payload is exchanged.
 #[test]
@@ -363,7 +363,7 @@ fn tls_untrusted_cert_rejected_at_handshake() {
     let _ = server.join();
 }
 
-/// AC-4.6 documentation gate: there is **no** plaintext-network
+/// Documentation gate: there is **no** plaintext-network
 /// constructor in the RPC public API — `tcp_debug` is the only TCP
 /// path, it is `rpc-tcp-debug`-gated and hard-wired `Anonymous`, and
 /// `tls` is the only real-network transport. This is enforced by
@@ -377,10 +377,8 @@ fn no_plaintext_network_backend_in_api() {
     // absence is the gate. (Compile-time: nothing to call.)
 }
 
-/// **Plan 2-15 E1 — TCP+TLS server e2e via `RpcServer::setup_tcp_server_tls`.**
-/// The pre-E1 TLS tests had to build the server as a manual
-/// `TcpListener` + thread-spawned `RpcSession::new(Acceptor)` because
-/// `RpcServer` was UDS-only. With E1 the server is a real `RpcServer`:
+/// TCP+TLS server e2e via `RpcServer::setup_tcp_server_tls`.
+/// The server is a real `RpcServer`:
 /// accept loop, worker-thread TLS handshake (so a slow-handshake peer
 /// never stalls accept), authorizer hook (post-handshake peer-id), and
 /// the rest of the `RpcServer` knob set all work unchanged.
@@ -402,7 +400,7 @@ fn setup_tcp_server_tls_e2e() {
         PingSvc,
     )))));
     let addr = server.tcp_address().expect("tcp_address");
-    // E0 accessor gates: tcp_address Some, path None.
+    // Accessor gates: tcp_address Some, path None.
     assert!(server.path().is_none(), "TCP server has no fs path");
     let bg = server.run_background();
 
@@ -421,7 +419,7 @@ fn setup_tcp_server_tls_e2e() {
     let _ = bg.join();
 }
 
-/// **Plan 2-15 F (AC-15.2) — vsock × TLS hermetic e2e**, server built
+/// vsock × TLS hermetic e2e, server built
 /// via `RpcServer::setup_vsock_server_tls`, client TLS-wraps a raw
 /// vsock stream with `TlsTransport::connect_stream`. The 1st-class
 /// Android AVF / Microdroid pVM scenario (vsock socket plane + TLS
@@ -485,7 +483,7 @@ fn vsock_tls_loopback_e2e() {
         client_config_trusting(CA),
     )
     .expect("client TLS handshake over vsock");
-    // AC-4.4 over vsock+TLS: peer identity is the leaf-cert fingerprint
+    // Over vsock+TLS: peer identity is the leaf-cert fingerprint
     // (not `Vsock { cid }` — that's the `VsockTransport` plain identity,
     // here the TLS layer overrides).
     match client_t.peer_identity() {
@@ -510,11 +508,11 @@ fn vsock_tls_loopback_e2e() {
     let _ = bg.join();
 }
 
-/// **Plan 2-15 E1 — UDS+TLS server e2e via `RpcServer::setup_unix_server_tls`.**
+/// UDS+TLS server e2e via `RpcServer::setup_unix_server_tls`.
 /// TLS is socket-kind-orthogonal (AOSP `RpcTransportCtx::newTransport(fd)`);
 /// the same TLS handshake runs over a UnixStream once `RpcServer` no
 /// longer pins the listener to UDS-without-TLS. Demonstrates the
-/// E0 listener generalization carrying the E1 TLS path through it.
+/// listener generalization carrying the TLS path through it.
 #[test]
 fn setup_unix_server_tls_e2e() {
     use rsbinder::rpc::RpcServer;

--- a/rsbinder/tests/rpc_vsock.rs
+++ b/rsbinder/tests/rpc_vsock.rs
@@ -1,8 +1,8 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Subplan 2-4 track V + **Plan 2-15 E2**: vsock backend e2e — **Linux-
-//! only, `#[ignore]` by default** (plan V6 environment gate: needs a
+//! vsock backend e2e — **Linux-
+//! only, `#[ignore]` by default** (environment gate: needs a
 //! peer VM or the `vsock_loopback` kernel module + `VMADDR_CID_LOCAL`).
 //!
 //! Run manually on a suitable Linux host with:
@@ -11,19 +11,15 @@
 //! cargo test -p rsbinder --features rpc-vsock --test rpc_vsock -- --ignored
 //! ```
 //!
-//! Demonstrates AC-4.1 (the 2-2/2-3 core runs unmodified with the
-//! transport swapped to vsock), AC-4.2 (host↔guest value round-trip),
-//! AC-4.3 (`PeerIdentity::Vsock{cid}`, never mis-reported as `Local`).
+//! Demonstrates that the core runs unmodified with the
+//! transport swapped to vsock, host↔guest value round-trip, and
+//! `PeerIdentity::Vsock{cid}` never mis-reported as `Local`.
 //!
-//! **E2 cleanup**: the original e2e built a raw `VsockListener` +
-//! thread-spawned `RpcSession::new(..)` server **outside** `RpcServer`
-//! to work around the (pre-E0) `RpcServer.listener: UnixListener` lock-
-//! in. With E0+E2 (`RpcServer::setup_vsock_server`) that workaround is
-//! gone — the server is built with the same factory + `run_background`
-//! pattern as the UDS e2e suite. The raw `VsockListener` path is no
-//! longer exercised here, but the underlying `VsockTransport::from_stream`
-//! / `VsockTransport::connect` still are (one through the server's
-//! accept loop, the other through the test's client construction).
+//! The server is built with the same `RpcServer::setup_vsock_server`
+//! factory + `run_background` pattern as the UDS e2e suite. The
+//! underlying `VsockTransport::from_stream` / `VsockTransport::connect`
+//! are exercised (one through the server's accept loop, the other
+//! through the test's client construction).
 
 #![cfg(all(feature = "rpc-vsock", target_os = "linux"))]
 
@@ -90,31 +86,31 @@ fn ping_via(root: &SIBinder, msg: &str) -> Result<String> {
     r.read::<String>()
 }
 
-/// AC-4.1/4.2/4.3 over loopback vsock (`VMADDR_CID_LOCAL`) — server
-/// built with **Plan 2-15 E2** `RpcServer::setup_vsock_server`.
+/// Core round-trip over loopback vsock (`VMADDR_CID_LOCAL`) — server
+/// built with `RpcServer::setup_vsock_server`.
 ///
 /// Server-side: the same factory + `run_background` shape used by the
 /// UDS e2e suite — backend swap is the only difference. Client-side:
-/// `VsockTransport::connect` (unchanged) so the `PeerIdentity::Vsock`
-/// assertion (AC-4.3) keeps its original wire-level reach.
+/// `VsockTransport::connect` so the `PeerIdentity::Vsock`
+/// assertion keeps its original wire-level reach.
 #[test]
 #[ignore = "needs Linux vsock loopback (modprobe vsock_loopback) or a peer VM"]
 fn vsock_loopback_e2e() {
     use vsock::VMADDR_CID_LOCAL;
 
-    // E2: same `RpcServer` API as UDS, vsock-backed listener.
+    // Same `RpcServer` API as UDS, vsock-backed listener.
     let server =
         RpcServer::setup_vsock_server(VMADDR_CID_LOCAL, TEST_PORT).expect("setup_vsock_server");
     server.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
         PingSvc,
     )))));
-    // E0 accessor gates: vsock_address `Some`, fs path `None`.
+    // Accessor gates: vsock_address `Some`, fs path `None`.
     assert_eq!(server.vsock_address(), Some((VMADDR_CID_LOCAL, TEST_PORT)));
     assert_eq!(server.path(), None, "vsock server has no filesystem entry");
     let bg = server.run_background();
 
     let client_t = VsockTransport::connect(VMADDR_CID_LOCAL, TEST_PORT).expect("client connect");
-    // AC-4.3: identity is Vsock{cid}, never Local.
+    // Identity is Vsock{cid}, never Local.
     match client_t.peer_identity() {
         PeerIdentity::Vsock { cid } => assert_eq!(cid, VMADDR_CID_LOCAL),
         other => panic!("expected Vsock peer id, got {other}"),

--- a/rsbinder/tests/rpc_vsock.rs
+++ b/rsbinder/tests/rpc_vsock.rs
@@ -1,9 +1,9 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Subplan 2-4 track V: vsock backend e2e — **Linux-only, `#[ignore]`
-//! by default** (plan V6 environment gate: needs a peer VM or the
-//! `vsock_loopback` kernel module + `VMADDR_CID_LOCAL`).
+//! Subplan 2-4 track V + **Plan 2-15 E2**: vsock backend e2e — **Linux-
+//! only, `#[ignore]` by default** (plan V6 environment gate: needs a
+//! peer VM or the `vsock_loopback` kernel module + `VMADDR_CID_LOCAL`).
 //!
 //! Run manually on a suitable Linux host with:
 //! ```text
@@ -14,13 +14,21 @@
 //! Demonstrates AC-4.1 (the 2-2/2-3 core runs unmodified with the
 //! transport swapped to vsock), AC-4.2 (host↔guest value round-trip),
 //! AC-4.3 (`PeerIdentity::Vsock{cid}`, never mis-reported as `Local`).
+//!
+//! **E2 cleanup**: the original e2e built a raw `VsockListener` +
+//! thread-spawned `RpcSession::new(..)` server **outside** `RpcServer`
+//! to work around the (pre-E0) `RpcServer.listener: UnixListener` lock-
+//! in. With E0+E2 (`RpcServer::setup_vsock_server`) that workaround is
+//! gone — the server is built with the same factory + `run_background`
+//! pattern as the UDS e2e suite. The raw `VsockListener` path is no
+//! longer exercised here, but the underlying `VsockTransport::from_stream`
+//! / `VsockTransport::connect` still are (one through the server's
+//! accept loop, the other through the test's client construction).
 
 #![cfg(all(feature = "rpc-vsock", target_os = "linux"))]
 
-use std::thread;
-
 use rsbinder::rpc::transport::VsockTransport;
-use rsbinder::rpc::{AddressSpace, PeerIdentity, RpcSession, RpcTransport};
+use rsbinder::rpc::{PeerIdentity, RpcServer, RpcSession, RpcTransport};
 use rsbinder::{
     Binder, Interface, Parcel, Remotable, Result, SIBinder, Status, StatusCode, TransactionCode,
     FIRST_CALL_TRANSACTION,
@@ -82,24 +90,28 @@ fn ping_via(root: &SIBinder, msg: &str) -> Result<String> {
     r.read::<String>()
 }
 
-/// AC-4.1/4.2/4.3 over loopback vsock (`VMADDR_CID_LOCAL`).
+/// AC-4.1/4.2/4.3 over loopback vsock (`VMADDR_CID_LOCAL`) — server
+/// built with **Plan 2-15 E2** `RpcServer::setup_vsock_server`.
+///
+/// Server-side: the same factory + `run_background` shape used by the
+/// UDS e2e suite — backend swap is the only difference. Client-side:
+/// `VsockTransport::connect` (unchanged) so the `PeerIdentity::Vsock`
+/// assertion (AC-4.3) keeps its original wire-level reach.
 #[test]
 #[ignore = "needs Linux vsock loopback (modprobe vsock_loopback) or a peer VM"]
 fn vsock_loopback_e2e() {
-    use vsock::{VsockListener, VMADDR_CID_LOCAL};
+    use vsock::VMADDR_CID_LOCAL;
 
-    let listener =
-        VsockListener::bind_with_cid_port(VMADDR_CID_LOCAL, TEST_PORT).expect("vsock bind");
-    let server = thread::spawn(move || {
-        let (stream, _addr) = listener.accept().expect("vsock accept");
-        let t = VsockTransport::from_stream(stream).expect("server transport");
-        let session =
-            RpcSession::new(Box::new(t), AddressSpace::Acceptor).expect("RpcSession::new");
-        session.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
-            PingSvc,
-        )))));
-        let _ = session.serve_blocking();
-    });
+    // E2: same `RpcServer` API as UDS, vsock-backed listener.
+    let server =
+        RpcServer::setup_vsock_server(VMADDR_CID_LOCAL, TEST_PORT).expect("setup_vsock_server");
+    server.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+        PingSvc,
+    )))));
+    // E0 accessor gates: vsock_address `Some`, fs path `None`.
+    assert_eq!(server.vsock_address(), Some((VMADDR_CID_LOCAL, TEST_PORT)));
+    assert_eq!(server.path(), None, "vsock server has no filesystem entry");
+    let bg = server.run_background();
 
     let client_t = VsockTransport::connect(VMADDR_CID_LOCAL, TEST_PORT).expect("client connect");
     // AC-4.3: identity is Vsock{cid}, never Local.
@@ -107,11 +119,14 @@ fn vsock_loopback_e2e() {
         PeerIdentity::Vsock { cid } => assert_eq!(cid, VMADDR_CID_LOCAL),
         other => panic!("expected Vsock peer id, got {other}"),
     }
-    let client =
-        RpcSession::new(Box::new(client_t), AddressSpace::Initiator).expect("RpcSession::new");
+    let client = RpcSession::new(Box::new(client_t), rsbinder::rpc::AddressSpace::Initiator)
+        .expect("RpcSession::new");
     let root = client.get_root().expect("get_root over vsock");
     assert_eq!(ping_via(&root, "hi").unwrap(), "pong:hi");
+
+    // Teardown — explicit shutdown + bg.join (same shape as UDS tests).
     drop(root);
     drop(client);
-    server.join().unwrap();
+    server.shutdown();
+    let _ = bg.join();
 }

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -85,7 +85,7 @@ fn main() {
         .generate()
         .unwrap();
 
-    // Subplan 2-6.B: test-only fixture for the generated-stub RPC e2e
+    // Test-only fixture for the generated-stub RPC e2e
     // (`tests/rpc_generated_stub.rs`). This integration-test crate —
     // not the production `rsbinder` crate — is the home for codegen
     // that combines `rsbinder-aidl` output with the `rsbinder` runtime.

--- a/tests/src/test_accessor_rsb_hub.rs
+++ b/tests/src/test_accessor_rsb_hub.rs
@@ -1,27 +1,25 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Plan 2-14 D.8.b — cross-process accessor discovery via `rsb_hub`.
+//! Cross-process accessor discovery via `rsb_hub`.
 //!
-//! Exercises the end-to-end path that B.6 + B.7 enable on the kernel
-//! binder side:
+//! Exercises the end-to-end path on the kernel binder side:
 //!
 //!   1. A *separate* server process (the
 //!      `example-hello/src/bin/rpc_accessor_register_interop_server`
-//!      binary, originally written for the D.9 STAGE3 emulator harness
-//!      — reused verbatim here) registers an `IAccessor` binder with
-//!      `rsb_hub` via `hub::add_service(instance, accessor_binder)`.
-//!      rsb_hub's `addService` (B.6) inspects
+//!      binary, reused verbatim here) registers an `IAccessor` binder
+//!      with `rsb_hub` via `hub::add_service(instance, accessor_binder)`.
+//!      rsb_hub's `addService` inspects
 //!      `service.descriptor() == "android.os.IAccessor"` and stamps
 //!      `is_accessor = true`.
 //!   2. This test process calls `hub::get_service(instance)`.
-//!      rsb_hub's `getService2` (B.7) sees the flag and returns
+//!      rsb_hub's `getService2` sees the flag and returns
 //!      `Service::Accessor(Some(binder))` — distinct from the regular
 //!      `ServiceWithMetadata` wrap.
 //!   3. The consume-side accessor arm in
 //!      [`rsbinder::hub::servicemanager_16::resolve_accessor_arm`]
-//!      (2-13) transparently calls `IAccessor::addConnection` → adopts
-//!      the returned fd → runs the 2-8 android-13+ handshake → returns
+//!      transparently calls `IAccessor::addConnection` → adopts
+//!      the returned fd → runs the android-13+ handshake → returns
 //!      the RPC root binder.
 //!   4. This test transacts `TX_ECHO` and `TX_GIVE_MARKER` against the
 //!      root, asserting full Parcel-body byte parity with the server's
@@ -47,7 +45,7 @@ use rsbinder::*;
 
 /// Service-manager instance name the server bin registers under. The
 /// orchestration script passes the same string as `argv[1]` to the
-/// server bin. Distinct from the D.9 STAGE3 emulator instance to
+/// server bin. Distinct from the STAGE3 emulator instance to
 /// avoid collisions when both harnesses share a binder driver.
 const INSTANCE: &str = "rsbinder.test.d8b.accessor";
 
@@ -80,7 +78,7 @@ fn d8b_cross_process_accessor_via_rsb_hub() -> Result<()> {
 
     // 1. Discover via rsb_hub.
     //    Under the hood: kernel-binder `getService2(INSTANCE)`
-    //                    → rsb_hub returns `Service::Accessor(Some(_))` (B.7)
+    //                    → rsb_hub returns `Service::Accessor(Some(_))`
     //                    → consume-side `resolve_accessor_arm` bridges to RPC
     //                    → returns the RPC root binder.
     let root = hub::get_service(INSTANCE).unwrap_or_else(|| {
@@ -94,7 +92,7 @@ fn d8b_cross_process_accessor_via_rsb_hub() -> Result<()> {
     // The accessor arm wraps the consumed RPC connection in an
     // `RpcProxy`; downcasting is the canonical way to use the
     // `build_request`/`transact` helpers without going through a
-    // generated AIDL stub. Same pattern the 2-13 D.8 client uses.
+    // generated AIDL stub.
     let rp = (*root)
         .as_any()
         .downcast_ref::<rsbinder::rpc::RpcProxy>()

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -1448,8 +1448,8 @@ fn test_hub() {
         .any(|s| s.name == ITestService::BpTestService::descriptor()));
 }
 
-/// Real-binder regression for the lock-decoupled slow path
-/// (PR #118, `481b8c9`). N threads concurrently resolve the same
+/// Real-binder regression for the lock-decoupled slow path.
+/// N threads concurrently resolve the same
 /// service, racing through `strong_proxy_for_handle`'s P1/P2/P3 slow
 /// path while it performs IPC (descriptor query / service-manager
 /// ping) with the `handle_to_proxy` lock released.
@@ -1744,7 +1744,7 @@ fn test_binder_extension_use_as_interface() {
 }
 
 // =============================================================================
-// Cache-pin model integration tests (FOLLOW_UP_PR_100 test plan #1, #2, #3, #5)
+// Cache-pin model integration tests
 // =============================================================================
 //
 // These tests validate the cache-pin model on real binderfs. They require:
@@ -1754,19 +1754,19 @@ fn test_binder_extension_use_as_interface() {
 // They are run as part of the standard `cargo test --package tests` invocation
 // in `.github/workflows/integration-test.yml`.
 
-/// Test plan #2 — kernel ref-count consistency under the cache-pin model.
+/// Kernel ref-count consistency under the cache-pin model.
 ///
 /// Verifies that user-space `SIBinder` clones do NOT raise the kernel
 /// strong count: under the cache-pin model the kernel observes exactly
 /// **one `BC_ACQUIRE` per `Arc<ProxyHandle>` lifetime**, regardless of
-/// how many `SIBinder` / `Strong<I>` clones exist. Pre-PR (PR #100 and
-/// earlier), each clone drove its own `RefCounter.strong` cycle which
-/// could elevate the kernel count.
+/// how many `SIBinder` / `Strong<I>` clones exist. A per-clone
+/// `RefCounter.strong` cycle would have been able to elevate the kernel
+/// count.
 ///
 /// Sampling discipline: every command must reach the kernel before we
 /// read the count, so we issue a `ping_binder()` (which forces a driver
 /// round-trip) before each `strong_ref_count_for_node` query. This is
-/// the test-side analog of plan §4's `barrier_then_sample`.
+/// the test-side analog of a `barrier_then_sample`.
 #[test]
 fn test_kernel_strong_ref_count_one_per_proxy_handle() {
     init_test();
@@ -1846,9 +1846,9 @@ fn test_kernel_strong_ref_count_one_per_proxy_handle() {
     );
 }
 
-/// Test plan #1 — race reproducer for slow-path case (b).
+/// Race reproducer for slow-path case (b).
 ///
-/// Under master pre-PR-#100 with aggressive concurrency, the cache
+/// Without the cache-pin model, under aggressive concurrency the cache
 /// could hand out a fresh `ProxyHandle` whose handle had been freed
 /// by a racing `BC_RELEASE`, surfacing as `DeadObject` / `BadType` /
 /// wrong descriptor. Under the cache-pin model the cache pin keeps
@@ -1935,7 +1935,7 @@ fn test_cache_pin_race_reproducer_no_descriptor_mismatch() {
     }
 }
 
-/// Test plan #5 — barrier-coordinated case (b) variant.
+/// Barrier-coordinated case (b) variant.
 ///
 /// Tighter than the bulk reproducer: explicitly drives the cache
 /// `Weak` to dangling between rounds, then re-resolves to force
@@ -2037,13 +2037,13 @@ fn test_weak_partial_eq_handle_identity_across_resurrection() {
     );
 }
 
-/// Test plan #3 second bullet — `WIBinder::upgrade()` `Err(DeadObject)`
+/// `WIBinder::upgrade()` `Err(DeadObject)`
 /// branch coverage on the in-tree death-recipient path.
 ///
-/// Pre-PR `WIBinder` held a strong `Arc<dyn IBinder>`, so
-/// `WIBinder::upgrade()` always succeeded — the `Err` branch was
-/// dead code. Under this PR `WIBinder` is `sync::Weak<dyn IBinder>`,
-/// and once the last `Arc<ProxyHandle>` is dropped (which happens
+/// A `WIBinder` holding a strong `Arc<dyn IBinder>` would make
+/// `WIBinder::upgrade()` always succeed — the `Err` branch dead code.
+/// Because `WIBinder` is `sync::Weak<dyn IBinder>`,
+/// once the last `Arc<ProxyHandle>` is dropped (which happens
 /// after `BR_DEAD_BINDER` removes the cache entry and any user-held
 /// Strong drops) `upgrade()` legitimately returns `Err(DeadObject)`.
 ///
@@ -2142,7 +2142,7 @@ fn test_wibinder_upgrade_after_obituary() {
 }
 
 // =============================================================================
-// FOLLOW_UP_PR_104 integration tests
+// Death-notification / extension / dump integration tests
 //
 // These exercise the death-notification / extension / dump fixes through real
 // binder communication against `test_service`, complementing the in-crate unit
@@ -2352,10 +2352,10 @@ fn test_link_to_death_rejects_already_dead_weak_remote_proxy() {
     );
 }
 
-/// Item 3: `set_extension` on a remote proxy must reject with
+/// `set_extension` on a remote proxy must reject with
 /// `InvalidOperation` — the operation is server-side only and a proxy
-/// has no way to inform the remote service. The post-PR-104 §4
-/// strong-cache common case would otherwise silently pin an unrelated
+/// has no way to inform the remote service. A strong-cache common case
+/// would otherwise silently pin an unrelated
 /// `Arc<dyn IBinder>` for the parent's lifetime. Non-destructive —
 /// `get_extension` continues to work, returning the extension that
 /// `test_service` set on its native side.

--- a/tests/tests/rpc_async.rs
+++ b/tests/tests/rpc_async.rs
@@ -1,11 +1,11 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Async-over-RPC e2e (subplan 2-3 §7-2 "async adapter is follow-up").
+//! Async-over-RPC e2e.
 //!
 //! Closes the documented capability gap: the generated **async** `Bp*`
 //! and the **async service** adapter (`new_async_binder`) were verified
-//! only over *kernel* binder (AC-6.5), never over the RPC transport.
+//! only over *kernel* binder, never over the RPC transport.
 //!
 //! There is **no new RPC production code** behind async-over-RPC — it is
 //! exactly the same `spawn_blocking` bridge the kernel async path uses:
@@ -20,16 +20,16 @@
 //!     `serve_blocking` worker.
 //!
 //! So this binary proves the existing adapters interoperate over a real
-//! `UnixTransport` (and `mem`), including the T1-1 / AC-3.2 invariant
+//! `UnixTransport` (and `mem`), including the shared-session invariant
 //! under genuine async concurrency: many in-flight calls on **one
 //! shared session** are serialized by the per-connection `conn_lock`
 //! and never cross-deliver replies (the r34 wire has no correlation id).
 //! True async *I/O* (a non-blocking `RpcTransport`, no blocking worker)
-//! remains the separately-deferred §7-2 item — it is *not* exercised
-//! here and is not required for this adapter to be correct.
+//! is not exercised here and is not required for this adapter to be
+//! correct.
 //!
 //! Separate test binary, `#![cfg(feature = "rpc")]`, so it never shares
-//! a process with the kernel-binder unit tests (master §6). P6: each
+//! a process with the kernel-binder unit tests. Each
 //! test builds its own session pair → parallel-safe.
 
 #![cfg(feature = "rpc")]
@@ -123,8 +123,8 @@ fn run(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>) {
         assert_eq!(e.unwrap(), "joined");
         assert_eq!(a.unwrap(), 30);
 
-        // Cross-task concurrency on **one shared session** (T1-1 /
-        // AC-3.2 under async): N tasks, each its own clone of the async
+        // Cross-task concurrency on **one shared session**
+        // under async: N tasks, each its own clone of the async
         // proxy, distinct payloads. Each task must observe *its own*
         // echo back — a frame interleave or reply mis-route would make
         // at least one assertion fail.

--- a/tests/tests/rpc_generated_stub.rs
+++ b/tests/tests/rpc_generated_stub.rs
@@ -1,25 +1,25 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! Subplan 2-6.B AC-6.3 / AC-6.4: the **generated** `Bp*` stub —
-//! which now emits `as_remote().ok_or(BadType)?` instead of the
+//! The **generated** `Bp*` stub —
+//! which emits `as_remote().ok_or(BadType)?` instead of the
 //! kernel-only `as_proxy().unwrap()` — driven over the RPC transport,
 //! with the **generated server stub reused unmodified**. No
-//! hand-written proxy (contrast `rpc_e2e.rs`, subplan 2-2): this is
+//! hand-written proxy (contrast `rpc_e2e.rs`): this is
 //! the single-stub end state. The interface (`rpcsmoke.IRpcSmoke`) is
 //! compiled by `build.rs` to `OUT_DIR/rpc_smoke.rs`.
 //!
-//! - **AC-6.3**: an arbitrary AIDL interface round-trips over `mem`,
+//! - an arbitrary AIDL interface round-trips over `mem`,
 //!   `unix` (and `tcp_debug` when its feature is on) through the
 //!   generated `BpRpcSmoke`, whose `from_binder` stamps the RPC
-//!   descriptor in place (subplan 2-6.B).
-//! - **AC-6.4**: a non-remote / wrong binder is graceful — the
+//!   descriptor in place.
+//! - a non-remote / wrong binder is graceful — the
 //!   generator's old `.unwrap()` panic is gone (golden-proven), and
 //!   `try_from` yields a value or `Err`, never a panic.
 //!
 //! Separate test binary, `#![cfg(feature = "rpc")]`, so it never
-//! shares a process with the kernel-binder unit tests (master §6).
-//! P6: each test builds its own session pair → parallel-safe.
+//! shares a process with the kernel-binder unit tests.
+//! Each test builds its own session pair → parallel-safe.
 
 #![cfg(feature = "rpc")]
 #![allow(non_snake_case)]
@@ -54,7 +54,7 @@ fn root() -> SIBinder {
     BnRpcSmoke::new_binder(SmokeSvc).as_binder()
 }
 
-// ---- AC-6.3: generated stub e2e over each transport -----------------
+// ---- generated stub e2e over each transport -------------------------
 
 fn run(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>) {
     let server = RpcSession::new(server_t, AddressSpace::Acceptor).expect("RpcSession::new");
@@ -114,7 +114,7 @@ fn generated_stub_over_tcp_debug() {
     run(Box::new(a), Box::new(b));
 }
 
-// ---- AC-6.4: bad binder is graceful, never a panic ------------------
+// ---- bad binder is graceful, never a panic --------------------------
 
 /// A foreign native binder of an unrelated descriptor — neither an
 /// `IRpcSmoke` proxy nor `BnRpcSmoke`.
@@ -136,7 +136,7 @@ impl Remotable for BnOther {
     }
 }
 
-/// AC-6.4: the generator's old `as_proxy().unwrap()` (which panicked
+/// The generator's old `as_proxy().unwrap()` (which panicked
 /// on a non-`ProxyHandle` binder) is gone — golden-proven it now
 /// emits `as_remote().ok_or(StatusCode::BadType)?`. At the boundary,
 /// `try_from`:


### PR DESCRIPTION
## Summary

This branch bundles three streams of work that accumulated on top of `master`:

1. **RPC transport (Plan 2-12 / 2-15)** — multi-connection wire fixes (Phase D + C, AC-12.6 a/b/c), typed `SessionLifecycle`, `setupClient` fan-out, shutdown-reject e2e, and the TLS decoupling line (RpcServer-side TLS over unix/TCP/vsock, vsock server, listener generalization, AC-15.2 vsock×TLS hermetic e2e).
2. **Plan 4 Android-compat modules** — calling identity + `IPermissionController` (4-1), `@EnforcePermission` codegen + annotation lock-ins (4-2), freeze observer UAPI (4-3 Phase A), extended error + RT inheritance (4-4/4-5), Stability mutation / proxy count / `attachObject` / `LazyServiceRegistrar` (4-6), and the `IMemory` skeleton (4-7 Phase B).
3. **Clone-reduction sweep** — redundant clones/allocations removed across rsbinder, rsbinder-aidl, the RPC transport stack, tools, tests, fuzz targets, and examples.

Also renames the RPC interop scripts/binaries from `stage3*` to descriptive names and adds per-feature interop harnesses (`calling_identity`, `enforce_permission`, `rt_inherit`, `update_txn`).

## Scope

110 files changed, +9440 / -2359 across 10 commits.

## Testing

Per prior validation: macOS hermetic + REMOTE_LINUX (kernel Rust binder) full matrices green, workspace clippy/fmt clean, and STAGE3 emulator/REMOTE_LINUX interop PASS for the landed Plan 4 sub-plans.
