### PR TITLE
fix: audit findings + AOSP-faithful WIBinder::upgrade

### DIFF
--- a/example-hello/src/bin/hello_client.rs
+++ b/example-hello/src/bin/hello_client.rs
@@ -4,20 +4,9 @@
 
 use env_logger::Env;
 use example_hello::*;
-use hub::{BnServiceCallback, IServiceCallback};
 use rsbinder::*;
 use std::sync::Arc;
-
-struct MyServiceCallback {}
-
-impl Interface for MyServiceCallback {}
-
-impl IServiceCallback for MyServiceCallback {
-    fn onRegistration(&self, name: &str, _service: &SIBinder) -> rsbinder::status::Result<()> {
-        println!("MyServiceCallback: {name}");
-        Ok(())
-    }
-}
+use std::time::Duration;
 
 struct MyDeathRecipient {}
 
@@ -39,12 +28,24 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         println!("{name}");
     }
 
-    let service_callback = BnServiceCallback::new_binder(MyServiceCallback {});
-    hub::register_for_notifications(SERVICE_NAME, &service_callback)?;
-
-    // Create a Hello proxy from binder service manager.
-    let hello: rsbinder::Strong<dyn IHello> =
-        hub::get_interface(SERVICE_NAME).unwrap_or_else(|_| panic!("Can't find {SERVICE_NAME}"));
+    // Create a Hello proxy from the binder service manager. If this client
+    // starts before the service has finished registering, the lookup fails, so
+    // retry a few times before giving up and surfacing the real Status error.
+    let hello: rsbinder::Strong<dyn IHello> = {
+        const RETRIES: u32 = 5;
+        let mut attempt = 0;
+        loop {
+            match hub::get_interface(SERVICE_NAME) {
+                Ok(hello) => break hello,
+                Err(e) if attempt < RETRIES => {
+                    attempt += 1;
+                    std::thread::sleep(Duration::from_millis(500));
+                    println!("Waiting for {SERVICE_NAME}... (retry {attempt}/{RETRIES}): {e}");
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+    };
 
     let recipient = Arc::new(MyDeathRecipient {});
     hello

--- a/rsbinder-aidl/src/generator.rs
+++ b/rsbinder-aidl/src/generator.rs
@@ -431,7 +431,7 @@ pub mod {{mod}} {
             };
             let binder = self.binder.clone();
             P::spawn(
-                move || binder.as_remote().ok_or({{crate}}::StatusCode::BadType)?.submit_transact(transactions::r#{{ member.identifier }}, &_aidl_data, {{crate}}::FLAG_CLEAR_BUF | {{crate}}::FLAG_PRIVATE_LOCAL),
+                move || binder.as_remote().ok_or({{crate}}::StatusCode::BadType)?.submit_transact(transactions::r#{{ member.identifier }}, &_aidl_data, {% if oneway or member.oneway %}{{crate}}::FLAG_ONEWAY | {% endif %}{{crate}}::FLAG_CLEAR_BUF | {{crate}}::FLAG_PRIVATE_LOCAL),
                 move |_aidl_reply| async move {
                     {%- if member.func_call_params|length > 0 %}
                     self.read_response_{{ member.identifier }}({{ member.func_call_params }}, _aidl_reply)
@@ -1214,7 +1214,16 @@ pub mod {mod} {{
             if let Some(expr) =
                 parser::enum_member_const_expr_from_lookup(&lookup_decl, &enumerator.identifier)
             {
-                members.push((enumerator.identifier.to_owned(), expr.to_i64().unwrap_or(0)));
+                let value = expr.to_i64().map_err(|e| {
+                    parser::make_invalid_operation_error(
+                        format!(
+                            "enum '{}' member '{}' has a non-integral discriminant: {e}",
+                            decl.name, enumerator.identifier
+                        ),
+                        decl.name_span,
+                    )
+                })?;
+                members.push((enumerator.identifier.to_owned(), value));
             }
         }
 

--- a/rsbinder-aidl/src/parser.rs
+++ b/rsbinder-aidl/src/parser.rs
@@ -415,20 +415,31 @@ pub(crate) fn enum_member_const_expr_from_lookup(
 
     // Resolve inside the enum declaration, not through a global member name.
     for enumerator in &enum_decl.enumerator_list {
+        // A genuinely non-integral explicit value (String/Array — not an
+        // unresolved Name) must not be swallowed into the auto-increment
+        // counter: that would fabricate a wrong, silently-zeroed wire
+        // discriminant. Carry the raw value out so `decl_enum`'s `to_i64()`
+        // guard surfaces the diagnostic.
+        let mut non_integral: Option<ConstExpr> = None;
         if let Some(const_expr) = &enumerator.const_expr {
             if let Ok(calculated) = const_expr.calculate() {
                 if !matches!(calculated.value, ValueType::Name(_)) {
-                    enum_val = calculated.to_i64().unwrap_or(enum_val);
+                    match calculated.to_i64() {
+                        Ok(v) => enum_val = v,
+                        Err(_) => non_integral = Some(calculated),
+                    }
                 }
             }
         }
 
         if enumerator.identifier == member_name {
-            result = Some(ConstExpr::new(ValueType::Reference {
-                enum_type: enum_type.clone(),
-                enum_name: enum_decl.name.clone(),
-                member_name: member_name.to_string(),
-                value: enum_val,
+            result = Some(non_integral.unwrap_or_else(|| {
+                ConstExpr::new(ValueType::Reference {
+                    enum_type: enum_type.clone(),
+                    enum_name: enum_decl.name.clone(),
+                    member_name: member_name.to_string(),
+                    value: enum_val,
+                })
             }));
             break;
         }
@@ -1104,7 +1115,10 @@ fn make_invalid_backing_type_error(type_name: String, span: Option<(usize, usize
 }
 
 /// Builds an `InvalidOperation` diagnostic from the active source context.
-fn make_invalid_operation_error(message: String, span: Option<(usize, usize)>) -> AidlError {
+pub(crate) fn make_invalid_operation_error(
+    message: String,
+    span: Option<(usize, usize)>,
+) -> AidlError {
     let filename = CURRENT_SOURCE_NAME.with(|name| name.borrow().clone());
     let source = CURRENT_SOURCE_TEXT.with(|text| text.borrow().clone());
     let (start, end) = span.unwrap_or((0, 0));

--- a/rsbinder-tools/src/bin/rsb_hub.rs
+++ b/rsbinder-tools/src/bin/rsb_hub.rs
@@ -30,6 +30,61 @@ struct Service {
     is_accessor: bool,
 }
 
+/// A callback invocation deferred until after the `Inner` mutex guard is
+/// dropped. Collected while holding the lock, fired afterwards — outbound
+/// binder transactions must never run while holding state (R1), and AOSP's
+/// servicemanager likewise fans out callbacks without holding its lock.
+enum PendingCallback {
+    Registration {
+        callback:
+            rsbinder::Strong<dyn hub::android_16::android::os::IServiceCallback::IServiceCallback>,
+        name: String,
+        binder: SIBinder,
+    },
+    Clients {
+        callback:
+            rsbinder::Strong<dyn hub::android_16::android::os::IClientCallback::IClientCallback>,
+        binder: SIBinder,
+        has_clients: bool,
+    },
+}
+
+impl PendingCallback {
+    fn fire(self) -> rsbinder::status::Result<()> {
+        match self {
+            PendingCallback::Registration {
+                callback,
+                name,
+                binder,
+            } => callback.onRegistration(&name, &binder),
+            PendingCallback::Clients {
+                callback,
+                binder,
+                has_clients,
+            } => callback.onClients(&binder, has_clients),
+        }
+    }
+}
+
+/// Fire each collected callback after the caller has dropped the `Inner`
+/// guard. Order is preserved (collection order = invocation order). Errors
+/// are logged and swallowed — matches the prior in-lock notification paths.
+fn fire_pending(pending: Vec<PendingCallback>) {
+    for cb in pending {
+        cb.fire()
+            .unwrap_or_else(|e| log::error!("Failed to notify client callback: {e:?}"));
+    }
+}
+
+/// Like [`fire_pending`] but propagates the first callback error, preserving
+/// `addService`'s original error-propagating semantics for `onRegistration`.
+fn fire_pending_propagate(pending: Vec<PendingCallback>) -> rsbinder::status::Result<()> {
+    for cb in pending {
+        cb.fire()?;
+    }
+    Ok(())
+}
+
 struct DeathRecipientWrapper(mpsc::Sender<rsbinder::WIBinder>);
 
 impl rsbinder::DeathRecipient for DeathRecipientWrapper {
@@ -86,11 +141,15 @@ impl Inner {
         Ok(())
     }
 
+    /// Mutate `service.has_clients` under the lock and *collect* (do not
+    /// invoke) the resulting `onClients` notifications into `pending`. The
+    /// caller fires them via [`fire_pending`] after dropping the guard (R1).
     fn send_client_callback_notification(
         &mut self,
         service_name: &str,
         has_clients: bool,
         context: &str,
+        pending: &mut Vec<PendingCallback>,
     ) {
         let service = if let Some(service) = self.name_to_service.get_mut(service_name) {
             service
@@ -122,25 +181,35 @@ impl Inner {
             context
         );
 
-        self.name_to_client_callbacks.get(service_name).map(|callbacks| {
-            for callback in callbacks {
-                callback.onClients(&service.binder, has_clients)
-                    .unwrap_or_else(|e| {
-                        log::error!("Failed to notify client callback: {e:?}");
+        let binder = service.binder.clone();
+        match self.name_to_client_callbacks.get(service_name) {
+            Some(callbacks) => {
+                for callback in callbacks {
+                    pending.push(PendingCallback::Clients {
+                        callback: callback.clone(),
+                        binder: binder.clone(),
+                        has_clients,
                     });
+                }
             }
-        }).unwrap_or_else(|| {
-            log::warn!("send_client_callback_notification could not find callbacks for service when {context}");
-        });
+            None => {
+                log::warn!("send_client_callback_notification could not find callbacks for service when {context}");
+            }
+        }
 
-        service.has_clients = has_clients;
+        if let Some(service) = self.name_to_service.get_mut(service_name) {
+            service.has_clients = has_clients;
+        }
     }
 
+    /// Like its name suggests, but collects callbacks into `pending` instead
+    /// of invoking them (see [`Inner::send_client_callback_notification`]).
     fn handle_service_client_callback(
         &mut self,
         known_clients: usize,
         service_name: &str,
         is_called_on_interval: bool,
+        pending: &mut Vec<PendingCallback>,
     ) -> Result<bool> {
         let service = if let Some(service) = self.name_to_service.get(service_name) {
             if self
@@ -183,6 +252,7 @@ impl Inner {
                     service_name,
                     true,
                     "service is guaranteed to be in use",
+                    pending,
                 );
             }
 
@@ -206,6 +276,7 @@ impl Inner {
                 service_name,
                 true,
                 "we now have a record of a client",
+                pending,
             );
             if let Some(service) = self.name_to_service.get(service_name) {
                 has_clients = service.has_clients;
@@ -217,6 +288,7 @@ impl Inner {
                 service_name,
                 false,
                 "we now have no record of a client",
+                pending,
             );
             if let Some(service) = self.name_to_service.get(service_name) {
                 has_clients = service.has_clients;
@@ -236,6 +308,7 @@ impl Inner {
         &mut self,
         name: &str,
         _start_if_not_found: bool,
+        pending: &mut Vec<PendingCallback>,
     ) -> rsbinder::status::Result<Option<(SIBinder, bool)>> {
         let service = if let Some(service) = self.name_to_service.get_mut(name) {
             service
@@ -246,7 +319,7 @@ impl Inner {
         let out = service.binder.clone();
         let is_accessor = service.is_accessor;
         service.guarantee_client = true;
-        self.handle_service_client_callback(Self::KNOWN_CLIENTS_ON_DEMAND, name, false)?;
+        self.handle_service_client_callback(Self::KNOWN_CLIENTS_ON_DEMAND, name, false, pending)?;
 
         if let Some(service) = self.name_to_service.get_mut(name) {
             service.guarantee_client = true;
@@ -395,13 +468,19 @@ impl ServiceManager {
                 // (one entry per registered service) — a transient `Vec`
                 // is cheaper than the alternative refactor.
                 let names: Vec<String> = inner.name_to_service.keys().cloned().collect();
+                let mut pending = Vec::new();
                 for name in &names {
-                    if let Err(e) =
-                        inner.handle_service_client_callback(Inner::KNOWN_CLIENTS_PERIODIC, name, true)
-                    {
+                    if let Err(e) = inner.handle_service_client_callback(
+                        Inner::KNOWN_CLIENTS_PERIODIC,
+                        name,
+                        true,
+                        &mut pending,
+                    ) {
                         log::error!("client callback poll failed for {name}: {e:?}");
                     }
                 }
+                drop(inner);
+                fire_pending(pending);
             });
         if let Err(e) = spawn_result {
             log::error!("Failed to spawn client callback poller thread: {e}");
@@ -471,12 +550,15 @@ impl IServiceManager for ServiceManager {
     /// callers that want it lives in
     /// [`getService2`](Self::getService2)/[`checkService2`](Self::checkService2).
     fn getService(&self, name: &str) -> rsbinder::status::Result<Option<rsbinder::SIBinder>> {
-        Ok(self
-            .inner
-            .lock()
-            .unwrap()
-            .try_get_binder(name, false)?
-            .map(|(b, _)| b))
+        let mut pending = Vec::new();
+        let result = {
+            let mut inner = self.inner.lock().unwrap();
+            inner
+                .try_get_binder(name, false, &mut pending)?
+                .map(|(b, _)| b)
+        };
+        fire_pending(pending);
+        Ok(result)
     }
 
     fn addService(
@@ -490,23 +572,6 @@ impl IServiceManager for ServiceManager {
             return Err(ExceptionCode::IllegalArgument.into());
         }
 
-        let mut inner = self.inner.lock().unwrap();
-
-        // Only if the service is a proxy, link to death.
-        // Because the native service does not support death notification.
-        if service.as_proxy().is_some() {
-            service.link_to_death(Arc::downgrade(
-                &(inner.death_recipient.clone() as Arc<dyn rsbinder::DeathRecipient>),
-            ))?;
-        }
-
-        let mut prev_clients = false;
-        {
-            if let Some(service) = inner.name_to_service.get(name) {
-                prev_clients = service.has_clients;
-            }
-        }
-
         // Detect `IAccessor` binders by interface descriptor at registration.
         // Hardcoding the AOSP-stable `android.os.IAccessor` string (instead of
         // pulling the `IAccessor` symbol) keeps rsb_hub buildable without the
@@ -518,39 +583,73 @@ impl IServiceManager for ServiceManager {
         // sandbox UID range to gate on.
         let _ = allowIsolated;
 
-        inner.add_service(
-            name,
-            Service {
-                binder: service.clone(),
-                dump_priority: dumpPriority,
-                has_clients: prev_clients,
-                guarantee_client: false,
-                context: rsbinder::thread_state::CallingContext::default(),
-                is_accessor,
-            },
-        )?;
+        // `client_pending` errors are swallowed (prior `onClients` path),
+        // `reg_pending` errors are propagated (prior `onRegistration` used `?`).
+        let mut client_pending = Vec::new();
+        let mut reg_pending = Vec::new();
+        let result: rsbinder::status::Result<()> = (|| {
+            let mut inner = self.inner.lock().unwrap();
 
-        if inner.name_to_registration_callbacks.contains_key(name) {
-            if let Some(service) = inner.name_to_service.get_mut(name) {
-                service.guarantee_client = true;
+            // Only if the service is a proxy, link to death.
+            // Because the native service does not support death notification.
+            if service.as_proxy().is_some() {
+                service.link_to_death(Arc::downgrade(
+                    &(inner.death_recipient.clone() as Arc<dyn rsbinder::DeathRecipient>),
+                ))?;
             }
 
-            inner.handle_service_client_callback(Inner::KNOWN_CLIENTS_ON_DEMAND, name, false)?;
-
-            if let Some(service) = inner.name_to_service.get_mut(name) {
-                service.guarantee_client = true;
+            let mut prev_clients = false;
+            if let Some(service) = inner.name_to_service.get(name) {
+                prev_clients = service.has_clients;
             }
 
-            let callbacks = inner
-                .name_to_registration_callbacks
-                .get(name)
-                .expect("name_to_registration_callbacks must have key");
-            for callback in callbacks {
-                callback.onRegistration(name, service)?;
-            }
-        }
+            inner.add_service(
+                name,
+                Service {
+                    binder: service.clone(),
+                    dump_priority: dumpPriority,
+                    has_clients: prev_clients,
+                    guarantee_client: false,
+                    context: rsbinder::thread_state::CallingContext::default(),
+                    is_accessor,
+                },
+            )?;
 
-        Ok(())
+            if inner.name_to_registration_callbacks.contains_key(name) {
+                if let Some(service) = inner.name_to_service.get_mut(name) {
+                    service.guarantee_client = true;
+                }
+
+                inner.handle_service_client_callback(
+                    Inner::KNOWN_CLIENTS_ON_DEMAND,
+                    name,
+                    false,
+                    &mut client_pending,
+                )?;
+
+                if let Some(service) = inner.name_to_service.get_mut(name) {
+                    service.guarantee_client = true;
+                }
+
+                let callbacks = inner
+                    .name_to_registration_callbacks
+                    .get(name)
+                    .expect("name_to_registration_callbacks must have key");
+                for callback in callbacks {
+                    reg_pending.push(PendingCallback::Registration {
+                        callback: callback.clone(),
+                        name: name.to_owned(),
+                        binder: service.clone(),
+                    });
+                }
+            }
+
+            Ok(())
+        })();
+
+        result?;
+        fire_pending(client_pending);
+        fire_pending_propagate(reg_pending)
     }
 
     /// Linux note: identical to [`getService`](Self::getService) —
@@ -558,12 +657,15 @@ impl IServiceManager for ServiceManager {
     /// (no lazy-service infrastructure). See `getService`'s rustdoc for
     /// the rationale.
     fn checkService(&self, name: &str) -> rsbinder::status::Result<Option<SIBinder>> {
-        Ok(self
-            .inner
-            .lock()
-            .unwrap()
-            .try_get_binder(name, false)?
-            .map(|(b, _)| b))
+        let mut pending = Vec::new();
+        let result = {
+            let mut inner = self.inner.lock().unwrap();
+            inner
+                .try_get_binder(name, false, &mut pending)?
+                .map(|(b, _)| b)
+        };
+        fire_pending(pending);
+        Ok(result)
     }
 
     fn listServices(&self, dump_priority: i32) -> rsbinder::status::Result<Vec<String>> {
@@ -591,25 +693,29 @@ impl IServiceManager for ServiceManager {
             return Err(ExceptionCode::IllegalArgument.into());
         }
 
-        let mut inner = self.inner.lock().unwrap();
+        let mut pending = Vec::new();
+        {
+            let mut inner = self.inner.lock().unwrap();
 
-        arg_callback.as_binder().link_to_death(Arc::downgrade(
-            &(inner.death_recipient.clone() as Arc<dyn rsbinder::DeathRecipient>),
-        ))?;
+            arg_callback.as_binder().link_to_death(Arc::downgrade(
+                &(inner.death_recipient.clone() as Arc<dyn rsbinder::DeathRecipient>),
+            ))?;
 
-        inner
-            .name_to_registration_callbacks
-            .entry(name.to_string())
-            .or_default()
-            .push(arg_callback.clone());
+            inner
+                .name_to_registration_callbacks
+                .entry(name.to_string())
+                .or_default()
+                .push(arg_callback.clone());
 
-        if let Some(service) = inner.name_to_service.get(name) {
-            arg_callback
-                .onRegistration(name, &service.binder)
-                .unwrap_or_else(|e| {
-                    log::error!("Failed to notify client callback: {e:?}");
+            if let Some(service) = inner.name_to_service.get(name) {
+                pending.push(PendingCallback::Registration {
+                    callback: arg_callback.clone(),
+                    name: name.to_owned(),
+                    binder: service.binder.clone(),
                 });
+            }
         }
+        fire_pending(pending);
 
         Ok(())
     }
@@ -690,51 +796,63 @@ impl IServiceManager for ServiceManager {
             dyn hub::android_16::android::os::IClientCallback::IClientCallback,
         >,
     ) -> rsbinder::status::Result<()> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut pending = Vec::new();
+        let result: rsbinder::status::Result<()> = (|| {
+            let mut inner = self.inner.lock().unwrap();
 
-        let service = if let Some(service) = inner.name_to_service.get(name) {
-            service
-        } else {
-            let msg = format!("registerClientCallback could not find service {name}");
-            log::warn!("{}", &msg);
-            return Err((ExceptionCode::IllegalArgument, msg.as_str()).into());
-        };
+            let service = if let Some(service) = inner.name_to_service.get(name) {
+                service
+            } else {
+                let msg = format!("registerClientCallback could not find service {name}");
+                log::warn!("{}", &msg);
+                return Err((ExceptionCode::IllegalArgument, msg.as_str()).into());
+            };
 
-        if service.context.pid != rsbinder::thread_state::CallingContext::default().pid {
-            let msg = format!(
-                "{:?} Only a server can register for client callbacks (for {})",
-                service.context, name
-            );
-            log::warn!("{}", &msg);
-            return Err((ExceptionCode::Security, msg.as_str()).into());
-        }
+            if service.context.pid != rsbinder::thread_state::CallingContext::default().pid {
+                let msg = format!(
+                    "{:?} Only a server can register for client callbacks (for {})",
+                    service.context, name
+                );
+                log::warn!("{}", &msg);
+                return Err((ExceptionCode::Security, msg.as_str()).into());
+            }
 
-        if service.binder != *arg_service {
-            let msg = format!("registerClientCallback called with wrong service {name}");
-            log::warn!("{}", &msg);
-            return Err((ExceptionCode::IllegalArgument, msg.as_str()).into());
-        }
+            if service.binder != *arg_service {
+                let msg = format!("registerClientCallback called with wrong service {name}");
+                log::warn!("{}", &msg);
+                return Err((ExceptionCode::IllegalArgument, msg.as_str()).into());
+            }
 
-        arg_callback.as_binder().link_to_death(Arc::downgrade(
-            &(inner.death_recipient.clone() as Arc<dyn rsbinder::DeathRecipient>),
-        ))?;
+            arg_callback.as_binder().link_to_death(Arc::downgrade(
+                &(inner.death_recipient.clone() as Arc<dyn rsbinder::DeathRecipient>),
+            ))?;
 
-        if service.has_clients {
-            arg_callback
-                .onClients(&service.binder, true)
-                .unwrap_or_else(|e| {
-                    log::error!("Failed to notify client callback: {e:?}");
+            if service.has_clients {
+                pending.push(PendingCallback::Clients {
+                    callback: arg_callback.clone(),
+                    binder: service.binder.clone(),
+                    has_clients: true,
                 });
-        }
+            }
 
-        inner
-            .name_to_client_callbacks
-            .entry(name.to_string())
-            .or_default()
-            .push(arg_callback.clone());
+            inner
+                .name_to_client_callbacks
+                .entry(name.to_string())
+                .or_default()
+                .push(arg_callback.clone());
 
-        inner.handle_service_client_callback(Inner::KNOWN_CLIENTS_ON_DEMAND, name, false)?;
+            inner.handle_service_client_callback(
+                Inner::KNOWN_CLIENTS_ON_DEMAND,
+                name,
+                false,
+                &mut pending,
+            )?;
 
+            Ok(())
+        })();
+
+        result?;
+        fire_pending(pending);
         Ok(())
     }
 
@@ -745,66 +863,77 @@ impl IServiceManager for ServiceManager {
     ) -> rsbinder::status::Result<()> {
         let context = rsbinder::thread_state::CallingContext::default();
 
-        let mut inner = self.inner.lock().unwrap();
-        let service = if let Some(service) = inner.name_to_service.get(name) {
-            service
-        } else {
-            let msg = format!(
-                "{context:?} Tried to unregister {name}, but that service wasn't registered to begin with."
-            );
-            log::warn!("{}", &msg);
-            return Err((ExceptionCode::IllegalArgument, msg.as_str()).into());
-        };
+        let mut pending = Vec::new();
+        let result: rsbinder::status::Result<()> = (|| {
+            let mut inner = self.inner.lock().unwrap();
+            let service = if let Some(service) = inner.name_to_service.get(name) {
+                service
+            } else {
+                let msg = format!(
+                    "{context:?} Tried to unregister {name}, but that service wasn't registered to begin with."
+                );
+                log::warn!("{}", &msg);
+                return Err((ExceptionCode::IllegalArgument, msg.as_str()).into());
+            };
 
-        if service.context.pid != rsbinder::thread_state::CallingContext::default().pid {
-            let msg = format!(
-                "{:?} Only a server can register for client callbacks (for {})",
-                service.context, name
-            );
-            log::warn!("{}", &msg);
-            return Err((ExceptionCode::Security, msg.as_str()).into());
-        }
-
-        if service.binder != *arg_service {
-            let msg = format!("{context:?} Tried to unregister {name}, but a different service is registered under this name.");
-            log::warn!("{}", &msg);
-            return Err((ExceptionCode::IllegalArgument, msg.as_str()).into());
-        }
-
-        if service.guarantee_client {
-            let msg = format!(
-                "{context:?} Tried to unregister {name}, but there is about to be a client."
-            );
-            log::warn!("{}", &msg);
-            return Err((ExceptionCode::IllegalState, msg.as_str()).into());
-        }
-
-        // AOSP `ServiceManager.cpp:1111` checks the *return value*
-        // (`bool` → "this service has clients, refuse to unregister").
-        // The earlier port checked `res.is_err()` instead — but
-        // `handle_service_client_callback` never returns `Err` in
-        // current rsbinder (all "can't determine" paths fall back to
-        // `Ok(true)`), so the refusal branch was dead and every
-        // unregister request silently succeeded even with live clients.
-        // `unwrap_or(true)` is defensive — if a future change makes
-        // `Err` reachable, we conservatively treat it as "clients
-        // present" (matches AOSP `ServiceManager.cpp:1001` `if (count
-        // == -1) return true;`).
-        let has_clients = inner
-            .handle_service_client_callback(Inner::KNOWN_CLIENTS_ON_DEMAND, name, false)
-            .unwrap_or(true);
-        if has_clients {
-            let msg = format!("{context:?} Tried to unregister {name}, but there are clients.");
-            log::warn!("{}", &msg);
-            if let Some(service) = inner.name_to_service.get_mut(name) {
-                service.guarantee_client = true;
+            if service.context.pid != rsbinder::thread_state::CallingContext::default().pid {
+                let msg = format!(
+                    "{:?} Only a server can register for client callbacks (for {})",
+                    service.context, name
+                );
+                log::warn!("{}", &msg);
+                return Err((ExceptionCode::Security, msg.as_str()).into());
             }
-            return Err((ExceptionCode::IllegalState, msg.as_str()).into());
-        }
 
-        inner.name_to_service.remove(name);
+            if service.binder != *arg_service {
+                let msg = format!("{context:?} Tried to unregister {name}, but a different service is registered under this name.");
+                log::warn!("{}", &msg);
+                return Err((ExceptionCode::IllegalArgument, msg.as_str()).into());
+            }
 
-        Ok(())
+            if service.guarantee_client {
+                let msg = format!(
+                    "{context:?} Tried to unregister {name}, but there is about to be a client."
+                );
+                log::warn!("{}", &msg);
+                return Err((ExceptionCode::IllegalState, msg.as_str()).into());
+            }
+
+            // AOSP `ServiceManager.cpp:1111` checks the *return value*
+            // (`bool` → "this service has clients, refuse to unregister").
+            // The earlier port checked `res.is_err()` instead — but
+            // `handle_service_client_callback` never returns `Err` in
+            // current rsbinder (all "can't determine" paths fall back to
+            // `Ok(true)`), so the refusal branch was dead and every
+            // unregister request silently succeeded even with live clients.
+            // `unwrap_or(true)` is defensive — if a future change makes
+            // `Err` reachable, we conservatively treat it as "clients
+            // present" (matches AOSP `ServiceManager.cpp:1001` `if (count
+            // == -1) return true;`).
+            let has_clients = inner
+                .handle_service_client_callback(
+                    Inner::KNOWN_CLIENTS_ON_DEMAND,
+                    name,
+                    false,
+                    &mut pending,
+                )
+                .unwrap_or(true);
+            if has_clients {
+                let msg = format!("{context:?} Tried to unregister {name}, but there are clients.");
+                log::warn!("{}", &msg);
+                if let Some(service) = inner.name_to_service.get_mut(name) {
+                    service.guarantee_client = true;
+                }
+                return Err((ExceptionCode::IllegalState, msg.as_str()).into());
+            }
+
+            inner.name_to_service.remove(name);
+
+            Ok(())
+        })();
+
+        fire_pending(pending);
+        result
     }
 
     fn getServiceDebugInfo(
@@ -835,7 +964,12 @@ impl IServiceManager for ServiceManager {
         // Routing logic lives in `classify_for_service_union` so
         // `checkService2` stays byte-identical without re-stating the
         // match arms.
-        let lookup = self.inner.lock().unwrap().try_get_binder(name, false)?;
+        let mut pending = Vec::new();
+        let lookup = {
+            let mut inner = self.inner.lock().unwrap();
+            inner.try_get_binder(name, false, &mut pending)?
+        };
+        fire_pending(pending);
         Ok(classify_for_service_union(lookup))
     }
 
@@ -845,7 +979,12 @@ impl IServiceManager for ServiceManager {
     ) -> rsbinder::status::Result<hub::android_16::android::os::Service::Service> {
         // See `getService2` — both route through
         // `classify_for_service_union`.
-        let lookup = self.inner.lock().unwrap().try_get_binder(name, false)?;
+        let mut pending = Vec::new();
+        let lookup = {
+            let mut inner = self.inner.lock().unwrap();
+            inner.try_get_binder(name, false, &mut pending)?
+        };
+        fire_pending(pending);
         Ok(classify_for_service_union(lookup))
     }
 

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -681,14 +681,20 @@ impl SIBinder {
     ///
     /// Pure `Arc::downgrade` — no kernel command, no trait dispatch.
     ///
-    /// For proxies, the resulting `WIBinder` snapshots `(handle,
-    /// stability, generation)` so a later `WIBinder::upgrade()` can
-    /// route through the process-wide proxy cache. As long as the
-    /// cache pin is alive (no obituary yet), `upgrade()` succeeds via
-    /// case-(b) resurrection — matching Android `wp<BpBinder>::promote()`
-    /// semantics. If the cache entry was removed (obituary) or the
-    /// handle id was recycled to a different binder_node (generation
-    /// mismatch), `upgrade()` returns `Err(DeadObject)`.
+    /// For proxies, the resulting `WIBinder` is genuinely weak: it
+    /// snapshots `(handle, stability, generation)` for identity
+    /// (`PartialEq`) but upgrades only while some `Arc<ProxyHandle>`
+    /// for the handle is still alive (kernel strong count > 0). Once
+    /// the last user `Strong` drops — sending `BC_RELEASE` and driving
+    /// the kernel strong count to 0 — `upgrade()` returns
+    /// `Err(DeadObject)`, matching Android `wp<BpBinder>::promote()`:
+    /// `BpBinder` is `OBJECT_LIFETIME_WEAK`, so a weak→strong promote
+    /// with strong == 0 is refused by
+    /// `IPCThreadState::attemptIncStrongHandle` (INVALID_OPERATION).
+    /// A re-`BC_ACQUIRE` on a strong-0 handle does NOT yield a
+    /// transactable ref (the kernel rejects the next transaction with
+    /// `BR_FAILED_REPLY`); re-resolving by name through the service
+    /// manager is the correct recovery.
     ///
     /// For native binders, the `WIBinder` is a plain
     /// `sync::Weak<dyn IBinder>` — `upgrade()` succeeds iff some
@@ -880,28 +886,33 @@ impl WIBinder {
                 .upgrade()
                 .map(SIBinder::from_arc)
                 .ok_or(StatusCode::DeadObject),
-            WIBinderInner::Proxy {
-                handle,
-                stability,
-                generation,
-                weak,
-            } => {
-                // Fast path: an `Arc<ProxyHandle>` is still alive
-                // somewhere in the process — reuse it without touching
-                // the cache lock.
-                if let Some(arc) = weak.upgrade() {
-                    return Ok(SIBinder::from_arc(arc));
-                }
-                // Slow path: drive cache-(b) resurrection. The cache
-                // pin keeps the kernel binder_ref slot alive, so the
-                // BC_ACQUIRE inside `new_acquired` is guaranteed to
-                // succeed unless the entry was obituary'd or recycled
-                // (in which case we get DeadObject).
-                crate::process_state::ProcessState::as_self().resurrect_proxy_for_handle_stability(
-                    *handle,
-                    *stability,
-                    *generation,
-                )
+            WIBinderInner::Proxy { weak, .. } => {
+                // A proxy weak reference is genuinely weak — it upgrades
+                // iff some `Arc<ProxyHandle>` for this handle is still
+                // alive in the process, which means the kernel strong
+                // count is > 0. This mirrors Android
+                // `wp<BpBinder>::promote()`: `BpBinder` is
+                // `OBJECT_LIFETIME_WEAK`, so promoting a weak when
+                // strong == 0 routes through
+                // `IPCThreadState::attemptIncStrongHandle`, which
+                // returns `INVALID_OPERATION` and refuses the promote
+                // (RefBase.cpp:627-703, BpBinder.cpp:267) — AOSP never
+                // revives a strong ref from weak-only on a binder handle.
+                //
+                // The slow path used to "resurrect" via a fresh
+                // `BC_ACQUIRE` on the cache-pinned handle. That is the
+                // bug: once the last user `Strong` dropped and its
+                // `BC_RELEASE` drove the kernel strong count to 0, a
+                // re-`BC_ACQUIRE` (0→1) followed by a transaction is
+                // rejected by the kernel with `BR_FAILED_REPLY` — the
+                // `BC_INCREFS` cache pin keeps the `binder_ref` slot
+                // from being freed but does NOT make a strong-0 ref
+                // transactable again. Re-acquiring a transactable strong
+                // ref requires a fresh wire delivery of the handle (e.g.
+                // re-resolving by name through the service manager).
+                weak.upgrade()
+                    .map(SIBinder::from_arc)
+                    .ok_or(StatusCode::DeadObject)
             }
         }
     }

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -833,29 +833,28 @@ impl Eq for SIBinder {}
 /// depend on whether the underlying binder is a proxy (remote) or a
 /// native (local) one:
 ///
-/// **Proxy.** `upgrade()` succeeds as long as the process-wide proxy
-/// cache entry for this binder is alive (no obituary yet) and the
-/// handle id has not been recycled to a different binder_node since
-/// this `WIBinder` was created. Specifically:
-///   - If some `Arc<ProxyHandle>` is still alive in the process,
-///     `upgrade()` returns it directly (analogous to a cache hit).
-///   - Otherwise the cache pin (`BC_INCREFS` taken at first
-///     resolution) keeps the kernel `binder_ref` slot alive, so a
-///     fresh `BC_ACQUIRE` succeeds and `upgrade()` returns a freshly
-///     allocated `Arc<ProxyHandle>` (case-(b) resurrection). The
-///     resurrected `Arc` is a different allocation than the original,
-///     but refers to the same kernel binder_node.
-///   - If `BR_DEAD_BINDER` was processed for this handle, the cache
-///     entry is gone and `upgrade()` returns `Err(DeadObject)`.
-///   - If the handle id was recycled to a different binder_node since
-///     this `WIBinder` was created, the snapshotted generation does
-///     not match the live entry's, and `upgrade()` returns
-///     `Err(DeadObject)`.
+/// **Proxy.** `upgrade()` is genuinely weak: it succeeds iff some
+/// `Arc<ProxyHandle>` for this handle is still alive in the process,
+/// which is exactly the condition under which the kernel strong count
+/// is still > 0.
+///   - If some `Arc<ProxyHandle>` is still alive, `upgrade()` returns
+///     it directly (a shared strong reference; no kernel command).
+///   - Otherwise (every user-side `Strong` has been dropped, so the
+///     last `BC_RELEASE` drove the kernel strong count to 0)
+///     `upgrade()` returns `Err(DeadObject)`. It does **not** try to
+///     re-acquire the handle: once strong has reached 0, a fresh
+///     `BC_ACQUIRE` followed by a transaction is rejected by the
+///     kernel with `BR_FAILED_REPLY` (the `BC_INCREFS` cache pin keeps
+///     the `binder_ref` slot from being freed, but does not make a
+///     strong-0 ref transactable again). Obtaining a fresh,
+///     transactable proxy requires re-resolving the handle through a
+///     new wire delivery (e.g. by name through the service manager).
 ///
-/// This matches Android `wp<BpBinder>::promote()` semantics: weak
-/// references can be promoted to strong as long as the binder is
-/// still alive in the kernel, even if every user-side strong ref has
-/// been dropped.
+/// This matches Android `wp<BpBinder>::promote()`: `BpBinder` is
+/// `OBJECT_LIFETIME_WEAK`, so a weak→strong promote while strong == 0
+/// routes through `IPCThreadState::attemptIncStrongHandle`, which
+/// returns `INVALID_OPERATION` and refuses the promote — AOSP never
+/// revives a strong ref from weak-only on a binder handle.
 ///
 /// **Native.** `upgrade()` succeeds iff some `Arc<dyn IBinder>` to the
 /// inner binder is still alive in the process. This is plain
@@ -866,9 +865,11 @@ pub struct WIBinder {
 }
 
 pub(crate) enum WIBinderInner {
-    /// Proxy weak reference. Carries `(handle, stability, generation)`
-    /// snapshot so `upgrade` can route through the proxy cache for
-    /// resurrection.
+    /// Proxy weak reference. Carries a `sync::Weak<dyn IBinder>` for the
+    /// actual upgrade, plus a `(handle, stability, generation)` snapshot
+    /// used for `PartialEq` identity (two `WIBinder`s are equal iff they
+    /// name the same kernel binder_node, stable across a re-resolve that
+    /// allocates a fresh `Arc<ProxyHandle>`).
     Proxy {
         handle: u32,
         stability: Stability,

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -202,13 +202,22 @@ fn commit_new_acquired(
 /// alive" invariant could otherwise break.
 ///
 /// `generation` is a process-wide monotonic counter snapshotted at
-/// case-(a) insertion. It enables `WIBinder::upgrade()` to detect when
-/// the same handle id has been recycled to a different `binder_node` —
-/// resurrection through case (b) is only safe when the snapshot taken
-/// at `SIBinder::downgrade` time still matches the live entry's
-/// generation. Case (b) preserves the existing entry's generation
-/// (same kernel slot, just user-space resurrection); only case (a)
-/// allocates a new generation.
+/// case-(a) insertion. A proxy `WIBinder` records the generation it
+/// observed at `SIBinder::downgrade` time so `WIBinder` identity
+/// (`PartialEq`) is stable across case-(b) re-lookups (a fresh
+/// `Arc<ProxyHandle>` is a new allocation, but the `(handle,
+/// generation)` pair is unchanged), and so a recycled handle id
+/// (different `binder_node`) is distinguishable. Case (b) preserves
+/// the existing entry's generation (same kernel slot, fresh
+/// wire-delivered strong ref re-establishes transactability); only
+/// case (a) allocates a new generation.
+///
+/// Case-(b) re-lookup here (via `strong_proxy_for_handle_stability`)
+/// is driven by a fresh wire delivery of the handle — e.g. servicemanager
+/// `checkService` or an incoming transaction carrying it — which gives
+/// the new `BC_ACQUIRE` a kernel strong count it can transact on. This
+/// is distinct from `WIBinder::upgrade()`, which is purely weak: it
+/// never re-`BC_ACQUIRE`s a strong-0 handle (see `WIBinder::upgrade`).
 pub(crate) struct CacheEntry {
     pub(crate) weak: sync::Weak<ProxyHandle>,
     pub(crate) descriptor: String,
@@ -789,76 +798,6 @@ impl ProcessState {
             .expect("Handle to proxy lock poisoned")
             .get(&handle)
             .map(|e| e.generation)
-    }
-
-    /// Resurrection-only proxy lookup. Companion to
-    /// `strong_proxy_for_handle_stability` but **never** enters
-    /// case (a) (fresh `BC_INCREFS` pin) — if no cache entry exists for
-    /// `handle`, returns `Err(StatusCode::DeadObject)`.
-    ///
-    /// Used by `WIBinder::upgrade` to promote a weak proxy reference to
-    /// a strong one without reissuing the cache pin. Three outcomes:
-    ///
-    ///   - `expected_generation` mismatch ⟹ the original binder_node
-    ///     was obituary'd and the handle id was recycled. Return
-    ///     `DeadObject`.
-    ///   - cache entry alive (some other thread/holder has a strong
-    ///     `Arc<ProxyHandle>`) ⟹ reuse it (analogous to case (c)).
-    ///   - cache entry's `weak` is dangling ⟹ resurrection (case (b)):
-    ///     allocate a fresh `Arc<ProxyHandle>`, issue `BC_ACQUIRE`. The
-    ///     cache pin invariant guarantees the kernel `binder_ref` slot
-    ///     is still alive, so this `BC_ACQUIRE` cannot race against a
-    ///     freed slot.
-    pub(crate) fn resurrect_proxy_for_handle_stability(
-        &self,
-        handle: u32,
-        stability: Stability,
-        expected_generation: u64,
-    ) -> Result<SIBinder> {
-        // Read fast path with generation check.
-        if let Some(arc) = self
-            .handle_to_proxy
-            .read()
-            .expect("Handle to proxy lock poisoned")
-            .get(&handle)
-            .filter(|e| e.generation == expected_generation)
-            .and_then(|e| e.weak.upgrade())
-        {
-            return Ok(SIBinder::from_arc(arc as Arc<dyn IBinder>));
-        }
-
-        // Slow path: write lock so insert in case (b) is atomic against
-        // concurrent resurrections / lookups.
-        let mut handle_to_proxy = self
-            .handle_to_proxy
-            .write()
-            .expect("Handle to proxy lock poisoned");
-
-        let (descriptor, generation) = match handle_to_proxy.get(&handle) {
-            None => return Err(StatusCode::DeadObject),
-            Some(entry) if entry.generation != expected_generation => {
-                return Err(StatusCode::DeadObject);
-            }
-            Some(entry) => {
-                if let Some(arc) = entry.weak.upgrade() {
-                    return Ok(SIBinder::from_arc(arc as Arc<dyn IBinder>));
-                }
-                (entry.descriptor.clone(), entry.generation)
-            }
-        };
-
-        // Case (b) resurrection. Cache pin (BC_INCREFS) is still active
-        // for this entry, so BC_ACQUIRE will succeed.
-        let arc = ProxyHandle::new_acquired(handle, descriptor.clone(), stability)?;
-        handle_to_proxy.insert(
-            handle,
-            CacheEntry {
-                weak: Arc::downgrade(&arc),
-                descriptor,
-                generation,
-            },
-        );
-        Ok(SIBinder::from_arc(arc as Arc<dyn IBinder>))
     }
 
     /// Phase 1 of obituary teardown: remove the cache entry under write

--- a/rsbinder/src/proxy.rs
+++ b/rsbinder/src/proxy.rs
@@ -398,9 +398,12 @@ impl Drop for ProxyHandle {
     fn drop(&mut self) {
         // The cache pin's BC_INCREFS keeps `binder_ref(handle).weak >= 1`,
         // so this BC_RELEASE is safe regardless of concurrent lookups: the
-        // kernel slot is alive on entry, and a future lookup that arrives
-        // after the strong count returns to 0 will resurrect a fresh
-        // `Arc<ProxyHandle>` via slow-path case (b).
+        // kernel slot is alive on entry. A future lookup that arrives after
+        // the strong count returns to 0 re-acquires a transactable strong
+        // ref only when a fresh wire delivery (e.g. servicemanager
+        // checkService) re-establishes kernel strong via slow-path case (b);
+        // a purely in-process `WIBinder::upgrade()` does not (it is weak and
+        // returns DeadObject once strong hits 0 — see `WIBinder::upgrade`).
         if let Err(err) = thread_state::dec_strong_handle(self.handle) {
             log::error!(
                 "BC_RELEASE for handle {} failed during Drop: {err:?}",

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -632,10 +632,12 @@ impl RpcServer {
     /// the accept loop. `None` disables the deadline (a hung peer may
     /// then hold a slot indefinitely).
     ///
-    /// The deadline bounds **only** the pre-serve handshake/first-contact
-    /// phase; it is cleared once serving begins, so an established
-    /// two-way session may sit idle between requests unbounded (the
-    /// per-call reply deadline is managed separately via
+    /// The deadline bounds **only** the handshake/first-contact phase. For
+    /// the android-13+ profile it is cleared after the explicit handshake;
+    /// for the default r34 profile (no separate handshake) it covers the
+    /// first serve-loop frame and is cleared once that frame is read. Either
+    /// way an established two-way session may then sit idle between requests
+    /// unbounded (the per-call reply deadline is managed separately via
     /// [`RpcSession::set_timeout`](super::RpcSession::set_timeout)).
     pub fn set_handshake_timeout(&self, timeout: Option<std::time::Duration>) {
         *self
@@ -1201,10 +1203,12 @@ impl RpcServer {
                 // free first-contact shape) + serve inline. We're
                 // already on the worker thread — no nested spawn.
                 // r34 has no separate handshake (first contact is the
-                // first serve-loop frame); lift the admission deadline
-                // before serving so an established idle session is not
-                // torn down by it.
-                Self::clear_handshake_timeout(transport.as_ref());
+                // first serve-loop frame), so the admission deadline must
+                // cover that first frame: a silent peer times out and
+                // releases its Arc + slot. `make_session`/`RpcSession::new`
+                // do no blocking read, so the still-armed deadline reaches
+                // the serve loop, which clears it after the first frame so
+                // an established idle session is not torn down by it.
                 let session = match server.make_session(transport) {
                     Ok(s) => s,
                     Err(e) => {
@@ -1212,7 +1216,7 @@ impl RpcServer {
                         return;
                     }
                 };
-                if let Err(e) = session.serve_blocking() {
+                if let Err(e) = session.serve_blocking_clearing_deadline_after_first() {
                     log::debug!("RPC session ended: {e:?}");
                 }
             }

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -198,6 +198,13 @@ impl RawAccepted {
 const DIRECTORY_DESC: &str = "rsbinder.rpc.IServiceDirectory";
 const TX_GET_SERVICE: TransactionCode = crate::binder::FIRST_CALL_TRANSACTION;
 
+/// Default handshake/admission read deadline (see
+/// [`RpcServer::set_handshake_timeout`]). Bounds only the pre-serve
+/// phase; a connected peer that never sends its handshake is dropped
+/// after this so it cannot hold a `max_connections` slot (or pin the
+/// server's `Arc`) forever.
+const DEFAULT_HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Built-in name → binder directory, used to back [`RpcServer::add_service`]
 /// (android RPC has a single root object; this *is* that root when
 /// named services are registered). Reused, unmodified, via the same
@@ -303,6 +310,16 @@ pub struct RpcServer {
     /// and does **not** reduce workers below the connection count
     /// (that would require I/O multiplexing — explicitly out of scope).
     max_connections: Mutex<Option<usize>>,
+    /// Handshake/admission read deadline applied to each accepted
+    /// connection *before* it enters the blocking serve loop.
+    /// `Some(d)` (the default — see [`DEFAULT_HANDSHAKE_TIMEOUT`]) ⇒ a
+    /// connected-but-silent peer that never sends its handshake surfaces
+    /// as a worker-loop error after `d`, releasing both its
+    /// `Arc<RpcServer>` and its `max_connections` admission slot. `None`
+    /// ⇒ no deadline (a hung peer can hold a slot indefinitely). The
+    /// deadline is cleared once serving begins, so an established
+    /// two-way session may idle between requests unbounded.
+    handshake_timeout: Mutex<Option<std::time::Duration>>,
     /// Opt-in authorization hook. `None`
     /// (default) ⇒ accept-all = byte-for-byte a server without the hook
     /// (additive invariant). When set, it runs at
@@ -446,6 +463,7 @@ impl RpcServer {
             fd_unix_supported: AtomicBool::new(false),
             wire_max_version: Mutex::new(None),
             max_connections: Mutex::new(None),
+            handshake_timeout: Mutex::new(Some(DEFAULT_HANDSHAKE_TIMEOUT)),
             authorizer: Mutex::new(None),
             attach_shutdown_probe: Mutex::new(None),
             sessions: Mutex::new(HashMap::new()),
@@ -589,11 +607,41 @@ impl RpcServer {
     /// AOSP `RpcServer`'s bounded server limits, **not** a wire/semantic
     /// port. It does not (and structurally cannot, without I/O
     /// multiplexing) make workers fewer than connections.
+    ///
+    /// **Slot exhaustion**: each worker holds its admission slot until it
+    /// exits, so a connected-but-silent peer would pin a slot forever
+    /// without a read deadline. The default
+    /// [`set_handshake_timeout`](RpcServer::set_handshake_timeout) guards
+    /// against this; do not set it to `None` together with a small `n`
+    /// unless the peer set is trusted.
     pub fn set_max_connections(&self, n: usize) {
         *self
             .max_connections
             .lock()
             .expect("max_connections poisoned") = Some(n.max(1));
+    }
+
+    /// Set (or disable) the **handshake/admission read deadline** applied
+    /// to each accepted connection before it enters the blocking serve
+    /// loop. Default [`DEFAULT_HANDSHAKE_TIMEOUT`] (10s). `Some(d)` ⇒ a
+    /// connected-but-silent peer that never sends its handshake is
+    /// dropped after `d`, releasing both its `Arc<RpcServer>` (so the
+    /// server's `Drop` cleanup can run) and its
+    /// [`set_max_connections`](RpcServer::set_max_connections) admission
+    /// slot — without it, a few idle peers can exhaust the cap and wedge
+    /// the accept loop. `None` disables the deadline (a hung peer may
+    /// then hold a slot indefinitely).
+    ///
+    /// The deadline bounds **only** the pre-serve handshake/first-contact
+    /// phase; it is cleared once serving begins, so an established
+    /// two-way session may sit idle between requests unbounded (the
+    /// per-call reply deadline is managed separately via
+    /// [`RpcSession::set_timeout`](super::RpcSession::set_timeout)).
+    pub fn set_handshake_timeout(&self, timeout: Option<std::time::Duration>) {
+        *self
+            .handshake_timeout
+            .lock()
+            .expect("handshake_timeout poisoned") = timeout;
     }
 
     /// Reap finished worker handles and return the live (concurrent)
@@ -899,6 +947,15 @@ impl RpcServer {
         raw.into_transport()
     }
 
+    /// Lift the admission read deadline (best-effort) once a connection
+    /// reaches the serving phase, so an established two-way session may
+    /// idle between requests unbounded.
+    fn clear_handshake_timeout(transport: &dyn RpcTransport) {
+        if let Err(e) = transport.set_read_timeout(None) {
+            log::debug!("RPC: failed to clear handshake read timeout: {e:?}");
+        }
+    }
+
     /// Runs **inside** the worker thread after the transport has been
     /// wrapped (native or TLS). Performs authorization, then dispatches
     /// to the r34 / android-13+ branch and serves the session inline
@@ -923,6 +980,20 @@ impl RpcServer {
             if !authz(&peer) {
                 log::warn!("RPC connection rejected by authorizer: peer {peer:?}");
                 return;
+            }
+        }
+        // Bound the pre-serve handshake/first-contact phase so a
+        // connected-but-silent peer can't pin its `Arc<RpcServer>` +
+        // admission slot forever. Cleared by `clear_handshake_timeout`
+        // before any long-lived serve so an established session idles
+        // unbounded. Best-effort: a set failure just means no deadline.
+        if let Some(d) = *server
+            .handshake_timeout
+            .lock()
+            .expect("handshake_timeout poisoned")
+        {
+            if let Err(e) = transport.set_read_timeout(Some(d)) {
+                log::debug!("RPC: failed to arm handshake read timeout: {e:?}");
             }
         }
         let a13_max = *server
@@ -955,6 +1026,9 @@ impl RpcServer {
                             return;
                         }
                     };
+                // Handshake done: lift the admission deadline so the
+                // serve loop / pooled callback slot is not bounded by it.
+                Self::clear_handshake_timeout(transport.as_ref());
                 if incoming {
                     // Attach + incoming (`server_accept` already
                     // rejected new + incoming): resolve the session,
@@ -1126,6 +1200,11 @@ impl RpcServer {
                 // r34 (default): build session (incl. its handshake-
                 // free first-contact shape) + serve inline. We're
                 // already on the worker thread — no nested spawn.
+                // r34 has no separate handshake (first contact is the
+                // first serve-loop frame); lift the admission deadline
+                // before serving so an established idle session is not
+                // torn down by it.
+                Self::clear_handshake_timeout(transport.as_ref());
                 let session = match server.make_session(transport) {
                     Ok(s) => s,
                     Err(e) => {

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -827,6 +827,24 @@ impl RpcSessionInner {
         }
     }
 
+    /// Lift the read deadline on a slot's transport (best-effort). Used by
+    /// the r34 serve path to clear the handshake/admission deadline after
+    /// the first frame so an established session idles unbounded.
+    fn clear_slot_read_timeout(&self, slot_id: u64) {
+        let transport = {
+            let st = self.conn_state.lock().expect("conn_state poisoned");
+            st.slots
+                .iter()
+                .find(|s| s.id == slot_id)
+                .map(|s| Arc::clone(&s.transport))
+        };
+        if let Some(t) = transport {
+            if let Err(e) = t.set_read_timeout(None) {
+                log::debug!("RPC: failed to clear first-frame read deadline: {e:?}");
+            }
+        }
+    }
+
     pub(crate) fn parcel_ops(&self) -> Arc<dyn RpcParcelOps> {
         Arc::new(SessionParcelOps(
             self.self_weak.lock().expect("self_weak").clone(),
@@ -2259,12 +2277,40 @@ impl RpcSession {
     /// [`serve_blocking`](RpcSession::serve_blocking) is exactly this
     /// on the founding slot (`FOUNDING_SLOT_ID`).
     pub fn serve_blocking_on(&self, slot_id: u64) -> Result<()> {
+        self.serve_blocking_on_inner(slot_id, false)
+    }
+
+    /// Like [`serve_blocking`](RpcSession::serve_blocking), but the
+    /// handshake/admission read deadline armed before the call is left in
+    /// place for the **first** frame only and cleared once that frame is
+    /// read (or a clean EOF arrives). Used by the r34 server path, where
+    /// there is no separate handshake: the first serve-loop frame *is* the
+    /// first contact, so a connected-but-silent peer's worker must still be
+    /// bounded by the deadline, while an established two-way session idles
+    /// unbounded between requests after that first frame.
+    pub fn serve_blocking_clearing_deadline_after_first(&self) -> Result<()> {
+        self.serve_blocking_on_inner(Self::FOUNDING_SLOT_ID, true)
+    }
+
+    fn serve_blocking_on_inner(&self, slot_id: u64, clear_deadline_after_first: bool) -> Result<()> {
         let result = {
             let mut r = Ok(());
+            let mut first = clear_deadline_after_first;
             loop {
                 match self.inner.serve_once_on_slot(slot_id) {
-                    Ok(true) => continue,
-                    Ok(false) => break,
+                    Ok(cont) => {
+                        // First-frame-only deadline: once the first frame is
+                        // read (or a clean EOF arrives), lift the admission
+                        // deadline so subsequent idle waits are unbounded.
+                        if first {
+                            self.inner.clear_slot_read_timeout(slot_id);
+                            first = false;
+                        }
+                        if cont {
+                            continue;
+                        }
+                        break;
+                    }
                     Err(e) => {
                         r = Err(e);
                         break;

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -2292,7 +2292,11 @@ impl RpcSession {
         self.serve_blocking_on_inner(Self::FOUNDING_SLOT_ID, true)
     }
 
-    fn serve_blocking_on_inner(&self, slot_id: u64, clear_deadline_after_first: bool) -> Result<()> {
+    fn serve_blocking_on_inner(
+        &self,
+        slot_id: u64,
+        clear_deadline_after_first: bool,
+    ) -> Result<()> {
         let result = {
             let mut r = Ok(());
             let mut first = clear_deadline_after_first;

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -619,7 +619,12 @@ impl RpcSessionInner {
     ///     here, return the guard.
     ///  4. **Pool exhausted** — `wait` on `slot_cv` (released on slot
     ///     drop OR `add_*_slot`). **Block-and-wait, never busy
-    ///     try-loop**.
+    ///     try-loop**. Each wakeup (and the first park) rechecks the
+    ///     session lifecycle and pool (mirroring
+    ///     [`find_conn_for_reaper`]) and returns
+    ///     `Err(StatusCode::DeadObject)` if the session is torn down or
+    ///     the pool has drained — `add_*_slot` can never refill a dead
+    ///     session, so re-`wait` would park forever.
     ///
     /// Single-slot default: step 3 always succeeds
     /// without `wait`; the `DRIVING`-keyed reentrancy bypass collapses
@@ -632,7 +637,7 @@ impl RpcSessionInner {
     /// the per-`mNodeForAddress` `asyncNumber` send-side counter +
     /// receive-side priority replay (see [`super::state`]), not by
     /// pinning oneway sends to a fixed slot.
-    fn find_conn(&self) -> ConnGuard<'_> {
+    fn find_conn(&self) -> Result<ConnGuard<'_>> {
         let tid = current_tid();
         let sess_ptr = self as *const RpcSessionInner as usize;
         // (1) Reentrant: a slot of this session is already driven by
@@ -651,15 +656,22 @@ impl RpcSessionInner {
                     .map(|s| Arc::clone(&s.transport))
                     .expect("DRIVING slot present")
             };
-            return ConnGuard {
+            return Ok(ConnGuard {
                 inner: self,
                 slot_id,
                 transport,
                 reentrant: true,
-            };
+            });
         }
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
         loop {
+            // Torn-down/drained recheck (mirrors `find_conn_for_reaper`):
+            // a concurrent peer-close can drain the last slot, and
+            // `add_*_slot` can never refill a dead session, so re-`wait`
+            // would park forever. Surface a typed dead-pool error instead.
+            if self.shared.lifecycle.is_torn_down() || st.slots.is_empty() {
+                return Err(StatusCode::DeadObject);
+            }
             // (2) Defensive exclusive match (shouldn't fire if (1) is correct).
             // (3) First available.
             if let Some(s) = st
@@ -671,12 +683,12 @@ impl RpcSessionInner {
                 let slot_id = s.id;
                 let transport = Arc::clone(&s.transport);
                 DRIVING.with(|d| d.borrow_mut().push((sess_ptr, slot_id)));
-                return ConnGuard {
+                return Ok(ConnGuard {
                     inner: self,
                     slot_id,
                     transport,
                     reentrant: false,
-                };
+                });
             }
             // (4) Pool exhausted — wait. The `Condvar` is woken on
             //     slot release (ConnGuard drop) or slot addition
@@ -1206,7 +1218,7 @@ impl RpcSessionInner {
         // if the pool is exhausted. Concurrent transacts on *other*
         // slots run unblocked.
         let oneway = (flags & FLAG_ONEWAY) != 0;
-        let conn = self.find_conn();
+        let conn = self.find_conn()?;
         let transport = conn.transport();
         // AOSP `BinderNode::asyncNumber` (send side, per-remote-addr).
         let async_number = if oneway {
@@ -1353,7 +1365,7 @@ impl RpcSessionInner {
         // `find_conn` picks an available slot (or — if this thread is
         // already driving one of the session's slots — reuses it via
         // `DRIVING`, the documented "interleaved DEC_STRONG" path).
-        let conn = self.find_conn();
+        let conn = self.find_conn()?;
         let frame = self.profile.codec().encode_dec_strong(&addr);
         self.send_msg(conn.transport(), &frame, &[])?;
         Ok(())
@@ -1416,7 +1428,7 @@ impl RpcSessionInner {
         // `find_conn`). For an outermost server reply
         // (`serve_once_on_slot` pinned the slot before dispatch) this
         // is the same slot the request arrived on.
-        let conn = self.find_conn();
+        let conn = self.find_conn()?;
         Ok(self.send_msg(conn.transport(), &frame, fds)?)
     }
 

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -530,6 +530,51 @@ fn max_connections_admission_bound() {
     // _cu handles teardown.
 }
 
+/// A connected-but-silent **r34** peer (the default profile, which has no
+/// separate handshake — first contact is the first serve-loop frame) must
+/// be torn down by the handshake/admission read deadline so it cannot pin
+/// its worker + admission slot forever.
+///
+/// Mutant: clearing the read deadline *before* the r34 serve loop (the
+/// pre-fix behavior) leaves the silent c1 worker blocked in `recv` with no
+/// deadline ⇒ the single `max_connections` slot is never freed ⇒ c2's
+/// bounded `get_root` times out, failing this test.
+#[test]
+fn silent_r34_peer_released_by_handshake_deadline() {
+    let path = tmp_sock("silent_r34");
+    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    // One slot so a pinned silent peer is directly observable, and a short
+    // deadline to keep the test fast + deterministic.
+    server.set_max_connections(1);
+    server.set_handshake_timeout(Some(Duration::from_millis(300)));
+    let bg = server.run_background();
+    let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
+    wait_for_sock(&path);
+
+    // c1 connects but sends nothing: r34 connect performs no wire, so this
+    // is the silent first-contact peer. It occupies the single worker slot.
+    let c1 = RpcSession::setup_unix_client(&path).expect("connect c1 (silent)");
+
+    // c2 connects into the backlog; it can only be served once c1's worker
+    // exits on the first-frame deadline and frees the slot. A deadline
+    // comfortably larger than the handshake timeout proves the slot is
+    // released (and not that c2 merely raced ahead).
+    let c2 = RpcSession::setup_unix_client(&path).expect("connect c2");
+    c2.set_timeout(Some(Duration::from_secs(5)));
+    assert_eq!(
+        EchoProxy(c2.get_root().expect("c2 get_root after c1 deadline"))
+            .echo("c2")
+            .unwrap(),
+        "c2",
+        "silent r34 peer's worker must release its slot on the handshake deadline"
+    );
+
+    drop(c1);
+    drop(c2);
+    // _cu handles teardown.
+}
+
 // ---- oneway FIFO + non-blocking send -------------------------------
 
 #[test]

--- a/tests/src/test_client.rs
+++ b/tests/src/test_client.rs
@@ -2352,22 +2352,47 @@ fn test_cache_pin_case_b_resurrection_round_trip() {
     }
 }
 
-/// `WIBinder::upgrade()` for proxies must succeed across user-side
-/// `drop(strong)` as long as the cache entry (and therefore the
-/// kernel `binder_ref` slot's `BC_INCREFS` pin) is alive — matching
-/// Android `wp<BpBinder>::promote()` semantics.
+/// `WIBinder::upgrade()` for proxies is genuinely weak, matching
+/// Android `wp<BpBinder>::promote()`: once every user-side `Strong`
+/// is dropped — sending `BC_RELEASE` and driving the kernel strong
+/// count to 0 — `upgrade()` returns `Err(DeadObject)`.
 ///
-/// Pre-PR `WIBinder::upgrade()` succeeded *unconditionally* because
-/// `WIBinder` held a strong Arc in disguise. The cache-pin refactor
-/// initially made it `sync::Weak::upgrade` only, which returned
-/// `DeadObject` once every user-side `Strong` was dropped — too
-/// strict, because the cache pin had already structurally guaranteed
-/// the kernel slot stayed alive. This test verifies the corrected
-/// semantics: `upgrade()` routes through the proxy cache and yields
-/// a freshly resurrected `Arc<ProxyHandle>` (different allocation,
-/// same kernel binder_node).
+/// `BpBinder` is `OBJECT_LIFETIME_WEAK`, so a weak→strong promote at
+/// strong == 0 routes through `IPCThreadState::attemptIncStrongHandle`,
+/// which returns `INVALID_OPERATION` and refuses the promote
+/// (RefBase.cpp:627-703, BpBinder.cpp:267). AOSP never revives a
+/// strong ref from weak-only on a binder handle.
+///
+/// rsbinder previously tried to "resurrect" the proxy by re-issuing
+/// `BC_ACQUIRE` (strong 0→1) on the cache-pinned handle and then
+/// transacting. That was a bug: empirically the kernel rejects the
+/// transaction on a ref that went through strong == 0 with
+/// `BR_FAILED_REPLY` (confirmed on the emulator — see the trace
+/// `inc_strong → dec_strong → inc_strong → BR_FAILED_REPLY`). The
+/// `BC_INCREFS` cache pin keeps the `binder_ref` slot from being
+/// freed, but does NOT make a strong-0 ref transactable again.
+///
+/// The correct recovery, exercised below, is to re-resolve the
+/// service by name through the service manager (a fresh wire delivery
+/// of the handle that re-establishes a transactable kernel strong
+/// ref).
+///
+/// Marked `#[ignore]` because it asserts the test is the *sole* strong
+/// holder of the shared `test_service` handle: it drops its `Strong`
+/// and requires the kernel strong count to reach 0. Run in parallel
+/// with the rest of the suite, a concurrent test holding its own
+/// `Strong` on the same handle keeps the kernel strong count > 0, so
+/// the weak `upgrade()` fast path legitimately succeeds (a live
+/// `Arc<ProxyHandle>` exists). Run explicitly with a fresh service:
+///
+/// ```text
+/// cargo test --package tests \
+///   test_weak_upgrade_after_sole_strong_drop_is_dead_then_reresolve_works \
+///   -- --ignored
+/// ```
 #[test]
-fn test_weak_upgrade_resurrects_proxy_after_strong_drop() {
+#[ignore]
+fn test_weak_upgrade_after_sole_strong_drop_is_dead_then_reresolve_works() {
     init_test();
 
     let canonical = <BpTestService as ITestService::ITestService>::descriptor().to_string();
@@ -2375,27 +2400,33 @@ fn test_weak_upgrade_resurrects_proxy_after_strong_drop() {
     let weak: WIBinder = SIBinder::downgrade(&svc.as_binder());
     drop(svc);
 
-    // After `drop(svc)` the only `Arc<ProxyHandle>` is gone, but the
-    // cache entry is still there with its BC_INCREFS pin keeping
-    // `binder_ref(handle).weak >= 1`. `upgrade()` must succeed via
-    // case-(b) resurrection.
-    let resurrected = weak
-        .upgrade()
-        .expect("weak.upgrade must succeed while cache entry alive");
+    // After `drop(svc)` the only `Arc<ProxyHandle>` is gone (its
+    // `BC_RELEASE` drove the kernel strong count to 0). `upgrade()`
+    // is purely weak — it must report `DeadObject`, never silently
+    // resurrect an untransactable ref.
+    match weak.upgrade() {
+        Err(rsbinder::StatusCode::DeadObject) => {}
+        Err(other) => panic!("expected DeadObject after sole Strong drop, got {other:?}"),
+        Ok(_) => panic!(
+            "regression: WIBinder::upgrade resurrected a strong-0 proxy \
+             (the kernel rejects transactions on such a ref with BR_FAILED_REPLY)"
+        ),
+    }
 
-    // Descriptor preserved across resurrection (cached, no new
-    // INTERFACE_TRANSACTION).
+    // AOSP-faithful recovery: re-resolve by name. A fresh
+    // `checkService`/`getService` delivers the handle anew and gives
+    // the new proxy a transactable kernel strong ref.
+    let resolved: rsbinder::Strong<dyn ITestService::ITestService> =
+        hub::get_interface(&canonical).expect("re-resolve by name must succeed");
     assert_eq!(
-        resurrected.descriptor(),
+        resolved.as_binder().descriptor(),
         canonical,
-        "resurrected proxy must carry the original descriptor"
+        "re-resolved proxy must carry the original descriptor"
     );
-
-    // Transaction succeeds, proving the resurrected proxy refers to
-    // the same kernel binder_node.
-    resurrected
+    resolved
+        .as_binder()
         .ping_binder()
-        .expect("ping after resurrection must succeed");
+        .expect("ping on a freshly re-resolved proxy must succeed");
 }
 
 /// Two `WIBinder` clones for the same underlying handle compare


### PR DESCRIPTION
## Summary

Two independent fixes, kept as separate commits.

### 1. Multi-agent audit findings (`a05a350`)
A whole-codebase audit surfaced six defects, concentrated in wire-format fidelity, concurrency/liveness, and resource lifetime (no memory-safety/UB issues). Each was adversarially verified and fixed:

- **rsb_hub — Mutex held across outbound binder callbacks (High).** `ServiceManager` invoked `onRegistration`/`onClients` while holding its non-reentrant `Mutex<Inner>`, risking re-entrancy self-deadlock and head-of-line blocking of all `IServiceManager` operations. Now collects target callbacks under the lock, drops the guard, then fires (R1 invariant; AOSP-faithful).
- **AIDL codegen — async proxy missing `FLAG_ONEWAY` (High).** `oneway` methods invoked through a generated `*Async` proxy were sent as two-way transactions. The async `submit_transact` now emits `FLAG_ONEWAY` like the sync path.
- **rpc/session — `find_conn` could park forever after teardown (Medium).** Made `find_conn` fallible and added the torn-down/empty-pool recheck on each `slot_cv` wakeup (mirroring `find_conn_for_reaper`), surfacing `DeadObject` instead of hanging.
- **rpc/server — idle peer pins a worker + slot (Low).** Default handshake-phase read timeout on accepted connections; cleared before the established serve loop so long-idle two-way sessions are unaffected.
- **AIDL codegen — enum discriminant swallowed to 0 (Low).** Non-integral discriminant evaluation now fails the build instead of emitting a wrong wire value.
- **example-hello — reference client discarded `Status` and hard-panicked (Low).** Uses `?` and a bounded startup-race retry.

### 2. `WIBinder::upgrade` no longer resurrects a dead handle (`9fbf7ba`)
`upgrade()` on a proxy whose last `Strong` had been dropped used to re-`BC_ACQUIRE` the handle (kernel strong 0→1) and transact — which the kernel rejects with `BR_FAILED_REPLY`, because a strong-0 ref is not transactable again even though the `BC_INCREFS` cache pin keeps its slot alive.

This matches AOSP: `BpBinder` is `OBJECT_LIFETIME_WEAK`, so a weak→strong promote at strong==0 routes through `IPCThreadState::attemptIncStrongHandle` → `INVALID_OPERATION` and is refused (`RefBase.cpp`, `BpBinder.cpp`). `upgrade()` now succeeds only via the fast path (a live `Arc<ProxyHandle>` ⇒ kernel strong > 0) and otherwise returns `DeadObject`; the dead `resurrect_proxy_for_handle_stability` path is removed. The normal deserialization path (`strong_proxy_for_handle_stability`) is unchanged — it legitimately resurrects on freshly wire-delivered refs.

## Verification (single- and multi-threaded)

| Environment | single | multi |
|---|---|---|
| Android emulator — rsbinder unit | 177/0 | 177/0 |
| Android emulator — tests suite | 136/0 | 136/0 |
| REMOTE_LINUX (zen kernel) — tests suite | 136/0 | 136/0 |
| REMOTE_LINUX (zen kernel) — lib | 191/0 | 191/0 |

macOS: `cargo build --workspace --all-targets`, `clippy` (0 warnings), `cargo test -p rsbinder-aidl` / `-p rsbinder-tools` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)