### PR TITLE
docs(book): accuracy & clarity fixes from a full review

### DIFF
--- a/book/src/aidl-enum-union.md
+++ b/book/src/aidl-enum-union.md
@@ -156,7 +156,7 @@ let u = Union::Union::S(Union::S1.to_string());
 
 ### Union Tags
 
-Each union has an associated `Tag` enum that identifies which variant is currently active. Tags are useful when you need to inspect or communicate which field a union holds without extracting the value itself.
+Each union has an associated `Tag` type that identifies which variant is currently active. (Like AIDL enums, it is generated as a newtype struct whose variants are exposed as associated constants such as `Union::Tag::n`.) Tags are useful when you need to inspect or communicate which field a union holds without extracting the value itself.
 
 ```rust
 let result = service.GetUnionTags(&[

--- a/book/src/aidl-parcelable.md
+++ b/book/src/aidl-parcelable.md
@@ -61,7 +61,7 @@ parcelable Config {
 In Rust, the constants are accessed through the type path:
 
 ```rust
-use config::Config;
+use Config::Config;
 
 let mut cfg = Config::default();
 assert_eq!(cfg.retryCount, 5);

--- a/book/src/android-build.md
+++ b/book/src/android-build.md
@@ -144,13 +144,15 @@ The `envsetup.sh` script also provides functions for remote Linux testing (`remo
 
 ### Configuration File: REMOTE_ANDROID
 
-Create a `REMOTE_ANDROID` file in the project root to configure your Android target:
+Create a `REMOTE_ANDROID` file in the project root to configure your Android target.
+It must contain **exactly three bare lines** in this order — the cargo-ndk target,
+the Rust target architecture, and the remote directory on the device. The file is
+read line by line, so do **not** add inline comments or blank lines:
 
-```bash
-# Example REMOTE_ANDROID file
-arm64-v8a           # cargo-ndk target
-aarch64             # rust target architecture
-/data/rsbinder      # remote directory on device
+```text
+arm64-v8a
+aarch64
+/data/rsbinder
 ```
 
 Common target configurations:

--- a/book/src/arch-linux.md
+++ b/book/src/arch-linux.md
@@ -50,7 +50,8 @@ $ cargo install rsbinder-tools
 Create a binder device and test the setup:
 
 ```bash
-# Create binder device
+# Create binder device (binderfs devices are not persistent —
+# re-run this after each reboot)
 $ sudo rsb_device binder
 
 # Verify device creation

--- a/book/src/async-service.md
+++ b/book/src/async-service.md
@@ -204,10 +204,12 @@ runtime.block_on(async {
 ```
 
 > The blocking bootstrap — `Broker::unix`, `get_interface` — is done *before* entering the
-> runtime; only the transacts themselves are `.await`ed. This mirrors the verified end-to-end
-> test `tests/tests/rpc_async.rs`, which drives the generated async `Bp*` against an async
-> service over a real Unix-socket session, including many in-flight calls on one shared
-> session under genuine async concurrency.
+> runtime; only the transacts themselves are `.await`ed. The async-over-RPC *bridge* shown
+> here (`new_async_binder` + `into_async::<Tokio>` over a real Unix-socket session, multi-thread
+> runtime) is verified end-to-end by `tests/tests/rpc_async.rs` — including many in-flight
+> calls on one shared session under genuine async concurrency. That test drives the bridge
+> through the lower-level `RpcSession` API directly rather than the `rpc::Host`/`Broker`
+> facade, but the facade is a thin wrapper over exactly that path.
 
 ### Switching transports
 

--- a/book/src/error-handling.md
+++ b/book/src/error-handling.md
@@ -97,6 +97,7 @@ status.is_ok()               // -> bool
 | `UnsupportedOperation` |         -7 | Requested operation is not supported                           |
 | `ServiceSpecific`      |         -8 | Application-defined error with custom code                     |
 | `Parcelable`           |         -9 | Embedded user parcelable exception (Java compatibility)        |
+| `HasNotedAppOpsReplyHeader` | -127 | Internal: reply parcel carries an AppOps noted-ops header       |
 | `HasReplyHeader`       |       -128 | Internal: reply parcel carries a header (Java-specific marker) |
 | `TransactionFailed`    |       -129 | Low-level transaction failure                                  |
 | `JustError`            |       -256 | Generic error fallback used internally by the library          |

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -48,9 +48,10 @@ If you are new to Binder IPC, we recommend following this learning path:
 
 **rsbinder** ships two parallel stacks — pick by platform and use case:
 
-- **Kernel binder** (the default in this guide): Linux 4.17+ with
-  binderfs enabled, or Android. Talks to the kernel binder driver
-  through `/dev/binderfs/binder` (Linux) or `/dev/binder` (Android).
+- **Kernel binder** (the default in this guide): Linux 5.0+ with
+  binderfs enabled (the `binderfs` filesystem landed in 5.0), or
+  Android. Talks to the kernel binder driver through
+  `/dev/binderfs/binder` (Linux) or `/dev/binder` (Android).
 - **RPC transport** (binder-over-socket, opt-in via the `rpc`
   feature): pure user-space, no kernel binder driver. Runs on
   **Linux, Android, and macOS** over Unix-domain sockets, vsock, or

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -3,9 +3,9 @@ Welcome to **rsbinder**!
 
 **rsbinder** is a Rust library and toolset that enables you to utilize Binder IPC on Linux and Android OS. It provides pure Rust implementations that make Binder IPC available across both platforms.
 
-Binder IPC is an object-oriented IPC (Inter-Process Communication) mechanism that Google added to the Linux kernel for Android. Android uses Binder IPC for all process communication, and it has been part of the mainline Linux kernel since version 4.17, making it available on all modern Linux systems.
+Binder IPC is an object-oriented IPC (Inter-Process Communication) mechanism that Google added to the Linux kernel for Android. Android uses Binder IPC for all process communication, and the binder driver has been part of the mainline Linux kernel since version 4.17 (with the `binderfs` filesystem rsbinder uses arriving in 5.0).
 
-However, since it is rarely used outside of Android, it is disabled by default in most Linux distributions.
+However, since it is rarely used outside of Android, it is disabled by default in most Linux distributions, so you typically need a kernel built with binder support to use the kernel-binder path (see [Enable binder for Linux](./enable-binder-for-linux.md)).
 
 **rsbinder ships two parallel stacks:**
 

--- a/book/src/rpc-transport.md
+++ b/book/src/rpc-transport.md
@@ -276,7 +276,9 @@ Each transport defines its own trust boundary, surfaced as a
   ACL basis on its own — the trust comes from hypervisor isolation).
 - **`Certificate(CertId)`** — TLS peer authenticated by its leaf cert.
 - **`Anonymous`** — no identity at all. ACL is impossible against an
