### PR TITLE
fix: harden parcel/RPC/AIDL/hub paths from second-pass review findings

### DIFF
--- a/rsbinder-aidl/src/const_expr.rs
+++ b/rsbinder-aidl/src/const_expr.rs
@@ -4,6 +4,16 @@
 use crate::error::ConstExprError;
 use crate::parser;
 
+/// Maximum structural nesting depth for constant-expression evaluation.
+///
+/// `.aidl` source is untrusted input to the compiler; a pathologically
+/// nested expression (e.g. thousands of parentheses) would otherwise
+/// recurse `calculate_with_visited` until the thread stack overflows and
+/// aborts the process. Real AIDL constants nest only a handful of levels,
+/// so this bound is far above any legitimate input while staying well
+/// below the frame budget that triggers a stack overflow.
+const MAX_EXPR_DEPTH: usize = 256;
+
 macro_rules! arithmetic_bit_op {
     ($lhs:expr, $op:tt, $rhs:expr, $desc:expr, $promoted:expr) => {
         {
@@ -538,6 +548,7 @@ impl ValueType {
         operator: &str,
         rhs: &ConstExpr,
         visited: &mut std::collections::HashSet<String>,
+        depth: usize,
     ) -> Result<ConstExpr, ConstExprError> {
         // Thread the cycle-guard `visited` set through operand resolution so
         // a reference cycle that crosses a binary operator (e.g.
@@ -545,8 +556,12 @@ impl ValueType {
         // of recursing until the stack overflows. Each operand gets its OWN
         // clone of the current resolution path so that sibling references to
         // a common (non-cyclic) constant are not mistaken for a cycle.
-        let lhs = lhs.value.calculate_with_visited(&mut visited.clone())?;
-        let rhs = rhs.value.calculate_with_visited(&mut visited.clone())?;
+        let lhs = lhs
+            .value
+            .calculate_with_visited(&mut visited.clone(), depth + 1)?;
+        let rhs = rhs
+            .value
+            .calculate_with_visited(&mut visited.clone(), depth + 1)?;
 
         let promoted = type_conversion(
             integral_promotion(lhs.value.clone()),
@@ -654,16 +669,27 @@ impl ValueType {
     }
 
     pub fn calculate(&self) -> Result<ConstExpr, ConstExprError> {
-        self.calculate_with_visited(&mut std::collections::HashSet::new())
+        self.calculate_with_visited(&mut std::collections::HashSet::new(), 0)
     }
 
     fn calculate_with_visited(
         &self,
         visited: &mut std::collections::HashSet<String>,
+        depth: usize,
     ) -> Result<ConstExpr, ConstExprError> {
+        // The `visited` set only breaks *name-reference* cycles; it does
+        // nothing for a deeply nested expression tree (e.g. thousands of
+        // parentheses) parsed from an untrusted `.aidl` file, which would
+        // otherwise recurse until the thread stack overflows and aborts
+        // the compiler. Bound the structural recursion depth as well.
+        if depth > MAX_EXPR_DEPTH {
+            return Err(ConstExprError::new(
+                "constant expression nested too deeply (exceeded recursion limit)",
+            ));
+        }
         match self {
             ValueType::Unary { operator, expr } => {
-                let expr = expr.value.calculate_with_visited(visited)?;
+                let expr = expr.value.calculate_with_visited(visited, depth + 1)?;
                 if operator == "-" {
                     expr.value.unary_minus()
                 } else if operator == "~" || operator == "!" {
@@ -673,13 +699,13 @@ impl ValueType {
                 }
             }
             ValueType::Expr { lhs, operator, rhs } => {
-                ValueType::calc_expr(lhs, operator, rhs, visited)
+                ValueType::calc_expr(lhs, operator, rhs, visited, depth)
             }
             ValueType::Array(v) => {
                 let mut array = Vec::new();
 
                 for value in v {
-                    array.push(value.value.calculate_with_visited(visited)?);
+                    array.push(value.value.calculate_with_visited(visited, depth + 1)?);
                 }
 
                 Ok(ConstExpr::new(ValueType::Array(array)))
@@ -691,7 +717,7 @@ impl ValueType {
                     visited.insert(name.clone());
                     let expr = parser::name_to_const_expr(name);
                     match expr {
-                        Some(expr) => expr.value.calculate_with_visited(visited),
+                        Some(expr) => expr.value.calculate_with_visited(visited, depth + 1),
                         None => Ok(ConstExpr::new(self.clone())),
                     }
                 }
@@ -1000,5 +1026,33 @@ mod tests {
         let arr = ValueType::Array(vec![ConstExpr::new(ValueType::Int32(1))]);
         let result = arr.to_f64();
         assert!(result.is_err());
+    }
+
+    // A pathologically deep expression tree (e.g. thousands of parens in an
+    // untrusted `.aidl`) must surface a diagnostic error rather than recurse
+    // until the thread stack overflows and aborts the compiler.
+    #[test]
+    fn deeply_nested_expr_returns_error_not_stack_overflow() {
+        let mut e = ConstExpr::new(ValueType::Int32(1));
+        for _ in 0..(MAX_EXPR_DEPTH + 16) {
+            e = ConstExpr::new(ValueType::Unary {
+                operator: "~".to_string(),
+                expr: Box::new(e),
+            });
+        }
+        assert!(e.value.calculate().is_err());
+    }
+
+    // A modest nesting depth (well under the limit) must still fold normally.
+    #[test]
+    fn moderately_nested_expr_still_evaluates() {
+        let mut e = ConstExpr::new(ValueType::Int32(0));
+        for _ in 0..8 {
+            e = ConstExpr::new(ValueType::Unary {
+                operator: "~".to_string(),
+                expr: Box::new(e),
+            });
+        }
+        assert!(e.value.calculate().is_ok());
     }
 }

--- a/rsbinder-tools/src/bin/rsb_hub.rs
+++ b/rsbinder-tools/src/bin/rsb_hub.rs
@@ -375,14 +375,20 @@ impl Inner {
 
 struct ServiceManager {
     inner: Arc<Mutex<Inner>>,
+    /// When `false` (the default), `addService` refuses to overwrite a live
+    /// registration owned by a different UID — the signature of a
+    /// service-name hijack. `--allow-cross-uid-overwrite` sets it `true`
+    /// for deployments that intentionally re-register across UIDs.
+    allow_cross_uid_overwrite: bool,
 }
 
 impl ServiceManager {
-    fn new() -> Self {
+    fn new(allow_cross_uid_overwrite: bool) -> Self {
         let (death_sender, death_receiver) = mpsc::channel();
 
         let this = Self {
             inner: Arc::new(Mutex::new(Inner::new(death_sender))),
+            allow_cross_uid_overwrite,
         };
 
         this.run_death_receiver(death_receiver);
@@ -509,6 +515,26 @@ impl ServiceManager {
 
         true
     }
+
+    /// Add-time access-control decision for an `addService` that would
+    /// overwrite an existing registration: returns `true` when the
+    /// overwrite must be rejected as a likely service-name hijack.
+    ///
+    /// Rejected iff the operator has NOT opted into cross-UID overwrites,
+    /// the incoming binder is a *different* object than the one registered
+    /// (`!same_binder`), AND the caller's UID differs from the registrant's.
+    /// A same-UID overwrite (e.g. a service restart under a new PID) and a
+    /// re-registration of the identical binder are always allowed. Pure and
+    /// total so the security-relevant branch is unit-testable without two
+    /// real OS UIDs.
+    fn is_cross_uid_overwrite_rejected(
+        allow_cross_uid_overwrite: bool,
+        same_binder: bool,
+        existing_uid: u32,
+        caller_uid: u32,
+    ) -> bool {
+        !allow_cross_uid_overwrite && !same_binder && existing_uid != caller_uid
+    }
 }
 
 impl Interface for ServiceManager {}
@@ -621,14 +647,43 @@ impl IServiceManager for ServiceManager {
             if let Some(existing) = inner.name_to_service.get(name) {
                 prev_clients = existing.has_clients;
                 same_binder = existing.binder == *service;
-                // No add-time access control on Linux (see fn rustdoc): we
-                // cannot reject a hijack, but overwriting an entry owned by
-                // a different uid/pid is its signature, so make it loud
-                // rather than silent (AOSP logs the same mismatch).
-                if existing.context.uid != caller.uid || existing.context.pid != caller.pid {
+                // Add-time access control (see fn rustdoc and
+                // `is_cross_uid_overwrite_rejected`). A cross-UID overwrite of
+                // a *different* live binder is the signature of a service-name
+                // hijack (MITM): AOSP rejects app UIDs and runs the SELinux
+                // canAddService hook, neither of which exists on a plain Linux
+                // host, so reject it by default. A same-UID re-registration
+                // (e.g. a service restart under a new PID) and re-registering
+                // the identical binder are always allowed; the owning UID
+                // dying frees the name via the death recipient, after which
+                // any UID may claim it. `--allow-cross-uid-overwrite` opts
+                // back into the prior permissive (warn-only) behavior.
+                if Self::is_cross_uid_overwrite_rejected(
+                    self.allow_cross_uid_overwrite,
+                    same_binder,
+                    existing.context.uid,
+                    caller.uid,
+                ) {
                     log::warn!(
-                        "addService: '{name}' overwritten by uid={} pid={} \
-                         (previously registered by uid={} pid={})",
+                        "addService: rejecting cross-uid overwrite of '{name}' by uid={} \
+                         pid={} (registered by uid={} pid={}); pass \
+                         --allow-cross-uid-overwrite to permit",
+                        caller.uid,
+                        caller.pid,
+                        existing.context.uid,
+                        existing.context.pid
+                    );
+                    return Err(ExceptionCode::Security.into());
+                }
+                // The opt-in cross-uid overwrite path: proceed but log loudly.
+                if self.allow_cross_uid_overwrite
+                    && !same_binder
+                    && existing.context.uid != caller.uid
+                {
+                    log::warn!(
+                        "addService: '{name}' overwritten across uid by uid={} pid={} \
+                         (previously uid={} pid={}); permitted by \
+                         --allow-cross-uid-overwrite",
                         caller.uid,
                         caller.pid,
                         existing.context.uid,
@@ -1072,6 +1127,17 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
                 .help("Name of the binder device to use (e.g., 'binder', 'mybinder')")
                 .default_value("binder"),
         )
+        .arg(
+            clap::Arg::new("allow-cross-uid-overwrite")
+                .long("allow-cross-uid-overwrite")
+                .action(clap::ArgAction::SetTrue)
+                .help(
+                    "Permit a client to overwrite a service name registered by a \
+                     different UID. Off by default: a cross-UID overwrite is the \
+                     signature of a service-name hijack, so it is rejected unless \
+                     this flag is set.",
+                ),
+        )
         .after_help(
             "Examples:\n    \
             Run with the default binder device:\n    \
@@ -1089,13 +1155,20 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .get_one::<String>("device")
         .expect("device has a default value");
     let binder_path = format!("{}/{}", DEFAULT_BINDERFS_PATH, device_name);
+    let allow_cross_uid_overwrite = matches.get_flag("allow-cross-uid-overwrite");
+    if allow_cross_uid_overwrite {
+        log::warn!(
+            "rsb_hub: --allow-cross-uid-overwrite is set; clients may overwrite \
+             services registered by other UIDs (service-hijack protection disabled)"
+        );
+    }
 
     log::info!("Starting rsb_hub with binder device: {}", binder_path);
 
     ProcessState::init(&binder_path, 0)?;
 
     // Create a binder service.
-    let service = BnServiceManager::new_binder(ServiceManager::new());
+    let service = BnServiceManager::new_binder(ServiceManager::new(allow_cross_uid_overwrite));
     service.addService(
         "manager",
         &service.as_binder(),
@@ -1111,6 +1184,35 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Add-time access control: a cross-UID overwrite of a different live
+    /// binder is rejected by default; same-UID restarts, identical-binder
+    /// re-registration, and the explicit opt-in are all allowed. (The
+    /// real two-UID transaction path is exercised by deployment; this pins
+    /// the decision predicate deterministically.)
+    #[test]
+    fn cross_uid_overwrite_decision() {
+        // Reject: different UID, different binder, flag off (hijack).
+        assert!(ServiceManager::is_cross_uid_overwrite_rejected(
+            false, false, 1000, 2000
+        ));
+        // Allow: same UID (e.g. a service restart under a new PID).
+        assert!(!ServiceManager::is_cross_uid_overwrite_rejected(
+            false, false, 1000, 1000
+        ));
+        // Allow: re-registering the identical binder, even across UIDs.
+        assert!(!ServiceManager::is_cross_uid_overwrite_rejected(
+            false, true, 1000, 2000
+        ));
+        // Allow: operator opted into cross-UID overwrites.
+        assert!(!ServiceManager::is_cross_uid_overwrite_rejected(
+            true, false, 1000, 2000
+        ));
+        // Allow: opt-in + same UID (trivially permitted).
+        assert!(!ServiceManager::is_cross_uid_overwrite_rejected(
+            true, false, 1000, 1000
+        ));
+    }
 
     #[test]
     fn test_is_valid_service_name_accepts_valid() {

--- a/rsbinder/src/parcelable.rs
+++ b/rsbinder/src/parcelable.rs
@@ -413,7 +413,18 @@ impl DeserializeOption for String {
         let len = parcel.read::<i32>()?;
 
         if (0..i32::MAX).contains(&len) {
-            let data = parcel.read_aligned_data((len as usize + 1) * std::mem::size_of::<u16>())?;
+            // String16 wire = `len + 1` UTF-16 code units (the trailing
+            // NUL terminator is sent too). Route the byte count through
+            // `checked_array_layout` so a hostile near-`i32::MAX` `len`
+            // cannot wrap `(len + 1) * 2` — nor the `+ 3` inside
+            // `read_aligned_data`'s `pad_size` — past `usize::MAX` on
+            // 32-bit targets (armv7 Android, i686 Linux) and slip past
+            // the bounds check into a slice-index panic (remote DoS).
+            // `len + 1` is in `1..=i32::MAX` here, and 64-bit is
+            // byte-identical to the previous unchecked arithmetic.
+            let (byte_count, _) =
+                crate::parcel::checked_array_layout(len + 1, std::mem::size_of::<u16>())?;
+            let data = parcel.read_aligned_data(byte_count)?;
             // `data` is borrowed from the parcel's `Vec<u8>` whose base is
             // only 1-byte aligned, so reinterpreting it as `&[u16]` via
             // `from_raw_parts(_ as *const u16, _)` would construct an
@@ -858,3 +869,48 @@ impl<T: std::fmt::Debug + DeserializeArray, const N: usize> DeserializeOption fo
 }
 
 impl<T: DeserializeArray, const N: usize> DeserializeArray for [T; N] {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A hostile String16 length (untrusted parcel input) must surface an
+    /// error rather than panic. On 32-bit targets the `(len + 1) * 2` byte
+    /// count — and the `+ 3` inside `pad_size` — could wrap `usize` and slip
+    /// past the bounds check into a slice-index panic; routing through
+    /// `checked_array_layout` rejects it as `BadValue` instead. (64-bit
+    /// surfaces it as `NotEnoughData`; either way it is an `Err`, not a
+    /// panic.)
+    #[test]
+    fn hostile_string16_length_returns_err_not_panic() {
+        let mut p = Parcel::new();
+        // Near-`i32::MAX` declared length with no following payload.
+        p.write::<i32>(&(i32::MAX - 1)).unwrap();
+        p.set_data_position(0);
+        let r = <String as DeserializeOption>::deserialize_option(&mut p);
+        assert!(r.is_err());
+    }
+
+    /// A normal string still round-trips byte-identically.
+    #[test]
+    fn string16_round_trip() {
+        let mut p = Parcel::new();
+        let s = "héllo".to_string();
+        p.write(&s).unwrap();
+        p.set_data_position(0);
+        let got: String = p.read::<String>().unwrap();
+        assert_eq!(got, s);
+    }
+
+    /// The empty-string boundary (len == 0 ⇒ only the NUL terminator) must
+    /// also round-trip without tripping the `len + 1` layout check.
+    #[test]
+    fn empty_string16_round_trip() {
+        let mut p = Parcel::new();
+        let s = String::new();
+        p.write(&s).unwrap();
+        p.set_data_position(0);
+        let got: String = p.read::<String>().unwrap();
+        assert_eq!(got, s);
+    }
+}

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -826,29 +826,45 @@ impl ProcessState {
     /// `DeathRecipient::binder_died` callbacks, which can issue nested
     /// binder calls. See [`thread_state`](super::thread_state) module doc.
     pub(crate) fn send_obituary_for_handle(&self, handle: u32) -> Result<()> {
-        let entry = {
+        // Downgrade to `who` BEFORE removing the cache entry: afterwards
+        // `cache_generation_for` returns `None` and `downgrade` yields a
+        // `Native` `WIBinder` that compares unequal to the registered `Proxy`,
+        // breaking `binder_died` identity matching. The read guard is dropped
+        // first — `downgrade` re-acquires the same (non-reentrant) RwLock read.
+        let arc = {
+            let handle_to_proxy = self
+                .handle_to_proxy
+                .read()
+                .expect("Handle to proxy lock poisoned");
+            // The entry's `weak` may or may not still upgrade. Recipients are
+            // only meaningful while a live proxy exists, since `link_to_death`
+            // requires an `Arc<ProxyHandle>` to hand out recipients.
+            handle_to_proxy
+                .get(&handle)
+                .and_then(|entry| entry.weak.upgrade())
+        };
+        let who = arc.as_ref().map(|arc| {
+            let sibinder = SIBinder::from_arc(arc.clone() as Arc<dyn IBinder>);
+            SIBinder::downgrade(&sibinder)
+        });
+
+        let existed = {
             let mut handle_to_proxy = self
                 .handle_to_proxy
                 .write()
                 .expect("Handle to proxy lock poisoned");
-            handle_to_proxy.remove(&handle)
+            handle_to_proxy.remove(&handle).is_some()
         };
 
-        if let Some(entry) = entry {
-            // The entry's `weak` may or may not still upgrade. Recipients
-            // are only meaningful while a live proxy exists, since
-            // `link_to_death` requires an `Arc<ProxyHandle>` to hand out
-            // recipients. If the Arc is gone, no recipients can be
-            // pending and we simply drop the cache entry.
-            if let Some(arc) = entry.weak.upgrade() {
-                let sibinder = SIBinder::from_arc(arc.clone() as Arc<dyn IBinder>);
-                let who = SIBinder::downgrade(&sibinder);
-                arc.send_obituary(&who)?;
-            } else {
+        // `send_obituary` runs user callbacks, so it is invoked with no
+        // `handle_to_proxy` lock held (and it is idempotent, so a racing
+        // double obituary for the same handle is harmless).
+        match (arc, who) {
+            (Some(arc), Some(who)) => arc.send_obituary(&who)?,
+            _ if existed => {
                 log::trace!("Object for handle {handle} already destroyed at obituary time");
             }
-        } else {
-            log::trace!("Handle {handle} was not in cache during obituary");
+            _ => log::trace!("Handle {handle} was not in cache during obituary"),
         }
 
         Ok(())

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -341,6 +341,18 @@ pub struct RpcServer {
     /// deadline is cleared once serving begins, so an established
     /// two-way session may idle between requests unbounded.
     handshake_timeout: Mutex<Option<std::time::Duration>>,
+    /// Optional per-connection *idle* read deadline applied to the
+    /// android-13+ serve loop **after** the handshake completes. `None`
+    /// (the default) ⇒ an established session idles between requests
+    /// unbounded (byte-identical to prior behavior). `Some(d)` ⇒ a peer
+    /// that completes the handshake and then goes silent surfaces as a
+    /// serve-loop read error after `d`, releasing its worker and its
+    /// [`set_max_connections`](Self::set_max_connections) admission slot —
+    /// the post-handshake Slowloris defense that
+    /// [`set_handshake_timeout`](Self::set_handshake_timeout) (handshake
+    /// phase only) does not cover. Set this only when the protocol has
+    /// regular traffic or idle eviction is acceptable.
+    idle_timeout: Mutex<Option<std::time::Duration>>,
     /// Opt-in authorization hook. `None`
     /// (default) ⇒ accept-all = byte-for-byte a server without the hook
     /// (additive invariant). When set, it runs at
@@ -485,6 +497,7 @@ impl RpcServer {
             wire_max_version: Mutex::new(None),
             max_connections: Mutex::new(None),
             handshake_timeout: Mutex::new(Some(DEFAULT_HANDSHAKE_TIMEOUT)),
+            idle_timeout: Mutex::new(None),
             authorizer: Mutex::new(None),
             attach_shutdown_probe: Mutex::new(None),
             sessions: Mutex::new(HashMap::new()),
@@ -665,6 +678,27 @@ impl RpcServer {
             .handshake_timeout
             .lock()
             .expect("handshake_timeout poisoned") = timeout;
+    }
+
+    /// Set (or disable) the **idle read deadline** applied to the
+    /// android-13+ serve loop *after* the handshake completes. Default
+    /// `None` ⇒ an established session may idle between requests unbounded
+    /// (byte-identical to prior behavior).
+    ///
+    /// [`set_handshake_timeout`](Self::set_handshake_timeout) only bounds
+    /// the handshake/first-contact phase; once a peer completes the
+    /// handshake it can then go silent and hold its worker — and, under
+    /// [`set_max_connections`](Self::set_max_connections), an admission
+    /// slot — indefinitely (a post-handshake Slowloris that starves the
+    /// accept loop). Setting a `Some(d)` idle timeout evicts such a peer
+    /// after `d` of silence, freeing the slot. Use it when the protocol
+    /// has regular traffic or idle eviction is acceptable; pair it with
+    /// `set_max_connections` for untrusted peers, since OS-level TCP
+    /// keepalive/timeouts are otherwise the only backstop. (Currently
+    /// honored on the android-13+ serve path; the r34 profile already
+    /// bounds its first frame via the handshake deadline.)
+    pub fn set_idle_timeout(&self, timeout: Option<std::time::Duration>) {
+        *self.idle_timeout.lock().expect("idle_timeout poisoned") = timeout;
     }
 
     /// Reap finished worker handles and return the live (concurrent)
@@ -986,12 +1020,20 @@ impl RpcServer {
         raw.into_transport()
     }
 
-    /// Lift the admission read deadline (best-effort) once a connection
-    /// reaches the serving phase, so an established two-way session may
-    /// idle between requests unbounded.
-    fn clear_handshake_timeout(transport: &dyn RpcTransport) {
-        if let Err(e) = transport.set_read_timeout(None) {
-            log::debug!("RPC: failed to clear handshake read timeout: {e:?}");
+    /// Transition a connection from the bounded handshake/admission phase
+    /// to the long-lived serving phase (best-effort). By default this
+    /// lifts the read deadline entirely (`None`), so an established
+    /// two-way session may idle between requests unbounded — byte-identical
+    /// to prior behavior. If [`set_idle_timeout`](Self::set_idle_timeout)
+    /// was called, the serve loop instead inherits that idle read deadline,
+    /// so a peer that completes the handshake and then goes silent (a
+    /// post-handshake Slowloris that would otherwise pin a
+    /// [`set_max_connections`](Self::set_max_connections) admission slot
+    /// forever) surfaces as a serve-loop read error and is evicted.
+    fn arm_serve_read_timeout(&self, transport: &dyn RpcTransport) {
+        let idle = *self.idle_timeout.lock().expect("idle_timeout poisoned");
+        if let Err(e) = transport.set_read_timeout(idle) {
+            log::debug!("RPC: failed to set serve-phase read timeout: {e:?}");
         }
     }
 
@@ -1023,9 +1065,10 @@ impl RpcServer {
         }
         // Bound the pre-serve handshake/first-contact phase so a
         // connected-but-silent peer can't pin its `Arc<RpcServer>` +
-        // admission slot forever. Cleared by `clear_handshake_timeout`
-        // before any long-lived serve so an established session idles
-        // unbounded. Best-effort: a set failure just means no deadline.
+        // admission slot forever. Transitioned to the serve-phase deadline
+        // by `arm_serve_read_timeout` before any long-lived serve (`None`
+        // ⇒ idle unbounded, or the configured `set_idle_timeout`).
+        // Best-effort: a set failure just means no deadline.
         if let Some(d) = *server
             .handshake_timeout
             .lock()
@@ -1065,9 +1108,11 @@ impl RpcServer {
                             return;
                         }
                     };
-                // Handshake done: lift the admission deadline so the
-                // serve loop / pooled callback slot is not bounded by it.
-                Self::clear_handshake_timeout(transport.as_ref());
+                // Handshake done: transition the admission deadline to the
+                // serve-phase deadline — `None` (default, unbounded idle) or
+                // the configured `set_idle_timeout` so a post-handshake
+                // silent peer is evicted instead of pinning its slot.
+                server.arm_serve_read_timeout(transport.as_ref());
                 if incoming {
                     // Attach + incoming (`server_accept` already
                     // rejected new + incoming): resolve the session,
@@ -1114,24 +1159,21 @@ impl RpcServer {
                             // shared pool at `2 * max_threads` — tight enough to
                             // bound the DoS, loose enough never to refuse a
                             // well-behaved client's callback connections.
+                            //
+                            // The cap is enforced atomically inside
+                            // `add_callback_slot` (check-and-push under the
+                            // `conn_state` lock) rather than via a separate
+                            // pre-check, so concurrent attach workers cannot
+                            // each clear an advisory check and overshoot it.
                             let incoming_cap =
                                 (inner.max_threads_value() as usize).saturating_mul(2);
-                            if inner.slot_count() >= incoming_cap {
+                            let session = RpcSession::wrap_inner(inner);
+                            if let Err(e) = session.add_callback_slot(transport, incoming_cap) {
                                 server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
                                 log::warn!(
                                     "android-13+ RPC: incoming callback attach refused \
-                                     (slot cap reached: slot_count={}, cap={incoming_cap})",
-                                    inner.slot_count()
-                                );
-                                drop(transport);
-                                return;
-                            }
-                            let session = RpcSession::wrap_inner(inner);
-                            if let Err(e) = session.add_callback_slot(transport) {
-                                server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
-                                log::warn!(
-                                    "android-13+ RPC: incoming attach raced session \
-                                     teardown; rejecting: {e:?}"
+                                     (slot cap {incoming_cap} reached or session torn \
+                                     down): {e:?}"
                                 );
                             }
                         }

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -894,6 +894,33 @@ impl RpcSessionInner {
         self.add_slot_inner(transport)
     }
 
+    /// Like [`add_slot_inner`](Self::add_slot_inner) but enforces a
+    /// maximum pool size **atomically** under the `conn_state` lock:
+    /// returns `None` (adding nothing, closing `transport`) when the pool
+    /// already holds `cap` slots. Used for the server callback-slot
+    /// admission cap — callback slots have no serve loop and are only
+    /// reclaimed at session teardown, so a separate pre-check + add would
+    /// let concurrent attach workers each pass the check and overshoot the
+    /// cap, letting an untrusted peer grow the pool (and its held fds)
+    /// unbounded. Folding the check into the push closes that TOCTOU.
+    fn add_slot_inner_capped(&self, transport: Box<dyn RpcTransport>, cap: usize) -> Option<u64> {
+        let mut st = self.conn_state.lock().expect("conn_state poisoned");
+        if st.slots.len() >= cap {
+            return None;
+        }
+        let transport: Arc<dyn RpcTransport> = Arc::from(transport);
+        let id = st.next_slot_id;
+        st.next_slot_id += 1;
+        st.slots.push(ConnSlot {
+            transport,
+            exclusive_tid: None,
+            id,
+        });
+        drop(st);
+        self.slot_cv.notify_all();
+        Some(id)
+    }
+
     /// Remove a slot from the pool on its worker's
     /// `serve_blocking_on` exit. Called by the slot's *own* worker
     /// (self-remove), so `find_conn_pinned(slot_id)`'s
@@ -1101,7 +1128,7 @@ impl RpcSessionInner {
                         .state
                         .lock()
                         .expect("rpc state poisoned")
-                        .on_binder_leaving(b)
+                        .on_binder_leaving(b)?
                 };
                 // AOSP `Parcel::flattenBinder`: `dataPos = mDataPos`
                 // is captured **before** `writeInt32(TYPE_BINDER)` —
@@ -1628,8 +1655,32 @@ impl RpcSessionInner {
         // authorization. The guard restores on drop, so a nested re-entrant
         // callback over the same connection nests correctly.
         let result = consume_rpc_interface_token(&mut reader, target.descriptor()).and_then(|()| {
-            let _calling = crate::thread_state::RpcCallingGuard::install(Arc::clone(&peer));
-            target.rpc_transact(t.code, &mut reader, &mut reply)
+            // Mirror the kernel server entrypoint's `dispatch_transact_caught`
+            // (thread_state.rs): a panic in the user `on_transact` handler
+            // must NOT unwind through the serve loop, because that would skip
+            // the `serve_blocking_on_inner` cleanup (drop_connection /
+            // send_session_obituaries / remove_slot) and leave a slot pinned
+            // to a dead worker — deadlock + session-lifecycle corruption +
+            // missed obituaries. Catch it here and turn it into a
+            // deterministic error reply, symmetric with the kernel path. The
+            // `RpcCallingGuard` is created inside the closure so its `Drop`
+            // (which restores the calling context) still runs on unwind. On
+            // the error path the reply parcel is unused (`send_reply` sends an
+            // empty body with the status), so a partially-written `reply`
+            // cannot leak to the peer.
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _calling = crate::thread_state::RpcCallingGuard::install(Arc::clone(&peer));
+                target.rpc_transact(t.code, &mut reader, &mut reply)
+            }))
+            .unwrap_or_else(|payload| {
+                let msg = payload
+                    .downcast_ref::<&'static str>()
+                    .copied()
+                    .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+                    .unwrap_or("<non-string panic payload>");
+                log::error!("RPC on_transact panicked for code {}: {msg}", t.code);
+                Err(crate::StatusCode::Unknown)
+            })
         });
 
         if oneway {
@@ -1909,15 +1960,27 @@ impl RpcSession {
     /// the lifecycle count (callback slots are not serve-driven; AOSP
     /// also does not gate session lifetime on `mOutgoing.size()`).
     /// `Err(DeadObject)` if the session is already torn down (the
-    /// lifecycle covers both `Dying` and `Dead` in a single check).
-    pub(crate) fn add_callback_slot(&self, transport: Box<dyn RpcTransport>) -> Result<u64> {
+    /// lifecycle covers both `Dying` and `Dead` in a single check), or
+    /// `Err(FailedTransaction)` if the pool is already at `cap` slots.
+    ///
+    /// `cap` is enforced atomically inside [`add_slot_inner_capped`]
+    /// (`RpcSessionInner`) so concurrent attach workers cannot each clear
+    /// an advisory pre-check and overshoot it — callback slots are never
+    /// serve-reclaimed, so an unbounded pool is a peer-driven DoS.
+    pub(crate) fn add_callback_slot(
+        &self,
+        transport: Box<dyn RpcTransport>,
+        cap: usize,
+    ) -> Result<u64> {
         // Snapshot gate, not CAS — a concurrent founding death after
         // this read is race-acceptable: the slot sits unused in a
         // dead session and is reclaimed via `Arc<RpcSessionInner>`.
         if self.inner.shared.lifecycle.is_torn_down() {
             return Err(StatusCode::DeadObject);
         }
-        Ok(self.inner.add_slot_inner(transport))
+        self.inner
+            .add_slot_inner_capped(transport, cap)
+            .ok_or(StatusCode::FailedTransaction)
     }
 
     /// This session's full inner state — including
@@ -2936,5 +2999,48 @@ mod tests {
             RpcSession::from_preconnected_fd(fd, 2).is_err(),
             "non-socket fd must reject before any handshake I/O"
         );
+    }
+
+    /// The incoming callback-slot admission cap is enforced **atomically**
+    /// inside `add_callback_slot` (check-and-push under the `conn_state`
+    /// lock), so concurrent attaches cannot clear an advisory pre-check and
+    /// overshoot it. Callback slots are never serve-reclaimed, so an
+    /// unbounded pool would be a peer-driven fd/memory DoS. This single-
+    /// threaded gate proves the cap is hard (never exceeded) and refuses
+    /// past it.
+    #[test]
+    fn callback_slot_cap_is_enforced() {
+        use crate::rpc::transport::MemTransport;
+        // Server-side post-handshake session form (no wire I/O).
+        let (t0, _p0) = MemTransport::pair();
+        let session = RpcSession::from_android13plus(
+            Box::new(t0),
+            Android13PlusCodec::android14_15(),
+            FD_MODE_NONE,
+            false,
+            None,
+        )
+        .expect("build session");
+
+        let base = session.inner.slot_count();
+        let cap = base + 2;
+        let mut peers = Vec::new();
+        let mut admitted = 0usize;
+        let mut refused = 0usize;
+        for _ in 0..5 {
+            let (t, p) = MemTransport::pair();
+            peers.push(p); // keep peer halves alive
+            match session.add_callback_slot(Box::new(t), cap) {
+                Ok(_) => admitted += 1,
+                Err(_) => refused += 1,
+            }
+        }
+        assert_eq!(
+            session.inner.slot_count(),
+            cap,
+            "pool never exceeds the cap"
+        );
+        assert_eq!(admitted, cap - base, "exactly cap-base slots admitted");
+        assert!(refused >= 1, "attaches past the cap are refused");
     }
 }

--- a/rsbinder/src/rpc/state.rs
+++ b/rsbinder/src/rpc/state.rs
@@ -187,13 +187,25 @@ impl RpcState {
     /// dedups; see the module doc). Returning without bumping would let
     /// the first connection's DEC free a node still referenced over a
     /// sibling connection (`DeadObject`).
-    pub fn on_binder_leaving(&mut self, binder: &SIBinder) -> RpcAddress {
+    pub fn on_binder_leaving(&mut self, binder: &SIBinder) -> crate::Result<RpcAddress> {
         let ptr = binder_ptr(binder);
         if let Some(&addr) = self.local_by_ptr.get(&ptr) {
             if let Some(node) = self.local_nodes.get_mut(&addr) {
                 node.strong += 1;
             }
-            return addr;
+            return Ok(addr);
+        }
+        // The android-13+ wire encodes only the low 32 bits of the address
+        // counter (`encode_addr`), so past `u32::MAX` two live nodes would
+        // alias to one `RpcWireAddress` and mis-dispatch. Hard-stop rather
+        // than alias (vs. the async-number wrap, an ordering-only concern that
+        // only warns); ~2^32 live local objects per session is unreachable.
+        if self.addr_counter >= u32::MAX as u64 {
+            log::error!(
+                "RPC: local address counter exhausted (>= u32::MAX) on one session; \
+                 refusing to mint an aliasing address"
+            );
+            return Err(crate::StatusCode::FailedTransaction);
         }
         let addr = RpcAddress::unique(&mut self.addr_counter, self.space);
         self.local_nodes.insert(
@@ -206,7 +218,7 @@ impl RpcState {
             },
         );
         self.local_by_ptr.insert(ptr, addr);
-        addr
+        Ok(addr)
     }
 
     /// The local object registered at `addr`, if any (an address that
@@ -512,8 +524,8 @@ mod tests {
     fn leaving_is_idempotent_by_identity() {
         let mut st = RpcState::new(AddressSpace::Acceptor);
         let b = SIBinder::new(Arc::new(Dummy)).unwrap();
-        let a1 = st.on_binder_leaving(&b);
-        let a2 = st.on_binder_leaving(&b);
+        let a1 = st.on_binder_leaving(&b).unwrap();
+        let a2 = st.on_binder_leaving(&b).unwrap();
         assert_eq!(a1, a2, "same object → same address");
         assert_eq!(st.local_node_count(), 1);
         assert!(st.lookup_local(&a1).is_some());
@@ -524,13 +536,33 @@ mod tests {
     fn dec_strong_releases_node() {
         let mut st = RpcState::new(AddressSpace::Acceptor);
         let b = SIBinder::new(Arc::new(Dummy)).unwrap();
-        let a = st.on_binder_leaving(&b);
+        let a = st.on_binder_leaving(&b).unwrap();
         assert_eq!(st.local_node_count(), 1);
         assert!(st.dec_strong_local(&a), "node removed at strong 0");
         assert_eq!(st.local_node_count(), 0, "no leak");
         assert!(st.lookup_local(&a).is_none());
         // DEC_STRONG on an unknown address is safe (idempotent).
         assert!(!st.dec_strong_local(&a));
+    }
+
+    /// The android-13+ wire encodes only the low 32 bits of the address
+    /// counter, so once it reaches `u32::MAX` two distinct live nodes would
+    /// alias to one `RpcWireAddress`. `on_binder_leaving` must refuse to
+    /// mint a *new* address past that bound (a hard error) rather than
+    /// silently aliasing — while still serving a resend of an already
+    /// registered object (no new mint).
+    #[test]
+    fn address_counter_exhaustion_is_rejected_not_aliased() {
+        let mut st = RpcState::new(AddressSpace::Acceptor);
+        // Just below the bound: minting still succeeds.
+        st.addr_counter = (u32::MAX as u64) - 1;
+        let b1 = SIBinder::new(Arc::new(Dummy)).unwrap();
+        assert!(st.on_binder_leaving(&b1).is_ok());
+        // At the bound: a *new* object cannot be minted (would alias).
+        let b2 = SIBinder::new(Arc::new(Dummy)).unwrap();
+        assert!(st.on_binder_leaving(&b2).is_err());
+        // A resend of the already-registered object reuses its address.
+        assert!(st.on_binder_leaving(&b1).is_ok());
     }
 
     /// Two `RpcState` instances have **independent**
@@ -544,7 +576,7 @@ mod tests {
         let mut s1 = RpcState::new(AddressSpace::Acceptor);
         let s2 = RpcState::new(AddressSpace::Acceptor); // fresh, empty, independent table
         let b1 = SIBinder::new(Arc::new(Dummy)).unwrap();
-        let a1 = s1.on_binder_leaving(&b1);
+        let a1 = s1.on_binder_leaving(&b1).unwrap();
 
         // s2 registered nothing → it does not resolve s1's address,
         // even though a per-session counter could mint the same bytes.
@@ -675,9 +707,9 @@ mod tests {
         //     excess DECs + 1 at proxy drop = N.
         let mut srv = RpcState::new(AddressSpace::Acceptor);
         let b = SIBinder::new(Arc::new(Dummy)).unwrap();
-        let a = srv.on_binder_leaving(&b);
-        let a2 = srv.on_binder_leaving(&b);
-        let a3 = srv.on_binder_leaving(&b);
+        let a = srv.on_binder_leaving(&b).unwrap();
+        let a2 = srv.on_binder_leaving(&b).unwrap();
+        let a3 = srv.on_binder_leaving(&b).unwrap();
         assert_eq!((a, a), (a2, a3), "identity ⇒ same address on re-send");
         assert_eq!(srv.local_node_count(), 1, "one node, strong = timesSent");
         // Peer side: 3 receipts of the same addr, proxy stays live ⇒
@@ -705,8 +737,8 @@ mod tests {
         //     survive until the 2nd.
         let mut s = RpcState::new(AddressSpace::Acceptor);
         let o = SIBinder::new(Arc::new(Dummy)).unwrap();
-        let x = s.on_binder_leaving(&o); // conn #1 send
-        let _ = s.on_binder_leaving(&o); // conn #2 send (timesSent ⇒ 2)
+        let x = s.on_binder_leaving(&o).unwrap(); // conn #1 send
+        let _ = s.on_binder_leaving(&o).unwrap(); // conn #2 send (timesSent ⇒ 2)
         assert!(
             !s.dec_strong_local(&x),
             "conn #1 proxy drop must NOT free a node conn #2 still holds (F7)"
@@ -756,7 +788,7 @@ mod tests {
     fn phase_c_in_order_dispatches_and_advances_counter() {
         let mut st = RpcState::new(AddressSpace::Acceptor);
         let b = SIBinder::new(Arc::new(Dummy)).unwrap();
-        let a = st.on_binder_leaving(&b);
+        let a = st.on_binder_leaving(&b).unwrap();
         assert_eq!(st.next_async_number(&a), 0);
         for i in 0..5u64 {
             let txn = mk_txn(a, i);
@@ -785,7 +817,7 @@ mod tests {
     fn phase_c_out_of_order_enqueues_then_drains_in_priority_order() {
         let mut st = RpcState::new(AddressSpace::Acceptor);
         let b = SIBinder::new(Arc::new(Dummy)).unwrap();
-        let a = st.on_binder_leaving(&b);
+        let a = st.on_binder_leaving(&b).unwrap();
 
         // Wire arrival: 2, 4, 1, 3, 0 (libbinder round-robin against
         // 2 outgoing slots delivers this kind of interleave). Expected
@@ -835,7 +867,7 @@ mod tests {
     fn phase_c_async_todo_terminate_caps_and_flushes_backlog() {
         let mut st = RpcState::new(AddressSpace::Acceptor);
         let b = SIBinder::new(Arc::new(Dummy)).unwrap();
-        let a = st.on_binder_leaving(&b);
+        let a = st.on_binder_leaving(&b).unwrap();
 
         // Expected is 0 and never arrives; 1..watermark all park.
         for n in 1..ASYNC_TODO_TERMINATE_LEVEL as u64 {
@@ -893,7 +925,7 @@ mod tests {
     fn phase_c_stale_arrival_drops_and_heap_drains_below_expected() {
         let mut st = RpcState::new(AddressSpace::Acceptor);
         let b = SIBinder::new(Arc::new(Dummy)).unwrap();
-        let a = st.on_binder_leaving(&b);
+        let a = st.on_binder_leaving(&b).unwrap();
 
         // Advance expected to 3 by dispatching 0,1,2 in order.
         for i in 0..3u64 {
@@ -938,8 +970,8 @@ mod tests {
         let mut st = RpcState::new(AddressSpace::Acceptor);
         let b1 = SIBinder::new(Arc::new(Dummy)).unwrap();
         let b2 = SIBinder::new(Arc::new(Dummy)).unwrap();
-        let a1 = st.on_binder_leaving(&b1);
-        let a2 = st.on_binder_leaving(&b2);
+        let a1 = st.on_binder_leaving(&b1).unwrap();
+        let a2 = st.on_binder_leaving(&b2).unwrap();
 
         // Node a1: arrival 1 enqueued (expected 0).
         let txn = mk_txn(a1, 1);

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -1102,38 +1102,63 @@ fn execute_command(cmd: i32) -> Result<()> {
                     }
                 };
                 let flags = tr_secctx.transaction_data.flags;
-                if (flags & transaction_flags_TF_ONE_WAY) == 0 {
-                    let flags = flags & transaction_flags_TF_CLEAR_BUF;
-                    let status: i32 = match result {
-                        Ok(_) => StatusCode::Ok.into(),
-                        Err(err) => err.into(),
-                    };
-                    thread_state.borrow_mut().write_transaction_data(
-                        binder::BC_REPLY,
-                        flags,
-                        u32::MAX,
-                        0,
-                        &reply,
-                        &status,
-                    )?;
-                    wait_for_response(UntilResponse::TransactionComplete)?;
-                } else if let Err(err) = result {
-                    let mut log = format!(
-                        "oneway function results for code {} on binder at {:X}",
-                        tr_secctx.transaction_data.code,
-                        // SAFETY: kernel-delivered transaction; `target.ptr`
-                        // is the active union variant. Read-only (logging).
-                        unsafe { tr_secctx.transaction_data.target.ptr }
-                    );
-                    log += &format!(" will be dropped but finished with status {err}");
+                // Restore the saved transaction state on every exit (an `Err`
+                // or panic must not leak it into the next command), and contain
+                // a panic from the reply flush/await — `talk_with_driver` or a
+                // nested dispatch; OOM aborts and is not catchable — rather than
+                // unwinding the worker loop (mirrors `dispatch_transact_caught`;
+                // a dropped reply reaches a sync caller as BR_DEAD_REPLY).
+                let reply_result =
+                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| -> Result<()> {
+                        if (flags & transaction_flags_TF_ONE_WAY) == 0 {
+                            let flags = flags & transaction_flags_TF_CLEAR_BUF;
+                            let status: i32 = match result {
+                                Ok(_) => StatusCode::Ok.into(),
+                                Err(err) => err.into(),
+                            };
+                            thread_state.borrow_mut().write_transaction_data(
+                                binder::BC_REPLY,
+                                flags,
+                                u32::MAX,
+                                0,
+                                &reply,
+                                &status,
+                            )?;
+                            wait_for_response(UntilResponse::TransactionComplete)?;
+                        } else if let Err(err) = result {
+                            let mut log = format!(
+                                "oneway function results for code {} on binder at {:X}",
+                                tr_secctx.transaction_data.code,
+                                // SAFETY: kernel-delivered transaction; `target.ptr`
+                                // is the active union variant. Read-only (logging).
+                                unsafe { tr_secctx.transaction_data.target.ptr }
+                            );
+                            log += &format!(" will be dropped but finished with status {err}");
 
-                    if reply.data_size() != 0 {
-                        log += &format!(" and reply parcel size {}", reply.data_size());
-                    }
-                    log::error!("{log}");
-                }
+                            if reply.data_size() != 0 {
+                                log += &format!(" and reply parcel size {}", reply.data_size());
+                            }
+                            log::error!("{log}");
+                        }
+                        Ok(())
+                    }));
 
                 thread_state.borrow_mut().transaction = transaction_old;
+
+                match reply_result {
+                    Ok(inner) => inner?,
+                    Err(_payload) => {
+                        // A caught panic may leave `out_parcel` holding an
+                        // unflushed/partial BC_REPLY; drop it so the next IPC
+                        // does not flush a malformed command.
+                        let _ = thread_state.borrow_mut().out_parcel.set_data_size(0);
+                        log::error!(
+                            "reply path panicked for code {}; reply dropped",
+                            tr_secctx.transaction_data.code
+                        );
+                        return Err(StatusCode::Unknown);
+                    }
+                }
             }
 
             binder::BR_INCREFS => {


### PR DESCRIPTION
## Summary

A two-pass multi-agent review of `rsbinder`, `rsbinder-aidl`, and `rsb_hub` surfaced 36 findings; an independent adversarial second pass narrowed them to **9 actionable items** (the rest were refuted as false positives or AOSP-faithful). This PR addresses those 9, with regression tests where hermetically testable.

No memory-safety/UB defects were found; the items are availability (DoS), IPC-protocol correctness, and forward/wire-compat hardening.

## Fixes

**Core (kernel binder)**
- **parcel**: route `String16` deserialization length through `checked_array_layout` so a hostile near-`i32::MAX` length cannot wrap `(len+1)*2` / `pad_size` on 32-bit targets (armv7/i686) and panic on the slice — a remote DoS. 64-bit is byte-identical.
- **thread_state**: wrap the post-dispatch reply write/wait in `catch_unwind` and **always restore the saved transaction state** (an `Err` on the reply path previously skipped restoration); drop a half-written `out_parcel` on a caught panic.
- **process_state**: build the death-recipient `WIBinder` *before* removing the obituary cache entry, so `who` is a `Proxy` (not `Native`) and matches the `WIBinder` a recipient registered against — restores `binder_died` identity matching.

**RPC**
- **session**: wrap `rpc_transact` in `catch_unwind` so a user-handler panic cannot unwind the serve loop and skip slot/connection/obituary cleanup (symmetric with the kernel dispatch path).
- **server/session**: enforce the incoming callback-slot cap atomically under the `conn_state` lock (was an advisory pre-check + add — a TOCTOU an untrusted peer could overshoot into an unbounded slot pool).
- **server**: add `RpcServer::set_idle_timeout` to evict a peer that completes the handshake then goes silent (post-handshake Slowloris); default `None` keeps the prior unbounded-idle behavior.
- **state**: refuse to mint a new RPC address once the counter reaches `u32::MAX`, since the android-13+ wire encodes only the low 32 bits (aliasing).

**AIDL**
- **const_expr**: bound constant-expression recursion depth (`MAX_EXPR_DEPTH`) — untrusted `.aidl` could stack-overflow the compiler via deeply nested expressions.

**rsb_hub**
- reject cross-UID service-name overwrites by default (hijack/MITM signature); add `--allow-cross-uid-overwrite` to opt back in. Same-UID restarts and identical-binder re-registration stay allowed.

## Tests

Regression tests added (hermetic): `String16` hostile-length / round-trip / empty; `const_expr` deep & moderate nesting; `rpc::state` address-counter exhaustion; `rpc::session` callback-slot cap; `rsb_hub` cross-UID decision.

## Validation

- **macOS hermetic**: lib + AIDL green; clippy (default / rpc-tcp-debug / rpc-tls / rpc-vsock) + fmt clean.
- **Linux, real `/dev/binder`** (zen kernel): lib 186/0, rpc 285/0, kernel 3-process e2e 138/0, RPC integration + death-recipient all green.
- **Android 16 emulator** (real binder): lib 279/0, `rpc_server` 26/0, `rpc_e2e` 4/0 — the kernel-binder tests that can't run on macOS pass here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)