### PR TITLE
refactor(rpc): house parcel RPC logic on RpcFields + stabilize macOS RPC tests

### DIFF
--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -308,6 +308,52 @@ struct RpcFields {
     record_fd_positions: bool,
 }
 
+/// The behaviour of the RPC serialization state lives here so that the
+/// `impl Parcel` accessors stay thin `Option`-lifting wrappers and the
+/// real logic is unit-cohesive on `RpcFields`. These are private to
+/// `parcel.rs`: callers always go through the matching `Parcel::rpc_*`
+/// method (which decides the kernel-mode no-op / default), keeping each
+/// `&mut self` borrow short enough to interleave with `Parcel::write`.
+#[cfg(feature = "rpc")]
+impl RpcFields {
+    /// Record an RPC object's start offset, keeping the table sorted
+    /// (AOSP `mObjectPositions.insert(upper_bound(...), dataPos)`).
+    /// `upper_bound` ⇒ O(1) push on the common ascending-write path.
+    fn record_object_position(&mut self, pos: usize) {
+        let pos = pos as u32;
+        let at = self.object_positions.partition_point(|&p| p <= pos);
+        self.object_positions.insert(at, pos);
+    }
+
+    /// AOSP `unflattenBinder` v2 strict check: the position must be in
+    /// the (sorted) object table (`binary_search`). A forged/unsorted
+    /// table simply misses ⇒ caller returns `BAD_VALUE`.
+    fn object_position_present(&self, pos: usize) -> bool {
+        let Ok(pos) = u32::try_from(pos) else {
+            return false;
+        };
+        self.object_positions.binary_search(&pos).is_ok()
+    }
+
+    /// Stash an outgoing fd (already an owned dup); return its in-body
+    /// table index.
+    fn push_out_fd(&mut self, fd: std::os::fd::OwnedFd) -> i32 {
+        let idx = self.fds_out.len() as i32;
+        self.fds_out.push(fd);
+        idx
+    }
+
+    /// Install the fds received out-of-band, before deserialization.
+    fn set_in_fds(&mut self, fds: Vec<std::os::fd::OwnedFd>) {
+        self.fds_in = fds.into_iter().map(Some).collect();
+    }
+
+    /// Take the received fd at table `index` (consumed once).
+    fn take_in_fd(&mut self, index: usize) -> Option<std::os::fd::OwnedFd> {
+        self.fds_in.get_mut(index).and_then(Option::take)
+    }
+}
+
 /// Parcel converts data into a byte stream (serialization), making it transferable.
 /// The receiving side then transforms this byte stream back into its original data form (deserialization).
 ///
@@ -460,6 +506,27 @@ impl Parcel {
         self.rpc.get_or_insert_with(RpcFields::default).ops = Some(ops);
     }
 