-  anonymous peer. Only the debug TCP backend returns this.
+  anonymous peer. The debug TCP backend always returns this, and **any**
+  backend falls back to it (logged loudly) if peer-credential resolution
+  fails — so an authorizer must treat `Anonymous` as deny.
 
 Use [`RpcServer::set_authorizer`] to enforce a per-connection policy.
 The closure runs once on accept, **before any RPC byte is exchanged**:


### PR DESCRIPTION
## Summary

Full pass over the book (all 28 chapters), cross-checking every claim against
the current source. Docs-only; no code change. mdBook builds clean.

### Correctness fixes
- **aidl-parcelable** — the constants example used `use config::Config;`, but the
  generated module keeps the parcelable's name verbatim. Fixed to
  `use Config::Config;` (the lowercase form does not compile). *(HIGH — broken example)*
- **rpc-transport** — `PeerIdentity::Anonymous` is not debug-TCP-only: the unix,
  vsock, and tls backends all fall back to it (logged loudly) when peer-credential
  resolution fails. Reworded, and noted an authorizer must treat `Anonymous` as deny.
- **android-build** — the `REMOTE_ANDROID` example carried inline `# ...` comments,
  but `read_remote_android` reads three bare lines without stripping comments, so the
  comments would be parsed into the values. Removed them and stated the exact format.

### Accuracy / consistency
- **overview / getting-started** — binderfs (the filesystem rsbinder uses) landed in
  Linux **5.0**, not 4.17; made the two chapters consistent and dropped the
  "available on all modern Linux systems" line that contradicted the next sentence.
- **async-service** — softened the claim that the `rpc::Host`/`Broker` facade example
  is mirrored by `rpc_async.rs`; that test exercises the same bridge through the
  lower-level `RpcSession` API.
- **aidl-enum-union** — the union `Tag` is a newtype struct, not an enum.
- **error-handling** — added the `HasNotedAppOpsReplyHeader (-127)` `ExceptionCode` row.

### Clarity
- **arch-linux** — noted binderfs devices are not persistent across reboot.

### Deliberately not changed
- Crate version pins stay at `0.8` — that is the latest crates.io release (workspace
  is at `0.9.0` but unreleased). These should bump to `0.9` when 0.9.0 publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)