### PR TITLE
fix: review-findings hardening (parcel/RPC/AIDL/service-manager)

### DIFF
--- a/rsbinder-aidl/src/const_expr.rs
+++ b/rsbinder-aidl/src/const_expr.rs
@@ -523,7 +523,13 @@ impl ValueType {
             ValueType::Unary { operator, expr } => {
                 format!("{} {}", operator, expr.to_value_string())
             }
-            _ => unimplemented!(),
+            // Map/IBinder/FileDescriptor/Holder/UserDefined have no
+            // value-literal form and are unreachable from parsed const
+            // expressions today (callers route them through their own
+            // `Default::default()` fallback first). Emit an empty string
+            // rather than `unimplemented!()` so a future caller can never
+            // turn this into a panic on user input.
+            _ => String::new(),
         }
     }
 

--- a/rsbinder-aidl/src/parser.rs
+++ b/rsbinder-aidl/src/parser.rs
@@ -1372,7 +1372,20 @@ fn parse_const_expr(pair: pest::iterators::Pair<Rule>) -> Result<ConstExpr, Aidl
             for pair in pair.into_inner() {
                 match pair.as_rule() {
                     Rule::const_expr => {
-                        value_list.push(parse_const_expr(pair.into_inner().next().unwrap())?);
+                        // An empty `{}` parses to a `const_expr` with no
+                        // inner pair; reject it with a diagnostic rather
+                        // than `unwrap()`-panicking on user input.
+                        let span = pair.as_span();
+                        match pair.into_inner().next() {
+                            Some(inner) => value_list.push(parse_const_expr(inner)?),
+                            None => {
+                                return Err(make_parse_error(
+                                    "empty `{}` is not a valid constant expression",
+                                    span.start(),
+                                    span.end(),
+                                ))
+                            }
+                        }
                     }
                     _ => unreachable!("Unexpected rule in Rule::constant_value_list: {}", pair),
                 }
@@ -1436,7 +1449,17 @@ fn parse_parameter(pairs: pest::iterators::Pairs<Rule>) -> Result<Parameter, Aid
                 parameter.identifier = pair.as_str().into();
             }
             Rule::const_expr => {
-                parameter.const_expr = parse_const_expr(pair.into_inner().next().unwrap())?;
+                let span = pair.as_span();
+                match pair.into_inner().next() {
+                    Some(inner) => parameter.const_expr = parse_const_expr(inner)?,
+                    None => {
+                        return Err(make_parse_error(
+                            "empty `{}` is not a valid annotation parameter value",
+                            span.start(),
+                            span.end(),
+                        ))
+                    }
+                }
             }
             _ => unreachable!("Unexpected rule in parse_parameter(): {}", pair),
         }
@@ -1467,7 +1490,17 @@ fn parse_annotation(pairs: pest::iterators::Pairs<Rule>) -> Result<Annotation, A
             }
 
             Rule::const_expr => {
-                annotation.const_expr = Some(parse_const_expr(pair.into_inner().next().unwrap())?);
+                let span = pair.as_span();
+                match pair.into_inner().next() {
+                    Some(inner) => annotation.const_expr = Some(parse_const_expr(inner)?),
+                    None => {
+                        return Err(make_parse_error(
+                            "empty `{}` is not a valid annotation argument",
+                            span.start(),
+                            span.end(),
+                        ))
+                    }
+                }
             }
 
             Rule::parameter_list => {
@@ -1574,7 +1607,17 @@ fn parse_array_type(pairs: pest::iterators::Pairs<Rule>) -> Result<ArrayType, Ai
     for pair in pairs {
         match pair.as_rule() {
             Rule::const_expr => {
-                array_type.const_expr = Some(parse_const_expr(pair.into_inner().next().unwrap())?);
+                let span = pair.as_span();
+                match pair.into_inner().next() {
+                    Some(inner) => array_type.const_expr = Some(parse_const_expr(inner)?),
+                    None => {
+                        return Err(make_parse_error(
+                            "empty `{}` is not a valid array dimension",
+                            span.start(),
+                            span.end(),
+                        ))
+                    }
+                }
             }
             _ => unreachable!("Unexpected rule in parse_array_type(): {}", pair),
         }
@@ -1964,7 +2007,17 @@ fn parse_enumerator(pairs: pest::iterators::Pairs<Rule>) -> Result<Enumerator, A
                 res.identifier = pair.as_str().into();
             }
             Rule::const_expr => {
-                res.const_expr = Some(parse_const_expr(pair.into_inner().next().unwrap())?);
+                let span = pair.as_span();
+                match pair.into_inner().next() {
+                    Some(inner) => res.const_expr = Some(parse_const_expr(inner)?),
+                    None => {
+                        return Err(make_parse_error(
+                            "empty `{}` is not a valid enumerator value",
+                            span.start(),
+                            span.end(),
+                        ))
+                    }
+                }
             }
             _ => unreachable!("Unexpected rule in parse_enumerator(): {}", pair),
         }

