### PR TITLE
Plan 2-16: RPC calling identity, cross-transport service facade & security

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -20,6 +20,8 @@
     - [Error Handling](./error-handling.md)
     - [Service Manager (HUB)](./service-manager.md)
 - [RPC Transport (binder-over-socket)](./rpc-transport.md)
+- [Cross-Transport Services](./cross-transport-services.md)
+- [Security & Authorization](./security.md)
 - [Stability Tiers](./stability-tiers.md)
 - [Enable binder for Linux](./enable-binder-for-linux.md)
     - [Arch Linux](./arch-linux.md)

--- a/book/src/aidl-annotations.md
+++ b/book/src/aidl-annotations.md
@@ -276,6 +276,38 @@ parcelable Coordinate {
 }
 ```
 
+## @EnforcePermission
+
+`@EnforcePermission` declares the Android permission(s) a method requires.
+The generated `on_transact` arm checks the caller against
+`PermissionManagerService` **before** your handler runs and returns
+`EX_SECURITY` if the check fails — so the handler body needs no
+authorization code:
+
+```aidl
+interface IExample {
+    @EnforcePermission("android.permission.INTERNET")
+    void doNetworking();
+
+    @EnforcePermission(allOf = {"android.permission.A", "android.permission.B"})
+    void needsBoth();
+
+    @EnforcePermission(anyOf = {"android.permission.A", "android.permission.B"})
+    void needsEither();
+}
+```
+
+The companion documentation-only annotations `@PermissionManuallyEnforced`
+and `@RequiresNoPermission` are recognized and emit no runtime check (they
+exist so every method can declare its permission posture).
+
+> **Kernel-only.** Android permissions are a kernel-binder concept. Over
+> the [RPC transport](./rpc-transport.md) an `@EnforcePermission` method is
+> **denied** (`EX_SECURITY`) unconditionally — granting would mean granting
+> *root* to an anonymous peer. For RPC authorization use the
+> transport-native mechanisms, or inject a `PermissionAuthority` to back the
+> check with your own policy. See [Security & Authorization](./security.md).
+
 ## Summary
 
 The following table provides a quick reference for all annotations covered in this chapter.
@@ -290,5 +322,6 @@ The following table provides a quick reference for all annotations covered in th
 | `@Descriptor` | interface | Overrides the wire descriptor string |
 | `@VintfStability` | parcelable, interface | Enforces VINTF stability rules |
 | `@FixedSize` | parcelable | Restricts fields to fixed-size types, enables `Copy` |
+| `@EnforcePermission` | interface method | Generates a `PermissionManagerService` check (kernel-only; denied over RPC) |
 
 When writing AIDL files for rsbinder, the most commonly used annotations are `@RustDerive` (for ergonomic Rust types), `@Backing` (for enums), and `@nullable` (for optional values). The remaining annotations are important for interoperability with Android or for specific use cases like recursive types and interface migration.

--- a/book/src/async-service.md
+++ b/book/src/async-service.md
@@ -10,6 +10,33 @@ If you have not yet read the [Hello, World!](./hello-world.md) chapter, it is re
 do so first -- the async concepts here build on the synchronous service and client covered
 there.
 
+## Async is transport-agnostic
+
+Async lives in the **AIDL-generated stubs**, not in the transport. The compiler
+emits the async trait (`IMyServiceAsyncService`), the async proxy
+(`into_async::<Tokio>()`), and the `new_async_binder` constructor *once*, and
+the very same async `impl` runs unchanged over **kernel binder or RPC** — including
+through the transport-agnostic [`service` facade](./cross-transport-services.md).
+
+The reason is that the facade and the transports only ever move a transport-agnostic
+`SIBinder` around (register a binder under a name, look one up). Whether that binder is
+sync- or async-backed is decided entirely by which constructor produced it
+(`new_binder` vs `new_async_binder`) — a fact the transport never sees. So async needs
+**no transport-specific code**: pick the constructor, pick the transport, and the two
+compose.
+
+This chapter starts with the kernel-binder setup, then shows the RPC and unified-facade
+variants — which differ only in the bootstrap and the runtime flavor.
+
+> **Under the hood — it is a thread bridge, not a reactor.** rsbinder async is *not*
+> epoll-driven non-blocking I/O. On the client a transact runs on
+> `tokio::task::spawn_blocking`; on the server each call is wrapped in `rt.block_on(..)`
+> and driven from a blocking worker thread (the binder thread pool for kernel, the
+> `serve` worker for RPC). This is the same bridge the kernel `binder_tokio` path uses.
+> You get async/await ergonomics and real concurrency, backed by blocking worker
+> threads — which is sufficient for typical service workloads. A true async I/O reactor
+> is deliberately out of scope.
+
 ## Sync vs Async at a Glance
 
 The following table summarizes the key differences between a synchronous and an asynchronous
@@ -28,9 +55,16 @@ The AIDL compiler generates both the sync trait (`IMyService`) and the async tra
 (`IMyServiceAsyncService`) from the same `.aidl` file. You choose which one to implement
 depending on whether your service needs async capabilities.
 
-## Setting Up the Tokio Runtime
+The trait, proxy, and constructor rows above are **identical across transports** — only the
+"Main loop" and "Runtime" rows are the kernel-binder values shown here. Over RPC the main
+loop is `rpc::Host::serve()` (or `serve_background()`) and the runtime must be
+**multi-threaded**; see [Async Over RPC and the Unified Facade](#async-over-rpc-and-the-unified-facade)
+below.
 
-An async Binder service must run inside a Tokio runtime. The standard pattern is:
+## Setting Up the Tokio Runtime (kernel binder)
+
+An async Binder service must run inside a Tokio runtime. The standard pattern for **kernel
+binder** is:
 
 1. Initialize the Binder process state and thread pool (same as sync).
 2. Build a Tokio runtime.
@@ -87,6 +121,111 @@ There are several things to note here:
 - **`std::future::pending().await`** is a future that never resolves. It keeps the `block_on`
   call (and therefore the process) alive indefinitely, which is the async equivalent of the
   synchronous `ProcessState::join_thread_pool()`.
+
+## Async Over RPC and the Unified Facade
+
+Because async lives in the generated stubs and the [`service`
+facade](./cross-transport-services.md) only moves an `SIBinder`, the *same* async service
+runs over RPC with no new code. You register the result of `new_async_binder` through the
+generic `Registry`, and the client converts the looked-up proxy with `into_async`:
+
+```rust
+use async_trait::async_trait;
+use rsbinder::service::{rpc, Registry, Broker};
+use rsbinder::*;
+
+struct IHelloService;
+impl Interface for IHelloService {}
+
+#[async_trait]
+impl IHelloAsyncService for IHelloService {
+    async fn echo(&self, echo: &str) -> rsbinder::status::Result<String> {
+        Ok(echo.to_owned())
+    }
+}
+
+/// Registration is written once, generic over the transport — identical to the
+/// sync facade example in "Cross-Transport Services". Only the binder
+/// constructor differs (`new_async_binder` instead of `new_binder`).
+fn register<R: Registry>(
+    reg: &R,
+    rt: TokioRuntime<tokio::runtime::Handle>,
+) -> rsbinder::Result<()> {
+    let binder = BnHello::new_async_binder(IHelloService {}, rt).as_binder();
+    reg.add_service("hello", binder)
+}
+```
+
+### The server needs a multi-threaded runtime
+
+This is the one substantive difference from the kernel setup. An RPC async server is driven
+by a **blocking `serve` worker** that calls `rt.block_on(handler)`. That `block_on` runs on a
+thread that is *not* the runtime's own, so the runtime must be a **multi-threaded** one — a
+`current_thread` runtime cannot be driven from an outside thread while it is also being kept
+alive elsewhere. (Kernel binder gets away with `current_thread` only because the binder
+thread pool, not a `serve` loop, supplies the worker threads.)
+
+```rust
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    // RPC async servers require a MULTI-THREAD runtime — the blocking serve
+    // worker calls `rt.block_on(handler)` from a non-runtime thread.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()?;
+    let handle = runtime.handle().clone();
+
+    let host = rpc::Host::unix("/tmp/hello.sock")?;
+    register(&host, TokioRuntime(handle))?;
+    println!("serving over RPC at /tmp/hello.sock");
+    host.serve()?; // blocks, driving this one socket
+    Ok(())
+}
+```
+
+Use [`rpc::Host::serve_background()`](./cross-transport-services.md) instead of `serve()`
+if you want the socket driven on a background thread while `main` does other work.
+
+### The client converts the looked-up proxy
+
+The client side is the ordinary facade lookup followed by `into_async`:
+
+```rust
+let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
+
+let broker = rpc::Broker::unix("/tmp/hello.sock")?;
+let hello = broker.get_interface::<dyn IHello>("hello")?; // sync Strong<dyn IHello>
+
+runtime.block_on(async {
+    let hello = hello.into_async::<Tokio>();
+    println!("{}", hello.echo("hi").await?);
+    Ok::<_, Box<dyn std::error::Error>>(())
+})?;
+```
+
+> The blocking bootstrap — `Broker::unix`, `get_interface` — is done *before* entering the
+> runtime; only the transacts themselves are `.await`ed. This mirrors the verified end-to-end
+> test `tests/tests/rpc_async.rs`, which drives the generated async `Bp*` against an async
+> service over a real Unix-socket session, including many in-flight calls on one shared
+> session under genuine async concurrency.
+
+### Switching transports
+
+To run the exact same async service over **kernel binder** instead, swap only the host
+construction and the runtime flavor — the `register` helper and the service `impl` are
+unchanged:
+
+```rust
+let host = kernel::Host::new()?;      // instead of rpc::Host::unix(..)
+register(&host, rt())?;
+host.serve()?;                        // joins the process-wide binder pool
+```
+
+Be aware that the two transports' trust boundaries differ: see
+[Security & Authorization](./security.md) — `@EnforcePermission` denies over RPC, and
+`get_calling_uid()` is the kernel-vouched peer uid on Unix RPC (fail-closed on uid-less
+transports). The facade makes the transport swap easy; it does not make the security models
+identical.
 
 ## Implementing an Async Service
 
@@ -378,7 +517,14 @@ steps:
 3. Implement `IMyServiceAsyncService` with `#[async_trait]` instead of `IMyService`.
 4. Create binders with `BnXxx::new_async_binder(impl, rt())`.
 5. Use `into_async::<Tokio>()` when calling other Binder services from async code.
-6. Keep the process alive with `std::future::pending().await`.
+6. Keep the process alive with `std::future::pending().await` (kernel binder) or
+   `rpc::Host::serve()` / `serve_background()` (RPC).
 
-For a complete working example, see `tests/src/bin/test_service_async.rs` in the rsbinder
-repository.
+Because async lives in the generated stubs, the same async service runs over **either
+transport** — register the `new_async_binder` result through the [`service`
+facade](./cross-transport-services.md)'s `Registry` and look it up through `Broker`. The only
+RPC-specific requirement is a **multi-threaded** runtime, because the blocking `serve` worker
+calls `rt.block_on(handler)`.
+
+For complete working examples, see `tests/src/bin/test_service_async.rs` (kernel binder) and
+`tests/tests/rpc_async.rs` (RPC) in the rsbinder repository.