+    /// Configure the session's RPC profile on this parcel in one call:
+    /// enter RPC mode + attach the object hooks, then stamp the
+    /// negotiated FD transport mode and position-recording flag.
+    /// Collapses the `attach_rpc_ops` + `set_rpc_fd_mode` +
+    /// `set_rpc_record_fd_positions` triple that every proxy/session
+    /// parcel-setup site otherwise repeats verbatim. The per-message
+    /// `rpc_set_in_fds` / `rpc_set_object_positions` stay separate —
+    /// they carry wire payload, not the session profile.
+    #[cfg(feature = "rpc")]
+    pub(crate) fn configure_rpc(
+        &mut self,
+        ops: std::sync::Arc<dyn RpcParcelOps>,
+        fd_mode: crate::rpc::FileDescriptorTransportMode,
+        record_fd_positions: bool,
+    ) {
+        let rpc = self.rpc.get_or_insert_with(RpcFields::default);
+        rpc.ops = Some(ops);
+        rpc.fd_mode = fd_mode;
+        rpc.record_fd_positions = record_fd_positions;
+    }
+
     #[cfg(feature = "rpc")]
     pub(crate) fn rpc_ops(&self) -> Option<std::sync::Arc<dyn RpcParcelOps>> {
         self.rpc.as_ref().and_then(|r| r.ops.clone())
@@ -502,12 +569,9 @@ impl Parcel {
     /// simply fails the search ⇒ the caller returns `BAD_VALUE` (safe).
     #[cfg(feature = "rpc")]
     pub(crate) fn rpc_object_position_present(&self, pos: usize) -> bool {
-        let Ok(pos) = u32::try_from(pos) else {
-            return false;
-        };
         self.rpc
             .as_ref()
-            .is_some_and(|r| r.object_positions.binary_search(&pos).is_ok())
+            .is_some_and(|r| r.object_position_present(pos))
     }
 
     /// Record the start offset of an RPC object just flattened into
@@ -523,15 +587,9 @@ impl Parcel {
     /// per-call version gate.
     #[cfg(feature = "rpc")]
     pub(crate) fn rpc_record_object_position(&mut self, pos: usize) {
-        let Some(rpc) = self.rpc.as_mut() else {
-            return;
-        };
-        let pos = pos as u32;
-        // `upper_bound` ⇒ stable, AOSP-faithful sorted insert (positions
-        // are produced in ascending write order in practice, so this is
-        // an O(1) push on the common path).
-        let at = rpc.object_positions.partition_point(|&p| p <= pos);
-        rpc.object_positions.insert(at, pos);
+        if let Some(rpc) = self.rpc.as_mut() {
+            rpc.record_object_position(pos);
+        }
     }
 
     // ---- FD-over-RPC (opt-in, Unix mode) ---------------------------
@@ -578,10 +636,10 @@ impl Parcel {
         // precondition — a stray kernel-parcel call is a programming
         // error, and returning a bogus index would be worse than a
         // clear panic.
-        let rpc = self.rpc.as_mut().expect("rpc_push_out_fd on kernel parcel");
-        let idx = rpc.fds_out.len() as i32;
-        rpc.fds_out.push(fd);
-        idx
+        self.rpc
+            .as_mut()
+            .expect("rpc_push_out_fd on kernel parcel")
+            .push_out_fd(fd)
     }
 
     /// Borrow the collected outgoing fds. The session sends them
@@ -597,16 +655,14 @@ impl Parcel {
     #[cfg(feature = "rpc")]
     pub(crate) fn rpc_set_in_fds(&mut self, fds: Vec<std::os::fd::OwnedFd>) {
         if let Some(rpc) = self.rpc.as_mut() {
-            rpc.fds_in = fds.into_iter().map(Some).collect();
+            rpc.set_in_fds(fds);
         }
     }
 
     /// Take the received fd at table `index` (consumed once).
     #[cfg(feature = "rpc")]
     pub(crate) fn rpc_take_in_fd(&mut self, index: usize) -> Option<std::os::fd::OwnedFd> {
-        self.rpc
-            .as_mut()
-            .and_then(|r| r.fds_in.get_mut(index).and_then(Option::take))
+        self.rpc.as_mut().and_then(|r| r.take_in_fd(index))
     }
 
     pub fn set_data_size(&mut self, new_len: usize) -> Result<()> {

--- a/rsbinder/src/rpc/lifecycle.rs
+++ b/rsbinder/src/rpc/lifecycle.rs
@@ -24,7 +24,7 @@
 //! between another's bump-and-rollback (the two-attacker hole the
 //! CAS-loop closes against a naive optimistic-bump shape). The typed
 //! enum makes the four reachable states explicit:
-//! a reviewer can grep [`SessionLifecycleSnapshot`] variants for every
+//! a reviewer can grep `SessionLifecycleSnapshot` variants for every
 //! point that branches on them.
 //!
 //! **Default single-connection sessions** never leave `Live(1)` until
@@ -35,6 +35,7 @@
 //! deadlocking on an empty pool; the prior `obituary_sent.load` only
 //! flipped after the obituary callback returned).
 
+#[cfg(test)]
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -49,14 +50,12 @@ const STATE_LIVE_TAG: u64 = 0;
 const STATE_DYING_TAG: u64 = 1;
 const STATE_DEAD_TAG: u64 = 2;
 
-/// A read-only snapshot of [`SessionLifecycle`] — the type the rest of
-/// the RPC crate matches against. Production code rarely needs every
-/// variant individually; the convenience helpers on `SessionLifecycle`
+/// A read-only snapshot of [`SessionLifecycle`] — the type the unit
+/// tests match against. Production code uses the boolean/count helpers
 /// ([`SessionLifecycle::is_torn_down`], [`SessionLifecycle::live_count`])
-/// cover the common cases. The unit tests below match against every
-/// variant explicitly.
-#[allow(dead_code)]
-// The hot path uses the boolean/count helpers; the typed snapshot is the grep-friendly exhaustive-match surface.
+/// for the hot path; the typed snapshot is the grep-friendly
+/// exhaustive-match surface and exists only in test builds.
+#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SessionLifecycleSnapshot {
     /// At least one connection is still driving the session. `n` is the
@@ -95,7 +94,7 @@ impl SessionLifecycle {
     /// [`live_count`](Self::live_count) (numeric) for the hot path;
     /// `snapshot` is the test surface that exhaustively matches every
     /// variant.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn snapshot(&self) -> SessionLifecycleSnapshot {
         decode(self.inner.load(Ordering::SeqCst))
     }
@@ -215,7 +214,7 @@ fn encode_dead() -> u64 {
     STATE_DEAD_TAG << STATE_SHIFT
 }
 
-#[allow(dead_code)] // used by snapshot(), itself test/grep surface
+#[cfg(test)] // used by snapshot(), itself the test exhaustive-match surface
 fn decode(v: u64) -> SessionLifecycleSnapshot {
     match v >> STATE_SHIFT {
         STATE_LIVE_TAG => {

--- a/rsbinder/src/rpc/lifecycle.rs
+++ b/rsbinder/src/rpc/lifecycle.rs
@@ -313,15 +313,24 @@ mod tests {
                     let lc = Arc::clone(&lc);
                     thread::spawn(move || {
                         let ok = lc.try_bump_live();
-                        // Whoever bumped must un-bump (preserve the
-                        // arithmetic so the test asserts the final state
-                        // from `Dying` is reachable). Concurrent unbump
-                        // from Dying/Dead is also forbidden — only one
-                        // dropper here.
                         if ok {
-                            // Re-validate: count must still be Live.
+                            // Re-validate: count must still be Live (this
+                            // attacker holds its own bump, so count >= 1).
                             assert!(matches!(lc.snapshot(), SessionLifecycleSnapshot::Live(_)));
-                            let _ = lc.drop_connection();
+                            // Honor the `drop_connection` contract: whichever
+                            // connection observes the 1→0 edge — the founding
+                            // dropper OR a racing attacker whose un-bump won
+                            // that edge — must complete the teardown with
+                            // `mark_dead`. Discarding `was_last` here left the
+                            // session stuck in `Dying` whenever an attacker
+                            // (not the dropper) took the edge, tripping the
+                            // `Dying` assertion below ~2.5% of the time under
+                            // load. The production state machine is unchanged;
+                            // this only makes the test faithful to the
+                            // "edge-observer marks dead" contract.
+                            if lc.drop_connection() {
+                                lc.mark_dead();
+                            }
                         }
                         ok
                     })

--- a/rsbinder/src/rpc/proxy.rs
+++ b/rsbinder/src/rpc/proxy.rs
@@ -173,11 +173,13 @@ impl RpcProxy {
     pub fn build_request(&self, descriptor: &str) -> Result<Parcel> {
         let inner = self.session.upgrade().ok_or(StatusCode::DeadObject)?;
         let mut data = Parcel::new();
-        data.attach_rpc_ops(inner.parcel_ops());
-        // So `ParcelFileDescriptor::serialize` applies the negotiated
-        // FD policy (default `None` ⇒ the categorical reject).
-        data.set_rpc_fd_mode(inner.fd_mode());
-        data.set_rpc_record_fd_positions(inner.records_fd_positions());
+        // Enter RPC mode + stamp the negotiated FD policy (default
+        // `None` ⇒ `ParcelFileDescriptor::serialize` rejects FDs).
+        data.configure_rpc(
+            inner.parcel_ops(),
+            inner.fd_mode(),
+            inner.records_fd_positions(),
+        );
         super::session::write_rpc_interface_token(&mut data, descriptor)?;
         Ok(data)
     }
@@ -205,9 +207,11 @@ impl crate::binder::RemoteProxy for RpcProxy {
     fn prepare_transact(&self, write_header: bool) -> Result<Parcel> {
         let inner = self.session.upgrade().ok_or(StatusCode::DeadObject)?;
         let mut data = Parcel::new();
-        data.attach_rpc_ops(inner.parcel_ops());
-        data.set_rpc_fd_mode(inner.fd_mode());
-        data.set_rpc_record_fd_positions(inner.records_fd_positions());
+        data.configure_rpc(
+            inner.parcel_ops(),
+            inner.fd_mode(),
+            inner.records_fd_positions(),
+        );
         if write_header {
             super::session::write_rpc_interface_token(&mut data, self.descriptor_str())?;
         }

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -1255,11 +1255,13 @@ impl RpcSessionInner {
                         return Err(StatusCode::from(status));
                     }
                     let mut reply = Parcel::from_vec(data);
-                    reply.attach_rpc_ops(self.parcel_ops());
-                    reply.set_rpc_fd_mode(self.fd_mode());
-                    reply.set_rpc_record_fd_positions(self.records_fd_positions());
+                    reply.configure_rpc(
+                        self.parcel_ops(),
+                        self.fd_mode(),
+                        self.records_fd_positions(),
+                    );
                     reply.rpc_set_in_fds(in_fds);
-                    // Install the wire object table (after attach_rpc_ops
+                    // Install the wire object table (after configure_rpc
                     // sets RPC mode) so binder/FD reads can validate
                     // positions.
                     reply.rpc_set_object_positions(object_positions);
@@ -1531,24 +1533,28 @@ impl RpcSessionInner {
         }
 
         let mut reader = Parcel::from_vec(t.data);
-        reader.attach_rpc_ops(self.parcel_ops());
-        reader.set_rpc_fd_mode(self.fd_mode());
-        // The inbound *args* parcel must know it
-        // speaks the v1+ AOSP fd body too (the reply paths already set
-        // this; the args path did not — a v1+ fd *argument* would
-        // otherwise be read as the R34 `[present|idx]` legacy shape and
-        // desync). v1+ ⇒ `[not-null|hasComm|TYPE|idx]` + strict
-        // position read; R34/v0 ⇒ legacy, byte-unchanged.
-        reader.set_rpc_record_fd_positions(self.records_fd_positions());
+        // The inbound *args* parcel must know it speaks the v1+ AOSP fd
+        // body too (the reply paths already set this; the args path did
+        // not — a v1+ fd *argument* would otherwise be read as the R34
+        // `[present|idx]` legacy shape and desync). v1+ ⇒
+        // `[not-null|hasComm|TYPE|idx]` + strict position read; R34/v0 ⇒
+        // legacy, byte-unchanged.
+        reader.configure_rpc(
+            self.parcel_ops(),
+            self.fd_mode(),
+            self.records_fd_positions(),
+        );
         reader.rpc_set_in_fds(in_fds);
         // Install the inbound wire object table (position validation);
         // empty on R34 / v0 / no-object.
         reader.rpc_set_object_positions(t.object_positions);
         reader.set_data_position(0);
         let mut reply = Parcel::new();
-        reply.attach_rpc_ops(self.parcel_ops());
-        reply.set_rpc_fd_mode(self.fd_mode());
-        reply.set_rpc_record_fd_positions(self.records_fd_positions());
+        reply.configure_rpc(
+            self.parcel_ops(),
+            self.fd_mode(),
+            self.records_fd_positions(),
+        );
 
         let result = consume_rpc_interface_token(&mut reader, target.descriptor())
             .and_then(|()| target.rpc_transact(t.code, &mut reader, &mut reply));

--- a/rsbinder/src/rpc/transport/vsock.rs
+++ b/rsbinder/src/rpc/transport/vsock.rs
@@ -19,7 +19,7 @@
 //! Tests are Linux+VM and `#[ignore]` by default (need a peer VM or
 //! `VMADDR_CID_LOCAL`).
 
-use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
+use std::os::fd::OwnedFd;
 
 use vsock::{VsockAddr, VsockStream};
 
@@ -48,17 +48,11 @@ impl VsockTransport {
 
     /// Wrap a preconnected vsock `OwnedFd` (the
     /// `IAccessor::addConnection()` fd-adopt path, `AF_VSOCK` family).
-    /// The `vsock` crate has no public `From<OwnedFd>` for `VsockStream`
-    /// so this goes through `FromRawFd` after taking ownership; the
-    /// caller is responsible for asserting the fd's address family.
+    /// `vsock` provides `From<OwnedFd> for VsockStream` (safe ownership
+    /// transfer, mirroring std's `UnixStream::from(OwnedFd)`); the caller
+    /// is responsible for asserting the fd's address family.
     pub fn from_owned_fd(fd: OwnedFd) -> RpcResult<Self> {
-        // SAFETY: `fd` is moved (consumed) here; `VsockStream::from_raw_fd`
-        // adopts exclusive ownership for the lifetime of the stream. The
-        // `OwnedFd` is converted via `into_raw_fd()` which is the AOSP-
-        // sanctioned "transfer ownership without closing" path.
-        let raw = fd.into_raw_fd();
-        let stream = unsafe { VsockStream::from_raw_fd(raw) };
-        Self::from_stream(stream)
+        Self::from_stream(VsockStream::from(fd))
     }
 
     /// Wrap an accepted/connected `VsockStream`. The peer cid is

--- a/rsbinder/src/rpc/wire_android13.rs
+++ b/rsbinder/src/rpc/wire_android13.rs
@@ -1127,6 +1127,65 @@ mod tests {
         }
     }
 
+    /// A `UnixStream::pair()` with read/write deadlines on both ends.
+    /// The handshake/e2e exchanges below complete in microseconds, so
+    /// the deadline never trips in normal operation; it bounds a
+    /// macOS-specific EOF-wakeup race (see [`drain_leftover`]) and any
+    /// stray stall so the (default, 5×-soak) CI job can never hang to
+    /// its wall-clock timeout.
+    fn timed_socketpair() -> (
+        std::os::unix::net::UnixStream,
+        std::os::unix::net::UnixStream,
+    ) {
+        let (c, s) = std::os::unix::net::UnixStream::pair().expect("socketpair");
+        let timeout = std::time::Duration::from_secs(10);
+        for sock in [&c, &s] {
+            sock.set_read_timeout(Some(timeout))
+                .expect("set read timeout");
+            sock.set_write_timeout(Some(timeout))
+                .expect("set write timeout");
+        }
+        (c, s)
+    }
+
+    /// Drain everything the peer sent after the handshake, returning all
+    /// bytes read. Stops at a clean EOF (the peer's write-half shutdown —
+    /// the Linux fast path) **or** at the [`timed_socketpair`] read
+    /// deadline.
+    ///
+    /// The deadline arm is load-bearing on macOS: a peer's
+    /// `shutdown(SHUT_WR)` does *not* reliably wake a `recv` already
+    /// parked in the kernel on an `AF_UNIX` `socketpair` (reproduced
+    /// ~1-in-50 full `rpc::` soak runs locally — the stuck thread sits
+    /// forever in `read_to_end` → `recvfrom`), so a plain blocking
+    /// `read_to_end` can wait for an EOF that never arrives. Treating
+    /// the deadline as end-of-stream is correct for the leftover-byte
+    /// assertions here: any *real* trailing byte was written by the peer
+    /// during the handshake and is already in the socket buffer, so it
+    /// comes back on the first `recv`; a timeout with nothing buffered
+    /// genuinely means the peer sent nothing.
+    fn drain_leftover(stream: &mut std::os::unix::net::UnixStream) -> Vec<u8> {
+        use std::io::Read;
+        let mut out = Vec::new();
+        let mut chunk = [0u8; 64];
+        loop {
+            match stream.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => out.extend_from_slice(&chunk[..n]),
+                Err(e)
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) =>
+                {
+                    break
+                }
+                Err(e) => panic!("drain_leftover: unexpected error: {e}"),
+            }
+        }
+        out
+    }
+
     /// Spec-conformance golden — byte-exact against AOSP
     /// `RpcWireFormat.h` (v0 = android-13.0.0_r84, v1 =
     /// android-15.0.0_r36 == android-14.0.0_r75). Device-free.
@@ -1479,7 +1538,6 @@ mod tests {
     /// version negotiation.
     #[test]
     fn android13plus_live_protocol_e2e_over_raw_socket() {
-        use std::os::unix::net::UnixStream;
         use std::thread;
 
         // (client_max, server_max, expected_negotiated) — incl.
@@ -1494,7 +1552,7 @@ mod tests {
             (1, 2, 1),
             (2, 0, 0),
         ] {
-            let (mut c, mut s) = UnixStream::pair().expect("socketpair");
+            let (mut c, mut s) = timed_socketpair();
 
             let srv = thread::spawn(move || -> u32 {
                 let (codec, fd_mode, sid, incoming) =
@@ -1661,9 +1719,7 @@ mod tests {
     /// after both shutdown their write halves.
     #[test]
     fn android13plus_attach_handshake_wire_byte_exact() {
-        use std::io::Read;
         use std::net::Shutdown;
-        use std::os::unix::net::UnixStream;
         use std::thread;
 
         let session_id = [0x42u8; 32];
@@ -1676,23 +1732,20 @@ mod tests {
             (true, PROTOCOL_V1),
             (true, PROTOCOL_V2),
         ] {
-            let (mut c, mut s) = UnixStream::pair().expect("pair");
+            let (mut c, mut s) = timed_socketpair();
             let sid = session_id;
             let srv = thread::spawn(move || -> (u32, bool, Vec<u8>, Vec<u8>) {
                 let (codec, _fd, got_sid, srv_incoming) =
                     server_accept(&mut s, version).expect("server_accept");
                 s.shutdown(Shutdown::Write).expect("srv shutdown w");
-                let mut leftover = Vec::new();
-                s.read_to_end(&mut leftover).expect("srv read_to_end");
+                let leftover = drain_leftover(&mut s);
                 (codec.version(), srv_incoming, got_sid, leftover)
             });
 
             let codec = client_connect_with_id(&mut c, version, incoming, FD_MODE_NONE, &sid)
                 .expect("client_connect_with_id");
             c.shutdown(Shutdown::Write).expect("cli shutdown w");
-            let mut client_leftover = Vec::new();
-            c.read_to_end(&mut client_leftover)
-                .expect("cli read_to_end");
+            let client_leftover = drain_leftover(&mut c);
             assert!(
                 client_leftover.is_empty(),
                 "(attach, incoming={incoming}, v={version}): server wrote {} unexpected \
@@ -1723,11 +1776,9 @@ mod tests {
     /// wire order.
     #[test]
     fn android13plus_new_session_incoming_rejected() {
-        use std::io::Read;
-        use std::os::unix::net::UnixStream;
         use std::thread;
 
-        let (mut c, mut s) = UnixStream::pair().expect("pair");
+        let (mut c, mut s) = timed_socketpair();
         let srv = thread::spawn(move || -> RpcResult<_> {
             let result = server_accept(&mut s, PROTOCOL_V1);
             drop(s);
@@ -1746,8 +1797,7 @@ mod tests {
             "server must reject new-session + incoming, got {r:?}"
         );
 
-        let mut buf = Vec::new();
-        c.read_to_end(&mut buf).expect("read response + EOF");
+        let buf = drain_leftover(&mut c);
         assert_eq!(
             buf.len(),
             A13_NEW_SESSION_RESP_LEN,


### PR DESCRIPTION
## Summary

Follow-ups on the `Option<RpcFields>` parcel work (the base
consolidation already landed on `master`). Two strands:

### Parcel RPC refactor (502f19c)
- Move the logic-bearing RPC serialization methods (sorted
  object-position record/lookup, fd push/take/install) from
  `impl Parcel` onto `impl RpcFields`, so the RPC state is cohesive and
  unit-testable on `RpcFields`.
- `Parcel::rpc_*` entry points stay as **thin `Option`-lifting
  wrappers** — on purpose. They keep each `&mut self` borrow short
  enough to interleave with `Parcel::write` on the FD
  serialize/deserialize hot path, and encapsulate the kernel-mode
  no-op / default that callers would otherwise repeat.
- Add `Parcel::configure_rpc(ops, fd_mode, record_fd_positions)` to
  collapse the `attach_rpc_ops` + `set_rpc_fd_mode` +
  `set_rpc_record_fd_positions` triple repeated verbatim at five
  proxy/session parcel-setup sites into one call.
- Pure relocation + call bundling — **wire output is byte-identical**.

### RPC test stabilization (12fa786, 0812b63, f8d249a)
- Tighten the test-only surface and drop unsafe fd adoption.
- Fix the `concurrent_bumpers` lifecycle test stuck-`Dying` flake.
- Fix the macOS `socketpair` EOF-wakeup hang in the android13+
  handshake tests.

## Testing
- macOS hermetic + RPC suites green; `clippy`/`fmt` clean.
- 14 kernel-binder unit tests fail on the macOS host only because
  `/dev/binder` is absent (known baseline, unrelated to these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)