--- a/rsbinder-aidl/tests/test_review_regressions.rs
+++ b/rsbinder-aidl/tests/test_review_regressions.rs
@@ -61,3 +61,31 @@ fn enum_autoincrement_overflow_does_not_panic() {
     // No panic / abort is the assertion.
     let _ = generate_ok(src);
 }
+
+/// An empty `{}` initializer used to `unwrap()`-panic in five parser
+/// positions where an aggregate initializer is not a valid value
+/// (enumerator value, nested array element, annotation argument, named
+/// annotation parameter, array dimension). Each must now surface as a
+/// recoverable parse diagnostic. Reaching the assertions without aborting
+/// is itself the regression guard: a revert reintroduces the panic and
+/// fails the test. The legitimate empty-array initializer `int[] x = {}`
+/// (the one position where `{}` is valid) must still parse + generate.
+#[test]
+fn empty_brace_initializer_is_rejected_not_panicked() {
+    for src in [
+        "enum E { A = {} }",                    // enumerator value
+        "parcelable P { int[] x = {{}}; }",     // nested array element
+        "@Foo({}) parcelable P { int x; }",     // annotation argument
+        "@Foo(bar={}) parcelable P { int x; }", // named annotation parameter
+        "parcelable P { int[{}] x; }",          // array dimension
+    ] {
+        assert!(
+            !generate_ok(src),
+            "empty `{{}}` initializer must error, not panic: {src:?}"
+        );
+    }
+    assert!(
+        generate_ok("parcelable P { int[] x = {}; }"),
+        "a legitimate empty-array initializer must still generate"
+    );
+}