--- a/book/src/cross-transport-services.md
+++ b/book/src/cross-transport-services.md
@@ -1,0 +1,111 @@
+# Cross-Transport Services
+
+The AIDL interface, the generated `Bp*`/`Bn*` stubs, your service `impl`,
+and the call sites are **already transport-agnostic** — the same `impl IFoo`
+runs unchanged over kernel binder or RPC. What differs is only the
+*bootstrap*: kernel binder uses `ProcessState` + the [`hub`](./service-manager.md)
+service manager, while RPC uses `RpcServer` / `RpcSession`.
+
+The `rsbinder::service` module is an **optional, additive** layer that makes
+that bootstrap transport-agnostic too, so you can write registration and
+lookup code **once** and pick the transport by construction. It is a thin
+typed wrapper over the existing APIs — those remain the direct path and are
+unchanged.
+
+## The traits
+
+```rust
+use rsbinder::service::{Registry, Broker};
+```
+
+- [`Registry`](https://docs.rs/rsbinder/latest/rsbinder/service/trait.Registry.html)
+  (server side) — `add_service(name, binder)`.
+- [`Broker`](https://docs.rs/rsbinder/latest/rsbinder/service/trait.Broker.html)
+  (client side) — `lookup(name)` plus a generic `get_interface::<T>(name)`
+  convenience that does the `interface_cast`.
+
+Only the genuine kernel∩RPC intersection is on the traits. Kernel-only
+powers (`list_services`, service notifications, lazy services) stay on the
+concrete kernel types / the `hub` module — they are not hidden behind the
+trait, nor faked on RPC.
+
+## Typed hosts and brokers
+
+Each transport is a distinct type, so the differences stay visible at the
+call site:
+
+| | Server (`Registry`) | Client (`Broker`) |
+|---|---|---|
+| kernel binder | `service::kernel::Host` | `service::kernel::Broker` |
+| RPC (`#[cfg(feature = "rpc")]`) | `service::rpc::Host` | `service::rpc::Broker` |
+
+```rust
+use rsbinder::service::{kernel, rpc, Registry, Broker};
+use rsbinder::{SIBinder, Strong};
+
+// Register once — generic over the transport.
+fn register_all<R: Registry>(reg: &R, svc: SIBinder) -> rsbinder::Result<()> {
+    reg.add_service("hello", svc)
+}
+
+// Look up + cast once — generic over the transport.
+fn talk<B: Broker>(broker: &B) -> rsbinder::Result<Strong<dyn IHello>> {
+    broker.get_interface("hello")
+}
+```
+
+Picking the transport is one line:
+
+```rust
+// Server
+let host = kernel::Host::new()?;            // kernel binder (process-global)
+// let host = rpc::Host::unix("/tmp/x.sock")?;  // RPC over a Unix socket
+register_all(&host, BnHello::new_binder(MyService).as_binder())?;
+host.serve()?;                              // see "serve()" below
+
+// Client
+let broker = kernel::Broker::new()?;        // or rpc::Broker::unix("/tmp/x.sock")?
+let hello = talk(&broker)?;
+hello.echo("hi")?;
+```
+
+### Why typed pairs, not one `Endpoint` enum
+
+`serve()` means different things per transport, the kernel host is a
+process-global singleton while an RPC host is a real instance, and the
+construction options don't overlap. Keeping them as distinct types makes a
+wrong-transport option a **compile error** rather than a silent no-op, and
+keeps the singleton nature of the kernel side honest.
+
+- **`kernel::Host::new()`** is a process-global, idempotent handle over
+  `ProcessState`. **`kernel::Host::serve()`** joins the **process-wide**
+  binder thread pool (blocks). A second host in the same process reuses the
+  existing `ProcessState`; a conflicting re-init (different driver /
+  max_threads) logs a warning rather than silently dropping the request.
+- **`rpc::Host::unix(path)`** binds one socket. **`rpc::Host::serve()`**
+  drives that one socket (and `serve_background()` returns a `JoinHandle`).
+
+Each host has a `builder()` for its own options — kernel: driver path,
+`max_threads`, call restriction; RPC: `max_threads`, `max_connections`,
+authorizer. RPC-only powers (TLS, fd modes, vsock, the connection
+counters) stay reachable via `host.server()`.
+
+## Security note
+
+Moving a service between transports changes its trust boundary. Before
+relying on the facade, read [Security & Authorization](./security.md):
+`@EnforcePermission` denies over RPC, and `get_calling_uid()` is the
+kernel-vouched peer uid on Unix RPC (fail-closed on uid-less transports).
+The facade makes the transport swap easy; it does **not** make the security
+models the same.
+
+## Worked example
+
+`example-hello` ships `bin/unified_service.rs` / `bin/unified_client.rs`:
+identical service, registration, and call code with the transport chosen by
+one `kernel::Host::new()` vs `rpc::Host::unix(path)` line.
+
+```text
+cargo run -p example-hello --features rpc --bin unified_service rpc
+cargo run -p example-hello --features rpc --bin unified_client rpc
+```

--- a/book/src/rpc-transport.md
+++ b/book/src/rpc-transport.md
@@ -159,9 +159,15 @@ let echo: Strong<dyn IEcho> =
     <dyn IEcho  as FromIBinder>::try_from(session.get_service("echo")?)?;
 ```
 
+`add_service` is O(1) per call: the directory is built once and shares
+the server's service map, so later registrations — even after the server
+is already serving — are seen through the same root with no rebuild.
 Mixing `set_root` with `add_service` on the same server is **not**
-supported — `add_service` rebuilds the root each call to keep the set
-consistent. Pick one publishing model per server.
+supported (the last one installed wins); pick one publishing model per
+server.
+
+> For registering and looking up services with the *same* code over
+> kernel binder or RPC, see [Cross-Transport Services](./cross-transport-services.md).
 
 ## Wire-protocol profiles
 
@@ -254,8 +260,12 @@ your own `Cargo.toml`.
 ## Security
 
 > **RPC is not a drop-in for kernel binder's security model.** Kernel
-> binder gives you `getCallingUid()` and SELinux for free. RPC does
-> not.
+> binder gives you a kernel-vouched uid/pid and SELinux for free; RPC's
+> trust boundary is the transport itself. This section covers the RPC
+> trust boundaries; for the full handler-side authorization story across
+> both transports — `calling_caller()`, `@EnforcePermission` over RPC,
+> uid ACLs, `PermissionAuthority` — see
+> [Security & Authorization](./security.md).
 
 Each transport defines its own trust boundary, surfaced as a
 [`PeerIdentity`](https://docs.rs/rsbinder/latest/rsbinder/rpc/enum.PeerIdentity.html):
@@ -282,6 +292,15 @@ server.set_authorizer(|peer| {
 A rejected peer's socket is closed; its next operation sees
 `DeadObject`. The hook is opt-in — without it, every connection is
 accepted (matching the prior behaviour).
+
+`set_authorizer` is **connection-level** (decided once, at handshake) —
+the right granularity for vsock and TLS, which carry no per-call uid. For
+**per-method** authorization, a handler can also read the caller directly:
+over a Unix-domain RPC connection `rsbinder::get_calling_uid()` returns the
+kernel-vouched peer uid (and `calling_caller()` the full transport-tagged
+identity), exactly as on kernel binder — so a uid ACL written once runs on
+both. Over a uid-less transport `get_calling_uid()` is the fail-closed
+`u32::MAX` sentinel. See [Security & Authorization](./security.md).
 
 ## Capabilities
 

--- a/book/src/security.md
+++ b/book/src/security.md
@@ -1,0 +1,213 @@
+# Security & Authorization
+
+A service handler often needs to answer "**who** is calling, and are they
+allowed to?" rsbinder gives you the caller's identity and several ways to
+authorize — but the right tool **differs by transport**, and that
+difference is deliberately made explicit rather than hidden.
+
+> **Core principle.** Kernel binder and RPC have genuinely different trust
+> boundaries. Kernel binder gives you a kernel-vouched uid/pid and SELinux
+> context; RPC's trust boundary is the transport itself (Unix peer
+> credentials, a TLS certificate, or hypervisor VM isolation). rsbinder
+> never papers over this: an authorization check that is safe on kernel
+> binder either keeps working, fails closed, or is denied over RPC — never
+> silently weakened.
+
+## Caller identity inside a handler
+
+The calling context is **ambient thread-local state**, set by the dispatch
+machinery just before your handler runs and cleared just after (this
+mirrors AOSP's `IPCThreadState`). So inside a `transact` handler you read
+it with no parameter threading:
+
+```rust
+use rsbinder::{Caller, ExceptionCode, Status};
+
+impl IExample for MyService {
+    fn do_thing(&self, arg: i32) -> rsbinder::status::Result<()> {
+        let uid = rsbinder::get_calling_uid();   // who is calling, right now
+        // ... authorize, then act ...
+        Ok(())
+    }
+}
+```
+
+The accessors (all `rsbinder::…`):
+
+| Accessor | Returns | Works over |
+|---|---|---|
+| `get_calling_uid()` | caller effective uid | kernel binder, **Unix RPC** |
+| `get_calling_pid()` | caller pid | kernel binder, **Unix RPC** |
+| `get_calling_sid()` | SELinux context (`Option<CString>`) | kernel binder only (RPC → `None`) |
+| `is_handling_transaction()` | `bool` | kernel binder, RPC |
+| `calling_caller()` | `Option<Caller>` (transport-tagged) | kernel binder, RPC |
+
+These are only meaningful **inside a handler, on the dispatching thread**.
+Outside a transaction they return `0` / `None`. If you spawn a new thread
+inside a handler, that thread has no calling context (it reads `0`) — just
+like AOSP.
+
+### Fail-closed values, never fabricated ones
+
+`get_calling_uid()` returns a real uid only where the transport carries
+one — kernel binder, and Unix-domain RPC (`SO_PEERCRED` on Linux/Android,
+`getpeereid` on macOS/BSD). Over a transport with **no** uid (vsock, TLS
+certificate, anonymous) it returns the **sentinel `u32::MAX`**, which is
+never `0` (root) and never a real privileged uid:
+
+```rust
+// Over vsock / TLS / anonymous, get_calling_uid() == u32::MAX:
+if rsbinder::get_calling_uid() == 0 {      // u32::MAX != 0  ⇒ never matches
+    // ... "allow root" ...                // so a uid-less peer can't slip through
+}
+if rsbinder::get_calling_uid() != AID_SYSTEM {
+    return Err(Status::from(ExceptionCode::Security));  // uid-less peer ⇒ denied
+}
+```
+
+This is intentional: fabricating a uid (say `0`) for a transport that
+doesn't have one would be a privilege-escalation hole. **uid ACLs simply
+fail closed over uid-less transports** — use a transport-appropriate check
+there instead (see below).
+
+## The transport-tagged caller
+
+For anything beyond a plain uid check, match on
+[`Caller`](https://docs.rs/rsbinder/latest/rsbinder/enum.Caller.html), which
+tags the identity by transport so you authorize **explicitly**:
+
+```rust
+use rsbinder::{Caller, ExceptionCode, Status};
+use rsbinder::rpc::PeerIdentity;
+
+fn authorize() -> rsbinder::status::Result<()> {
+    match rsbinder::calling_caller() {
+        // Kernel binder: Android permission, uid, or SELinux `sid`.
+        Some(Caller::Kernel { uid, .. }) if uid == 1000 => Ok(()),
+        // Unix RPC: kernel-vouched peer uid.
+        Some(Caller::Rpc(PeerIdentity::Local { uid, .. })) if uid == 1000 => Ok(()),
+        // TLS RPC: certificate subject allowlist.
+        Some(Caller::Rpc(PeerIdentity::Certificate(cert)))
+            if cert.subject() == "CN=trusted-client" => Ok(()),
+        // vsock cid, anonymous, no transaction, or a future variant:
+        // fail closed.
+        _ => Err(Status::from(ExceptionCode::Security)),
+    }
+}
+```
+
+`Caller` and `PeerIdentity` are `#[non_exhaustive]`, so the compiler forces
+a catch-all arm — which nudges you toward a fail-closed default.
+
+## Four ways to authorize
+
+| When | Use |
+|---|---|
+| uid check, common to kernel + Unix RPC | `get_calling_uid()` |
+| different rule per transport (uid / cert / cid / sid) | `match calling_caller()` |
+| Android permission on a kernel service | `@EnforcePermission(...)` (declarative) |
+| one policy across many methods / introducing RPC authz | `PermissionAuthority` (injected) |
+
+### `@EnforcePermission` (declarative, kernel-only)
+
+Annotate the AIDL method and the generated code checks Android's
+`PermissionManagerService` before your handler runs — no authorization
+code in the body:
+
+```aidl
+interface IExample {
+    @EnforcePermission("android.permission.INTERNET")
+    void doNetworking();
+}
+```
+
+**Over RPC this method is denied** (returns `EX_SECURITY`), unconditionally
+and regardless of process shape. Android permissions are a kernel-binder
+concept; the RPC dispatch path has no PMS-backed uid, so granting would
+mean granting *root* to any anonymous peer. rsbinder fails closed instead.
+For RPC authorization use the transport-native means above.
+
+### `PermissionAuthority` (injected, cross-transport policy)
+
+To back every `@EnforcePermission` check with one centralized,
+transport-aware policy — for example to *introduce* authorization over RPC
+that the default denies — install a
+[`PermissionAuthority`](https://docs.rs/rsbinder/latest/rsbinder/permission_controller/trait.PermissionAuthority.html)
+at startup:
+
+```rust
+use rsbinder::Caller;
+use rsbinder::permission_controller::{PermissionAuthority, set_permission_authority};
+use rsbinder::rpc::PeerIdentity;
+use std::sync::Arc;
+
+struct MyPolicy;
+impl PermissionAuthority for MyPolicy {
+    fn check(&self, permission: &str, caller: &Caller) -> bool {
+        match caller {
+            Caller::Rpc(PeerIdentity::Local { uid, .. }) => *uid == 1000,
+            Caller::Rpc(PeerIdentity::Certificate(c)) => c.subject() == "CN=admin",
+            _ => false,   // fail closed
+        }
+    }
+}
+
+set_permission_authority(Arc::new(MyPolicy));
+```
+
+When installed, the authority **owns the whole decision** for every
+generated `check_permission` call, on every transport, receiving the
+transport-tagged `Caller`. With **no** authority installed, the default is
+unchanged: kernel → PMS, RPC → deny.
+
+> The core crate ships only this *slot*, never a policy. Token/JWT formats,
+> certificate→permission tables, and uid→permission maps are deployment
+> concerns. **Caveat:** an installed authority also replaces the kernel PMS
+> path — if you want "kernel = PMS, RPC = custom", handle the
+> `Caller::Kernel` arm explicitly (most deployments that inject an authority
+> are pure-RPC, where that arm never fires).
+
+### Connection-level authorization (RPC)
+
+For RPC, the most natural granularity is often the **whole connection**,
+decided at handshake before any transaction — this is the right tool for
+vsock and TLS, which carry no per-call uid. Use
+[`RpcServer::set_authorizer`](https://docs.rs/rsbinder/latest/rsbinder/rpc/struct.RpcServer.html#method.set_authorizer):
+
+```rust
+server.set_authorizer(|peer| match peer {
+    rsbinder::rpc::PeerIdentity::Certificate(cert) => cert.subject() == "CN=trusted",
+    rsbinder::rpc::PeerIdentity::Vsock { cid } => *cid == TRUSTED_VM_CID,
+    _ => false,
+});
+```
+
+A rejected peer's socket is closed before any RPC byte is exchanged.
+
+## Worked example
+
+`example-hello` ships a runnable handler-authorization demo —
+`bin/authz_service.rs` / `bin/authz_client.rs`:
+
+```text
+cargo run -p example-hello --features rpc --bin authz_service
+cargo run -p example-hello --features rpc --bin authz_client
+# whoami    -> OK: unix-rpc caller uid=1000 pid=12345
+# adminOnly -> DENIED (Security)
+```
+
+`whoami()` authorizes any identifiable local caller and reports it;
+`adminOnly()` requires uid 0 and denies a normal user — demonstrating both
+the allow and the fail-closed deny path.
+
+## Summary
+
+- Read the caller with `get_calling_uid/pid/sid` and `calling_caller()` —
+  ambient thread-local state, valid only inside a handler.
+- uid ACLs work on kernel binder and Unix RPC, and **fail closed**
+  (`u32::MAX` sentinel) on uid-less transports.
+- `@EnforcePermission` is kernel-only and **denies over RPC**.
+- Use `match calling_caller()` for transport-aware rules, `set_authorizer`
+  for connection-level RPC policy, and `PermissionAuthority` to centralize.
+- The default everywhere is fail-closed; weakening a boundary is always an
+  explicit, opt-in choice.

--- a/example-hello/Cargo.toml
+++ b/example-hello/Cargo.toml
@@ -40,6 +40,19 @@ required-features = ["rpc"]
 name = "unified_client"
 required-features = ["rpc"]
 
+# Plan 2-16 handler-side authorization example: the service impl authorizes
+# each call via `rsbinder::calling_caller()` and denies with EX_SECURITY.
+# Uses `rsbinder::Caller` / `rpc::PeerIdentity`, so gated on the `rpc` feature.
+#   cargo run -p example-hello --features rpc --bin authz_service
+#   cargo run -p example-hello --features rpc --bin authz_client
+[[bin]]
+name = "authz_service"
+required-features = ["rpc"]
+
+[[bin]]
+name = "authz_client"
+required-features = ["rpc"]
+
 # Subplan 2-13 D.8 STAGE3 — rsbinder side of the IAccessor bridge
 # real-libbinder interop. Cross-compile with
 #   cargo ndk -t arm64-v8a -p 36 build -p example-hello \

--- a/example-hello/Cargo.toml
+++ b/example-hello/Cargo.toml
@@ -27,6 +27,19 @@ required-features = ["rpc"]
 name = "rpc_hello_client"
 required-features = ["rpc"]
 
+# Plan 2-16 Phase D — the cross-transport facade example: identical
+# service/registration/call code, kernel vs RPC chosen by one line. Uses
+# `rsbinder::service::rpc`, so it is gated on the `rpc` feature.
+#   cargo run -p example-hello --features rpc --bin unified_service rpc
+#   cargo run -p example-hello --features rpc --bin unified_client rpc
+[[bin]]
+name = "unified_service"
+required-features = ["rpc"]
+
+[[bin]]
+name = "unified_client"
+required-features = ["rpc"]
+
 # Subplan 2-13 D.8 STAGE3 — rsbinder side of the IAccessor bridge
 # real-libbinder interop. Cross-compile with
 #   cargo ndk -t arm64-v8a -p 36 build -p example-hello \

--- a/example-hello/aidl/authz/IAuthz.aidl
+++ b/example-hello/aidl/authz/IAuthz.aidl
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Plan 2-16 handler-side authorization example. The service `impl`
+// authorizes each call by inspecting the transport-tagged caller
+// (`rsbinder::calling_caller()`), and denies with `EX_SECURITY`. The same
+// `impl` runs over kernel binder and RPC; see `bin/authz_service.rs`.
+
+package authz;
+
+interface IAuthz {
+    /**
+     * Allowed for any *identifiable local* caller (kernel binder, or a
+     * Unix-domain RPC peer whose uid the kernel vouches for). A uid-less
+     * RPC transport (vsock / TLS certificate / anonymous) is fail-closed.
+     * Returns a human-readable description of the observed caller.
+     */
+    String whoami();
+
+    /**
+     * Requires the caller to be root (uid 0). A normal caller is denied
+     * with `EX_SECURITY` — this demonstrates the deny path. (uid is the
+     * kernel sender uid, or the Unix-RPC peer uid; never the fail-closed
+     * sentinel, which is not 0.)
+     */
+    String adminOnly();
+}

--- a/example-hello/build.rs
+++ b/example-hello/build.rs
@@ -24,4 +24,6 @@ fn main() {
     aidl("aidl/update_txn/IUpdateTxnDedup.aidl", "update_txn.rs");
     // RT inheritance fixture.
     aidl("aidl/rt_inherit/IRtCheck.aidl", "rt_inherit.rs");
+    // Plan 2-16 handler-side authorization example interface.
+    aidl("aidl/authz/IAuthz.aidl", "authz.rs");
 }

--- a/example-hello/src/bin/authz_client.rs
+++ b/example-hello/src/bin/authz_client.rs
@@ -1,0 +1,39 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Client for `authz_service` (Plan 2-16 handler-side authorization).
+//!
+//! Calls both methods and prints the outcome: `whoami()` is authorized
+//! (the handler reports this connection's uid), while `adminOnly()` is
+//! denied with `EX_SECURITY` for a normal (non-root) user.
+//!
+//! ```text
+//! cargo run -p example-hello --features rpc --bin authz_service
+//! cargo run -p example-hello --features rpc --bin authz_client
+//! ```
+
+use env_logger::Env;
+use example_hello::authz::*;
+use rsbinder::rpc::RpcSession;
+use rsbinder::{FromIBinder, Strong};
+
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
+
+    let session = RpcSession::setup_unix_client(RPC_SOCKET)?;
+    let authz: Strong<dyn IAuthz> = FromIBinder::try_from(session.get_root()?)?;
+
+    // Allowed: an identifiable Unix-RPC peer (this process).
+    match authz.whoami() {
+        Ok(who) => println!("whoami    -> OK: {who}"),
+        Err(e) => println!("whoami    -> DENIED ({:?})", e.exception_code()),
+    }
+
+    // Denied: requires uid 0, and we are not root.
+    match authz.adminOnly() {
+        Ok(msg) => println!("adminOnly -> OK: {msg}"),
+        Err(e) => println!("adminOnly -> DENIED ({:?})", e.exception_code()),
+    }
+
+    Ok(())
+}

--- a/example-hello/src/bin/authz_service.rs
+++ b/example-hello/src/bin/authz_service.rs
@@ -1,0 +1,89 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Plan 2-16 — **handler-side authorization** over RPC.
+//!
+//! The service `impl` authorizes each call by inspecting the
+//! transport-tagged caller ([`rsbinder::calling_caller`]) and denies with
+//! `EX_SECURITY`. This is the explicit, transport-aware approach: the
+//! kernel and RPC trust boundaries differ, so the handler `match`es on the
+//! [`Caller`] arm and applies the right rule. Run with `authz_client`:
+//!
+//! ```text
+//! cargo run -p example-hello --features rpc --bin authz_service
+//! cargo run -p example-hello --features rpc --bin authz_client
+//! ```
+//!
+//! Over a Unix-domain socket the peer uid is the connecting process's
+//! (kernel-vouched via `SO_PEERCRED`), so `whoami()` is authorized and
+//! reports it, while `adminOnly()` (requires uid 0) is denied for a normal
+//! user — demonstrating both the allow and deny paths.
+//!
+//! ## Other ways to authorize (not shown here)
+//!
+//! - **Declarative, kernel-only:** annotate the AIDL method with
+//!   `@EnforcePermission("android.permission.X")` — generated code checks
+//!   `PermissionManagerService`; over RPC it auto-denies (Plan 2-16 Phase A).
+//! - **Centralized policy:** install a
+//!   [`rsbinder::permission_controller::PermissionAuthority`] via
+//!   `set_permission_authority` to back every `@EnforcePermission` check
+//!   with one injected, transport-aware policy.
+//! - **Connection-level (RPC):** `RpcServer::set_authorizer(|peer| …)`
+//!   admits/refuses a whole connection at handshake — the right
+//!   granularity for vsock/TLS, which carry no uid.
+
+use env_logger::Env;
+use example_hello::authz::*;
+use rsbinder::rpc::{PeerIdentity, RpcServer};
+use rsbinder::{Caller, ExceptionCode, Interface, Status};
+
+struct AuthzService;
+impl Interface for AuthzService {}
+
+impl IAuthz for AuthzService {
+    fn whoami(&self) -> rsbinder::status::Result<String> {
+        // Authorize: only an *identifiable local* caller is allowed. A
+        // uid-less RPC transport (vsock / TLS cert / anonymous) or no
+        // in-flight transaction falls through to a fail-closed deny.
+        match rsbinder::calling_caller() {
+            Some(Caller::Kernel { uid, pid, .. }) => {
+                Ok(format!("kernel caller uid={uid} pid={pid}"))
+            }
+            Some(Caller::Rpc(PeerIdentity::Local { uid, pid })) => {
+                Ok(format!("unix-rpc caller uid={uid} pid={pid}"))
+            }
+            other => {
+                // `Caller`/`PeerIdentity` are `#[non_exhaustive]`: vsock,
+                // certificate, anonymous, and "no caller" all land here.
+                eprintln!("authz_service: denying unidentifiable caller: {other:?}");
+                Err(Status::from(ExceptionCode::Security))
+            }
+        }
+    }
+
+    fn adminOnly(&self) -> rsbinder::status::Result<String> {
+        // `get_calling_uid()` is the kernel sender uid or the Unix-RPC peer
+        // uid; a uid-less transport returns the `u32::MAX` sentinel (never
+        // 0), so this comparison fail-closes there too — no root bypass.
+        if rsbinder::get_calling_uid() == 0 {
+            Ok("admin action performed".to_string())
+        } else {
+            Err(Status::from(ExceptionCode::Security))
+        }
+    }
+}
+
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
+
+    // The same `AuthzService` impl would also work over kernel binder
+    // (`ProcessState` + `hub::add_service`); served here over RPC so the
+    // transport-aware authorization is demonstrable without `/dev/binder`.
+    let _ = std::fs::remove_file(RPC_SOCKET);
+    let server = RpcServer::setup_unix_server(RPC_SOCKET)?;
+    server.set_root(BnAuthz::new_binder(AuthzService).as_binder());
+
+    println!("authz_service listening on {RPC_SOCKET}");
+    server.run()?;
+    Ok(())
+}

--- a/example-hello/src/bin/unified_client.rs
+++ b/example-hello/src/bin/unified_client.rs
@@ -1,0 +1,48 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Plan 2-16 Phase D — the client counterpart of `unified_service`.
+//!
+//! The `talk<B: Broker>` helper (look up + cast + call) is
+//! transport-agnostic; only the broker constructor differs:
+//!
+//! ```text
+//! cargo run -p example-hello --features rpc --bin unified_client kernel
+//! cargo run -p example-hello --features rpc --bin unified_client rpc
+//! ```
+
+use env_logger::Env;
+use example_hello::*;
+use rsbinder::service::{kernel, rpc, Broker};
+use rsbinder::*;
+
+const RPC_SOCKET: &str = "/tmp/rsb_unified.sock";
+
+/// Transport-agnostic lookup + call — written once, generic over the
+/// [`Broker`] trait. `get_interface` is the `interface_cast` step.
+fn talk<B: Broker>(broker: &B) -> rsbinder::Result<()> {
+    let hello: Strong<dyn IHello> = broker.get_interface(SERVICE_NAME)?;
+    let reply = hello.echo("hello over the facade")?;
+    println!("unified_client: echo -> {reply:?}");
+    Ok(())
+}
+
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
+
+    match std::env::args().nth(1).as_deref() {
+        Some("kernel") => {
+            let broker = kernel::Broker::new()?;
+            talk(&broker)?;
+        }
+        Some("rpc") => {
+            let broker = rpc::Broker::unix(RPC_SOCKET)?;
+            talk(&broker)?;
+        }
+        _ => {
+            eprintln!("usage: unified_client <kernel|rpc>");
+            std::process::exit(2);
+        }
+    }
+    Ok(())
+}

--- a/example-hello/src/bin/unified_service.rs
+++ b/example-hello/src/bin/unified_service.rs
@@ -1,0 +1,67 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Plan 2-16 Phase D — the **same** service, registration, and serve code
+//! over kernel binder *or* RPC, chosen by one line.
+//!
+//! The `IHello` impl, the `register<R: Registry>` helper, and the call to
+//! it are transport-agnostic. Only the host constructor differs:
+//!
+//! ```text
+//! # kernel binder (needs /dev/binder + a running service manager, e.g. rsb_hub)
+//! cargo run -p example-hello --features rpc --bin unified_service kernel
+//! # RPC over a Unix-domain socket (no kernel binder, no service manager)
+//! cargo run -p example-hello --features rpc --bin unified_service rpc
+//! ```
+//!
+//! Pair with `unified_client` using the matching transport argument.
+
+use env_logger::Env;
+use example_hello::*;
+use rsbinder::service::{kernel, rpc, Registry};
+use rsbinder::*;
+
+const RPC_SOCKET: &str = "/tmp/rsb_unified.sock";
+
+struct IHelloService;
+impl Interface for IHelloService {}
+impl IHello for IHelloService {
+    fn echo(&self, echo: &str) -> rsbinder::status::Result<String> {
+        println!("unified_service: echo({echo:?})");
+        Ok(echo.to_owned())
+    }
+}
+
+/// Transport-agnostic registration — written once, generic over the
+/// [`Registry`] trait. Identical for kernel binder and RPC.
+fn register<R: Registry>(reg: &R) -> rsbinder::Result<()> {
+    let binder = BnHello::new_binder(IHelloService {}).as_binder();
+    reg.add_service(SERVICE_NAME, binder)
+}
+
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
+
+    match std::env::args().nth(1).as_deref() {
+        Some("kernel") => {
+            // One line picks kernel binder. `serve()` joins the
+            // process-wide thread pool.
+            let host = kernel::Host::new()?;
+            register(&host)?;
+            println!("unified_service: serving {SERVICE_NAME} over kernel binder");
+            host.serve()?;
+        }
+        Some("rpc") => {
+            // One line picks RPC. `serve()` drives this one socket.
+            let host = rpc::Host::unix(RPC_SOCKET)?;
+            register(&host)?;
+            println!("unified_service: serving {SERVICE_NAME} over RPC at {RPC_SOCKET}");
+            host.serve()?;
+        }
+        _ => {
+            eprintln!("usage: unified_service <kernel|rpc>");
+            std::process::exit(2);
+        }
+    }
+    Ok(())
+}

