### PR TITLE
docs(book): correct AIDL/RPC chapters to match implementation

### DIFF
--- a/book/src/aidl-annotations.md
+++ b/book/src/aidl-annotations.md
@@ -235,15 +235,9 @@ parcelable VintfData {
 
 ### Stability Rules
 
-VINTF-stable types enforce the following constraints:
+In the upstream Android toolchain, VINTF-stable types are meant to contain only other VINTF-stable types so that their serialization format stays stable across independent system/vendor updates — critical for framework↔HAL compatibility.
 
-- A VINTF-stable parcelable can only contain fields whose types are also VINTF-stable.
-- A VINTF-stable interface can only use VINTF-stable types in its method signatures.
-- Attempting to embed a non-VINTF type inside a VINTF-stable type will produce a `StatusCode::BadValue` error at runtime.
-
-These rules exist to guarantee that the serialization format of VINTF types remains stable across system updates. On Android, this is critical for maintaining compatibility between the framework and vendor HAL implementations.
-
-On Linux, the `@VintfStability` annotation is recognized by the code generator but the stability enforcement depends on how the service manager is configured.
+rsbinder's generator **recognizes** `@VintfStability` and stamps the generated type/interface with `Stability::Vintf` (so it carries the right stability tier on the wire), but it does **not** statically or dynamically enforce the "fields must also be VINTF-stable" rule — there is no field-tree validation and no `BadValue` raised for embedding a non-VINTF type. Treat the constraint as a contract you are responsible for upholding, not one the compiler checks for you.
 
 ## @FixedSize
 
@@ -257,25 +251,21 @@ parcelable FixedPoint {
 }
 ```
 
-### Constraints
+### Intended constraints
 
-Fixed-size parcelables can only contain:
+In upstream Android, a fixed-size parcelable may only contain:
 
 - Primitive types (`boolean`, `byte`, `char`, `int`, `long`, `float`, `double`)
 - Other `@FixedSize` parcelables
 - Enums with a `@Backing` annotation
 
-They cannot contain:
+and may not contain `String`/`@utf8InCpp String`, arrays (`T[]`), `ParcelFileDescriptor`, `IBinder`, or any other variable-length type.
 
-- `String` or `@utf8InCpp String`
-- Arrays (`T[]`)
-- `ParcelFileDescriptor`
-- `IBinder`
-- Any variable-length type
+> **rsbinder note:** the generator accepts `@FixedSize` but currently treats it as a no-op — it neither validates these constraints nor changes the generated layout or wire format. The constraints above are the contract you should follow; rsbinder does not check them for you.
 
 ### Relationship with @RustDerive(Copy=true)
 
-The `@FixedSize` annotation is a prerequisite for deriving `Copy` in Rust, because only types with a fixed memory layout can be safely copied with a bitwise copy:
+`Copy` is derived purely from `@RustDerive(Copy=true)`; `@FixedSize` is **not** a prerequisite for it in rsbinder. Conceptually you should still only add `Copy` to types with a fixed layout, so pairing the two documents intent:
 
 ```aidl
 @RustDerive(Clone=true, Copy=true, PartialEq=true)
@@ -285,8 +275,6 @@ parcelable Coordinate {
     double longitude;
 }
 ```
-
-Without `@FixedSize`, adding `Copy` to the derive list may compile but violates the intended semantics. Always pair `Copy` with `@FixedSize` to make the intent explicit.
 
 ## Summary
 

--- a/book/src/aidl-data-types.md
+++ b/book/src/aidl-data-types.md
@@ -6,21 +6,21 @@ This chapter covers the supported AIDL data types, how they map to Rust, and com
 
 ## Primitive Types
 
-The following table shows how AIDL primitive types map to Rust types. Input parameters (`in`) are passed by value or by reference, while output parameters (`out`) are passed as mutable references so the service can write results back to the caller.
+The following table shows how AIDL primitive types map to Rust types. Input parameters (`in`) are passed by value or by reference. Only *non-scalar* types — arrays, parcelables, and nullable references — may be `out`/`inout`; the generator rejects a primitive or a `String` marked `out`/`inout` at compile time (it has no fixed slot to write back into).
 
 | AIDL Type | Rust Type (in) | Rust Type (out) | Notes |
 |-----------|---------------|-----------------|-------|
-| boolean | bool | &mut bool | |
-| byte | i8 | &mut i8 | Single values use i8; array Reverse uses u8 |
-| char | u16 | &mut u16 | UTF-16 code unit |
-| int | i32 | &mut i32 | |
-| long | i64 | &mut i64 | |
-| float | f32 | &mut f32 | |
-| double | f64 | &mut f64 | |
-| String | &str | &mut String | |
-| @utf8InCpp String | &str | &mut String | Same mapping in rsbinder |
+| boolean | bool | — (not allowed) | |
+| byte | i8 | — (not allowed) | Single values use i8; array Reverse uses u8 |
+| char | u16 | — (not allowed) | UTF-16 code unit |
+| int | i32 | — (not allowed) | |
+| long | i64 | — (not allowed) | |
+| float | f32 | — (not allowed) | |
+| double | f64 | — (not allowed) | |
+| String | &str | — (not allowed) | `out`/`inout` String is rejected by the generator |
+| @utf8InCpp String | &str | — (not allowed) | Same mapping in rsbinder |
 | T[] | &[T] | &mut Vec\<T\> | |
-| @nullable T | Option\<&T\> | &mut Option\<T\> | |
+| @nullable T | Option\<&T\> | &mut Option\<T\> | A nullable `String` input is `Option<&str>` |
 | IBinder | &SIBinder | | |
 | ParcelFileDescriptor | &ParcelFileDescriptor | | |
 
@@ -177,7 +177,7 @@ void Transform(inout int[] data);
 
 Use `inout` when the service needs to read the existing value and modify it in place. Prefer `in` or `out` when data only needs to flow in one direction, as this avoids unnecessary serialization overhead.
 
-> **Note**: Primitive types (`boolean`, `byte`, `char`, `int`, `long`, `float`, `double`) do not require a direction tag. Direction tags are only meaningful for non-primitive types such as arrays, strings, and parcelable types.
+> **Note**: Primitive types (`boolean`, `byte`, `char`, `int`, `long`, `float`, `double`) and `String` cannot carry an `out`/`inout` direction tag — the generator rejects it. As scalar (or, for `String`, value-typed) parameters they only ever flow `in`. Direction tags are meaningful only for arrays and parcelable types.
 
 ## Tips
 

--- a/book/src/aidl-enum-union.md
+++ b/book/src/aidl-enum-union.md
@@ -10,7 +10,7 @@ AIDL enums are backed by a specific integer type, declared using the `@Backing` 
 
 ### Defining Enums in AIDL
 
-The `@Backing(type=...)` annotation is required and specifies the underlying integer type. Here are examples for each supported backing type:
+The `@Backing(type=...)` annotation specifies the underlying integer type. It is optional — when omitted, the backing type defaults to `byte`. Here are examples for each supported backing type:
 
 **Byte-backed enum:**
 
@@ -59,7 +59,7 @@ The AIDL backing type determines the Rust integer type used inside the generated
 
 ### Using Enums in Rust
 
-Enum values are accessed as associated constants on the generated struct. The generated type implements `Default`, `Debug`, `PartialEq`, `Eq`, and serialization traits automatically.
+Enum values are accessed as associated constants on the generated struct. The generated type derives `Debug`, `Default`, `Copy`, `Clone`, `PartialOrd`, `Ord`, `PartialEq`, `Eq`, and `Hash`, plus serialization traits automatically.
 
 ```rust
 // Access enum values as associated constants
@@ -77,7 +77,7 @@ let mut repeated = vec![];
 let reversed = service.ReverseByteEnum(&input, &mut repeated)?;
 ```
 
-Each generated enum type provides an `enum_values()` method that returns a slice of all defined values, which is useful for iteration and validation:
+Each generated enum type provides an `enum_values()` method that returns a fixed-size array (`[Self; N]`) of all defined values, which is useful for iteration and validation:
 
 ```rust
 // enum_values() returns all defined values
@@ -205,7 +205,7 @@ In this example, the default value is the first field (`intEnum`) initialized to
 assert_eq!(EnumUnion::default(), EnumUnion::IntEnum(IntEnum::FOO));
 ```
 
-Note that the `@deprecated` Javadoc annotation on `deprecatedField` will generate a `#[deprecated]` attribute in the Rust code, so using that variant will produce a compiler warning.
+Note that AIDL accepts a `@deprecated` Javadoc tag on a field, but rsbinder's generator does not currently translate it into a Rust `#[deprecated]` attribute — the field is generated normally and using it produces no compiler warning.
 
 ### Nested Unions
 
@@ -222,7 +222,7 @@ This allows building complex tagged-value hierarchies that are fully type-safe o
 
 ## Tips and Best Practices
 
-- **Always specify `@Backing`** for enums. The AIDL compiler requires it, and the choice of backing type affects both the wire format and the Rust integer type.
+- **Specify `@Backing` explicitly** for enums. It is optional (the default is `byte`), but stating it makes the wire format and the Rust integer type unambiguous to readers.
 - **The union default is always the first field.** Order your fields accordingly, placing the most common or natural default first.
 - **Use `@RustDerive(Clone=true, PartialEq=true)`** on unions so they can be compared and cloned in Rust. Without this, you cannot use `==` or `.clone()` on union values.
 - **Union constants are module-level**, not variants. Access them as `Union::S1`, not through any variant.

--- a/book/src/aidl-parcelable.md
+++ b/book/src/aidl-parcelable.md
@@ -43,7 +43,7 @@ assert_eq!(default_profile.age, 0);
 
 ## Constants in Parcelable
 
-Parcelable types can define constants, including numeric values and bit flags. These become associated constants on the generated Rust struct. This pattern is commonly used for configuration values and flag fields.
+Parcelable types can define constants, including numeric values and bit flags. These are emitted as module-level `pub const` items inside the generated parcelable module. Because the module shares its name with the struct, you still reach them with the familiar `TypeName::CONSTANT` path. This pattern is commonly used for configuration values and flag fields.
 
 ```aidl
 @RustDerive(Clone=true, PartialEq=true)
@@ -58,7 +58,7 @@ parcelable Config {
 }
 ```
 
-In Rust, the constants are accessed as associated constants on the struct:
+In Rust, the constants are accessed through the type path:
 
 ```rust
 use config::Config;

--- a/book/src/rpc-transport.md
+++ b/book/src/rpc-transport.md
@@ -310,18 +310,12 @@ kernel binder for, with a few extras specific to socket transport:
 ### Sessions with multiple connections
 
 `RpcServer::set_max_threads(N)` matches AOSP's
-`setMaxIncomingThreads`. The default `N == 1` (one connection per
-session) is fully supported and validated against real Android 13–16
-libbinder peers — this is the mode every example in the book
-uses.
-
-**`N ≥ 2` (multi-connection sessions) is currently experimental.**
-The hermetic rsbinder↔rsbinder tests pass, but the real-libbinder
-interop gate has not yet been cleared, so production code that needs
-to interoperate with a real Android `libbinder` peer should stay on
-the default. See the rustdoc on
+`setMaxIncomingThreads`. Both `N == 1` (the default — one connection
+per session, the mode every example in the book uses) and `N >= 2`
+(multi-connection sessions) are validated against real Android 13–16
+libbinder peers. See the rustdoc on
 [`RpcServer::set_max_threads`](https://docs.rs/rsbinder/latest/rsbinder/rpc/struct.RpcServer.html#method.set_max_threads)
-for the current status.
+for the per-mode details.
 
 `set_max_threads` caps *incoming slots per session*. To cap
 *server-wide concurrent connections* — for example to bound the

--- a/book/src/stability-tiers.md
+++ b/book/src/stability-tiers.md
@@ -35,13 +35,13 @@ Implemented and validated, but the public-API shape is still under
 review for 1.0. Expect at most a single round of renames or signature
 tweaks; wire formats are already locked.
 
-- **RPC transport single-connection** — `RpcServer`, `RpcSession`
-  (single-conn role), `setup_unix_server`, `setup_unix_client*`,
-  `from_preconnected_fd`, `set_root`, `get_root`, `set_android13plus`,
-  `set_max_threads(1)` semantics, `set_max_connections`,
-  `set_supported_fd_modes(&[FdMode::Unix])`. Validated against real
-  android-13 / 14 / 15 / 16 `libbinder` (plans 2-1 … 2-11 / 2-13 / 2-14
-  STAGE3).
+- **RPC transport** — `RpcServer`, `RpcSession`, `setup_unix_server`,
+  `setup_unix_client*`, `from_preconnected_fd`, `set_root`, `get_root`,
+  `set_android13plus`, `set_max_threads(N)` (both `N == 1` and
+  `N >= 2` multi-connection), `set_max_connections`,
+  `set_supported_fd_modes(&[FileDescriptorTransportMode::Unix])`.
+  Validated against real android-13 / 14 / 15 / 16 `libbinder`
+  (plans 2-1 … 2-12 / 2-13 / 2-14 STAGE3).
 - **FD-over-RPC** (v1+ AOSP-faithful, AC-11.3 gate passed).
 - **RPC death notification** (session-disconnect, AOSP-faithful).
 - **IAccessor client / server** (plans 2-13 D.8 + 2-14 D.9 STAGE3
@@ -60,7 +60,6 @@ change without a deprecation cycle.
 | `rpc-tcp-debug` | `TcpDebugTransport` — plain TCP backend | Bring-up / interop only, never production. |
 | `rpc-vsock` | `VsockTransport` — host↔VM | Linux/Android only; loopback testing requires `vsock_loopback.ko`. |
 | `rpc-tls` | TLS over rustls, socket-orthogonal (tcp / unix / vsock) | Hermetic green; the `StreamOwned` decoupling (plan 2-15) has landed. Real-`libbinder` STAGE3 not yet attempted — stock emulator images ship no `libbinder_tls`. |
-| `rpc-experimental-multiconn` | `RpcServer::set_max_threads(N ≥ 2)` slot-cap > 1 | Hermetic passes; real-`libbinder` interop gate AC-12.6 not yet passed (plan 2-12 §3). Default builds clamp the attach-arm cap to 1 — see `RpcServer::set_max_threads` rustdoc. |
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

Re-audited the mdbook (`book/`) against the actual code and AIDL generator. Several chapters documented *AOSP* semantics or stale status instead of rsbinder's real behavior. This PR fixes the substantive mismatches (no version churn — the `0.8` pins are intentionally kept, since `0.9.0` is unreleased).

## Fixes

**Broken / uncompilable examples**
- `stability-tiers.md`: `FdMode::Unix` → `FileDescriptorTransportMode::Unix` (the real type name).
- `aidl-data-types.md`: primitives and `String` cannot be `out`/`inout` — the generator rejects them (`DirectionPrimitive` / "String cannot be an out or inout parameter"). Fixed the type table's "out" column and the direction note.

**Stale status**
- `rpc-transport.md` + `stability-tiers.md`: multi-connection (`set_max_threads(N>=2)`) is now validated against real android-13/14/15/16 libbinder — no longer experimental. Dropped the retired `rpc-experimental-multiconn` feature row (feature retired in-tree).

**AOSP-vs-rsbinder behavior corrected**
- `aidl-enum-union.md`: `@Backing` is optional (defaults to `byte`), not required; `@deprecated` does **not** emit `#[deprecated]`; `enum_values()` returns `[Self; N]`, not a slice; documented the full enum derive set.
- `aidl-annotations.md`: `@FixedSize` is accepted but a no-op in rsbinder (no constraint enforcement, not a `Copy` prerequisite); `@VintfStability` stamps the stability tier but does **not** enforce VINTF field rules.
- `aidl-parcelable.md`: parcelable constants are module-level `pub const` reached via the type path, not struct associated constants.

## Verification
- Every claim cross-checked against `rsbinder-aidl/src/{parser,type_generator,generator}.rs`, `rsbinder/src/rpc/`, and `macros.rs`.
- `mdbook build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)