--- a/rsbinder-tools/src/bin/rsb_device.rs
+++ b/rsbinder-tools/src/bin/rsb_device.rs
@@ -90,7 +90,12 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             binderfs_path.display()
         )),
         Ok(false) => {
-            let status = Command::new("mount")
+            // Absolute path, not `mount` via `$PATH`: this runs as root,
+            // so resolving the binary through `$PATH` would let a planted
+            // `mount` earlier on the path execute as root. `/bin/mount`
+            // is the util-linux location on both merged- and split-`/usr`
+            // systems.
+            let status = Command::new("/bin/mount")
                 .arg("-t")
                 .arg("binder")
                 .arg("binder")

--- a/rsbinder-tools/src/bin/rsb_device.rs
+++ b/rsbinder-tools/src/bin/rsb_device.rs
@@ -114,6 +114,19 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Add binder device.
     let device_name = app.get_one::<String>("device_name").unwrap();
 
+    // This runs as root and the name is interpolated into binderfs and
+    // /dev paths below, so require a single path component — otherwise a
+    // name like "../etc/foo" would redirect the chmod'd device or the
+    // /dev symlink outside its intended directory.
+    if device_name.is_empty()
+        || device_name == "."
+        || device_name == ".."
+        || device_name.contains('/')
+        || device_name.contains('\0')
+    {
+        log_err(&format!("Invalid binder device name: {device_name:?}"));
+    }
+
     match binderfs::add_device(control_path, device_name) {
         Ok((_, _)) => log_ok(&format!(
             "New binder device allocated:\n\t- Device name: {device_name}\n\t- Accessible path: /dev/binderfs/{device_name}"

--- a/rsbinder-tools/src/bin/rsb_hub.rs
+++ b/rsbinder-tools/src/bin/rsb_hub.rs
@@ -608,18 +608,19 @@ impl IServiceManager for ServiceManager {
         let mut reg_pending = Vec::new();
         let result: rsbinder::status::Result<()> = (|| {
             let mut inner = self.inner.lock().unwrap();
-
-            // Only if the service is a proxy, link to death.
-            // Because the native service does not support death notification.
-            if service.as_proxy().is_some() {
-                service.link_to_death(Arc::downgrade(
-                    &(inner.death_recipient.clone() as Arc<dyn rsbinder::DeathRecipient>),
-                ))?;
-            }
+            let recipient: Arc<dyn rsbinder::DeathRecipient> = inner.death_recipient.clone();
 
             let mut prev_clients = false;
+            // `SIBinder: PartialEq` is `Arc::ptr_eq`, so this is binder
+            // identity: is the *same* object being re-registered under this
+            // name?
+            let mut same_binder = false;
+            // The old binder being replaced, captured (cheap Arc clone) so it
+            // can be unlinked *after* the new one is linked — see below.
+            let mut old_to_unlink: Option<SIBinder> = None;
             if let Some(existing) = inner.name_to_service.get(name) {
                 prev_clients = existing.has_clients;
+                same_binder = existing.binder == *service;
                 // No add-time access control on Linux (see fn rustdoc): we
                 // cannot reject a hijack, but overwriting an entry owned by
                 // a different uid/pid is its signature, so make it loud
@@ -632,6 +633,34 @@ impl IServiceManager for ServiceManager {
                         caller.pid,
                         existing.context.uid,
                         existing.context.pid
+                    );
+                }
+                if !same_binder && existing.binder.as_proxy().is_some() {
+                    old_to_unlink = Some(existing.binder.clone());
+                }
+            }
+
+            // Link the new binder FIRST (proxies only — native binders have
+            // no death notification), before unlinking the old one: a link
+            // failure then leaves the existing registration and its death
+            // link intact (clean no-op), instead of stranding an unmonitored
+            // entry. Skip when the same binder is re-registered (already
+            // linked; relinking would stack a duplicate recipient that fires
+            // `binder_died` once per copy).
+            if !same_binder && service.as_proxy().is_some() {
+                service.link_to_death(Arc::downgrade(&recipient))?;
+            }
+
+            // New link is in place: unlink the old binder we are about to
+            // drop. `ProxyHandle::Drop` does *not* clear death notifications,
+            // so without this its kernel subscription would leak until that
+            // binder dies. (AOSP drops the link in `~Service`; rsbinder has
+            // no such dtor hook.)
+            if let Some(old) = old_to_unlink {
+                if let Err(e) = old.unlink_to_death(Arc::downgrade(&recipient)) {
+                    log::warn!(
+                        "addService: failed to unlink death notification for \
+                         replaced '{name}': {e:?}"
                     );
                 }
             }

--- a/rsbinder-tools/src/bin/rsb_hub.rs
+++ b/rsbinder-tools/src/bin/rsb_hub.rs
@@ -561,6 +561,20 @@ impl IServiceManager for ServiceManager {
         Ok(result)
     }
 
+    /// Security note (Linux): unlike AOSP's `servicemanager`, this
+    /// implementation performs **no add-time access control**. AOSP
+    /// rejects app UIDs (`multiuser_get_app_id(uid) >= AID_APP`) and
+    /// runs the SELinux `canAddService` hook; both depend on Android's
+    /// UID model / policy and have no equivalent on a plain Linux host.
+    /// Consequently any client can register, or silently overwrite, any
+    /// service name — and a binder that reports the
+    /// `android.os.IAccessor` descriptor is trusted as an accessor on
+    /// the registrant's word alone (AOSP instead derives the accessor
+    /// relationship from a signed VINTF `<accessor>` manifest entry).
+    /// As a minimal mitigation we log a loud warning when a registration
+    /// overwrites an entry owned by a different uid/pid (the signature of
+    /// a hijack). Vendors needing real enforcement must wrap this with
+    /// their own authorization layer.
     fn addService(
         &self,
         name: &str,
@@ -575,8 +589,13 @@ impl IServiceManager for ServiceManager {
         // Detect `IAccessor` binders by interface descriptor at registration.
         // Hardcoding the AOSP-stable `android.os.IAccessor` string (instead of
         // pulling the `IAccessor` symbol) keeps rsb_hub buildable without the
-        // `rpc` feature.
+        // `rpc` feature. NOTE: self-asserted by the registrant — see the fn
+        // rustdoc for the trust caveat vs. AOSP's VINTF-derived accessors.
         let is_accessor = service.descriptor() == "android.os.IAccessor";
+
+        // Capture the registrant's identity once on this binder thread, so
+        // we can both stamp the new entry and detect cross-identity overwrites.
+        let caller = rsbinder::thread_state::CallingContext::default();
 
         // `allowIsolated` is accepted by AIDL for AOSP source
         // compatibility but unused on Linux — there is no isolated-app
@@ -599,8 +618,22 @@ impl IServiceManager for ServiceManager {
             }
 
             let mut prev_clients = false;
-            if let Some(service) = inner.name_to_service.get(name) {
-                prev_clients = service.has_clients;
+            if let Some(existing) = inner.name_to_service.get(name) {
+                prev_clients = existing.has_clients;
+                // No add-time access control on Linux (see fn rustdoc): we
+                // cannot reject a hijack, but overwriting an entry owned by
+                // a different uid/pid is its signature, so make it loud
+                // rather than silent (AOSP logs the same mismatch).
+                if existing.context.uid != caller.uid || existing.context.pid != caller.pid {
+                    log::warn!(
+                        "addService: '{name}' overwritten by uid={} pid={} \
+                         (previously registered by uid={} pid={})",
+                        caller.uid,
+                        caller.pid,
+                        existing.context.uid,
+                        existing.context.pid
+                    );
+                }
             }
 
             inner.add_service(
@@ -610,7 +643,7 @@ impl IServiceManager for ServiceManager {
                     dump_priority: dumpPriority,
                     has_clients: prev_clients,
                     guarantee_client: false,
-                    context: rsbinder::thread_state::CallingContext::default(),
+                    context: caller,
                     is_accessor,
                 },
             )?;

--- a/rsbinder/src/hub/mod.rs
+++ b/rsbinder/src/hub/mod.rs
@@ -343,6 +343,11 @@ pub fn default() -> Result<Arc<ServiceManager>> {
 
         match sdk_version {
             sdk_versions::ANDROID_16 => create_service_manager!(Android16, android_16),
+            // Android 15 (SDK 35) shares Android 14's service-manager wire
+            // format, so it is served by the `android_14` feature — there
+            // is no separate `android_15` feature. A build that enables
+            // only `android_16` therefore returns `InvalidOperation` on an
+            // Android 15 device; enable `android_14` to cover 14 *and* 15.
             #[cfg(feature = "android_14")]
             sdk_versions::ANDROID_14 | sdk_versions::ANDROID_15 => {
                 create_service_manager!(Android14, android_14)

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -964,18 +964,16 @@ impl Parcel {
             return Err(StatusCode::NotEnoughData);
         }
 
-        let mut result = Vec::with_capacity(len as usize);
         let pos = self.pos;
-        // SAFETY: `parcel` storage is aligned to at least 4 bytes (binder
-        // ABI guarantee, see `Parcel::write_aligned`), and the
-        // `pos..pos + size` slice was just bounds-checked above. `i32`
-        // and `u8` have compatible bit patterns for the values written
-        // here. The `align_to` middle slice is therefore a valid view of
-        // the requested element count.
-        let (_, ints, _) = unsafe { self.data.as_slice()[pos..pos + size].align_to::<i32>() };
-        for i in ints {
-            result.push(D::from(i));
-        }
+        // The parcel's `Vec<u8>` has only 1-byte base alignment, so
+        // `align_to::<i32>()` would silently drop a mis-aligned prefix
+        // (data corruption, not UB). Copy each 4-byte element out by
+        // value instead — `size == len * 4` exactly (checked above), so
+        // `chunks_exact` yields exactly `len` elements with no remainder.
+        let result = self.data.as_slice()[pos..pos + size]
+            .chunks_exact(std::mem::size_of::<i32>())
+            .map(|c| D::from(&i32::from_ne_bytes([c[0], c[1], c[2], c[3]])))
+            .collect();
 
         self.set_data_position(pos + padded);
 

--- a/rsbinder/src/parcelable.rs
+++ b/rsbinder/src/parcelable.rs
@@ -418,8 +418,8 @@ impl DeserializeOption for String {
             // only 1-byte aligned, so reinterpreting it as `&[u16]` via
             // `from_raw_parts(_ as *const u16, _)` would construct an
             // under-aligned reference (UB; Miri-detectable). Copy the bytes
-            // into an aligned `Vec<u16>` instead — mirroring the safe
-            // `align_to` idiom used by `read_array_char`.
+            // into an aligned `Vec<u16>` instead — mirroring the
+            // `chunks_exact` copy used by `read_array_char`.
             let u16_data: Vec<u16> = data[..len as usize * std::mem::size_of::<u16>()]
                 .chunks_exact(std::mem::size_of::<u16>())
                 .map(|c| u16::from_ne_bytes([c[0], c[1]]))

--- a/rsbinder/src/ref_counter.rs
+++ b/rsbinder/src/ref_counter.rs
@@ -46,9 +46,9 @@ impl RefCounter {
         // We don't need to synchronize with previous operations here
         let c = self.count.fetch_add(1, Ordering::Relaxed);
         if c == INITIAL_STRONG_VALUE {
-            // Android uses Relaxed here, but we use Release to be more conservative.
-            // This ensures the initialization (calling f()) is visible to other threads.
-            // Note: Android's onFirstRef() may have internal synchronization that we don't.
+            // Relaxed matches AOSP RefBase: this only clears the sentinel
+            // bias on the first strong ref; any synchronization the
+            // first-ref initializer needs is provided by `f()` itself.
             self.count
                 .fetch_sub(INITIAL_STRONG_VALUE, Ordering::Relaxed);
             f()?;

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -149,6 +149,27 @@ impl ServerListener {
 }
 
 impl RawAccepted {
+    /// Arm a read deadline on the raw stream *before* it is wrapped, so
+    /// the pre-wrap TLS handshake (driven inside [`into_transport`],
+    /// which performs blocking reads on this socket) is itself bounded.
+    /// Without this, the [`run_connection_in_worker`] deadline — armed
+    /// only after the wrap returns — never covers the handshake, so a
+    /// connected-but-silent TLS peer would pin its worker thread (and,
+    /// under [`set_max_connections`](RpcServer::set_max_connections), the
+    /// whole accept loop) indefinitely. Best-effort: a set failure just
+    /// means no deadline. Harmless on the plain (UDS/vsock) path — that
+    /// wrap performs no I/O and the same deadline is re-armed before the
+    /// native handshake reads.
+    fn set_read_timeout(&self, timeout: Option<std::time::Duration>) -> std::io::Result<()> {
+        match self {
+            RawAccepted::Unix(s) => s.set_read_timeout(timeout),
+            #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
+            RawAccepted::Vsock(s) => s.set_read_timeout(timeout),
+            #[cfg(feature = "rpc-tls")]
+            RawAccepted::Tcp(s) => s.set_read_timeout(timeout),
+        }
+    }
+
     /// Wrap the raw stream as `RpcTransport`, on the
     /// worker thread. `tls_config = Some(cfg)` ⇒ drive a server-side
     /// TLS handshake via [`TlsTransport::accept_stream`] over the raw
@@ -919,6 +940,22 @@ impl RpcServer {
     fn serve_connection_raw(self: &Arc<Self>, raw: RawAccepted) {
         let server = Arc::clone(self);
         let handle = std::thread::spawn(move || {
+            // Bound the pre-wrap handshake phase on the raw socket before
+            // any blocking I/O. The TLS handshake runs inside
+            // `wrap_accepted` (below), *before* `run_connection_in_worker`
+            // arms its deadline, so a silent peer would otherwise pin this
+            // worker — and, with `set_max_connections`, the accept loop —
+            // forever. `run_connection_in_worker` re-arms (idempotent) and
+            // clears it before the long-lived serve.
+            if let Some(d) = *server
+                .handshake_timeout
+                .lock()
+                .expect("handshake_timeout poisoned")
+            {
+                if let Err(e) = raw.set_read_timeout(Some(d)) {
+                    log::debug!("RPC: failed to arm pre-wrap handshake read timeout: {e:?}");
+                }
+            }
             let transport = match server.wrap_accepted(raw) {
                 Ok(t) => t,
                 Err(e) => {
@@ -1061,6 +1098,30 @@ impl RpcServer {
                                 log::warn!(
                                     "android-13+ RPC: incoming attach after server \
                                      shutdown; rejecting"
+                                );
+                                drop(transport);
+                                return;
+                            }
+                            // Bound callback (incoming) slots. Unlike outgoing
+                            // attaches — which carry a serve loop and are
+                            // reclaimed by `remove_slot` on disconnect — a
+                            // callback slot has no read loop and lives until
+                            // the whole session tears down, so without a cap a
+                            // peer holding the session id could grow the slot
+                            // pool (and its held fds) without bound. AOSP opens
+                            // symmetric incoming+outgoing connections (each
+                            // bounded by the negotiated max-threads), so cap the
+                            // shared pool at `2 * max_threads` — tight enough to
+                            // bound the DoS, loose enough never to refuse a
+                            // well-behaved client's callback connections.
+                            let incoming_cap =
+                                (inner.max_threads_value() as usize).saturating_mul(2);
+                            if inner.slot_count() >= incoming_cap {
+                                server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
+                                log::warn!(
+                                    "android-13+ RPC: incoming callback attach refused \
+                                     (slot cap reached: slot_count={}, cap={incoming_cap})",
+                                    inner.slot_count()
                                 );
                                 drop(transport);
                                 return;

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -1511,6 +1511,20 @@ impl RpcSessionInner {
                     );
                     None
                 }
+                super::state::AsyncDecision::Terminate(num_pending) => {
+                    // The out-of-order oneway backlog hit the terminate
+                    // watermark; `dispatch_async_or_enqueue` already
+                    // flushed the node's queue. Returning Err breaks the
+                    // serve loop and tears this connection down
+                    // (FAILED_TRANSACTION). This is connection-level, not
+                    // AOSP's whole-session shutdownAndWait, but the flush
+                    // already reclaimed the backlog.
+                    log::error!(
+                        "RPC: {num_pending} pending oneway transactions on {addr:?}; \
+                         flushing backlog and tearing down connection"
+                    );
+                    return Err(StatusCode::FailedTransaction);
+                }
             }
         };
         while let Some((t, fds)) = next {

--- a/rsbinder/src/rpc/state.rs
+++ b/rsbinder/src/rpc/state.rs
@@ -81,6 +81,20 @@ pub enum DropReason {
     StaleAsyncNumber,
 }
 
+/// AOSP `RpcState.cpp` `kArbitraryOnewayCallTerminateLevel`: once this
+/// many out-of-order oneways are parked on a single node, the peer is
+/// treated as hostile/buggy — the node's parked backlog is flushed
+/// (reclaiming its memory + held fds at once) and the delivering
+/// connection is torn down, rather than letting the per-node
+/// `async_todo` queue grow without bound (memory + fd exhaustion DoS).
+/// This bounds a node to at most this many parked entries at any instant.
+const ASYNC_TODO_TERMINATE_LEVEL: usize = 10000;
+/// AOSP `kArbitraryOnewayCallWarnLevel` / `kArbitraryOnewayCallWarnPer`
+/// (both 1000): emit a warning at each multiple of this once the queue
+/// is this deep, so a building backlog is observable before the
+/// terminate watermark.
+const ASYNC_TODO_WARN_PER: usize = 1000;
+
 /// Outcome of [`RpcState::dispatch_async_or_enqueue`] for an inbound
 /// oneway. Caller dispatches the [`AsyncDecision::Dispatch`] variant
 /// outside the state lock, then calls
@@ -91,6 +105,14 @@ pub enum AsyncDecision {
     Dispatch(WireTransaction, Vec<OwnedFd>),
     Enqueued,
     Drop(DropReason),
+    /// The per-node `async_todo` queue reached the terminate watermark
+    /// (count carried for logging); the backlog has already been flushed
+    /// here. The caller must tear the delivering connection down with
+    /// `FAILED_TRANSACTION`. Unlike AOSP `shutdownAndWait` this is
+    /// connection-level, not whole-session — but the flush above means
+    /// the backlog is reclaimed regardless of how many connections the
+    /// session has.
+    Terminate(usize),
 }
 
 /// A local object exposed to the peer under [`RpcAddress`].
@@ -340,6 +362,27 @@ impl RpcState {
                 transaction: txn,
                 in_fds,
             }));
+            // AOSP RpcState.cpp lines 1109–1129: bound the out-of-order
+            // backlog so a peer that addresses a known node with
+            // ever-increasing future async numbers (while the expected
+            // one never arrives) cannot grow this heap — and the fds it
+            // owns — without limit.
+            let num_pending = node.async_todo.len();
+            if num_pending >= ASYNC_TODO_TERMINATE_LEVEL {
+                // Flush the abusive node's backlog now so its memory +
+                // any held fds are reclaimed immediately, independent of
+                // the caller's connection teardown. Without this, on a
+                // multi-connection session the heap would persist (and a
+                // reconnecting peer could re-accrete one entry per
+                // terminate); flushing keeps the bound tight.
+                node.async_todo.clear();
+                return AsyncDecision::Terminate(num_pending);
+            }
+            if num_pending % ASYNC_TODO_WARN_PER == 0 {
+                log::warn!(
+                    "RPC: {num_pending} pending out-of-order oneway transactions on {addr:?}"
+                );
+            }
             AsyncDecision::Enqueued
         } else {
             AsyncDecision::Drop(DropReason::StaleAsyncNumber)
@@ -780,6 +823,43 @@ mod tests {
         // After draining 4 (the last one), counter still advances
         // once for the dispatch of 4 — so expected is now 5.
         assert_eq!(st.next_async_number(&a), 5);
+    }
+
+    /// A peer that parks out-of-order oneways while withholding the
+    /// expected `async_number` cannot grow a node's `async_todo` without
+    /// bound: at the AOSP terminate watermark the decision flips to
+    /// `Terminate` and the backlog is flushed (memory + any held fds
+    /// reclaimed), bounding the node to `ASYNC_TODO_TERMINATE_LEVEL`
+    /// entries at any instant.
+    #[test]
+    fn phase_c_async_todo_terminate_caps_and_flushes_backlog() {
+        let mut st = RpcState::new(AddressSpace::Acceptor);
+        let b = SIBinder::new(Arc::new(Dummy)).unwrap();
+        let a = st.on_binder_leaving(&b);
+
+        // Expected is 0 and never arrives; 1..watermark all park.
+        for n in 1..ASYNC_TODO_TERMINATE_LEVEL as u64 {
+            let txn = mk_txn(a, n);
+            assert!(
+                matches!(
+                    st.dispatch_async_or_enqueue(a, n, txn, vec![]),
+                    AsyncDecision::Enqueued
+                ),
+                "async_number {n} below the watermark must park"
+            );
+        }
+        assert_eq!(st.async_todo_len(&a), ASYNC_TODO_TERMINATE_LEVEL - 1);
+
+        // The push that reaches the watermark terminates and flushes.
+        let n = ASYNC_TODO_TERMINATE_LEVEL as u64;
+        let txn = mk_txn(a, n);
+        match st.dispatch_async_or_enqueue(a, n, txn, vec![]) {
+            AsyncDecision::Terminate(pending) => {
+                assert_eq!(pending, ASYNC_TODO_TERMINATE_LEVEL)
+            }
+            other => panic!("watermark must terminate, got {other:?}"),
+        }
+        assert_eq!(st.async_todo_len(&a), 0, "backlog flushed on terminate");
     }
 
     /// Unknown address: AOSP `RpcState` only enqueues if

--- a/rsbinder/src/rpc/transport/tls.rs
+++ b/rsbinder/src/rpc/transport/tls.rs
@@ -222,6 +222,11 @@ impl TlsTransport {
     /// Server side over **any** stream: TLS-handshake per `config`. With
     /// an mTLS config the client certificate is required + verified by
     /// rustls; its absence/invalidity fails the handshake here.
+    ///
+    /// Note: a non-mTLS `ServerConfig` (no client-auth verifier) yields a
+    /// [`PeerIdentity::Anonymous`] connection — encrypted but with no
+    /// authenticated peer. Authorization of such peers must be enforced
+    /// by the caller's `set_authorizer` chokepoint.
     pub fn accept_stream(
         stream: Box<dyn TlsStream>,
         config: Arc<rustls::ServerConfig>,


### PR DESCRIPTION
## Summary

Two rounds of source-review findings for rsbinder, each cross-checked against AOSP behavior and kept wire-compatible / zero-cost when the relevant feature is off.

### Round 1 — `4a456d4` (parcel decode, service registration, RPC oneway backlog)
- **parcel**: `read_array_char` reinterpreted a 1-byte-aligned buffer via `align_to::<i32>()`, which silently drops a misaligned prefix (data corruption). Copy each element out with `chunks_exact` instead; aligns the `String` u16 path comment with it.
- **aidl**: `const_expr` value-string fallback returns `String::new()` instead of `unimplemented!()` so a future caller can't turn it into a panic on user input.
- **rsb_device**: reject binder device names that aren't a single path component (`/`, `.`, `..`, empty, NUL) before they're interpolated into root-owned `/dev` / binderfs paths.
- **rsb_hub**: warn loudly on a cross-uid/pid service overwrite (the signature of a hijack) and document the no-add-time-access-control caveat vs AOSP's VINTF/SELinux model.
- **rpc(oneway)**: bound the out-of-order async backlog with AOSP's `kArbitraryOnewayCallTerminateLevel` (10000) — flush the node and tear the connection down rather than letting a peer grow the per-node `async_todo` (memory + fd DoS).

### Round 2 — `808edfa` (AIDL parser panics, RPC server admission, service registration)
- **aidl**: an empty `{}` initializer panicked in five parser positions (enumerator value, nested array element, annotation argument, named annotation parameter, array dimension) via `into_inner().next().unwrap()` on a `const_expr` node with no inner pair. Now emits a miette diagnostic, matching the already-fixed variable-decl site. The legitimate `int[] x = {}` still parses. New regression test covers all five.
- **rpc(server)**: the TLS handshake ran with **no read deadline** — it is driven inside `wrap_accepted`, before `run_connection_in_worker` arms `handshake_timeout`. A connected-but-silent TLS peer pinned its worker thread (and, under `set_max_connections`, the whole accept loop) indefinitely. The deadline is now armed on the raw stream before the handshake.
- **rpc(server)**: the incoming (callback) attach arm had no slot cap, unlike the outgoing arm. A peer holding the 32-byte session id could grow the per-session slot pool (and its held fds) without bound. Capped at `2 * max_threads`, which bounds the growth while preserving AOSP's symmetric incoming+outgoing connection geometry.
- **rsb_hub**: `addService` overwriting a name with a *different* binder never unlinked the old binder's death notification (`ProxyHandle::Drop` does not clear it), leaking the kernel subscription; re-registering the *same* binder stacked duplicate recipients. Now links the new binder first (so a link failure is a clean no-op), then unlinks the replaced one, and skips relinking an identical binder.
- **rsb_device**: resolve `mount` via an absolute `/bin/mount` path rather than `$PATH`, since the tool runs as root.

## Test plan
- macOS hermetic: `cargo clippy --workspace --all-targets` and `-p rsbinder --features rpc,rpc-tls` clean; `cargo fmt --check` clean.
- `rsbinder-aidl` 32/0 incl. the new `empty_brace_initializer_is_rejected_not_panicked` regression test (all five `{}` cases reproduce the pre-fix panic; legitimate `int[] x = {}` still generates).
- `rsbinder --features rpc`: `rpc::` unit tests 62/0; `rpc_server` 27/0 (multi-conn cap `ac_12_4` + nested-callback slot-pin unaffected); with `rpc-tls` 28/0 incl. `tls_android13plus_nested_callback_e2e`; `rpc_tls` 9/0, `rpc_scenarios` 7/0, `rpc_e2e` 4/0.
- The 14 failing lib tests on macOS (`process_state`/`binderfs`/`thread_state`) require `/dev/binder` and are the known macOS baseline — unchanged by this branch.
- **Pending**: kernel-binder runtime validation of the `rsb_hub` death-link and `rsb_device` mount changes needs a Linux binder device (REMOTE_LINUX) / Android emulator; verified here by compilation + reasoning only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)