--- a/example-hello/src/lib.rs
+++ b/example-hello/src/lib.rs
@@ -48,3 +48,12 @@ pub mod rt_inherit {
     pub use self::rt_inherit::IRtCheck::*;
     pub const SERVICE_NAME: &str = "rsbinder.test.rt_inherit";
 }
+
+/// Plan 2-16 handler-side authorization example (`bin/authz_{service,client}`).
+pub mod authz {
+    include!(concat!(env!("OUT_DIR"), "/authz.rs"));
+    pub use self::authz::IAuthz::*;
+    pub const SERVICE_NAME: &str = "example.authz";
+    /// Unix-domain socket the example service binds and client connects to.
+    pub const RPC_SOCKET: &str = "/tmp/rsb_authz.sock";
+}

--- a/rsbinder-aidl/src/generator.rs
+++ b/rsbinder-aidl/src/generator.rs
@@ -719,9 +719,14 @@ fn render_enforce_permission_check(
     // everywhere else (`crate::` for AIDL compiled inside the rsbinder crate
     // via `set_crate_support(true)`, `rsbinder::` otherwise) — a hardcoded
     // `rsbinder::` would not resolve for internally-compiled AIDL.
+    // Pass the inbound `_reader` parcel so the runtime can fail-closed when
+    // the transaction arrived over RPC (Plan 2-16 Phase A): `@EnforcePermission`
+    // is kernel-only and must deny over RPC instead of silently granting
+    // (uid 0 on the RPC path reads as root, which PMS unconditionally grants).
+    // `_reader` is in scope at the `on_transact` arm where this renders.
     let call = |p: &str| {
         format!(
-            "{crate_name}::permission_controller::check_permission(\"{}\")",
+            "{crate_name}::permission_controller::check_permission(_reader, \"{}\")",
             lit(p)
         )
     };

--- a/rsbinder-aidl/tests/test_enforce_permission.rs
+++ b/rsbinder-aidl/tests/test_enforce_permission.rs
@@ -62,7 +62,7 @@ interface IFoo {
         "#,
     );
     let arm = arm_for("doNet", &out);
-    let needle = "rsbinder::permission_controller::check_permission(\"INTERNET\")";
+    let needle = "rsbinder::permission_controller::check_permission(_reader, \"INTERNET\")";
     assert!(
         arm.contains(needle),
         "missing single check `{needle}` in arm:\n{arm}"
@@ -87,7 +87,10 @@ interface IFoo {
         "#,
     );
     let arm = arm_for("doNet", &out);
-    assert!(arm.contains("check_permission(\"INTERNET\")"), "{arm}");
+    assert!(
+        arm.contains("check_permission(_reader, \"INTERNET\")"),
+        "{arm}"
+    );
     // Must NOT contain `&&` or `||` for the single form.
     assert!(
         !arm.contains(" && "),
@@ -107,9 +110,12 @@ interface IFoo {
         "#,
     );
     let arm = arm_for("doNetAndState", &out);
-    assert!(arm.contains("check_permission(\"INTERNET\")"), "{arm}");
     assert!(
-        arm.contains("check_permission(\"ACCESS_NETWORK_STATE\")"),
+        arm.contains("check_permission(_reader, \"INTERNET\")"),
+        "{arm}"
+    );
+    assert!(
+        arm.contains("check_permission(_reader, \"ACCESS_NETWORK_STATE\")"),
         "{arm}"
     );
     // The `&&` is the documented AOSP short-circuit shape.
@@ -129,9 +135,12 @@ interface IFoo {
         "#,
     );
     let arm = arm_for("doBluetooth", &out);
-    assert!(arm.contains("check_permission(\"BLUETOOTH\")"), "{arm}");
     assert!(
-        arm.contains("check_permission(\"BLUETOOTH_ADMIN\")"),
+        arm.contains("check_permission(_reader, \"BLUETOOTH\")"),
+        "{arm}"
+    );
+    assert!(
+        arm.contains("check_permission(_reader, \"BLUETOOTH_ADMIN\")"),
         "{arm}"
     );
     assert!(arm.contains(" || "), "AnyOf must join with `||`:\n{arm}");
@@ -157,7 +166,7 @@ interface IFoo {
     );
     let arm = arm_for("doNet", &out);
     let check_pos = arm
-        .find("check_permission(\"INTERNET\")")
+        .find("check_permission(_reader, \"INTERNET\")")
         .expect("check_permission must be emitted");
     let read_pos = arm.find("_reader.read");
     if let Some(read_pos) = read_pos {
@@ -300,7 +309,7 @@ interface IMixed {
     let arm_net = arm_for("doNet", &out);
     let arm_echo = arm_for("echo", &out);
     assert!(
-        arm_net.contains("check_permission(\"INTERNET\")"),
+        arm_net.contains("check_permission(_reader, \"INTERNET\")"),
         "{arm_net}"
     );
     assert!(

--- a/rsbinder-aidl/tests/test_enforce_permission.rs
+++ b/rsbinder-aidl/tests/test_enforce_permission.rs
@@ -23,6 +23,13 @@ fn generate(input: &str) -> String {
     gen.document(&document).expect("generate").1
 }
 
+fn generate_async(input: &str) -> String {
+    let ctx = rsbinder_aidl::SourceContext::new("test.aidl", input);
+    let document = rsbinder_aidl::parse_document(&ctx).expect("parse");
+    let gen = rsbinder_aidl::Generator::new(true, false); // enabled_async = true
+    gen.document(&document).expect("generate").1
+}
+
 fn arm_for(method_id: &str, generated: &str) -> String {
     // Extract from `transactions::r#<method> => {` up to the matching
     // `}` brace of the arm. The arms are emitted single-level inside a
@@ -315,5 +322,49 @@ interface IMixed {
     assert!(
         !arm_echo.contains("check_permission"),
         "echo arm should not contain check_permission:\n{arm_echo}"
+    );
+}
+
+#[test]
+fn enforce_permission_emitted_for_async_service() {
+    // The async service stub dispatches through the *same* generated
+    // `on_transact` (the `Bn*Adapter` calls `on_transact(self.as_sync(), …)`),
+    // so an `@EnforcePermission` method served by an *async* impl must still
+    // be checked before the handler runs. This guards against a regression
+    // where the deny would be emitted only on the sync path — an async
+    // service would otherwise silently skip authorization.
+    let input = r#"
+package test;
+interface IFoo {
+    @EnforcePermission("INTERNET")
+    void doNet(in String url);
+}
+        "#;
+    let out = generate_async(input);
+    let arm = arm_for("doNet", &out);
+    assert!(
+        arm.contains("check_permission(_reader, \"INTERNET\")"),
+        "async-enabled codegen must still emit the deny in on_transact:\n{arm}"
+    );
+    assert!(
+        arm.contains("rsbinder::ExceptionCode::Security"),
+        "async deny branch missing:\n{arm}"
+    );
+    // And it must precede argument deserialization, same as sync.
+    let check_pos = arm
+        .find("check_permission(_reader,")
+        .expect("check present");
+    if let Some(read_pos) = arm.find("_reader.read") {
+        assert!(
+            check_pos < read_pos,
+            "check must precede arg deserialization in async codegen:\n{arm}"
+        );
+    }
+
+    // Sanity: the async path is actually generated (so this isn't silently
+    // testing the sync output).
+    assert!(
+        out.contains("AsyncService"),
+        "expected async service stub in async-enabled generation"
     );
 }

--- a/rsbinder/src/lib.rs
+++ b/rsbinder/src/lib.rs
@@ -237,10 +237,10 @@ pub use native::{is_handling_transaction, Binder, BinderFeatures};
 // `IPCThreadState::getCalling*`). Kernel-path only; the RPC stack has
 // its own `PeerIdentity` model under `rpc::PeerIdentity`.
 pub use thread_state::{
-    clear_calling_identity, get_calling_pid, get_calling_sid, get_calling_uid,
+    calling_caller, clear_calling_identity, get_calling_pid, get_calling_sid, get_calling_uid,
     get_current_scheduler_policy, get_extended_error, get_strict_mode_policy,
-    has_explicit_identity, restore_calling_identity, set_strict_mode_policy, CallingContext,
-    ExtendedError,
+    has_explicit_identity, restore_calling_identity, set_strict_mode_policy, Caller,
+    CallingContext, ExtendedError,
 };
 
 pub use parcel::Parcel;

--- a/rsbinder/src/lib.rs
+++ b/rsbinder/src/lib.rs
@@ -195,9 +195,14 @@ pub mod hub;
 /// (`android.os.IPermissionController`). See module doc for the
 /// AOSP-faithful surface and fail-closed `check_permission` helper.
 pub mod permission_controller;
+
 /// Async runtime implementations
 #[cfg(feature = "async")]
 mod rt;
+/// Cross-transport service facade (Plan 2-16 Phase D): register/look up
+/// services once, choosing kernel binder or RPC by construction. Additive
+/// layer over `ProcessState`/`hub`/`RpcServer`/`RpcSession`.
+pub mod service;
 
 // Explicit re-exports: glob re-exports would silently leak every
 // newly-added `pub` item in these modules, defeating semver review.

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -499,6 +499,17 @@ impl Parcel {
         self.rpc.is_some()
     }
 
+    /// `false` always — without the `rpc` feature there is no RPC
+    /// serialization mode. This `cfg`-off arm exists so callers that
+    /// branch on transport (notably
+    /// [`crate::permission_controller::check_permission`], which denies
+    /// `@EnforcePermission` over RPC — Plan 2-16 Phase A) compile in any
+    /// feature configuration without a `cfg` of their own.
+    #[cfg(not(feature = "rpc"))]
+    pub fn is_for_rpc(&self) -> bool {
+        false
+    }
+
     /// Attach the RPC object-marshalling hooks and enter RPC mode
     /// (android `Parcel::markForRpc`/`mSession` equivalent).
     #[cfg(feature = "rpc")]

--- a/rsbinder/src/permission_controller.rs
+++ b/rsbinder/src/permission_controller.rs
@@ -34,7 +34,7 @@ pub use android::os::IPermissionController::{
 };
 
 use crate::error::Result;
-use crate::{hub, FromIBinder, Strong};
+use crate::{hub, FromIBinder, Parcel, Strong};
 
 /// Service name registered by Android's `PermissionManagerService`. Used
 /// as the key for [`crate::hub::get_service`].
@@ -62,13 +62,36 @@ pub fn default() -> Result<Strong<dyn IPermissionController>> {
 /// [`crate::get_calling_uid`] / [`crate::get_calling_pid`]) holds
 /// `permission_name`.
 ///
+/// This is the runtime backing the generated `@EnforcePermission` deny
+/// block; `reader` is the inbound transaction parcel held by
+/// `on_transact`, used to detect the transport (see *RPC fail-closed*).
+///
 /// Intended for server-side use inside a [`crate::Transactable::transact`]
 /// dispatch, mirroring AOSP `IPCThreadState::self()->getCallingUid()` +
 /// `IPermissionController::checkPermission(...)`.
 ///
+/// # RPC fail-closed (`@EnforcePermission` is kernel-only) — Plan 2-16 Phase A
+///
+/// `@EnforcePermission` has **no meaning over the RPC transport**: AOSP's
+/// RPC stack carries no uid/permission concept, and on the RPC dispatch
+/// path [`crate::get_calling_uid`] is not populated, so it would read `0`
+/// (= root) — and `PermissionManagerService` *unconditionally grants
+/// root*. That would turn every guarded method into a **silent grant to
+/// any anonymous RPC peer**. To prevent this, when `reader` is an RPC
+/// parcel ([`Parcel::is_for_rpc`]) this returns `false` **before any uid
+/// read or PMS lookup**, regardless of process shape, and emits a
+/// one-time `warn`. The deny is therefore independent of whether uid is
+/// later wired over Unix RPC (Plan 2-16 Phase B): `is_for_rpc()` stays
+/// `true` no matter what uid is populated.
+///
+/// RPC services needing authorization must use transport-native means
+/// (`PeerIdentity` + `RpcServer::set_authorizer`, or hand-rolled uid ACLs
+/// via [`crate::get_calling_uid`] over Unix RPC).
+///
 /// # Fail-closed semantics
 ///
 /// Returns `false` when:
+/// - The transaction arrived over RPC (see above).
 /// - The current thread is not handling a binder transaction
 ///   (`get_calling_uid()` / `get_calling_pid()` both `0`).
 /// - The `permission` service is unreachable (`system_server` absent or
@@ -78,7 +101,15 @@ pub fn default() -> Result<Strong<dyn IPermissionController>> {
 /// This matches AOSP's "if in doubt, deny" posture for missing
 /// PermissionManagerService — see Android `checkPermission` callers in
 /// `frameworks/native/services/` for the same pattern.
-pub fn check_permission(permission_name: &str) -> bool {
+pub fn check_permission(reader: &Parcel, permission_name: &str) -> bool {
+    // RPC fail-closed: deny before reading uid or reaching PMS — uid 0 on
+    // the RPC path would otherwise read as root and PMS grants root. The
+    // deny is transport-driven (the reader knows it is an RPC parcel), so
+    // it is independent of Plan 2-16 Phase B uid wiring.
+    if reader.is_for_rpc() {
+        warn_enforce_permission_over_rpc();
+        return false;
+    }
     let calling_pid = crate::get_calling_pid();
     let calling_uid = crate::get_calling_uid();
     let Ok(pc) = default() else {
@@ -86,6 +117,21 @@ pub fn check_permission(permission_name: &str) -> bool {
     };
     pc.checkPermission(permission_name, calling_pid as i32, calling_uid as i32)
         .unwrap_or(false)
+}
+
+/// One-time `warn` the first time an `@EnforcePermission` method is denied
+/// because it was dispatched over RPC. Per-process, not per-interface —
+/// the message states the general rule, not a specific permission.
+fn warn_enforce_permission_over_rpc() {
+    use std::sync::Once;
+    static WARNED: Once = Once::new();
+    WARNED.call_once(|| {
+        log::warn!(
+            "@EnforcePermission is unsupported over RPC and denies every \
+             guarded method (Plan 2-16 Phase A); use PeerIdentity / \
+             set_authorizer or uid ACLs for RPC authorization"
+        );
+    });
 }
 
 #[cfg(test)]
@@ -115,5 +161,26 @@ mod tests {
     #[test]
     fn test_service_name_matches_system_server_registration() {
         assert_eq!(SERVICE_NAME, "permission");
+    }
+
+    /// Plan 2-16 Phase A unit-level proof: `check_permission` denies for
+    /// an RPC parcel **before** consulting PMS. A kernel parcel falls
+    /// through to the PMS path (which returns `false` here only because
+    /// `system_server` is unreachable in this hermetic build) — the RPC
+    /// arm is the new transport gate this asserts.
+    #[cfg(feature = "rpc")]
+    #[test]
+    fn check_permission_denies_rpc_parcel() {
+        let mut rpc_parcel = Parcel::new();
+        rpc_parcel.set_for_rpc(true);
+        assert!(
+            !check_permission(&rpc_parcel, "android.permission.INTERNET"),
+            "RPC parcel must fail-closed regardless of uid/PMS"
+        );
+
+        // Sanity: a kernel parcel takes the non-RPC branch (it does not
+        // short-circuit on `is_for_rpc`).
+        let kernel_parcel = Parcel::new();
+        assert!(!kernel_parcel.is_for_rpc());
     }
 }

--- a/rsbinder/src/permission_controller.rs
+++ b/rsbinder/src/permission_controller.rs
@@ -33,12 +33,52 @@ pub use android::os::IPermissionController::{
     IPermissionControllerAsync, IPermissionControllerAsyncService,
 };
 
+use std::sync::{Arc, RwLock};
+
 use crate::error::Result;
-use crate::{hub, FromIBinder, Parcel, Strong};
+use crate::{hub, Caller, FromIBinder, Parcel, Strong};
 
 /// Service name registered by Android's `PermissionManagerService`. Used
 /// as the key for [`crate::hub::get_service`].
 pub const SERVICE_NAME: &str = "permission";
+
+/// An injectable, **transport-aware** authorization policy (Plan 2-16
+/// Phase C). When one is installed via [`set_permission_authority`], it
+/// **owns the whole decision** for every generated `@EnforcePermission`
+/// check ([`check_permission`]) — across kernel binder *and* RPC — and
+/// receives the transport-tagged [`Caller`] so it can apply the right rule
+/// per transport (Android permission for [`Caller::Kernel`]; a uid ACL,
+/// TLS-certificate allowlist, or token scope for [`Caller::Rpc`]).
+///
+/// The core crate ships only this **slot**, never a policy: token/JWT
+/// formats, certificate→permission tables, and uid→permission maps are
+/// deployment concerns. With **no** authority installed, [`check_permission`]
+/// keeps its safe default — kernel → `PermissionManagerService`, RPC →
+/// deny (Plan 2-16 Phase A).
+pub trait PermissionAuthority: Send + Sync {
+    /// Return `true` to grant `permission` to `caller`. Implementations
+    /// should fail closed for callers/transports they do not recognize.
+    fn check(&self, permission: &str, caller: &Caller) -> bool;
+}
+
+/// Process-wide injected authority. `None` ⇒ the built-in default
+/// ([`check_permission`] kernel-PMS / RPC-deny). Deployment policy, set
+/// once at startup; a `RwLock` (not `OnceLock`) so tests and dynamic
+/// reconfiguration can replace or [`clear_permission_authority`] it.
+static AUTHORITY: RwLock<Option<Arc<dyn PermissionAuthority>>> = RwLock::new(None);
+
+/// Install the process-wide [`PermissionAuthority`]; subsequent
+/// [`check_permission`] calls delegate the whole decision to it. Replaces
+/// any previously installed authority.
+pub fn set_permission_authority(authority: Arc<dyn PermissionAuthority>) {
+    *AUTHORITY.write().expect("permission authority poisoned") = Some(authority);
+}
+
+/// Remove any installed [`PermissionAuthority`], restoring the built-in
+/// default (kernel → PMS, RPC → deny).
+pub fn clear_permission_authority() {
+    *AUTHORITY.write().expect("permission authority poisoned") = None;
+}
 
 /// Acquire a `BpPermissionController` proxy for the system-wide
 /// `permission` service, mirroring AOSP
@@ -101,11 +141,33 @@ pub fn default() -> Result<Strong<dyn IPermissionController>> {
 /// This matches AOSP's "if in doubt, deny" posture for missing
 /// PermissionManagerService — see Android `checkPermission` callers in
 /// `frameworks/native/services/` for the same pattern.
+///
+/// # Injected authority (Plan 2-16 Phase C)
+///
+/// If a [`PermissionAuthority`] is installed via
+/// [`set_permission_authority`], it **replaces** the default decision for
+/// every transport and receives the transport-tagged [`Caller`]. With no
+/// authority installed (the default), the kernel→PMS / RPC→deny behavior
+/// below applies unchanged.
 pub fn check_permission(reader: &Parcel, permission_name: &str) -> bool {
-    // RPC fail-closed: deny before reading uid or reaching PMS — uid 0 on
-    // the RPC path would otherwise read as root and PMS grants root. The
-    // deny is transport-driven (the reader knows it is an RPC parcel), so
-    // it is independent of Plan 2-16 Phase B uid wiring.
+    // Injected deployment policy owns the whole decision when present. The
+    // Arc is cloned out so the read lock is released before the (possibly
+    // re-entrant) policy runs.
+    let authority = AUTHORITY
+        .read()
+        .expect("permission authority poisoned")
+        .clone();
+    if let Some(authority) = authority {
+        // Pass the transport-tagged caller; no caller (not in a
+        // transaction) ⇒ fail closed.
+        return crate::calling_caller()
+            .is_some_and(|caller| authority.check(permission_name, &caller));
+    }
+
+    // Default (no authority). RPC fail-closed: deny before reading uid or
+    // reaching PMS — uid 0 on the RPC path would otherwise read as root and
+    // PMS grants root. The deny is transport-driven (the reader knows it is
+    // an RPC parcel), so it is independent of Plan 2-16 Phase B uid wiring.
     if reader.is_for_rpc() {
         warn_enforce_permission_over_rpc();
         return false;
@@ -168,7 +230,11 @@ mod tests {
     /// through to the PMS path (which returns `false` here only because
     /// `system_server` is unreachable in this hermetic build) — the RPC
     /// arm is the new transport gate this asserts.
+    //
+    // `serial(authority)`: `AUTHORITY` is a process global, so this default
+    // test must not run concurrently with the authority-delegation test.
     #[cfg(feature = "rpc")]
+    #[serial_test::serial(authority)]
     #[test]
     fn check_permission_denies_rpc_parcel() {
         let mut rpc_parcel = Parcel::new();
@@ -182,5 +248,71 @@ mod tests {
         // short-circuit on `is_for_rpc`).
         let kernel_parcel = Parcel::new();
         assert!(!kernel_parcel.is_for_rpc());
+    }
+
+    /// Plan 2-16 Phase C: an installed [`PermissionAuthority`] owns the
+    /// decision for every transport and receives the transport-tagged
+    /// [`Caller`]. Here a policy grants one permission to a specific
+    /// Unix-RPC uid — which the *default* path would unconditionally deny
+    /// over RPC — proving the slot can implement RPC authorization.
+    #[cfg(feature = "rpc")]
+    #[serial_test::serial(authority)]
+    #[test]
+    fn injected_authority_overrides_default_rpc_deny() {
+        use crate::rpc::transport::PeerIdentity;
+        use crate::thread_state::RpcCallingGuard;
+        use crate::Caller;
+        use std::sync::Arc;
+
+        struct UidGrant {
+            allow_uid: u32,
+            permission: String,
+        }
+        impl PermissionAuthority for UidGrant {
+            fn check(&self, permission: &str, caller: &Caller) -> bool {
+                matches!(caller, Caller::Rpc(PeerIdentity::Local { uid, .. })
+                    if *uid == self.allow_uid && permission == self.permission)
+            }
+        }
+
+        set_permission_authority(Arc::new(UidGrant {
+            allow_uid: 1000,
+            permission: "com.example.DO_THING".to_string(),
+        }));
+
+        let mut rpc_parcel = Parcel::new();
+        rpc_parcel.set_for_rpc(true);
+
+        // Inside an RPC transaction from uid 1000: the authority grants the
+        // one permission it knows, and denies everything else.
+        {
+            let _g = RpcCallingGuard::install(Arc::new(PeerIdentity::Local { uid: 1000, pid: 7 }));
+            assert!(
+                check_permission(&rpc_parcel, "com.example.DO_THING"),
+                "authority must grant the allowed uid+permission over RPC"
+            );
+            assert!(
+                !check_permission(&rpc_parcel, "com.example.OTHER"),
+                "authority must deny an unknown permission"
+            );
+        }
+        // Different uid ⇒ deny.
+        {
+            let _g = RpcCallingGuard::install(Arc::new(PeerIdentity::Local { uid: 2000, pid: 7 }));
+            assert!(
+                !check_permission(&rpc_parcel, "com.example.DO_THING"),
+                "authority must deny a non-allowed uid"
+            );
+        }
+        // No in-flight transaction ⇒ no caller ⇒ fail closed.
+        assert!(!check_permission(&rpc_parcel, "com.example.DO_THING"));
+
+        // Restore the default so other tests see kernel-PMS / RPC-deny.
+        clear_permission_authority();
+        let _g = RpcCallingGuard::install(Arc::new(PeerIdentity::Local { uid: 1000, pid: 7 }));
+        assert!(
+            !check_permission(&rpc_parcel, "com.example.DO_THING"),
+            "after clear, the default RPC deny is restored"
+        );
     }
 }

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -1175,6 +1175,20 @@ impl ProcessState {
         self.driver.clone()
     }
 
+    /// The binder driver path this process was initialized with. Used by
+    /// the [`crate::service::kernel::Host`] builder to detect a
+    /// conflicting re-init (Plan 2-16 §6) — `init`/`init_default` are
+    /// idempotent and keep the first config.
+    pub(crate) fn driver_name(&self) -> &std::path::Path {
+        &self.driver_name
+    }
+
+    /// The max-threads value this process was initialized with (`0` =
+    /// kernel default). See [`Self::driver_name`].
+    pub(crate) fn max_threads(&self) -> u32 {
+        self.max_threads
+    }
+
     pub fn start_thread_pool() {
         let this = Self::as_self();
         if this

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -373,15 +373,24 @@ impl ProcessState {
             .expect("Call restriction lock poisoned")
     }
 
+    /// The effective max-threads `inner_init` will store for a requested
+    /// value: `0` and any value `>= DEFAULT_MAX_BINDER_THREADS` clamp to
+    /// the default. Shared with the [`crate::service::kernel`] re-init
+    /// check so its "requested differs from stored" comparison matches
+    /// what was actually stored.
+    pub(crate) fn clamp_max_threads(max_threads: u32) -> u32 {
+        if max_threads != 0 && max_threads < DEFAULT_MAX_BINDER_THREADS {
+            max_threads
+        } else {
+            DEFAULT_MAX_BINDER_THREADS
+        }
+    }
+
     fn inner_init(
         driver_name: &str,
         max_threads: u32,
     ) -> std::result::Result<ProcessState, Box<dyn std::error::Error>> {
-        let max_threads = if max_threads != 0 && max_threads < DEFAULT_MAX_BINDER_THREADS {
-            max_threads
-        } else {
-            DEFAULT_MAX_BINDER_THREADS
-        };
+        let max_threads = Self::clamp_max_threads(max_threads);
 
         let driver_name = PathBuf::from(driver_name);
 

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -202,8 +202,13 @@ const TX_GET_SERVICE: TransactionCode = crate::binder::FIRST_CALL_TRANSACTION;
 /// (android RPC has a single root object; this *is* that root when
 /// named services are registered). Reused, unmodified, via the same
 /// `Remotable::on_transact` server path as any AIDL stub.
+///
+/// The map is **shared** (`Arc<Mutex<…>>`) with [`RpcServer::named`], so
+/// the directory binder is built once and every later
+/// [`RpcServer::add_service`] is an O(1) insert visible through this same
+/// directory — no per-call rebuild or root swap.
 struct ServiceDirectory {
-    services: HashMap<String, SIBinder>,
+    services: Arc<Mutex<HashMap<String, SIBinder>>>,
 }
 
 impl Remotable for ServiceDirectory {
@@ -219,10 +224,17 @@ impl Remotable for ServiceDirectory {
         match code {
             TX_GET_SERVICE => {
                 let name: String = reader.read()?;
-                match self.services.get(&name) {
+                // Clone the binder out from under the lock before writing.
+                let found = self
+                    .services
+                    .lock()
+                    .expect("named poisoned")
+                    .get(&name)
+                    .cloned();
+                match found {
                     Some(b) => {
                         reply.write(&crate::Status::from(StatusCode::Ok))?;
-                        reply.write(b)
+                        reply.write(&b)
                     }
                     None => reply.write(&crate::Status::from(StatusCode::NameNotFound)),
                 }
@@ -260,7 +272,15 @@ pub struct RpcServer {
     #[cfg(feature = "rpc-tls")]
     tls_config: TlsServerConfigCell,
     root: Mutex<Option<SIBinder>>,
-    named: Mutex<HashMap<String, SIBinder>>,
+    /// Named services backing [`add_service`](RpcServer::add_service).
+    /// `Arc` so the single [`ServiceDirectory`] root (`directory`) shares
+    /// this exact map — each later `add_service` is an O(1) insert, no
+    /// rebuild. Per-server instance state, not a process global.
+    named: Arc<Mutex<HashMap<String, SIBinder>>>,
+    /// The directory root binder, built once at construction over the
+    /// shared `named` map (so it reads later inserts live) and installed
+    /// as the root on the first `add_service`. Per-server instance state.
+    directory: SIBinder,
     max_threads: Mutex<u32>,
     /// Whether per-connection sessions advertise `Unix` FD support
     /// (default false ⇒ FD reject everywhere).
@@ -408,13 +428,20 @@ impl RpcServer {
     /// factories) funnel through here so the field set stays in one
     /// place.
     fn wrap(listener: ServerListener, bind: BindAddress) -> Arc<RpcServer> {
+        // Build the directory root once over the shared `named` map; later
+        // `add_service` inserts are seen through it with no rebuild.
+        let named: Arc<Mutex<HashMap<String, SIBinder>>> = Arc::new(Mutex::new(HashMap::new()));
+        let directory = Interface::as_binder(&Binder::new(ServiceDirectory {
+            services: Arc::clone(&named),
+        }));
         Arc::new(RpcServer {
             listener,
             bind,
             #[cfg(feature = "rpc-tls")]
             tls_config: Mutex::new(None),
             root: Mutex::new(None),
-            named: Mutex::new(HashMap::new()),
+            named,
+            directory,
             max_threads: Mutex::new(1),
             fd_unix_supported: AtomicBool::new(false),
             wire_max_version: Mutex::new(None),
@@ -505,18 +532,21 @@ impl RpcServer {
         *self.root.lock().expect("root poisoned") = Some(binder);
     }
 
-    /// Register a named service. The first call makes the root a
-    /// built-in `ServiceDirectory` (rebuilt on each call so the set
-    /// is consistent); clients reach it via
+    /// Register a named service. The first call installs a built-in
+    /// `ServiceDirectory` as the root; that directory shares this server's
+    /// service map, so every later call is an O(1) insert seen through the
+    /// same root — no rebuild or root swap. Clients reach it via
     /// [`RpcSession::get_service`].
     pub fn add_service(&self, name: &str, binder: SIBinder) -> Result<()> {
-        let mut named = self.named.lock().expect("named poisoned");
-        named.insert(name.to_string(), binder);
-        let dir = ServiceDirectory {
-            services: named.clone(),
-        };
-        let root = Interface::as_binder(&Binder::new(dir));
-        *self.root.lock().expect("root poisoned") = Some(root);
+        self.named
+            .lock()
+            .expect("named poisoned")
+            .insert(name.to_string(), binder);
+        // Install the once-built directory as the root (idempotent; shares
+        // `named`, so the just-inserted entry is already visible through
+        // it). Reinstalling makes `add_service` win over any prior
+        // `set_root`.
+        *self.root.lock().expect("root poisoned") = Some(self.directory.clone());
         Ok(())
     }
 

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -29,7 +29,7 @@ use crate::parcel::{Parcel, RpcParcelOps};
 use super::address::{AddressSpace, RpcAddress, SpecialTransaction, RPC_ADDR_LEN};
 use super::proxy::RpcProxy;
 use super::state::RpcState;
-use super::transport::RpcTransport;
+use super::transport::{PeerIdentity, RpcTransport};
 use super::wire::{R34Codec, WireCodec, WireMessage, WireReply, WireTransaction};
 use super::wire_android13::{
     client_connect_with_id, read_aosp_message, read_aosp_message_with_fds, server_accept,
@@ -1287,7 +1287,8 @@ impl RpcSessionInner {
                     // panic out of `dispatch_transact` can no longer
                     // leave the timeout desynchronized.
                     let _restore = NestedDeadlineGuard::lift(transport, deadline)?;
-                    self.dispatch_transact(t, in_fds)?;
+                    let peer = transport.peer_identity();
+                    self.dispatch_transact(t, in_fds, peer)?;
                 }
             }
         }
@@ -1423,15 +1424,22 @@ impl RpcSessionInner {
     /// callback while a client call is in flight) and send its reply.
     /// Shared by [`RpcSessionInner::serve_once`] and the nested-call
     /// arm of [`RpcSessionInner::client_transact`].
-    fn dispatch_transact(&self, t: WireTransaction, in_fds: Vec<OwnedFd>) -> Result<()> {
+    fn dispatch_transact(
+        &self,
+        t: WireTransaction,
+        in_fds: Vec<OwnedFd>,
+        peer: PeerIdentity,
+    ) -> Result<()> {
         let oneway = (t.flags & FLAG_ONEWAY) != 0;
         if t.address.is_zero() {
+            // Special zero-address transactions (GET_ROOT etc.) have no
+            // caller identity — they never reach a user handler.
             return self.serve_special(&t, oneway);
         }
         if oneway {
-            self.dispatch_oneway_ordered(t, in_fds)
+            self.dispatch_oneway_ordered(t, in_fds, peer)
         } else {
-            self.execute_dispatched(t, in_fds, false)
+            self.execute_dispatched(t, in_fds, false, peer)
         }
     }
 
@@ -1439,7 +1447,12 @@ impl RpcSessionInner {
     /// priority queue (AOSP `RpcState::processTransactInternal` enqueue and
     /// drain). The state lock is released before dispatch so a nested
     /// callback re-entry can reacquire it.
-    fn dispatch_oneway_ordered(&self, t: WireTransaction, in_fds: Vec<OwnedFd>) -> Result<()> {
+    fn dispatch_oneway_ordered(
+        &self,
+        t: WireTransaction,
+        in_fds: Vec<OwnedFd>,
+        peer: PeerIdentity,
+    ) -> Result<()> {
         let addr = t.address;
         let wire_async = t.async_number;
         let mut next = {
@@ -1466,7 +1479,9 @@ impl RpcSessionInner {
             }
         };
         while let Some((t, fds)) = next {
-            self.execute_dispatched(t, fds, true)?;
+            // All replayed oneways belong to this session, so the peer
+            // identity is the same for every drained entry.
+            self.execute_dispatched(t, fds, true, peer.clone())?;
             next = {
                 let mut state = self.shared.state.lock().expect("rpc state poisoned");
                 state.advance_and_pop_async(addr)
@@ -1484,6 +1499,7 @@ impl RpcSessionInner {
         t: WireTransaction,
         in_fds: Vec<OwnedFd>,
         oneway: bool,
+        peer: PeerIdentity,
     ) -> Result<()> {
         let target = self
             .shared
@@ -1556,8 +1572,20 @@ impl RpcSessionInner {
             self.records_fd_positions(),
         );
 
-        let result = consume_rpc_interface_token(&mut reader, target.descriptor())
-            .and_then(|()| target.rpc_transact(t.code, &mut reader, &mut reply));
+        // Plan 2-16 Phase B: stamp the caller's uid/pid into the RPC
+        // calling context for the duration of the user handler so
+        // `get_calling_uid()` / `get_calling_pid()` work over Unix RPC.
+        // Non-uid transports fail-closed to `RPC_UNKNOWN_CALLING_UID`. The
+        // guard restores on drop, so a nested re-entrant callback over the
+        // same connection nests correctly.
+        let (caller_uid, caller_pid) = match &peer {
+            PeerIdentity::Local { uid, pid } => (*uid, *pid),
+            _ => (crate::thread_state::RPC_UNKNOWN_CALLING_UID, -1),
+        };
+        let result = consume_rpc_interface_token(&mut reader, target.descriptor()).and_then(|()| {
+            let _calling = crate::thread_state::RpcCallingGuard::install(caller_uid, caller_pid);
+            target.rpc_transact(t.code, &mut reader, &mut reply)
+        });
 
         if oneway {
             if let Err(e) = result {
@@ -1596,7 +1624,10 @@ impl RpcSessionInner {
         };
         match self.profile.codec().decode_message(&frame)? {
             WireMessage::Transact(t) => {
-                self.dispatch_transact(t, in_fds)?;
+                // Resolve the connecting peer's identity (Plan 2-16
+                // Phase B) so the dispatch can stamp the calling uid/pid.
+                let peer = transport.peer_identity();
+                self.dispatch_transact(t, in_fds, peer)?;
                 Ok(true)
             }
             WireMessage::DecStrong(a) => {

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -597,17 +597,6 @@ impl RpcParcelOps for SessionParcelOps {
     }
 }
 
-/// Resolve an inbound peer to the `(uid, pid)` stamped into the RPC
-/// calling context (Plan 2-16 Phase B). Unix peers carry a kernel-vouched
-/// uid/pid; uid-less transports (`Vsock` / `Certificate` / `Anonymous`)
-/// fail-closed to the `RPC_UNKNOWN_CALLING_UID` sentinel, never `0`/root.
-fn caller_ids(peer: &PeerIdentity) -> (u32, i32) {
-    match peer {
-        PeerIdentity::Local { uid, pid } => (*uid, *pid),
-        _ => (crate::thread_state::RPC_UNKNOWN_CALLING_UID, -1),
-    }
-}
-
 impl RpcSessionInner {
     /// AOSP `RpcSession::ExclusiveConnection::find`. Selects
     /// **a** connection slot for this thread to drive (outgoing
@@ -1447,14 +1436,15 @@ impl RpcSessionInner {
             // caller identity — they never reach a user handler.
             return self.serve_special(&t, oneway);
         }
-        // Resolve the caller's (uid, pid) once (Plan 2-16 Phase B). The
-        // resolved pair is `Copy`, so the oneway drain reuses it without
-        // cloning the (possibly `String`-bearing) `PeerIdentity` per entry.
-        let caller = caller_ids(&peer);
+        // Wrap the peer once (Plan 2-16 Phase B / Phase C): handlers can
+        // read the full identity via `calling_caller()`, and the `Arc`
+        // keeps the oneway drain's per-entry install a cheap refcount bump
+        // (no `String`-bearing `PeerIdentity` clone).
+        let peer = Arc::new(peer);
         if oneway {
-            self.dispatch_oneway_ordered(t, in_fds, caller)
+            self.dispatch_oneway_ordered(t, in_fds, peer)
         } else {
-            self.execute_dispatched(t, in_fds, false, caller)
+            self.execute_dispatched(t, in_fds, false, peer)
         }
     }
 
@@ -1466,7 +1456,7 @@ impl RpcSessionInner {
         &self,
         t: WireTransaction,
         in_fds: Vec<OwnedFd>,
-        caller: (u32, i32),
+        peer: Arc<PeerIdentity>,
     ) -> Result<()> {
         let addr = t.address;
         let wire_async = t.async_number;
@@ -1495,8 +1485,8 @@ impl RpcSessionInner {
         };
         while let Some((t, fds)) = next {
             // All replayed oneways belong to this session, so the caller
-            // identity is the same for every drained entry (`Copy`, no clone).
-            self.execute_dispatched(t, fds, true, caller)?;
+            // identity is the same for every drained entry (cheap `Arc` clone).
+            self.execute_dispatched(t, fds, true, Arc::clone(&peer))?;
             next = {
                 let mut state = self.shared.state.lock().expect("rpc state poisoned");
                 state.advance_and_pop_async(addr)
@@ -1514,7 +1504,7 @@ impl RpcSessionInner {
         t: WireTransaction,
         in_fds: Vec<OwnedFd>,
         oneway: bool,
-        caller: (u32, i32),
+        peer: Arc<PeerIdentity>,
     ) -> Result<()> {
         let target = self
             .shared
@@ -1587,15 +1577,14 @@ impl RpcSessionInner {
             self.records_fd_positions(),
         );
 
-        // Plan 2-16 Phase B: stamp the caller's uid/pid (resolved once in
-        // `dispatch_transact` via `caller_ids`) into the RPC calling context
-        // for the duration of the user handler so `get_calling_uid()` /
-        // `get_calling_pid()` work over Unix RPC. The guard restores on
-        // drop, so a nested re-entrant callback over the same connection
-        // nests correctly.
-        let (caller_uid, caller_pid) = caller;
+        // Plan 2-16 Phase B/C: stamp the caller's peer identity into the
+        // RPC calling context for the duration of the user handler, so
+        // `get_calling_uid()`/`get_calling_pid()` work over Unix RPC and
+        // `calling_caller()` exposes the full peer (uid / cert / vsock) for
+        // authorization. The guard restores on drop, so a nested re-entrant
+        // callback over the same connection nests correctly.
         let result = consume_rpc_interface_token(&mut reader, target.descriptor()).and_then(|()| {
-            let _calling = crate::thread_state::RpcCallingGuard::install(caller_uid, caller_pid);
+            let _calling = crate::thread_state::RpcCallingGuard::install(Arc::clone(&peer));
             target.rpc_transact(t.code, &mut reader, &mut reply)
         });
 

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -597,6 +597,17 @@ impl RpcParcelOps for SessionParcelOps {
     }
 }
 
+/// Resolve an inbound peer to the `(uid, pid)` stamped into the RPC
+/// calling context (Plan 2-16 Phase B). Unix peers carry a kernel-vouched
+/// uid/pid; uid-less transports (`Vsock` / `Certificate` / `Anonymous`)
+/// fail-closed to the `RPC_UNKNOWN_CALLING_UID` sentinel, never `0`/root.
+fn caller_ids(peer: &PeerIdentity) -> (u32, i32) {
+    match peer {
+        PeerIdentity::Local { uid, pid } => (*uid, *pid),
+        _ => (crate::thread_state::RPC_UNKNOWN_CALLING_UID, -1),
+    }
+}
+
 impl RpcSessionInner {
     /// AOSP `RpcSession::ExclusiveConnection::find`. Selects
     /// **a** connection slot for this thread to drive (outgoing
@@ -1436,10 +1447,14 @@ impl RpcSessionInner {
             // caller identity — they never reach a user handler.
             return self.serve_special(&t, oneway);
         }
+        // Resolve the caller's (uid, pid) once (Plan 2-16 Phase B). The
+        // resolved pair is `Copy`, so the oneway drain reuses it without
+        // cloning the (possibly `String`-bearing) `PeerIdentity` per entry.
+        let caller = caller_ids(&peer);
         if oneway {
-            self.dispatch_oneway_ordered(t, in_fds, peer)
+            self.dispatch_oneway_ordered(t, in_fds, caller)
         } else {
-            self.execute_dispatched(t, in_fds, false, peer)
+            self.execute_dispatched(t, in_fds, false, caller)
         }
     }
 
@@ -1451,7 +1466,7 @@ impl RpcSessionInner {
         &self,
         t: WireTransaction,
         in_fds: Vec<OwnedFd>,
-        peer: PeerIdentity,
+        caller: (u32, i32),
     ) -> Result<()> {
         let addr = t.address;
         let wire_async = t.async_number;
@@ -1479,9 +1494,9 @@ impl RpcSessionInner {
             }
         };
         while let Some((t, fds)) = next {
-            // All replayed oneways belong to this session, so the peer
-            // identity is the same for every drained entry.
-            self.execute_dispatched(t, fds, true, peer.clone())?;
+            // All replayed oneways belong to this session, so the caller
+            // identity is the same for every drained entry (`Copy`, no clone).
+            self.execute_dispatched(t, fds, true, caller)?;
             next = {
                 let mut state = self.shared.state.lock().expect("rpc state poisoned");
                 state.advance_and_pop_async(addr)
@@ -1499,7 +1514,7 @@ impl RpcSessionInner {
         t: WireTransaction,
         in_fds: Vec<OwnedFd>,
         oneway: bool,
-        peer: PeerIdentity,
+        caller: (u32, i32),
     ) -> Result<()> {
         let target = self
             .shared
@@ -1572,16 +1587,13 @@ impl RpcSessionInner {
             self.records_fd_positions(),
         );
 
-        // Plan 2-16 Phase B: stamp the caller's uid/pid into the RPC
-        // calling context for the duration of the user handler so
-        // `get_calling_uid()` / `get_calling_pid()` work over Unix RPC.
-        // Non-uid transports fail-closed to `RPC_UNKNOWN_CALLING_UID`. The
-        // guard restores on drop, so a nested re-entrant callback over the
-        // same connection nests correctly.
-        let (caller_uid, caller_pid) = match &peer {
-            PeerIdentity::Local { uid, pid } => (*uid, *pid),
-            _ => (crate::thread_state::RPC_UNKNOWN_CALLING_UID, -1),
-        };
+        // Plan 2-16 Phase B: stamp the caller's uid/pid (resolved once in
+        // `dispatch_transact` via `caller_ids`) into the RPC calling context
+        // for the duration of the user handler so `get_calling_uid()` /
+        // `get_calling_pid()` work over Unix RPC. The guard restores on
+        // drop, so a nested re-entrant callback over the same connection
+        // nests correctly.
+        let (caller_uid, caller_pid) = caller;
         let result = consume_rpc_interface_token(&mut reader, target.descriptor()).and_then(|()| {
             let _calling = crate::thread_state::RpcCallingGuard::install(caller_uid, caller_pid);
             target.rpc_transact(t.code, &mut reader, &mut reply)

--- a/rsbinder/src/service.rs
+++ b/rsbinder/src/service.rs
@@ -92,7 +92,15 @@ pub trait Broker {
 
     /// Resolve `name` and cast it to the interface `T` (the
     /// `interface_cast` step), mirroring [`crate::hub::get_interface`].
-    fn get_interface<T: FromIBinder + ?Sized>(&self, name: &str) -> Result<Strong<T>> {
+    ///
+    /// `where Self: Sized` keeps the trait object-safe: this generic
+    /// convenience stays callable on a concrete broker or an
+    /// `impl Broker` bound, while `&dyn Broker` remains usable via
+    /// [`Broker::lookup`] + a free [`FromIBinder::try_from`].
+    fn get_interface<T: FromIBinder + ?Sized>(&self, name: &str) -> Result<Strong<T>>
+    where
+        Self: Sized,
+    {
         FromIBinder::try_from(self.lookup(name)?)
     }
 }
@@ -129,7 +137,11 @@ pub mod kernel {
             let driver_mismatch = want_driver
                 .as_deref()
                 .is_some_and(|d| d != ps.driver_name());
-            let threads_mismatch = max_threads != 0 && max_threads != ps.max_threads();
+            // Compare the *clamped* requested value against what was
+            // actually stored, so re-requesting the same out-of-range
+            // `max_threads` (both clamped to the default) does not warn.
+            let threads_mismatch = max_threads != 0
+                && ProcessState::clamp_max_threads(max_threads) != ps.max_threads();
             if driver_mismatch || threads_mismatch {
                 log::warn!(
                     "kernel::Host: ProcessState already initialized; requested \
@@ -358,7 +370,9 @@ pub mod rpc {
                 server.set_max_connections(n);
             }
             if let Some(f) = self.authorizer {
-                server.set_authorizer(move |p| f(p));
+                // `Box<dyn Fn..>` already implements `Fn`, so hand it to
+                // `set_authorizer` directly — no second closure/box layer.
+                server.set_authorizer(f);
             }
             Ok(Host { server })
         }
@@ -388,5 +402,20 @@ pub mod rpc {
         fn lookup(&self, name: &str) -> Result<SIBinder> {
             self.session.get_service(name)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Both facade traits are object-safe (the module/trait rustdoc says
+    /// so). `Broker::get_interface` is generic, so it must carry
+    /// `where Self: Sized` to stay out of the vtable — this lock-in fails
+    /// to compile if that bound is dropped (the original review finding).
+    #[test]
+    fn traits_are_object_safe() {
+        fn _registry(_: &dyn Registry) {}
+        fn _broker(_: &dyn Broker) {}
     }
 }

--- a/rsbinder/src/service.rs
+++ b/rsbinder/src/service.rs
@@ -1,0 +1,392 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cross-transport service facade (Plan 2-16 Phase D).
+//!
+//! Write service **registration and lookup code once** and pick the
+//! transport — kernel binder or RPC — by construction. The AIDL
+//! interface, the generated `Bp*`/`Bn*` stubs, the service `impl`, and the
+//! call sites are already transport-agnostic; this layer makes the
+//! *bootstrap* (register / look up) transport-agnostic too, behind two
+//! small object-safe traits:
+//!
+//! - [`Registry`] (server side) — `add_service(name, binder)`.
+//! - [`Broker`] (client side) — `lookup(name)` + `get_interface::<T>(name)`.
+//!
+//! and two typed host/broker pairs, one per transport:
+//!
+//! - [`kernel::Host`] / [`kernel::Broker`] — over `ProcessState` + `hub`.
+//! - [`rpc::Host`] / [`rpc::Broker`] — over `RpcServer` + `RpcSession`
+//!   (`#[cfg(feature = "rpc")]`).
+//!
+//! # This is additive, not a replacement
+//!
+//! The low-level `ProcessState` / `hub` / `RpcServer` / `RpcSession` APIs
+//! are unchanged and remain the direct path. This is a *typed* convenience
+//! layer over them (no wire change, kernel byte-identical — R3).
+//!
+//! # The intersection is deliberately small (Plan 2-16 §2, objection 3)
+//!
+//! Only `add_service` / `lookup` are on the shared traits — the genuine
+//! kernel∩RPC intersection. Kernel-only powers (`list_services`,
+//! service-notification callbacks, lazy services, dumpsys priority) stay
+//! on the concrete kernel types / the [`crate::hub`] module: they are not
+//! hidden behind the trait, and **not** faked on RPC.
+//!
+//! # The transports' security differs — and that is made loud, not hidden
+//!
+//! Moving a service kernel→RPC changes the trust boundary. Plan 2-16
+//! Phase A/B made that explicit so this facade is safe to use:
+//! `@EnforcePermission` methods **deny** over RPC (never silently grant —
+//! Phase A), and [`crate::get_calling_uid`] returns the kernel-vouched
+//! peer uid over Unix RPC / a fail-closed sentinel on uid-less transports
+//! (Phase B). Authorization on RPC is the transport's own boundary
+//! (`PeerIdentity` + [`crate::rpc::RpcServer::set_authorizer`]).
+//!
+//! # Why typed pairs, not one `Endpoint` enum
+//!
+//! `serve()` means different things per transport (kernel = the whole
+//! process pool; RPC = this one socket), the kernel host is a
+//! process-global singleton while an RPC host is a real instance, and the
+//! construction options do not overlap. Distinct types keep all of that
+//! visible at the call site and make a wrong-transport option a compile
+//! error rather than a silent no-op.
+//!
+//! ```no_run
+//! use rsbinder::service::{Registry, Broker};
+//! # use rsbinder::{SIBinder, Strong, FromIBinder};
+//! # fn demo<R: Registry>(reg: &R, svc: SIBinder) -> rsbinder::Result<()> {
+//! // register once, generic over the transport
+//! reg.add_service("hello", svc)?;
+//! # Ok(()) }
+//! ```
+
+use crate::error::{Result, StatusCode};
+use crate::{FromIBinder, SIBinder, Strong};
+
+/// Server side of the facade: register a binder under a name.
+///
+/// The **genuine kernel∩RPC intersection** — kernel-only registration
+/// extras (notifications, lazy services, list/dump) stay on the concrete
+/// kernel type, not here. Object-safe.
+pub trait Registry {
+    /// Publish `binder` under `name` so a [`Broker`] on the same transport
+    /// can [`Broker::lookup`] it.
+    ///
+    /// Kernel: delegates to [`crate::hub::add_service`] (the system service
+    /// manager). RPC: delegates to
+    /// [`crate::rpc::RpcServer::add_service`] (an in-process directory the
+    /// session root resolves) — there is no system-wide RPC service
+    /// manager, by design (mirrors AOSP).
+    fn add_service(&self, name: &str, binder: SIBinder) -> Result<()>;
+}
+
+/// Client side of the facade: resolve a binder (and cast it) by name.
+///
+/// Object-safe in `lookup`; the generic [`Broker::get_interface`] cast is
+/// a provided default so the common `Strong<dyn IFoo>` path is one call.
+pub trait Broker {
+    /// Resolve the raw binder published under `name`, or
+    /// [`StatusCode::NameNotFound`] if absent.
+    fn lookup(&self, name: &str) -> Result<SIBinder>;
+
+    /// Resolve `name` and cast it to the interface `T` (the
+    /// `interface_cast` step), mirroring [`crate::hub::get_interface`].
+    fn get_interface<T: FromIBinder + ?Sized>(&self, name: &str) -> Result<Strong<T>> {
+        FromIBinder::try_from(self.lookup(name)?)
+    }
+}
+
+pub mod kernel {
+    //! Kernel-binder transport. [`Host`]/[`Broker`] are process-global
+    //! handles over the singleton [`crate::ProcessState`] + the system
+    //! [`crate::hub`] service manager.
+
+    use super::*;
+    use crate::process_state::{CallRestriction, ProcessState};
+
+    /// Initialize (idempotently) the process-global kernel `ProcessState`
+    /// and return a handle. `ProcessState::init`/`init_default` is
+    /// process-wide; a second `Host` in the same process **reuses** the
+    /// existing instance. See [`Host::builder`] for the loud-on-conflict
+    /// behavior.
+    fn init(driver: Option<&std::path::Path>, max_threads: u32) -> Result<()> {
+        let pre = ProcessState::is_initialized();
+        let ps = match driver {
+            Some(p) => ProcessState::init(&p.to_string_lossy(), max_threads),
+            None => ProcessState::init_default(),
+        }
+        .map_err(|e| {
+            log::error!("kernel::Host: ProcessState init failed: {e}");
+            StatusCode::NoInit
+        })?;
+
+        // Loud on lost config (Plan 2-16 §6): keep the idempotent reuse
+        // (two independent hosts in one process is a valid pattern), but
+        // never silently drop a *different* requested config.
+        if pre {
+            let want_driver = driver.map(|p| p.to_path_buf());
+            let driver_mismatch = want_driver
+                .as_deref()
+                .is_some_and(|d| d != ps.driver_name());
+            let threads_mismatch = max_threads != 0 && max_threads != ps.max_threads();
+            if driver_mismatch || threads_mismatch {
+                log::warn!(
+                    "kernel::Host: ProcessState already initialized; requested \
+                     driver={driver:?} max_threads={max_threads} ignored, using \
+                     existing driver={:?} max_threads={}",
+                    ps.driver_name(),
+                    ps.max_threads()
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Process-global kernel-binder service host.
+    ///
+    /// Construction is **idempotent** (`ProcessState` is process-wide);
+    /// [`Host::serve`] joins the **process-wide** binder thread pool — it
+    /// is not a per-instance lifecycle. Contrast [`super::rpc::Host`],
+    /// whose `serve()` drives a single socket.
+    pub struct Host {
+        _priv: (),
+    }
+
+    impl Host {
+        /// Initialize the process `ProcessState` with the default binder
+        /// path (idempotent) and return a host.
+        pub fn new() -> Result<Self> {
+            init(None, 0)?;
+            Ok(Host { _priv: () })
+        }
+
+        /// Builder for the non-default cases (custom driver path,
+        /// `max_threads`, call restriction). All options map onto the
+        /// existing [`crate::ProcessState`] surface.
+        pub fn builder() -> HostBuilder {
+            HostBuilder::default()
+        }
+
+        /// Start the binder thread pool and **block**, joining the
+        /// process-wide pool until it terminates. Process-wide, not
+        /// per-instance (see the type docs).
+        pub fn serve(&self) -> Result<()> {
+            ProcessState::start_thread_pool();
+            ProcessState::join_thread_pool()
+        }
+    }
+
+    impl Registry for Host {
+        fn add_service(&self, name: &str, binder: SIBinder) -> Result<()> {
+            crate::hub::add_service(name, binder).map_err(StatusCode::from)
+        }
+    }
+
+    /// Builder for [`Host`]. The options live here (not on a shared
+    /// cross-transport builder) precisely because they are kernel-only —
+    /// a wrong-transport option is a compile error, not a silent no-op.
+    #[derive(Default)]
+    pub struct HostBuilder {
+        driver: Option<std::path::PathBuf>,
+        max_threads: u32,
+        call_restriction: Option<CallRestriction>,
+    }
+
+    impl HostBuilder {
+        /// Binder driver path (default `/dev/binderfs/binder`). Maps to
+        /// [`crate::ProcessState::init`].
+        pub fn driver(mut self, path: impl Into<std::path::PathBuf>) -> Self {
+            self.driver = Some(path.into());
+            self
+        }
+
+        /// Kernel thread-pool size (`0` = kernel default).
+        pub fn max_threads(mut self, n: u32) -> Self {
+            self.max_threads = n;
+            self
+        }
+
+        /// Restrict outgoing calls (AOSP `setCallRestriction`).
+        pub fn call_restriction(mut self, cr: CallRestriction) -> Self {
+            self.call_restriction = Some(cr);
+            self
+        }
+
+        /// Initialize `ProcessState` (idempotent — warns if a prior init
+        /// used a different driver/`max_threads`) and return the host.
+        pub fn build(self) -> Result<Host> {
+            init(self.driver.as_deref(), self.max_threads)?;
+            if let Some(cr) = self.call_restriction {
+                ProcessState::as_self().set_call_restriction(cr);
+            }
+            Ok(Host { _priv: () })
+        }
+    }
+
+    /// Process-global kernel-binder client broker over the system
+    /// [`crate::hub`] service manager.
+    pub struct Broker {
+        _priv: (),
+    }
+
+    impl Broker {
+        /// Initialize the process `ProcessState` (idempotent) so the
+        /// system service manager is reachable, and return a broker.
+        pub fn new() -> Result<Self> {
+            init(None, 0)?;
+            Ok(Broker { _priv: () })
+        }
+    }
+
+    impl super::Broker for Broker {
+        fn lookup(&self, name: &str) -> Result<SIBinder> {
+            crate::hub::get_service(name).ok_or(StatusCode::NameNotFound)
+        }
+    }
+}
+
+#[cfg(feature = "rpc")]
+pub mod rpc {
+    //! RPC transport. [`Host`] wraps an [`crate::rpc::RpcServer`] (one
+    //! socket); [`Broker`] wraps an [`crate::rpc::RpcSession`] client.
+
+    use super::*;
+    use crate::rpc::transport::PeerIdentity;
+    use crate::rpc::{RpcServer, RpcSession};
+    use std::sync::Arc;
+
+    /// RPC service host — one listening socket (contrast the process-wide
+    /// [`super::kernel::Host`]).
+    pub struct Host {
+        server: Arc<RpcServer>,
+    }
+
+    impl Host {
+        /// Listen on a Unix-domain socket at `path`.
+        pub fn unix(path: impl Into<std::path::PathBuf>) -> Result<Self> {
+            Ok(Host {
+                server: RpcServer::setup_unix_server(path)?,
+            })
+        }
+
+        /// Builder for the optioned case (max threads, max connections,
+        /// authorizer). The options are RPC-only — they live here, not on
+        /// a shared builder.
+        pub fn builder() -> HostBuilder {
+            HostBuilder::default()
+        }
+
+        /// Borrow the underlying [`RpcServer`] for the RPC-only powers not
+        /// on [`Registry`] (`set_max_connections`, fd modes, TLS, the
+        /// session/connection counters, …).
+        pub fn server(&self) -> &Arc<RpcServer> {
+            &self.server
+        }
+
+        /// Serve this socket and **block** until shutdown.
+        pub fn serve(&self) -> Result<()> {
+            self.server.run()
+        }
+
+        /// Serve this socket on a background thread, returning its
+        /// [`JoinHandle`](std::thread::JoinHandle). RPC-specific lifecycle
+        /// (no kernel analogue), so it is on the concrete type only.
+        pub fn serve_background(&self) -> std::thread::JoinHandle<()> {
+            self.server.run_background()
+        }
+    }
+
+    impl Registry for Host {
+        fn add_service(&self, name: &str, binder: SIBinder) -> Result<()> {
+            self.server.add_service(name, binder)
+        }
+    }
+
+    type Authorizer = Box<dyn Fn(&PeerIdentity) -> bool + Send + Sync + 'static>;
+
+    /// Builder for [`Host`].
+    #[derive(Default)]
+    pub struct HostBuilder {
+        path: Option<std::path::PathBuf>,
+        max_threads: Option<u32>,
+        max_connections: Option<usize>,
+        authorizer: Option<Authorizer>,
+    }
+
+    impl HostBuilder {
+        /// Listen on a Unix-domain socket at `path`.
+        pub fn unix(mut self, path: impl Into<std::path::PathBuf>) -> Self {
+            self.path = Some(path.into());
+            self
+        }
+
+        /// Advertised / incoming-slot max threads
+        /// ([`RpcServer::set_max_threads`]).
+        pub fn max_threads(mut self, n: u32) -> Self {
+            self.max_threads = Some(n);
+            self
+        }
+
+        /// Concurrent connection-worker cap
+        /// ([`RpcServer::set_max_connections`]).
+        pub fn max_connections(mut self, n: usize) -> Self {
+            self.max_connections = Some(n);
+            self
+        }
+
+        /// Per-connection authorizer over the peer's
+        /// [`PeerIdentity`] ([`RpcServer::set_authorizer`]) — the RPC
+        /// trust-boundary hook (there is no uid/permission model on RPC).
+        pub fn authorizer<F>(mut self, f: F) -> Self
+        where
+            F: Fn(&PeerIdentity) -> bool + Send + Sync + 'static,
+        {
+            self.authorizer = Some(Box::new(f));
+            self
+        }
+
+        /// Build the [`Host`] (currently Unix-only; use the low-level
+        /// [`RpcServer`] setup constructors for vsock/TLS).
+        pub fn build(self) -> Result<Host> {
+            let path = self.path.ok_or(StatusCode::BadValue)?;
+            let server = RpcServer::setup_unix_server(path)?;
+            if let Some(n) = self.max_threads {
+                server.set_max_threads(n);
+            }
+            if let Some(n) = self.max_connections {
+                server.set_max_connections(n);
+            }
+            if let Some(f) = self.authorizer {
+                server.set_authorizer(move |p| f(p));
+            }
+            Ok(Host { server })
+        }
+    }
+
+    /// RPC client broker over an [`RpcSession`] connection.
+    pub struct Broker {
+        session: RpcSession,
+    }
+
+    impl Broker {
+        /// Connect to a Unix-domain RPC server at `path`.
+        pub fn unix(path: impl AsRef<std::path::Path>) -> Result<Self> {
+            Ok(Broker {
+                session: RpcSession::setup_unix_client(path)?,
+            })
+        }
+
+        /// Borrow the underlying [`RpcSession`] for RPC-only client powers
+        /// (the negotiated root object, fan-out connect, …).
+        pub fn session(&self) -> &RpcSession {
+            &self.session
+        }
+    }
+
+    impl super::Broker for Broker {
+        fn lookup(&self, name: &str) -> Result<SIBinder> {
+            self.session.get_service(name)
+        }
+    }
+}

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -76,6 +76,87 @@ thread_local! {
     static BINDER_DEREFS: RefCell<BinderDerefs> = RefCell::new(BinderDerefs::new());
 }
 
+// ---- RPC calling context (Plan 2-16 Phase B) ------------------------
+//
+// The kernel calling identity lives in `THREAD_STATE.transaction`, but
+// `ThreadState::new()` eagerly pulls `ProcessState::as_self()`, which
+// **panics in a pure-RPC process** (no kernel binder). The RPC dispatch
+// path therefore must NOT touch `THREAD_STATE`. Instead it stamps the
+// caller's uid/pid into this separate, ProcessState-independent
+// thread-local for the duration of one RPC `on_transact`, and the public
+// calling-identity accessors consult it *first* (so they work in a
+// pure-RPC process and never force the kernel thread-local).
+//
+// The store is a plain `Cell` — the value is `Copy` and never borrowed
+// across the user handler, so the R1 borrow discipline that governs
+// `THREAD_STATE`/`BINDER_DEREFS` does not apply here (set → run handler →
+// restore, no live borrow during the callout).
+#[cfg(feature = "rpc")]
+thread_local! {
+    static RPC_CALLING: std::cell::Cell<Option<RpcCallingContext>> = const {
+        std::cell::Cell::new(None)
+    };
+}
+
+/// Caller identity for an in-flight RPC transaction. `Copy` so the
+/// `Cell` swap in [`RpcCallingGuard`] needs no clone.
+#[cfg(feature = "rpc")]
+#[derive(Clone, Copy)]
+struct RpcCallingContext {
+    uid: binder::uid_t,
+    pid: binder::pid_t,
+}
+
+/// Fail-closed calling uid for RPC transports that carry **no** uid
+/// (`Vsock` cid, TLS `Certificate`, `Anonymous`). `u32::MAX`
+/// (`(uid_t)-1`) is never a real privileged uid, so a hand-rolled uid
+/// ACL (`if get_calling_uid() == AID_SYSTEM { … }`) can never
+/// accidentally match — and it is deliberately **not** `0`, so it can
+/// never be mistaken for root. See Plan 2-16 §1.2.
+#[cfg(feature = "rpc")]
+pub(crate) const RPC_UNKNOWN_CALLING_UID: binder::uid_t = binder::uid_t::MAX;
+
+/// Stamp the RPC caller's `(uid, pid)` into [`RPC_CALLING`] for the
+/// duration of one `on_transact`, restoring the previous value on drop
+/// (so nested re-entrant callbacks over the same connection nest
+/// correctly). Installed by the RPC dispatch path
+/// (`rpc::session::execute_dispatched`) around `rpc_transact`.
+#[cfg(feature = "rpc")]
+pub(crate) struct RpcCallingGuard {
+    previous: Option<RpcCallingContext>,
+}
+
+#[cfg(feature = "rpc")]
+impl RpcCallingGuard {
+    pub(crate) fn install(uid: binder::uid_t, pid: binder::pid_t) -> Self {
+        let previous = RPC_CALLING.with(|c| c.replace(Some(RpcCallingContext { uid, pid })));
+        RpcCallingGuard { previous }
+    }
+}
+
+#[cfg(feature = "rpc")]
+impl Drop for RpcCallingGuard {
+    fn drop(&mut self) {
+        RPC_CALLING.with(|c| c.set(self.previous));
+    }
+}
+
+/// The current RPC caller's `(uid, pid)`, or `None` when not dispatching
+/// an RPC transaction (always `None` without the `rpc` feature). Never
+/// touches `THREAD_STATE`/`ProcessState`, so it is safe to call in a
+/// pure-RPC process.
+#[inline]
+fn rpc_calling() -> Option<(binder::uid_t, binder::pid_t)> {
+    #[cfg(feature = "rpc")]
+    {
+        RPC_CALLING.with(|c| c.get()).map(|r| (r.uid, r.pid))
+    }
+    #[cfg(not(feature = "rpc"))]
+    {
+        None
+    }
+}
+
 // Freeze observer BR labels (nr=20/21/22).
 // `BR_TRANSACTION_SEC_CTX` (nr=2) is dispatched by the special-case
 // above `return_to_str`'s indexed lookup, so the nr=20 slot is free
@@ -1625,6 +1706,28 @@ pub struct CallingContext {
 
 impl std::default::Default for CallingContext {
     fn default() -> CallingContext {
+        // Plan 2-16 Phase B: an in-flight RPC transaction takes precedence
+        // and is read from the ProcessState-independent thread-local
+        // (works in a pure-RPC process). RPC has no SELinux context, so
+        // `sid` is always `None`.
+        if let Some((uid, pid)) = rpc_calling() {
+            return CallingContext {
+                pid,
+                uid,
+                sid: None,
+            };
+        }
+        // Kernel path. `THREAD_STATE`'s ctor pulls `ProcessState::as_self()`,
+        // which panics if uninitialized — so in a pure-RPC process with no
+        // in-flight RPC transaction, return the documented
+        // out-of-transaction self identity without forcing the thread-local.
+        if !ProcessState::is_initialized() {
+            return CallingContext {
+                pid: rustix::process::getpid().as_raw_nonzero().get() as _,
+                uid: rustix::process::getuid().as_raw(),
+                sid: None,
+            };
+        }
         THREAD_STATE.with(|thread_state| -> CallingContext {
             let thread_state = thread_state.borrow();
             match thread_state.transaction.as_ref() {
@@ -1658,7 +1761,14 @@ impl std::default::Default for CallingContext {
 }
 
 pub fn is_handling_transaction() -> bool {
-    THREAD_STATE.with(|thread_state| thread_state.borrow().transaction.is_some())
+    // Plan 2-16 Phase B: an in-flight RPC transaction counts (and is
+    // detected without forcing the ProcessState-coupled `THREAD_STATE`,
+    // which would panic in a pure-RPC process).
+    if rpc_calling().is_some() {
+        return true;
+    }
+    ProcessState::is_initialized()
+        && THREAD_STATE.with(|thread_state| thread_state.borrow().transaction.is_some())
 }
 
 /// SELinux security context of the caller for the current in-flight
@@ -1685,6 +1795,12 @@ pub fn is_handling_transaction() -> bool {
 /// pointer is lazily copied at every call, so leaking is not possible).
 ///
 pub fn get_calling_sid() -> Option<CString> {
+    // RPC carries no SELinux context (see `PeerIdentity`); during an RPC
+    // transaction return `None` without forcing `THREAD_STATE` (which
+    // would panic in a pure-RPC process).
+    if rpc_calling().is_some() || !ProcessState::is_initialized() {
+        return None;
+    }
     THREAD_STATE.with(|thread_state| {
         let thread_state = thread_state.borrow();
         let transaction = thread_state.transaction.as_ref()?;
@@ -1715,6 +1831,15 @@ pub fn get_calling_sid() -> Option<CString> {
 /// common case where only the PID is needed — avoids the
 /// `Option<CString>` allocation of the full context.
 pub fn get_calling_pid() -> binder::pid_t {
+    // Plan 2-16 Phase B: an RPC transaction's pid (Unix RPC; `-1`/unknown
+    // on transports without a pid) takes precedence and is read without
+    // forcing `THREAD_STATE` (pure-RPC safe).
+    if let Some((_, pid)) = rpc_calling() {
+        return pid;
+    }
+    if !ProcessState::is_initialized() {
+        return 0;
+    }
     THREAD_STATE.with(|thread_state| {
         thread_state
             .borrow()
@@ -1739,7 +1864,32 @@ pub fn get_calling_pid() -> binder::pid_t {
 /// replace it for a nested outbound call (the AOSP
 /// `clearCallingIdentity` pattern), see [`clear_calling_identity`] and
 /// [`restore_calling_identity`].
+///
+/// # RPC transports (Plan 2-16 Phase B)
+///
+/// Over a **Unix-domain RPC** connection this returns the kernel-vouched
+/// peer uid (`SO_PEERCRED` on Linux/Android, `getpeereid` on macOS/BSD) —
+/// so a hand-rolled uid ACL runs transport-agnostically on kernel binder
+/// *and* Unix RPC. The granularity is **connection-level**, not
+/// per-method (an RPC connection is opened once by one peer process).
+///
+/// Over RPC transports that carry **no** uid (`Vsock` cid, TLS
+/// `Certificate`, `Anonymous`) this returns a **fail-closed sentinel**
+/// (`u32::MAX`, never `0`/root and never a real privileged uid) — uid is
+/// the wrong authorization basis there; use `PeerIdentity` /
+/// `RpcServer::set_authorizer` instead. `@EnforcePermission` over RPC is
+/// always denied regardless of uid (Plan 2-16 Phase A).
 pub fn get_calling_uid() -> binder::uid_t {
+    // Plan 2-16 Phase B: an RPC transaction's uid takes precedence and is
+    // read without forcing `THREAD_STATE` (pure-RPC safe). Non-uid
+    // transports were stamped with `RPC_UNKNOWN_CALLING_UID` by the
+    // dispatch path, so this stays fail-closed there.
+    if let Some((uid, _)) = rpc_calling() {
+        return uid;
+    }
+    if !ProcessState::is_initialized() {
+        return 0;
+    }
     THREAD_STATE.with(|thread_state| {
         thread_state
             .borrow()
@@ -1757,6 +1907,15 @@ pub fn get_calling_uid() -> binder::uid_t {
 /// (e.g. per-uid accounting in [`crate::proxy_count`]) get the same
 /// attribution they would on real Android.
 pub fn get_calling_uid_or_self() -> binder::uid_t {
+    // Plan 2-16 Phase B: prefer the RPC caller uid when dispatching an RPC
+    // transaction; otherwise fall back to the process's own uid without
+    // forcing `THREAD_STATE` in a pure-RPC process.
+    if let Some((uid, _)) = rpc_calling() {
+        return uid;
+    }
+    if !ProcessState::is_initialized() {
+        return rustix::process::getuid().as_raw();
+    }
     THREAD_STATE
         .with(|thread_state| {
             thread_state
@@ -1990,6 +2149,53 @@ pub fn has_explicit_identity() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Plan 2-16 Phase B: the RPC calling context is read by the public
+    /// accessors, restores on guard drop, nests correctly, and is
+    /// fail-closed for non-uid transports — all without a kernel
+    /// `ProcessState` (hermetic, runs on macOS). The `0`/`!handling`
+    /// outside the guard also proves the pure-RPC accessors are
+    /// panic-free with `ProcessState` uninitialized.
+    #[cfg(feature = "rpc")]
+    #[test]
+    fn rpc_calling_context_is_read_restored_and_failclosed() {
+        // Outside any transaction (pure-RPC, no ProcessState): defined,
+        // not a panic.
+        assert_eq!(get_calling_uid(), 0);
+        assert_eq!(get_calling_pid(), 0);
+        assert!(!is_handling_transaction());
+        assert!(get_calling_sid().is_none());
+
+        {
+            let _g = RpcCallingGuard::install(1234, 42);
+            assert_eq!(get_calling_uid(), 1234);
+            assert_eq!(get_calling_pid(), 42);
+            assert!(is_handling_transaction());
+            // RPC carries no SELinux context.
+            assert!(get_calling_sid().is_none());
+            assert_eq!(CallingContext::default().uid, 1234);
+            assert_eq!(CallingContext::default().pid, 42);
+
+            // Nested re-entrant callback over the same connection: a
+            // non-uid transport stamps the fail-closed sentinel; the
+            // outer identity is restored when it returns.
+            {
+                let _g2 = RpcCallingGuard::install(RPC_UNKNOWN_CALLING_UID, -1);
+                assert_eq!(get_calling_uid(), RPC_UNKNOWN_CALLING_UID);
+                assert_ne!(get_calling_uid(), 0, "sentinel must never read as root");
+                assert_eq!(get_calling_pid(), -1);
+            }
+            assert_eq!(
+                get_calling_uid(),
+                1234,
+                "outer identity restored after nesting"
+            );
+        }
+
+        // Fully restored.
+        assert_eq!(get_calling_uid(), 0);
+        assert!(!is_handling_transaction());
+    }
 
     #[test]
     fn test_return_to_str() {

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -87,24 +87,16 @@ thread_local! {
 // calling-identity accessors consult it *first* (so they work in a
 // pure-RPC process and never force the kernel thread-local).
 //
-// The store is a plain `Cell` — the value is `Copy` and never borrowed
-// across the user handler, so the R1 borrow discipline that governs
-// `THREAD_STATE`/`BINDER_DEREFS` does not apply here (set → run handler →
-// restore, no live borrow during the callout).
+// The store holds an `Arc<PeerIdentity>` (the full peer, so handler-side
+// authorization can see uid *and* the cert/vsock identity), borrowed only
+// momentarily (clone-out) and never across the user handler, so the R1
+// borrow discipline that governs `THREAD_STATE`/`BINDER_DEREFS` does not
+// apply here (set → run handler → restore, no live borrow during the
+// callout). `Arc` keeps the per-dispatch and oneway-drain installs cheap.
 #[cfg(feature = "rpc")]
 thread_local! {
-    static RPC_CALLING: std::cell::Cell<Option<RpcCallingContext>> = const {
-        std::cell::Cell::new(None)
-    };
-}
-
-/// Caller identity for an in-flight RPC transaction. `Copy` so the
-/// `Cell` swap in [`RpcCallingGuard`] needs no clone.
-#[cfg(feature = "rpc")]
-#[derive(Clone, Copy)]
-struct RpcCallingContext {
-    uid: binder::uid_t,
-    pid: binder::pid_t,
+    static RPC_CALLING: std::cell::RefCell<Option<std::sync::Arc<crate::rpc::transport::PeerIdentity>>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 /// Fail-closed calling uid for RPC transports that carry **no** uid
@@ -116,20 +108,20 @@ struct RpcCallingContext {
 #[cfg(feature = "rpc")]
 pub(crate) const RPC_UNKNOWN_CALLING_UID: binder::uid_t = binder::uid_t::MAX;
 
-/// Stamp the RPC caller's `(uid, pid)` into [`RPC_CALLING`] for the
-/// duration of one `on_transact`, restoring the previous value on drop
-/// (so nested re-entrant callbacks over the same connection nest
-/// correctly). Installed by the RPC dispatch path
+/// Stamp the RPC caller's [`PeerIdentity`](crate::rpc::PeerIdentity) into
+/// [`RPC_CALLING`] for the duration of one `on_transact`, restoring the
+/// previous value on drop (so nested re-entrant callbacks over the same
+/// connection nest correctly). Installed by the RPC dispatch path
 /// (`rpc::session::execute_dispatched`) around `rpc_transact`.
 #[cfg(feature = "rpc")]
 pub(crate) struct RpcCallingGuard {
-    previous: Option<RpcCallingContext>,
+    previous: Option<std::sync::Arc<crate::rpc::transport::PeerIdentity>>,
 }
 
 #[cfg(feature = "rpc")]
 impl RpcCallingGuard {
-    pub(crate) fn install(uid: binder::uid_t, pid: binder::pid_t) -> Self {
-        let previous = RPC_CALLING.with(|c| c.replace(Some(RpcCallingContext { uid, pid })));
+    pub(crate) fn install(peer: std::sync::Arc<crate::rpc::transport::PeerIdentity>) -> Self {
+        let previous = RPC_CALLING.with(|c| c.borrow_mut().replace(peer));
         RpcCallingGuard { previous }
     }
 }
@@ -137,7 +129,19 @@ impl RpcCallingGuard {
 #[cfg(feature = "rpc")]
 impl Drop for RpcCallingGuard {
     fn drop(&mut self) {
-        RPC_CALLING.with(|c| c.set(self.previous));
+        RPC_CALLING.with(|c| *c.borrow_mut() = self.previous.take());
+    }
+}
+
+/// `(uid, pid)` mapping for the current RPC peer: a Unix peer carries a
+/// kernel-vouched uid/pid; transports without a uid (`Vsock` /
+/// `Certificate` / `Anonymous`) map to the fail-closed
+/// [`RPC_UNKNOWN_CALLING_UID`] sentinel and pid `-1`.
+#[cfg(feature = "rpc")]
+fn peer_uid_pid(peer: &crate::rpc::transport::PeerIdentity) -> (binder::uid_t, binder::pid_t) {
+    match peer {
+        crate::rpc::transport::PeerIdentity::Local { uid, pid } => (*uid, *pid),
+        _ => (RPC_UNKNOWN_CALLING_UID, -1),
     }
 }
 
@@ -149,12 +153,87 @@ impl Drop for RpcCallingGuard {
 fn rpc_calling() -> Option<(binder::uid_t, binder::pid_t)> {
     #[cfg(feature = "rpc")]
     {
-        RPC_CALLING.with(|c| c.get()).map(|r| (r.uid, r.pid))
+        RPC_CALLING.with(|c| c.borrow().as_deref().map(peer_uid_pid))
     }
     #[cfg(not(feature = "rpc"))]
     {
         None
     }
+}
+
+/// The caller of the in-flight binder transaction, tagged by transport so
+/// handler-side authorization can branch **explicitly** — the kernel and
+/// RPC trust boundaries are genuinely different and must not be papered
+/// over (Plan 2-16). Returned by [`calling_caller`].
+///
+/// Authorization differs by arm:
+/// - [`Caller::Kernel`] — Android permissions (`@EnforcePermission` /
+///   [`crate::permission_controller::check_permission`]), `uid`/`pid`
+///   ACLs, or the SELinux `sid`.
+/// - [`Caller::Rpc`] — the transport's own trust boundary: a Unix
+///   [`PeerIdentity::Local`](crate::rpc::PeerIdentity) uid ACL, a TLS
+///   `Certificate` subject/fingerprint allowlist, etc.
+///   `@EnforcePermission` is **denied** over RPC (Plan 2-16 Phase A).
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum Caller {
+    /// A kernel-binder caller. `sid` is the SELinux context when the
+    /// target binder requested it (`BinderFeatures::set_requesting_sid`).
+    Kernel {
+        /// Caller effective uid (kernel `sender_euid`).
+        uid: binder::uid_t,
+        /// Caller pid (kernel `sender_pid`).
+        pid: binder::pid_t,
+        /// SELinux context, if delivered (see [`get_calling_sid`]).
+        sid: Option<CString>,
+    },
+    /// An RPC caller, identified by its transport peer identity.
+    #[cfg(feature = "rpc")]
+    Rpc(crate::rpc::transport::PeerIdentity),
+}
+
+/// The caller of the current in-flight binder transaction, tagged by
+/// transport ([`Caller`]), or `None` when this thread is not dispatching
+/// one. Pure-RPC safe (never forces the kernel `THREAD_STATE` /
+/// `ProcessState`).
+///
+/// This is the transport-aware basis for handler-side authorization: a
+/// service `match`es on the [`Caller`] arm and applies the right check
+/// (Android permission vs uid ACL vs TLS-cert allowlist). For a single
+/// injectable policy across both transports, see
+/// [`crate::permission_controller::PermissionAuthority`].
+pub fn calling_caller() -> Option<Caller> {
+    // RPC takes precedence and never touches the ProcessState-coupled
+    // kernel thread-local (works in a pure-RPC process).
+    #[cfg(feature = "rpc")]
+    {
+        if let Some(peer) = RPC_CALLING.with(|c| c.borrow().as_deref().cloned()) {
+            return Some(Caller::Rpc(peer));
+        }
+    }
+    if !ProcessState::is_initialized() {
+        return None;
+    }
+    THREAD_STATE.with(|thread_state| {
+        let thread_state = thread_state.borrow();
+        thread_state.transaction.as_ref().map(|tr| {
+            let sid = if tr.calling_sid.is_null() {
+                None
+            } else {
+                // SAFETY: `calling_sid` is the kernel-delivered, NUL-
+                // terminated SELinux context for this in-flight
+                // `BR_TRANSACTION_SEC_CTX`, valid until `BC_FREE_BUFFER`
+                // (after the handler returns). Same contract as
+                // `get_calling_sid`.
+                Some(unsafe { CStr::from_ptr(tr.calling_sid as _).to_owned() })
+            };
+            Caller::Kernel {
+                uid: tr.calling_uid,
+                pid: tr.calling_pid,
+                sid,
+            }
+        })
+    })
 }
 
 // Freeze observer BR labels (nr=20/21/22).
@@ -2160,24 +2239,28 @@ pub fn has_explicit_identity() -> bool {
 mod tests {
     use super::*;
 
-    /// Plan 2-16 Phase B: the RPC calling context is read by the public
-    /// accessors, restores on guard drop, nests correctly, and is
-    /// fail-closed for non-uid transports — all without a kernel
-    /// `ProcessState` (hermetic, runs on macOS). The `0`/`!handling`
-    /// outside the guard also proves the pure-RPC accessors are
-    /// panic-free with `ProcessState` uninitialized.
+    /// Plan 2-16 Phase B/C: the RPC calling context is read by the public
+    /// accessors (`get_calling_uid/pid`, `calling_caller`), restores on
+    /// guard drop, nests correctly, and is fail-closed for non-uid
+    /// transports — all without a kernel `ProcessState` (hermetic, runs on
+    /// macOS). The `0`/`!handling`/`None` outside the guard also proves the
+    /// pure-RPC accessors are panic-free with `ProcessState` uninitialized.
     #[cfg(feature = "rpc")]
     #[test]
     fn rpc_calling_context_is_read_restored_and_failclosed() {
+        use crate::rpc::transport::PeerIdentity;
+        use std::sync::Arc;
+
         // Outside any transaction (pure-RPC, no ProcessState): defined,
         // not a panic.
         assert_eq!(get_calling_uid(), 0);
         assert_eq!(get_calling_pid(), 0);
         assert!(!is_handling_transaction());
         assert!(get_calling_sid().is_none());
+        assert!(calling_caller().is_none());
 
         {
-            let _g = RpcCallingGuard::install(1234, 42);
+            let _g = RpcCallingGuard::install(Arc::new(PeerIdentity::Local { uid: 1234, pid: 42 }));
             assert_eq!(get_calling_uid(), 1234);
             assert_eq!(get_calling_pid(), 42);
             assert!(is_handling_transaction());
@@ -2185,15 +2268,27 @@ mod tests {
             assert!(get_calling_sid().is_none());
             assert_eq!(CallingContext::default().uid, 1234);
             assert_eq!(CallingContext::default().pid, 42);
+            // `calling_caller` exposes the full RPC peer (Phase C).
+            match calling_caller() {
+                Some(Caller::Rpc(PeerIdentity::Local { uid, pid })) => {
+                    assert_eq!((uid, pid), (1234, 42));
+                }
+                other => panic!("expected Caller::Rpc(Local), got {other:?}"),
+            }
 
             // Nested re-entrant callback over the same connection: a
-            // non-uid transport stamps the fail-closed sentinel; the
-            // outer identity is restored when it returns.
+            // non-uid transport (vsock) stamps the fail-closed sentinel;
+            // the outer identity is restored when it returns.
             {
-                let _g2 = RpcCallingGuard::install(RPC_UNKNOWN_CALLING_UID, -1);
+                let _g2 = RpcCallingGuard::install(Arc::new(PeerIdentity::Vsock { cid: 7 }));
                 assert_eq!(get_calling_uid(), RPC_UNKNOWN_CALLING_UID);
                 assert_ne!(get_calling_uid(), 0, "sentinel must never read as root");
                 assert_eq!(get_calling_pid(), -1);
+                // The full peer is still exposed for cid-based decisions.
+                assert!(matches!(
+                    calling_caller(),
+                    Some(Caller::Rpc(PeerIdentity::Vsock { cid: 7 }))
+                ));
             }
             assert_eq!(
                 get_calling_uid(),
@@ -2205,6 +2300,7 @@ mod tests {
         // Fully restored.
         assert_eq!(get_calling_uid(), 0);
         assert!(!is_handling_transaction());
+        assert!(calling_caller().is_none());
     }
 
     #[test]

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -1906,6 +1906,16 @@ pub fn get_calling_uid() -> binder::uid_t {
 /// `mCallingUid` to `getuid()` rather than zero — observers downstream
 /// (e.g. per-uid accounting in [`crate::proxy_count`]) get the same
 /// attribution they would on real Android.
+///
+/// # RPC transports (Plan 2-16 Phase B)
+///
+/// During an RPC transaction this returns the RPC caller uid, exactly as
+/// [`get_calling_uid`]: the kernel-vouched peer uid over Unix RPC, or the
+/// fail-closed sentinel (`u32::MAX`) over transports without a uid
+/// (`Vsock` / TLS `Certificate` / `Anonymous`). The self-uid fallback
+/// applies only outside any (kernel or RPC) transaction, so
+/// [`crate::proxy_count`] attribution over a uid-less RPC transport buckets
+/// under the `u32::MAX` sentinel rather than this process's uid.
 pub fn get_calling_uid_or_self() -> binder::uid_t {
     // Plan 2-16 Phase B: prefer the RPC caller uid when dispatching an RPC
     // transaction; otherwise fall back to the process's own uid without

--- a/tests/aidl/rpc_perm/IRpcCaller.aidl
+++ b/tests/aidl/rpc_perm/IRpcCaller.aidl
@@ -17,4 +17,12 @@ interface IRpcCaller {
 
     /** Returns `is_handling_transaction()` observed inside this handler. */
     boolean handlingTransaction();
+
+    /**
+     * Classifies `calling_caller()` observed inside this handler
+     * (Plan 2-16 Phase C): `"rpc-local:<uid>"` for a Unix RPC peer,
+     * `"rpc-other"` for a uid-less RPC transport, `"kernel"` for kernel
+     * binder, or `"none"` outside a transaction.
+     */
+    String callerKind();
 }

--- a/tests/aidl/rpc_perm/IRpcCaller.aidl
+++ b/tests/aidl/rpc_perm/IRpcCaller.aidl
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Plan 2-16 Phase B hermetic fixture: a service that reports the calling
+// identity it observes *inside* its handler, so a test can assert that
+// `get_calling_uid()` / `get_calling_pid()` / `is_handling_transaction()`
+// work over the RPC transport (Unix RPC carries a kernel-vouched peer
+// uid). `long` (i64) holds the unsigned uid without truncation.
+
+package rpccaller;
+
+interface IRpcCaller {
+    /** Returns `get_calling_uid()` observed inside this handler. */
+    long callingUid();
+
+    /** Returns `get_calling_pid()` observed inside this handler. */
+    long callingPid();
+
+    /** Returns `is_handling_transaction()` observed inside this handler. */
+    boolean handlingTransaction();
+}

--- a/tests/aidl/rpc_perm/IRpcPermGuard.aidl
+++ b/tests/aidl/rpc_perm/IRpcPermGuard.aidl
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Plan 2-16 Phase A hermetic fixture: an `@EnforcePermission` interface
+// served over the RPC transport. Every guarded method must deny with
+// `EX_SECURITY` regardless of process shape (the RPC root-bypass close),
+// while the un-annotated method round-trips normally — proving the deny
+// is scoped to the guarded arms, not the whole interface.
+
+package rpcperm;
+
+interface IRpcPermGuard {
+    @EnforcePermission("android.permission.INTERNET")
+    boolean doSingle();
+
+    @EnforcePermission(allOf = {"android.permission.INTERNET", "android.permission.ACCESS_NETWORK_STATE"})
+    boolean doAllOf();
+
+    @EnforcePermission(anyOf = {"android.permission.BLUETOOTH", "android.permission.BLUETOOTH_ADMIN"})
+    boolean doAnyOf();
+
+    /** Un-annotated: must round-trip over RPC, no deny. */
+    String echo(in String message);
+}

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -143,5 +143,22 @@ fn main() {
             .output(PathBuf::from("rpc_smoke.rs"))
             .generate()
             .unwrap();
+
+        // Plan 2-16 Phase A: an `@EnforcePermission` interface served over
+        // RPC, used by `tests/rpc_enforce_permission_deny.rs` to prove
+        // every guarded method denies (the RPC root-bypass close).
+        rsbinder_aidl::Builder::new()
+            .source(PathBuf::from("aidl/rpc_perm/IRpcPermGuard.aidl"))
+            .output(PathBuf::from("rpc_perm_guard.rs"))
+            .generate()
+            .unwrap();
+
+        // Plan 2-16 Phase B: a service that reports the calling identity it
+        // observes inside its handler, for `tests/rpc_calling_identity.rs`.
+        rsbinder_aidl::Builder::new()
+            .source(PathBuf::from("aidl/rpc_perm/IRpcCaller.aidl"))
+            .output(PathBuf::from("rpc_caller.rs"))
+            .generate()
+            .unwrap();
     }
 }

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -70,6 +70,28 @@ fn get_test_service() -> rsbinder::Strong<dyn ITestService::ITestService> {
     )
 }
 
+/// Plan 2-16 Phase D — kernel-transport parity for the service facade.
+/// The `kernel::Broker` resolves the *same* running test service that the
+/// rest of this suite reaches via `hub::get_interface`, and the resolved
+/// binder is fully functional. This is the kernel half of the facade's
+/// transport-parity proof; the RPC half is `tests/service_facade.rs`
+/// (`rpc::{Host, Broker}`). Both drive the same `Registry`/`Broker`
+/// traits, so registration/lookup code is written once.
+#[test]
+fn test_facade_kernel_broker_parity() {
+    use rsbinder::service::{kernel, Broker as _};
+    init_test();
+    let broker = kernel::Broker::new().expect("kernel::Broker::new");
+    let service: rsbinder::Strong<dyn ITestService::ITestService> = broker
+        .get_interface(<BpTestService as ITestService::ITestService>::descriptor())
+        .expect("facade kernel::Broker must resolve the running test service");
+    // The facade-resolved binder behaves exactly like a `hub`-resolved one.
+    assert_eq!(
+        service.RepeatString(&"facade".to_string()),
+        Ok("facade".to_string())
+    );
+}
+
 #[test]
 fn test_constants() {
     assert_eq!(ITestService::A1, 1);

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -86,10 +86,7 @@ fn test_facade_kernel_broker_parity() {
         .get_interface(<BpTestService as ITestService::ITestService>::descriptor())
         .expect("facade kernel::Broker must resolve the running test service");
     // The facade-resolved binder behaves exactly like a `hub`-resolved one.
-    assert_eq!(
-        service.RepeatString(&"facade".to_string()),
-        Ok("facade".to_string())
-    );
+    assert_eq!(service.RepeatString("facade"), Ok("facade".to_string()));
 }
 
 #[test]

--- a/tests/tests/rpc_calling_identity.rs
+++ b/tests/tests/rpc_calling_identity.rs
@@ -1,0 +1,110 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Plan 2-16 Phase B — `get_calling_uid()` / `get_calling_pid()` /
+//! `is_handling_transaction()` over the RPC transport.
+//!
+//! A Unix-domain (and the in-memory) RPC connection carries a
+//! kernel-vouched `PeerIdentity::Local { uid, pid }`; the dispatch path
+//! stamps it into the RPC calling context for the handler's duration. A
+//! handler served over RPC therefore observes the connecting peer's
+//! identity — proving a hand-written uid ACL runs transport-agnostically
+//! on kernel binder *and* Unix RPC. For a same-process hermetic transport
+//! (`mem` / `socketpair`) the peer *is* this process, so the observed uid
+//! is `getuid()` and pid is `process::id()` — exactly what a cross-process
+//! peer ACL would compare against, just with a known value.
+//!
+//! Granularity caveat (documented): the identity is **connection-level**,
+//! not per-method — an RPC connection is opened once by one peer process.
+//!
+//! Separate test binary, `#![cfg(feature = "rpc")]`. Each test builds its
+//! own session pair → parallel-safe.
+
+#![cfg(feature = "rpc")]
+#![allow(non_snake_case)]
+
+use std::thread;
+
+use rsbinder::rpc::transport::{MemTransport, UnixTransport};
+use rsbinder::rpc::{AddressSpace, RpcSession, RpcTransport};
+use rsbinder::{Interface, SIBinder};
+
+include!(concat!(env!("OUT_DIR"), "/rpc_caller.rs"));
+
+use rpccaller::IRpcCaller::{BnRpcCaller, IRpcCaller};
+
+struct CallerSvc;
+impl Interface for CallerSvc {}
+impl IRpcCaller for CallerSvc {
+    fn r#callingUid(&self) -> rsbinder::status::Result<i64> {
+        Ok(rsbinder::get_calling_uid() as i64)
+    }
+    fn r#callingPid(&self) -> rsbinder::status::Result<i64> {
+        Ok(rsbinder::get_calling_pid() as i64)
+    }
+    fn r#handlingTransaction(&self) -> rsbinder::status::Result<bool> {
+        Ok(rsbinder::is_handling_transaction())
+    }
+}
+
+fn root() -> SIBinder {
+    BnRpcCaller::new_binder(CallerSvc).as_binder()
+}
+
+fn run(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>) {
+    let server = RpcSession::new(server_t, AddressSpace::Acceptor).expect("RpcSession::new");
+    server.set_root(root());
+    let server_for_thread = server.clone();
+    let handle = thread::spawn(move || {
+        let _ = server_for_thread.serve_blocking();
+    });
+
+    {
+        let client = RpcSession::new(client_t, AddressSpace::Initiator).expect("RpcSession::new");
+        let sib = client.get_root().expect("get_root");
+        let caller = <dyn IRpcCaller as rsbinder::FromIBinder>::try_from(sib)
+            .expect("generated BpRpcCaller resolves from an RPC binder");
+
+        // The hermetic transports report this process as the peer, so the
+        // handler observes our own uid/pid — never the `0` (= root) that a
+        // pre-Phase-B (unpopulated) RPC dispatch would have surfaced.
+        let expected_uid = rustix::process::getuid().as_raw() as i64; // peer == this process
+        assert_eq!(
+            caller.r#callingUid().unwrap(),
+            expected_uid,
+            "RPC handler must observe the peer uid (here: this process)"
+        );
+        assert_ne!(
+            caller.r#callingUid().unwrap(),
+            0,
+            "uid must be the real peer uid, not the pre-Phase-B root bypass"
+        );
+        assert_eq!(
+            caller.r#callingPid().unwrap(),
+            std::process::id() as i64,
+            "RPC handler must observe the peer pid"
+        );
+        assert!(
+            caller.r#handlingTransaction().unwrap(),
+            "is_handling_transaction() must be true inside an RPC handler"
+        );
+
+        // Outside any handler the calling context is clear.
+        assert_eq!(rsbinder::get_calling_uid(), 0);
+        assert!(!rsbinder::is_handling_transaction());
+    }
+
+    handle.join().expect("server thread");
+}
+
+#[test]
+fn calling_identity_over_mem() {
+    let (a, b) = MemTransport::pair();
+    run(Box::new(a), Box::new(b));
+}
+
+#[test]
+fn calling_identity_over_unix_socketpair() {
+    let (a, b) = UnixTransport::pair().expect("socketpair");
+    run(Box::new(a), Box::new(b));
+}

--- a/tests/tests/rpc_calling_identity.rs
+++ b/tests/tests/rpc_calling_identity.rs
@@ -68,17 +68,22 @@ fn run(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>) {
         // The hermetic transports report this process as the peer, so the
         // handler observes our own uid/pid — never the `0` (= root) that a
         // pre-Phase-B (unpopulated) RPC dispatch would have surfaced.
-        let expected_uid = rustix::process::getuid().as_raw() as i64; // peer == this process
+        let expected_uid = rustix::process::getuid().as_raw() as i64;
         assert_eq!(
             caller.r#callingUid().unwrap(),
             expected_uid,
             "RPC handler must observe the peer uid (here: this process)"
         );
-        assert_ne!(
-            caller.r#callingUid().unwrap(),
-            0,
-            "uid must be the real peer uid, not the pre-Phase-B root bypass"
-        );
+        // The pre-Phase-B bypass surfaced `0` (root). Guard against it only
+        // when we are not actually running as root, so the test is not
+        // self-contradictory under a root runner (where expected_uid == 0).
+        if expected_uid != 0 {
+            assert_ne!(
+                caller.r#callingUid().unwrap(),
+                0,
+                "uid must be the real peer uid, not the pre-Phase-B root bypass"
+            );
+        }
         assert_eq!(
             caller.r#callingPid().unwrap(),
             std::process::id() as i64,

--- a/tests/tests/rpc_calling_identity.rs
+++ b/tests/tests/rpc_calling_identity.rs
@@ -45,6 +45,18 @@ impl IRpcCaller for CallerSvc {
     fn r#handlingTransaction(&self) -> rsbinder::status::Result<bool> {
         Ok(rsbinder::is_handling_transaction())
     }
+    fn r#callerKind(&self) -> rsbinder::status::Result<String> {
+        use rsbinder::rpc::PeerIdentity;
+        use rsbinder::Caller;
+        Ok(match rsbinder::calling_caller() {
+            Some(Caller::Rpc(PeerIdentity::Local { uid, .. })) => format!("rpc-local:{uid}"),
+            Some(Caller::Kernel { .. }) => "kernel".to_string(),
+            // `Caller` / `PeerIdentity` are `#[non_exhaustive]`: a uid-less
+            // RPC transport (or a future variant) lands here.
+            Some(_) => "rpc-other".to_string(),
+            None => "none".to_string(),
+        })
+    }
 }
 
 fn root() -> SIBinder {
@@ -92,6 +104,13 @@ fn run(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>) {
         assert!(
             caller.r#handlingTransaction().unwrap(),
             "is_handling_transaction() must be true inside an RPC handler"
+        );
+        // Phase C: `calling_caller()` exposes the full transport-tagged
+        // peer — here a Unix RPC local peer with this process's uid.
+        assert_eq!(
+            caller.r#callerKind().unwrap(),
+            format!("rpc-local:{}", rustix::process::getuid().as_raw()),
+            "calling_caller() must surface Caller::Rpc(PeerIdentity::Local) over Unix RPC"
         );
 
         // Outside any handler the calling context is clear.

--- a/tests/tests/rpc_enforce_permission_deny.rs
+++ b/tests/tests/rpc_enforce_permission_deny.rs
@@ -1,0 +1,120 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Plan 2-16 Phase A — `@EnforcePermission` over RPC fail-closes.
+//!
+//! An `@EnforcePermission` interface served over the RPC transport must
+//! deny **every guarded method** with `EX_SECURITY`, never silently
+//! grant. The bypass it closes: on the RPC dispatch path the kernel
+//! thread-local calling context is never populated, so
+//! `get_calling_uid()` reads `0` (= root), and Android's
+//! `PermissionManagerService` *unconditionally grants root* — turning a
+//! guarded method into a grant to any anonymous RPC peer. The deny is
+//! transport-driven (`reader.is_for_rpc()` in
+//! `permission_controller::check_permission`), so it fires **before** any
+//! uid read or PMS lookup, independent of process shape and of any future
+//! uid wiring (Phase B).
+//!
+//! Hermetic note on "both process shapes" (plan A.4): the pure-RPC shape
+//! (`ProcessState` uninitialized) and the hybrid shape (kernel binder up
+//! so PMS is reachable) take the **same** code path here — the deny
+//! short-circuits ahead of PMS, so it is PMS-independent by construction.
+//! This test runs the pure-RPC shape (no kernel binder on macOS/hermetic);
+//! the deny's PMS-independence is what makes the hybrid case equivalent.
+//! The un-annotated `echo` round-trips, proving the deny is scoped to the
+//! guarded arms, not the whole interface.
+//!
+//! Separate test binary, `#![cfg(feature = "rpc")]`, so it never shares a
+//! process with the kernel-binder unit tests. Each test builds its own
+//! session pair → parallel-safe.
+
+#![cfg(feature = "rpc")]
+#![allow(non_snake_case)]
+
+use std::thread;
+
+use rsbinder::rpc::transport::{MemTransport, UnixTransport};
+use rsbinder::rpc::{AddressSpace, RpcSession, RpcTransport};
+use rsbinder::{ExceptionCode, Interface, SIBinder};
+
+include!(concat!(env!("OUT_DIR"), "/rpc_perm_guard.rs"));
+
+use rpcperm::IRpcPermGuard::{BnRpcPermGuard, IRpcPermGuard};
+
+// ---- server impl: every guarded body would return `true` if reached ---
+//
+// The bodies intentionally return `Ok(true)` / echo the input — so if the
+// `@EnforcePermission` deny did NOT fire, the client would observe `true`
+// / the echoed string instead of `EX_SECURITY`. That makes a leaked check
+// a hard failure, not a silent pass.
+
+struct GuardSvc;
+impl Interface for GuardSvc {}
+impl IRpcPermGuard for GuardSvc {
+    fn r#doSingle(&self) -> rsbinder::status::Result<bool> {
+        Ok(true)
+    }
+    fn r#doAllOf(&self) -> rsbinder::status::Result<bool> {
+        Ok(true)
+    }
+    fn r#doAnyOf(&self) -> rsbinder::status::Result<bool> {
+        Ok(true)
+    }
+    fn r#echo(&self, message: &str) -> rsbinder::status::Result<String> {
+        Ok(message.to_string())
+    }
+}
+
+fn root() -> SIBinder {
+    BnRpcPermGuard::new_binder(GuardSvc).as_binder()
+}
+
+fn run(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>) {
+    let server = RpcSession::new(server_t, AddressSpace::Acceptor).expect("RpcSession::new");
+    server.set_root(root());
+    let server_for_thread = server.clone();
+    let handle = thread::spawn(move || {
+        let _ = server_for_thread.serve_blocking();
+    });
+
+    {
+        let client = RpcSession::new(client_t, AddressSpace::Initiator).expect("RpcSession::new");
+        let sib = client.get_root().expect("get_root");
+        let guard = <dyn IRpcPermGuard as rsbinder::FromIBinder>::try_from(sib)
+            .expect("generated BpRpcPermGuard resolves from an RPC binder");
+
+        // Every guarded form denies with EX_SECURITY over RPC.
+        for (name, res) in [
+            ("doSingle", guard.r#doSingle()),
+            ("doAllOf", guard.r#doAllOf()),
+            ("doAnyOf", guard.r#doAnyOf()),
+        ] {
+            let err = res.expect_err(&format!(
+                "{name}: @EnforcePermission must deny over RPC, not grant"
+            ));
+            assert_eq!(
+                err.exception_code(),
+                ExceptionCode::Security,
+                "{name}: deny must be EX_SECURITY (got {err:?})"
+            );
+        }
+
+        // The un-annotated method is unaffected — deny is per-arm, not
+        // per-interface.
+        assert_eq!(guard.r#echo("hi").unwrap(), "hi");
+    }
+
+    handle.join().expect("server thread");
+}
+
+#[test]
+fn enforce_permission_denies_over_mem() {
+    let (a, b) = MemTransport::pair();
+    run(Box::new(a), Box::new(b));
+}
+
+#[test]
+fn enforce_permission_denies_over_unix_socketpair() {
+    let (a, b) = UnixTransport::pair().expect("socketpair");
+    run(Box::new(a), Box::new(b));
+}

--- a/tests/tests/service_facade.rs
+++ b/tests/tests/service_facade.rs
@@ -39,6 +39,26 @@ impl IRpcSmoke for SmokeSvc {
     }
 }
 
+/// A service that prefixes its own `tag` onto every echo, so a caller can
+/// tell *which* registered binder answered. Used by
+/// `facade_incremental_services_all_resolve` to verify the directory maps
+/// each name to its own binder, not merely that some binder answers.
+struct TaggedSvc {
+    tag: String,
+}
+impl Interface for TaggedSvc {}
+impl IRpcSmoke for TaggedSvc {
+    fn r#echo(&self, s: &str) -> rsbinder::status::Result<String> {
+        Ok(format!("{}:{}", self.tag, s))
+    }
+    fn r#add(&self, a: i32, b: i32) -> rsbinder::status::Result<i32> {
+        Ok(a + b)
+    }
+    fn r#ping(&self) -> rsbinder::status::Result<()> {
+        Ok(())
+    }
+}
+
 // ---- the transport-agnostic code: written ONCE, generic over the trait --
 
 fn register_all<R: Registry>(reg: &R, binder: SIBinder) -> rsbinder::Result<()> {
@@ -98,6 +118,40 @@ fn facade_lookup_missing_is_name_not_found() {
         missing.is_err(),
         "looking up an unregistered name must be an Err, got {missing:?}"
     );
+
+    host.server().shutdown();
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Incremental registration: several `add_service` calls — including one
+/// made *after* the server is already serving — each resolve to **their
+/// own** binder. Locks in the O(1) shared-map `add_service` (the directory
+/// is built once and reads the live map): a service added later is seen
+/// without a per-call rebuild/root-swap, and each name maps to its own
+/// binder (the `TaggedSvc` prefix would expose a name→binder mismap).
+#[test]
+fn facade_incremental_services_all_resolve() {
+    use rsbinder::service::rpc::{Broker as RpcBroker, Host as RpcHost};
+
+    let path = unique_socket_path("incremental");
+    let host = RpcHost::unix(&path).expect("RpcHost::unix");
+
+    let tagged = |tag: &str| BnRpcSmoke::new_binder(TaggedSvc { tag: tag.into() }).as_binder();
+    // Two services registered before serving, one after — separate calls.
+    host.add_service("first", tagged("first")).unwrap();
+    host.add_service("second", tagged("second")).unwrap();
+    let _bg = host.serve_background();
+    host.add_service("third", tagged("third")).unwrap();
+
+    let broker = RpcBroker::unix(&path).expect("RpcBroker::unix");
+    for name in ["first", "second", "third"] {
+        let svc: Strong<dyn IRpcSmoke> = broker
+            .get_interface(name)
+            .unwrap_or_else(|e| panic!("{name} must resolve, got {e:?}"));
+        // `TaggedSvc` prefixes its own name, so this fails if the directory
+        // returned a different service's binder for this name.
+        assert_eq!(svc.r#echo("x").unwrap(), format!("{name}:x"));
+    }
 
     host.server().shutdown();
     let _ = std::fs::remove_file(&path);

--- a/tests/tests/service_facade.rs
+++ b/tests/tests/service_facade.rs
@@ -1,0 +1,104 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Plan 2-16 Phase D — cross-transport service facade.
+//!
+//! The whole point of the facade is that **registration and lookup code is
+//! written once** and the transport is picked by construction. This test
+//! proves it: a single generic `register_all<R: Registry>` and a single
+//! generic `talk<B: Broker>` are driven over the RPC transport via
+//! `service::rpc::{Host, Broker}`. The same generic functions would accept
+//! `service::kernel::{Host, Broker}` (exercised on REMOTE_LINUX, where
+//! `/dev/binder` exists).
+//!
+//! Separate test binary, `#![cfg(feature = "rpc")]`.
+
+#![cfg(feature = "rpc")]
+#![allow(non_snake_case)]
+
+use std::path::PathBuf;
+
+use rsbinder::service::{Broker, Registry};
+use rsbinder::{Interface, SIBinder, Strong};
+
+include!(concat!(env!("OUT_DIR"), "/rpc_smoke.rs"));
+
+use rpcsmoke::IRpcSmoke::{BnRpcSmoke, IRpcSmoke};
+
+struct SmokeSvc;
+impl Interface for SmokeSvc {}
+impl IRpcSmoke for SmokeSvc {
+    fn r#echo(&self, s: &str) -> rsbinder::status::Result<String> {
+        Ok(s.to_string())
+    }
+    fn r#add(&self, a: i32, b: i32) -> rsbinder::status::Result<i32> {
+        Ok(a + b)
+    }
+    fn r#ping(&self) -> rsbinder::status::Result<()> {
+        Ok(())
+    }
+}
+
+// ---- the transport-agnostic code: written ONCE, generic over the trait --
+
+fn register_all<R: Registry>(reg: &R, binder: SIBinder) -> rsbinder::Result<()> {
+    reg.add_service("smoke", binder)
+}
+
+fn talk<B: Broker>(broker: &B) -> rsbinder::Result<()> {
+    let smoke: Strong<dyn IRpcSmoke> = broker.get_interface("smoke")?;
+    assert_eq!(smoke.r#echo("facade").unwrap(), "facade");
+    assert_eq!(smoke.r#add(40, 2).unwrap(), 42);
+    smoke.r#ping().unwrap();
+    Ok(())
+}
+
+fn unique_socket_path(tag: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("rsb_facade_{}_{}.sock", tag, std::process::id()));
+    p
+}
+
+#[test]
+fn facade_register_and_talk_over_rpc_unix() {
+    use rsbinder::service::rpc::{Broker as RpcBroker, Host as RpcHost};
+
+    let path = unique_socket_path("rpc");
+
+    // Server: build a host, register generically, serve in the background.
+    let host = RpcHost::unix(&path).expect("RpcHost::unix");
+    let svc = BnRpcSmoke::new_binder(SmokeSvc).as_binder();
+    register_all(&host, svc).expect("register_all over RpcHost");
+    let _bg = host.serve_background();
+
+    // Client: build a broker, look up + call generically.
+    let broker = RpcBroker::unix(&path).expect("RpcBroker::unix");
+    talk(&broker).expect("talk over RpcBroker");
+
+    // The host's RPC-only powers stay reachable on the concrete type
+    // (not faked onto the shared trait).
+    host.server().shutdown();
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn facade_lookup_missing_is_name_not_found() {
+    use rsbinder::service::rpc::{Broker as RpcBroker, Host as RpcHost};
+
+    let path = unique_socket_path("missing");
+    let host = RpcHost::unix(&path).expect("RpcHost::unix");
+    // Register one service so the directory root exists, then look up a
+    // different name.
+    register_all(&host, BnRpcSmoke::new_binder(SmokeSvc).as_binder()).unwrap();
+    let _bg = host.serve_background();
+
+    let broker = RpcBroker::unix(&path).expect("RpcBroker::unix");
+    let missing = broker.lookup("does-not-exist");
+    assert!(
+        missing.is_err(),
+        "looking up an unregistered name must be an Err, got {missing:?}"
+    );
+
+    host.server().shutdown();
+    let _ = std::fs::remove_file(&path);
+}


### PR DESCRIPTION
## Summary

Plan 2-16 makes calling identity and authorization work coherently across the
kernel-binder and RPC transports, and adds a thin **cross-transport service
facade** so registration/lookup code can be written once and run over either
transport. Documentation is updated to match.

This is **additive and zero-cost when unused** — the low-level
`ProcessState` / `hub` / `RpcServer` / `RpcSession` APIs are unchanged and the
kernel wire stays byte-identical.

## What's in it

**Calling identity over RPC (Phase A + B)**
- Fail-closed calling identity over the RPC transport: `get_calling_uid()`
  returns the kernel-vouched peer uid on Unix RPC and a fail-closed sentinel on
  uid-less transports; `@EnforcePermission` methods **deny** over RPC rather
  than silently granting.

**Authorization plumbing (Phase C)**
- Transport-tagged `Caller` accessor so handlers can authorize regardless of
  transport.
- Injectable `PermissionAuthority` slot for cross-transport authz.

**Cross-transport service facade (Phase D)**
- New `rsbinder::service` module: object-safe `Registry` (server) / `Broker`
  (client) traits plus typed `kernel::{Host,Broker}` and
  `rpc::{Host,Broker}` pairs. Only the genuine kernel∩RPC intersection
  (`add_service` / `lookup`) is on the traits; kernel-only powers stay on the
  concrete types.
- O(1) `add_service` via a shared, build-once `ServiceDirectory`.

**AIDL**
- `@EnforcePermission` codegen covered on the async service path.

**Examples & tests**
- `example-hello`: `unified_service` / `unified_client` (one-line transport
  swap) and a handler-side `authz` example.
- New hermetic tests: `service_facade`, `rpc_calling_identity`,
  `rpc_enforce_permission_deny`.

**Docs (book)**
- New chapters: *Cross-Transport Services*, *Security & Authorization*.
- Reframed the *Async Service* chapter around transport-agnostic async (the
  same async service runs over kernel binder or RPC through the facade), with
  an honest note that async is a `spawn_blocking`/`block_on` thread bridge
  (same as the kernel `binder_tokio` path), not an epoll reactor, and the one
  real RPC requirement: a multi-threaded runtime.
- Corrected AIDL/RPC/stability chapters to match the implementation.

## Verification

Hermetic test suites pass on macOS; the calling-identity and
`@EnforcePermission`-deny behaviors are exercised end-to-end over a real Unix
RPC session. Kernel wire is byte-unchanged when the new opt-in paths are not
used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)