### PR TITLE
fix: address multi-perspective review findings across parcel, RPC, AIDL, and hub

### DIFF
--- a/rsbinder-aidl/src/aidl.pest
+++ b/rsbinder-aidl/src/aidl.pest
@@ -197,14 +197,21 @@ FALSE_LITERAL = { "false" }
 // CHARVALUE = @{ !"\n" ~ ANY }
 // CHARVALUE = @{ "'" ~ (!("'" | "\n") ~ ANY) ~ "'" }
 CHARVALUE = @{ "'" ~ ("\\" ~ ANY | !"'" ~ ANY) ~ "'" }
-INTVALUE = @{ ASCII_DIGIT+ ~ ("l" | "L" | "u8")? }
-// int_value = @{ ASCII_DIGIT+ }
-// int_suffix = @{ ("l" | "L") | "u8" }
-// FLOATVALUE = @{ float_value ~ float_suffix? }
-// float_value = @{ ASCII_DIGIT* ~ "."? ~ ASCII_DIGIT+ ~ (("e" | "E") ~ ("-" | "+")? ~ ASCII_DIGIT+)? }
-// float_suffix = @{ "f" }
-FLOATVALUE = @{ ASCII_DIGIT* ~ "."? ~ ASCII_DIGIT+ ~ (("e" | "E") ~ ("-" | "+")? ~ ASCII_DIGIT+)? ~ "f"? }
-HEXVALUE = @{ "0" ~ ("x" | "X") ~ (ASCII_DIGIT | 'a'..'f' | 'A'..'F')+ ~ ("l" | "L" | "u8")? }
+INT_SUFFIX = _{ "l" | "L" | "u8" | "u32" | "u64" }
+// Digits with optional `_` separators between digits (AOSP allows e.g.
+// `1_000_000`); the suffixes match AOSP's u8/u32/u64/l/L set.
+INTVALUE = @{ ASCII_DIGIT ~ ("_"? ~ ASCII_DIGIT)* ~ INT_SUFFIX? }
+HEXVALUE = @{ "0" ~ ("x" | "X") ~ ASCII_HEX_DIGIT ~ ("_"? ~ ASCII_HEX_DIGIT)* ~ INT_SUFFIX? }
+// A PEG cannot backtrack a leading `ASCII_DIGIT*`, so each float shape is
+// spelled out with a fixed trailing requirement (a dot, an exponent, or an
+// `f`) — covering `5f` / `10f` / `1e10` — while a bare integer still falls
+// through to INTVALUE.
+FLOATVALUE = @{
+    (ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ ~ (("e" | "E") ~ ("-" | "+")? ~ ASCII_DIGIT+)? ~ "f"?)
+  | ("." ~ ASCII_DIGIT+ ~ (("e" | "E") ~ ("-" | "+")? ~ ASCII_DIGIT+)? ~ "f"?)
+  | (ASCII_DIGIT+ ~ ("e" | "E") ~ ("-" | "+")? ~ ASCII_DIGIT+ ~ "f"?)
+  | (ASCII_DIGIT+ ~ "f")
+}
 // HEXVALUE = @{ hex_value ~ int_suffix? }
 // hex_value = @{ "0" ~ ("x" | "X") ~ (ASCII_DIGIT | 'a'..'f' | 'A'..'F')+ }
 C_STR = @{ "\"" ~ ( !("\"") ~ ANY | "\\" ~ ANY)* ~ "\"" }

--- a/rsbinder-aidl/src/const_expr.rs
+++ b/rsbinder-aidl/src/const_expr.rs
@@ -248,8 +248,30 @@ impl ValueType {
                 Ok(ConstExpr::new(ValueType::Array(list)))
             }
             _ => Err(ConstExprError::new(format!(
-                "can't apply unary operator '~' or '!' to {self:?}"
+                "can't apply unary operator '~' to {self:?}"
             ))),
+        }
+    }
+
+    /// Logical negation (`!`). Unlike `~` (bitwise complement) this yields
+    /// a boolean: `!5 == false` (0 when coerced to an integer target) and
+    /// `!0 == true` (1) — matching AIDL/C++ semantics. Routed separately
+    /// from [`unary_not`](Self::unary_not) (which is `~`) so an integer `!`
+    /// is not mistakenly bit-complemented.
+    fn logical_not(&self) -> Result<ConstExpr, ConstExprError> {
+        match self {
+            ValueType::Expr { .. } | ValueType::Unary { .. } => {
+                let expr = self.calculate()?;
+                expr.value.logical_not()
+            }
+            ValueType::Array(v) => {
+                let mut list = Vec::new();
+                for expr in v {
+                    list.push(expr.value.logical_not()?)
+                }
+                Ok(ConstExpr::new(ValueType::Array(list)))
+            }
+            _ => Ok(ConstExpr::new(ValueType::Bool(!self.to_bool()?))),
         }
     }
 
@@ -403,7 +425,14 @@ impl ValueType {
             '\"' => String::from("\\\""),
             '\n' => String::from("\\n"),
             '\t' => String::from("\\t"),
-            // ... add other special characters as needed ...
+            '\r' => String::from("\\r"),
+            '\0' => String::from("\\0"),
+            // Any other control / non-printable character has no single-
+            // character Rust escape (`\a`/`\b`/`\f`/`\v` do not exist in
+            // Rust), so emit a unicode escape — otherwise the raw byte lands
+            // inside a `'...'` char literal and the generated code fails to
+            // compile. AOSP `PrintCharLiteral` likewise hex-escapes these.
+            c if c.is_control() => format!("\\u{{{:x}}}", c as u32),
             _ => ch.to_string(),
         }
     }
@@ -692,8 +721,10 @@ impl ValueType {
                 let expr = expr.value.calculate_with_visited(visited, depth + 1)?;
                 if operator == "-" {
                     expr.value.unary_minus()
-                } else if operator == "~" || operator == "!" {
+                } else if operator == "~" {
                     expr.value.unary_not()
+                } else if operator == "!" {
+                    expr.value.logical_not()
                 } else {
                     Ok(expr)
                 }

--- a/rsbinder-aidl/src/error.rs
+++ b/rsbinder-aidl/src/error.rs
@@ -92,6 +92,29 @@ pub struct ParseError {
     pub help: Option<String>,
 }
 
+impl ParseError {
+    /// Error for input rejected by the pre-parse nesting guard. Both
+    /// pest's recursive-descent parser and the recursive AST walkers
+    /// recurse once per nesting level, so deeply nested brackets/generics
+    /// in untrusted/attacker-influenced AIDL would overflow the stack and
+    /// abort the process (an uncatchable SIGABRT). This surfaces it as a
+    /// normal, catchable diagnostic instead.
+    pub fn nesting_too_deep(filename: &str, source: &str, offset: usize, limit: usize) -> Self {
+        let len = if offset >= source.len() { 0 } else { 1 };
+        Self {
+            src: NamedSource::new(filename, source.to_string()),
+            span: SourceSpan::new(offset.into(), len),
+            message: format!(
+                "nesting too deep (exceeds {limit}); refusing to parse to avoid stack overflow"
+            ),
+            help: Some(
+                "deeply nested types or expressions are rejected as a denial-of-service guard"
+                    .to_string(),
+            ),
+        }
+    }
+}
+
 /// Semantic errors (type validation, transaction codes, etc.)
 #[allow(unused)]
 #[derive(Error, Debug, Diagnostic)]
@@ -157,6 +180,21 @@ pub enum SemanticError {
         #[source_code]
         src: NamedSource<String>,
         #[label("overflowing code here")]
+        span: SourceSpan,
+    },
+
+    #[error("Interface '{interface}': method '{method}' has transaction code {code} in the reserved meta-method range")]
+    #[diagnostic(
+        code(aidl::transaction_code_reserved),
+        help("user-defined transaction codes must be between 0 and 16777114 inclusive; the top 100 IDs are reserved for AIDL meta methods (getInterfaceVersion/Hash, ...)")
+    )]
+    TransactionCodeReserved {
+        interface: String,
+        method: String,
+        code: i64,
+        #[source_code]
+        src: NamedSource<String>,
+        #[label("reserved code here")]
         span: SourceSpan,
     },
 

--- a/rsbinder-aidl/src/generator.rs
+++ b/rsbinder-aidl/src/generator.rs
@@ -126,7 +126,11 @@ pub mod {{mod}} {
         fn write_to_parcel(&self, _parcel: &mut {{crate}}::Parcel) -> {{crate}}::Result<()> {
             _parcel.sized_write(|_sub_parcel| {
                 {%- for member in members %}
+                {%- if member.4 %}
+                _sub_parcel.write(self.r#{{ member.0 }}.as_ref().ok_or({{crate}}::StatusCode::UnexpectedNull)?)?;
+                {%- else %}
                 _sub_parcel.write(&self.r#{{ member.0 }})?;
+                {%- endif %}
                 {%- endfor %}
                 Ok(())
             })
@@ -805,6 +809,24 @@ fn validate_transaction_codes(decl: &parser::InterfaceDecl) -> Result<(), AidlEr
             }
             .into());
         }
+        // AOSP reserves the top 100 transaction IDs for auto-generated meta
+        // methods (getInterfaceVersion = 16777214, getInterfaceHash =
+        // 16777213, ...). A user code in that range silently collides with
+        // a meta method, producing two `on_transact` arms with the same
+        // value (the user-vs-user dup check below cannot catch it). Reject
+        // codes above `kMaxUserSetMethodId` (16777114), mirroring AOSP
+        // `aidl.cpp` (`system/tools/aidl/include/aidl/transaction_ids.h`).
+        const K_MAX_USER_SET_METHOD_ID: i64 = 16_777_114;
+        if code > K_MAX_USER_SET_METHOD_ID {
+            return Err(SemanticError::TransactionCodeReserved {
+                interface: decl.name.clone(),
+                method: method.identifier.clone(),
+                code,
+                src: NamedSource::new(&source_name, source_text.clone()),
+                span: span_of(method.intvalue_span),
+            }
+            .into());
+        }
         if let Some((prev_name, prev_span)) =
             seen.insert(code, (method.identifier.clone(), method.identifier_span))
         {
@@ -1131,6 +1153,12 @@ pub mod {mod} {{
                             // pre-set stability survives (see ParcelableHolder
                             // ::deserialize_from).
                             matches!(generator.value_type, ValueType::Holder),
+                            // needs_unexpected_null: a non-nullable
+                            // IBinder/interface/PFD field is stored as
+                            // `Option<T>` only for lack of `Default`; on
+                            // write, unwrap with `UNEXPECTED_NULL` instead of
+                            // emitting a null marker (AOSP-faithful).
+                            generator.is_option_but_not_nullable(),
                         ))
                     }
                 } else {

--- a/rsbinder-aidl/src/parser.rs
+++ b/rsbinder-aidl/src/parser.rs
@@ -1194,15 +1194,57 @@ fn parse_intvalue(arg_value: &str, span: (usize, usize)) -> Result<ConstExpr, Ai
         (arg_value, 10)
     };
 
-    let value = if value.ends_with('l') || value.ends_with('L') {
-        is_long = true;
-        &value[..value.len() - 1]
+    // Strip the integer suffix. AOSP accepts u8 / u32 / u64 / l / L; check
+    // the multi-character unsigned suffixes before the single-char `l`/`L`.
+    let mut is_u32 = false;
+    let mut is_u64 = false;
+    let value = if let Some(stripped) = value.strip_suffix("u64") {
+        is_u64 = true;
+        stripped
+    } else if let Some(stripped) = value.strip_suffix("u32") {
+        is_u32 = true;
+        stripped
     } else if let Some(stripped) = value.strip_suffix("u8") {
         is_u8 = true;
         stripped
+    } else if value.ends_with('l') || value.ends_with('L') {
+        is_long = true;
+        &value[..value.len() - 1]
     } else {
         value
     };
+
+    // AOSP permits `_` digit separators (e.g. `1_000_000`, `0xFF_FF`);
+    // Rust's `from_str_radix` rejects them, so strip them before parsing.
+    let cleaned;
+    let value: &str = if value.contains('_') {
+        cleaned = value.replace('_', "");
+        &cleaned
+    } else {
+        value
+    };
+
+    // Explicit u32 / u64 suffixes pin the target size regardless of radix.
+    if is_u32 {
+        let parsed_value = u32::from_str_radix(value, radix).map_err(|err| {
+            make_parse_error(
+                format!("invalid u32 literal '{arg_value}': {err}"),
+                span.0,
+                span.1,
+            )
+        })?;
+        return Ok(ConstExpr::new(ValueType::Int32(parsed_value as i32 as _)));
+    }
+    if is_u64 {
+        let parsed_value = u64::from_str_radix(value, radix).map_err(|err| {
+            make_parse_error(
+                format!("invalid u64 literal '{arg_value}': {err}"),
+                span.0,
+                span.1,
+            )
+        })?;
+        return Ok(ConstExpr::new(ValueType::Int64(parsed_value as i64 as _)));
+    }
 
     if radix == 16 {
         if is_u8 {
@@ -2180,8 +2222,100 @@ fn calculate_namespace(
     }
 }
 
+/// Maximum bracket/generic nesting depth accepted before parsing.
+/// Orders of magnitude above any legitimate AIDL, well below the stack-
+/// overflow threshold of the recursive parser/walkers — see
+/// [`check_nesting_depth`].
+const MAX_NESTING_DEPTH: usize = 256;
+
+/// Pre-parse denial-of-service guard. pest's recursive-descent parser and
+/// the recursive AST walkers recurse once per nesting level, so deeply
+/// nested input (`((((...))))` or `List<List<...>>`) would overflow the
+/// stack and abort the whole process (an uncatchable SIGABRT) on
+/// untrusted or build-pipeline-influenced AIDL — `MAX_EXPR_DEPTH` only
+/// guards the post-parse expression evaluator, too late to help. This
+/// scans the raw source (skipping string/char literals and comments) and
+/// returns the byte offset at which `()[]{}` or `<>` nesting first exceeds
+/// [`MAX_NESTING_DEPTH`], so the caller can reject it as an ordinary
+/// diagnostic. Angle-bracket depth is reset at `;` (a generic type never
+/// crosses a statement boundary) so shift/comparison operators in const
+/// expressions cannot drift the count into a false positive.
+fn check_nesting_depth(source: &str) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let mut i = 0;
+    let mut bracket_depth: usize = 0; // () [] {}
+    let mut angle_depth: usize = 0; // <> generics
+    let next = |i: usize| bytes.get(i + 1).copied();
+    while i < bytes.len() {
+        match bytes[i] {
+            // Skip string / char literals (with escapes) so brackets in
+            // text are not counted.
+            q @ (b'"' | b'\'') => {
+                i += 1;
+                while i < bytes.len() {
+                    match bytes[i] {
+                        b'\\' => i += 2,
+                        c if c == q => {
+                            i += 1;
+                            break;
+                        }
+                        _ => i += 1,
+                    }
+                }
+                continue;
+            }
+            b'/' if next(i) == Some(b'/') => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            b'/' if next(i) == Some(b'*') => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i += 2;
+                continue;
+            }
+            b'(' | b'[' | b'{' => bracket_depth += 1,
+            b')' | b']' | b'}' => bracket_depth = bracket_depth.saturating_sub(1),
+            // `<<` shift / `<=` are not generic openers.
+            b'<' if matches!(next(i), Some(b'<') | Some(b'=')) => {
+                i += 2;
+                continue;
+            }
+            b'<' => angle_depth += 1,
+            // `>>` shift / `>=` are not generic closers.
+            b'>' if matches!(next(i), Some(b'>') | Some(b'=')) => {
+                i += 2;
+                continue;
+            }
+            b'>' => angle_depth = angle_depth.saturating_sub(1),
+            b';' => angle_depth = 0,
+            _ => {}
+        }
+        if bracket_depth > MAX_NESTING_DEPTH || angle_depth > MAX_NESTING_DEPTH {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
 pub fn parse_document(ctx: &SourceContext) -> Result<Document, AidlError> {
     let _guard = SourceGuard::new(&ctx.filename, &ctx.source);
+    // DoS guard: reject pathologically nested input *before* handing it to
+    // the recursive pest parser, which would otherwise overflow the stack.
+    if let Some(offset) = check_nesting_depth(&ctx.source) {
+        return Err(ParseError::nesting_too_deep(
+            &ctx.filename,
+            &ctx.source,
+            offset,
+            MAX_NESTING_DEPTH,
+        )
+        .into());
+    }
     reset_enum_resolution_state();
     // Take any leftover warnings from a previous call so this document's
     // warning set is scoped to its own parse.
@@ -2203,6 +2337,27 @@ pub fn parse_document(ctx: &SourceContext) -> Result<Document, AidlError> {
                                 Some(idx) => &import[(idx + 1)..],
                                 None => &import,
                             };
+                            // Two imports with the same simple name but
+                            // different fully-qualified names: the map is
+                            // keyed by simple name, so the later wins
+                            // silently and an unqualified reference would
+                            // resolve to the wrong type. AOSP errors on the
+                            // conflict; warn here (idempotent re-imports of
+                            // the same FQN stay silent).
+                            if let Some(existing) = document.imports.get(key) {
+                                if existing != &import {
+                                    CURRENT_WARNINGS.with(|w| {
+                                        w.borrow_mut().push(crate::error::AidlWarning::new(
+                                            format!(
+                                                "duplicate import of simple name '{key}': \
+                                                 '{existing}' is shadowed by '{import}'; an \
+                                                 unqualified reference to '{key}' resolves to \
+                                                 the latter"
+                                            ),
+                                        ));
+                                    });
+                                }
+                            }
                             document.imports.insert(key.into(), import);
                         }
                     }
@@ -2335,6 +2490,64 @@ mod tests {
             ConstExpr::new(ValueType::Int64(-20))
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_nesting_depth_guard_rejects_deep_input() {
+        // Deeply nested parens / generics would overflow the recursive
+        // parser; the pre-scan must flag them (returns the offending
+        // offset) before they reach pest.
+        let deep_parens = format!("{}1{}", "(".repeat(1000), ")".repeat(1000));
+        assert!(check_nesting_depth(&deep_parens).is_some());
+        let deep_generics = format!("{}int{}", "List<".repeat(1000), ">".repeat(1000));
+        assert!(check_nesting_depth(&deep_generics).is_some());
+        // A normal document (and shift/comparison operators) must not trip.
+        assert!(check_nesting_depth("interface IFoo { void m(); }").is_none());
+        assert!(check_nesting_depth("const int X = 1 << 8 >> 2; const int Y = 3;").is_none());
+    }
+
+    #[test]
+    fn test_intvalue_underscores_and_unsigned_suffixes() -> Result<(), Box<dyn Error>> {
+        // AOSP digit separators and u32/u64 suffixes.
+        assert_eq!(
+            parse_intvalue("1_000_000", (0, 0))?.value,
+            ValueType::Int32(1_000_000)
+        );
+        assert_eq!(
+            parse_intvalue("0xFF_FF", (0, 0))?.value,
+            ValueType::Int32(0xFFFF)
+        );
+        assert_eq!(parse_intvalue("10u32", (0, 0))?.value, ValueType::Int32(10));
+        assert_eq!(parse_intvalue("10u64", (0, 0))?.value, ValueType::Int64(10));
+        Ok(())
+    }
+
+    #[test]
+    fn test_floatvalue_without_decimal_point() {
+        // `5f`, `10f`, `1e10`, `1E5` must parse as floats — the PEG cannot
+        // backtrack leading digits, so each shape is spelled out explicitly.
+        for s in ["5f", "10f", "1e10", "1E5", "3.14", ".5"] {
+            assert!(
+                AIDLParser::parse(Rule::FLOATVALUE, s).is_ok(),
+                "FLOATVALUE should accept {s}"
+            );
+        }
+        // A bare integer is NOT a float (must fall through to INTVALUE).
+        assert!(AIDLParser::parse(Rule::FLOATVALUE, "5").is_err());
+    }
+
+    #[test]
+    fn test_logical_not_is_not_bitwise() -> Result<(), Box<dyn Error>> {
+        // `!5` is logical negation (false), not bitwise complement (-6);
+        // `!0` is true.
+        let mut res = AIDLParser::parse(Rule::expression, "!5")?;
+        let calc = parse_expression(res.next().unwrap().into_inner())?.calculate()?;
+        assert_eq!(calc.value, ValueType::Bool(false));
+
+        let mut res0 = AIDLParser::parse(Rule::expression, "!0")?;
+        let calc0 = parse_expression(res0.next().unwrap().into_inner())?.calculate()?;
+        assert_eq!(calc0.value, ValueType::Bool(true));
         Ok(())
     }
 

--- a/rsbinder-aidl/src/type_generator.rs
+++ b/rsbinder-aidl/src/type_generator.rs
@@ -164,6 +164,31 @@ impl TypeGenerator {
         let mut this = Self::new(&_type.non_array_type)?;
 
         if !_type.array_types.is_empty() {
+            // An array of `List<T>` (`List<T>[]`): the non-array type is
+            // already a List (stored as `ValueType::Array`), so the
+            // trailing `[]` would be silently dropped by `array()`'s
+            // early-return — generating code byte-identical to a bare
+            // `List<T>`. AOSP rejects arrays of lists.
+            if matches!(this.value_type, ValueType::Array(_)) {
+                return Err(make_type_error(
+                    "an array of List is not supported",
+                    _type.non_array_type.name_span,
+                ));
+            }
+            // A variable-length array must be one-dimensional; multi-
+            // dimensional arrays must be fixed-size in *every* dimension.
+            // Otherwise the extra dimensions silently collapse into one
+            // (`int[][]`/`int[3][]`/`int[][3]` all become `Vec<i32>`),
+            // dropping wire length-prefixes. AOSP rejects this.
+            if _type.array_types.len() > 1
+                && _type.array_types.iter().any(|a| a.const_expr.is_none())
+            {
+                return Err(make_type_error(
+                    "a variable-length array must be one-dimensional \
+                     (multi-dimensional arrays must be fixed-size)",
+                    _type.non_array_type.name_span,
+                ));
+            }
             this = this.array(&_type.array_types);
         }
 
@@ -561,6 +586,25 @@ impl TypeGenerator {
         }
     }
 
+    /// True when a *struct field* of this type is stored as `Option<T>`
+    /// only because the type has no `Default` (IBinder / interface `Strong`
+    /// / `ParcelFileDescriptor`), not because it is `@nullable`. AOSP
+    /// serializes such a non-nullable field by unwrapping it with
+    /// `UNEXPECTED_NULL` on `None` instead of writing a null marker, so a
+    /// real peer never sees an unexpected null. Mirrors the exact condition
+    /// under which [`type_declaration`](Self::type_declaration) wraps the
+    /// field in `Option` for `is_struct == true`.
+    pub fn is_option_but_not_nullable(&self) -> bool {
+        if self.is_nullable {
+            return false;
+        }
+        match &self.value_type {
+            // Array element nullability is handled separately.
+            ValueType::Array(_) => false,
+            vt => !Self::can_be_defaulted(vt, true),
+        }
+    }
+
     fn func_list_type_decl_fixed(&self, array_info: &ArrayInfo) -> String {
         let fixed_array = self.make_fixed_array(array_info, false);
 
@@ -717,7 +761,11 @@ impl TypeGenerator {
         self.check_identifier();
 
         let (mutable, init) = match self.direction {
-            Direction::Out => ("mut ", "Default::default()".to_owned()),
+            Direction::Out => (
+                "mut ",
+                self.fixed_array_default()
+                    .unwrap_or_else(|| "Default::default()".to_owned()),
+            ),
             Direction::Inout => ("mut ", format!("{reader}.read()?")),
             _ => ("", format!("{reader}.read()?")),
         };
@@ -729,7 +777,33 @@ impl TypeGenerator {
         )
     }
 
+    /// Initializer for a fixed-size array whose `Default::default()` would
+    /// not compile. `Default` is only implemented for arrays up to length
+    /// 32, so a non-nullable fixed-size array with any dimension > 32 needs
+    /// an explicit `std::array::from_fn` (one per dimension; sizes inferred
+    /// from the field/param type annotation). Returns `None` (keep
+    /// `Default::default()`, unchanged output) for nullable arrays
+    /// (`Option<[T;N]>::default()` is `None`) and for arrays whose every
+    /// dimension is <= 32.
+    fn fixed_array_default(&self) -> Option<String> {
+        if self.is_nullable {
+            return None;
+        }
+        let info = self.array_types.first()?;
+        if !info.is_fixed() || info.sizes.iter().all(|&n| n <= 32) {
+            return None;
+        }
+        let mut init = "Default::default()".to_string();
+        for _ in 0..info.sizes.len() {
+            init = format!("std::array::from_fn(|_| {init})");
+        }
+        Some(init)
+    }
+
     pub fn default_value(&self) -> String {
+        if let Some(init) = self.fixed_array_default() {
+            return init;
+        }
         match &self.value_type {
             ValueType::UserDefined(name) => {
                 match lookup_decl_from_name(name, crate::Namespace::AIDL) {
@@ -961,6 +1035,16 @@ impl TypeGenerator {
         param: InitParam,
     ) -> Result<String, AidlError> {
         let Some(expr) = const_expr else {
+            // A non-nullable fixed-size array with any dimension > 32 cannot
+            // use `Default::default()` (Default is only implemented up to
+            // length 32). This is the parcelable struct-field path (the most
+            // common place such a field appears); `default_value` /
+            // `transaction_decl` handle the other sites. Returns `None` for
+            // nullable (`Option<[T;N]>::default()` is `None`) and for arrays
+            // whose every dimension is <= 32, so output is unchanged there.
+            if let Some(init) = self.fixed_array_default() {
+                return Ok(init);
+            }
             return Ok(ValueType::Void.to_init(param.with_fixed_array(false).with_nullable(false)));
         };
 
@@ -1191,6 +1275,46 @@ mod tests {
             nullable_array_gen.type_decl_for_func().unwrap(),
             "Option<&[Option<String>]>"
         );
+    }
+
+    #[test]
+    fn fixed_array_over_32_uses_array_from_fn_default() {
+        // A non-nullable `int[40]` field cannot use `Default::default()`
+        // (Default is only implemented for arrays up to length 32), so every
+        // default-emission path must use `std::array::from_fn`. Covers the
+        // parcelable struct-field path (`init_value(None)`) — the most common
+        // site — plus `default_value` (out-params / union members).
+        let big = TypeGenerator::new(&NonArrayType {
+            name: "int".to_owned(),
+            generic: None,
+            name_span: None,
+        })
+        .unwrap()
+        .array(&[crate::parser::ArrayType {
+            const_expr: Some(ConstExpr::new(ValueType::Int32(40))),
+        }]);
+
+        let field_default = big
+            .init_value(None, InitParam::builder().with_const(false))
+            .unwrap();
+        assert!(
+            field_default.contains("std::array::from_fn"),
+            "parcelable field default must not be bare Default::default(): {field_default}"
+        );
+        assert!(big.default_value().contains("std::array::from_fn"));
+
+        // A fixed array whose every dimension is <= 32 keeps Default::default()
+        // (Default is implemented there) — no codegen churn.
+        let small = TypeGenerator::new(&NonArrayType {
+            name: "int".to_owned(),
+            generic: None,
+            name_span: None,
+        })
+        .unwrap()
+        .array(&[crate::parser::ArrayType {
+            const_expr: Some(ConstExpr::new(ValueType::Int32(8))),
+        }]);
+        assert_eq!(small.default_value(), "Default::default()");
     }
 
     #[test]

--- a/rsbinder-aidl/tests/test_error_output.rs
+++ b/rsbinder-aidl/tests/test_error_output.rs
@@ -192,13 +192,35 @@ fn test_unicode_in_string_constant() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-// 5.5q: Transaction code at u32::MAX should succeed
+// A transaction code in the reserved meta-method range (the top 100 IDs,
+// i.e. > kMaxUserSetMethodId = 16777114) must be rejected — AOSP reserves
+// them for getInterfaceVersion/getInterfaceHash etc. (`u32::MAX` is well
+// inside that range).
 #[test]
-fn test_transaction_code_u32_max() -> Result<(), Box<dyn Error>> {
-    let input = r#"
+fn test_transaction_code_reserved_range() {
+    let err = expect_generation_error(
+        r#"
 interface IFoo {
     void m1() = 4294967295;
-    void m2() = 4294967294;
+}
+        "#,
+        "test.aidl",
+    );
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("reserved") || msg.contains("16777114"),
+        "Error should mention the reserved meta-method range: {msg}"
+    );
+}
+
+// The largest user-settable transaction code (kMaxUserSetMethodId =
+// 16777114) and below are accepted.
+#[test]
+fn test_transaction_code_max_user_id_accepted() -> Result<(), Box<dyn Error>> {
+    let input = r#"
+interface IFoo {
+    void m1() = 16777114;
+    void m2() = 16777113;
 }
     "#;
     let ctx = SourceContext::new("test.aidl", input);

--- a/rsbinder-tools/src/bin/rsb_hub.rs
+++ b/rsbinder-tools/src/bin/rsb_hub.rs
@@ -95,6 +95,31 @@ impl rsbinder::DeathRecipient for DeathRecipientWrapper {
     }
 }
 
+/// Lock the registry mutex, recovering from poisoning instead of
+/// propagating it. The service manager is the single point of failure for
+/// the whole device's IPC: every transaction handler runs under
+/// `catch_unwind`, so a panic *under* the guard poisons the mutex rather
+/// than crashing the process — and a plain `.lock().unwrap()` would then
+/// turn that one panic into a permanent outage (every subsequent request,
+/// and the death-notification thread, would panic on the poison).
+/// `into_inner` always yields a type-valid `Inner`, and the worst surviving
+/// inconsistency from a panic mid-section is a leaked death link or a
+/// skipped notification — never a corrupted map or a deadlock — so
+/// continuing on the recovered state degrades gracefully rather than
+/// wedging device IPC.
+fn lock_recover<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Upper bound on registration / client callbacks held per service name.
+/// `registerForNotifications` has no uid gating on Linux, so without a cap
+/// (and identity de-duplication) a client could loop-register to grow the
+/// heap without bound and multiply every per-service notification by the
+/// duplicate count. AOSP relies on SELinux/uid admission that rsb_hub does
+/// not have; this is the defense in its place. Generous enough that no
+/// legitimate caller hits it.
+const MAX_CALLBACKS_PER_NAME: usize = 256;
+
 struct Inner {
     death_recipient: Arc<DeathRecipientWrapper>,
     name_to_service: HashMap<String, Service>,
@@ -403,7 +428,7 @@ impl ServiceManager {
             .name("rsb_hub:death".to_owned())
             .spawn(move || {
                 for who in death_receiver {
-                    let mut inner = inner_clone.lock().unwrap();
+                    let mut inner = lock_recover(&inner_clone);
 
                     inner
                         .name_to_service
@@ -457,15 +482,12 @@ impl ServiceManager {
                     return;
                 };
 
-                let mut inner = match inner_arc.lock() {
-                    Ok(guard) => guard,
-                    Err(_) => {
-                        log::error!(
-                            "client callback poller: Inner mutex poisoned by another thread, exiting"
-                        );
-                        return;
-                    }
-                };
+                // Recover from poisoning rather than exiting: if the poller
+                // gave up here, lazy services would never again receive their
+                // periodic `onClients(false)` and could never shut down. The
+                // guarded state is a self-contained map mutation, so the
+                // recovered state is safe to continue from.
+                let mut inner = lock_recover(&inner_arc);
 
                 // Snapshot the names before iterating so we don't hold a
                 // borrow into `name_to_service` across calls that may
@@ -560,7 +582,17 @@ fn classify_for_service_union(
                 isLazyService: false,
             })
         }
-        None => Service::Service::Accessor(None),
+        // Not found. AOSP returns `serviceWithMetadata(nullptr)` for a
+        // missing non-accessor name, which an AOSP client routes into its
+        // local `getInjectedAccessor(name)` fallback; an `accessor(nullptr)`
+        // reply would instead just log and return null, skipping that
+        // fallback. rsbinder's own consume side runs
+        // `try_process_local_fallback` on this arm too (it handles
+        // `swm.service.is_none()` identically).
+        None => Service::Service::ServiceWithMetadata(ServiceWithMetadata::ServiceWithMetadata {
+            service: None,
+            isLazyService: false,
+        }),
     }
 }
 
@@ -578,7 +610,7 @@ impl IServiceManager for ServiceManager {
     fn getService(&self, name: &str) -> rsbinder::status::Result<Option<rsbinder::SIBinder>> {
         let mut pending = Vec::new();
         let result = {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = lock_recover(&self.inner);
             inner
                 .try_get_binder(name, false, &mut pending)?
                 .map(|(b, _)| b)
@@ -633,7 +665,7 @@ impl IServiceManager for ServiceManager {
         let mut client_pending = Vec::new();
         let mut reg_pending = Vec::new();
         let result: rsbinder::status::Result<()> = (|| {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = lock_recover(&self.inner);
             let recipient: Arc<dyn rsbinder::DeathRecipient> = inner.death_recipient.clone();
 
             let mut prev_clients = false;
@@ -776,7 +808,7 @@ impl IServiceManager for ServiceManager {
     fn checkService(&self, name: &str) -> rsbinder::status::Result<Option<SIBinder>> {
         let mut pending = Vec::new();
         let result = {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = lock_recover(&self.inner);
             inner
                 .try_get_binder(name, false, &mut pending)?
                 .map(|(b, _)| b)
@@ -786,7 +818,7 @@ impl IServiceManager for ServiceManager {
     }
 
     fn listServices(&self, dump_priority: i32) -> rsbinder::status::Result<Vec<String>> {
-        let inner = self.inner.lock().unwrap();
+        let inner = lock_recover(&self.inner);
 
         let mut services = Vec::new();
 
@@ -812,7 +844,24 @@ impl IServiceManager for ServiceManager {
 
         let mut pending = Vec::new();
         {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = lock_recover(&self.inner);
+
+            // Drop idempotent re-registrations and cap the list before
+            // taking a death link or storing the callback (so neither leaks
+            // on the rejected paths). See `MAX_CALLBACKS_PER_NAME`.
+            if let Some(existing) = inner.name_to_registration_callbacks.get(name) {
+                let cb_binder = arg_callback.as_binder();
+                if existing.iter().any(|c| c.as_binder() == cb_binder) {
+                    return Ok(());
+                }
+                if existing.len() >= MAX_CALLBACKS_PER_NAME {
+                    let msg = format!(
+                        "registerForNotifications: too many callbacks for {name} (max {MAX_CALLBACKS_PER_NAME})"
+                    );
+                    log::warn!("{}", &msg);
+                    return Err((ExceptionCode::IllegalState, msg.as_str()).into());
+                }
+            }
 
             arg_callback.as_binder().link_to_death(Arc::downgrade(
                 &(inner.death_recipient.clone() as Arc<dyn rsbinder::DeathRecipient>),
@@ -844,7 +893,7 @@ impl IServiceManager for ServiceManager {
             dyn hub::android_16::android::os::IServiceCallback::IServiceCallback,
         >,
     ) -> rsbinder::status::Result<()> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = lock_recover(&self.inner);
 
         if inner
             .remove_registration_callback(Some(name), &SIBinder::downgrade(&callback.as_binder()))
@@ -915,7 +964,7 @@ impl IServiceManager for ServiceManager {
     ) -> rsbinder::status::Result<()> {
         let mut pending = Vec::new();
         let result: rsbinder::status::Result<()> = (|| {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = lock_recover(&self.inner);
 
             let service = if let Some(service) = inner.name_to_service.get(name) {
                 service
@@ -938,6 +987,23 @@ impl IServiceManager for ServiceManager {
                 let msg = format!("registerClientCallback called with wrong service {name}");
                 log::warn!("{}", &msg);
                 return Err((ExceptionCode::IllegalArgument, msg.as_str()).into());
+            }
+
+            // Drop idempotent re-registrations and cap the list before
+            // taking a death link or storing the callback. See
+            // `MAX_CALLBACKS_PER_NAME`.
+            if let Some(existing) = inner.name_to_client_callbacks.get(name) {
+                let cb_binder = arg_callback.as_binder();
+                if existing.iter().any(|c| c.as_binder() == cb_binder) {
+                    return Ok(());
+                }
+                if existing.len() >= MAX_CALLBACKS_PER_NAME {
+                    let msg = format!(
+                        "registerClientCallback: too many callbacks for {name} (max {MAX_CALLBACKS_PER_NAME})"
+                    );
+                    log::warn!("{}", &msg);
+                    return Err((ExceptionCode::IllegalState, msg.as_str()).into());
+                }
             }
 
             arg_callback.as_binder().link_to_death(Arc::downgrade(
@@ -982,7 +1048,7 @@ impl IServiceManager for ServiceManager {
 
         let mut pending = Vec::new();
         let result: rsbinder::status::Result<()> = (|| {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = lock_recover(&self.inner);
             let service = if let Some(service) = inner.name_to_service.get(name) {
                 service
             } else {
@@ -1044,6 +1110,22 @@ impl IServiceManager for ServiceManager {
                 return Err((ExceptionCode::IllegalState, msg.as_str()).into());
             }
 
+            // Drop the death subscription before removing the entry.
+            // `ProxyHandle::Drop` does not clear the kernel death
+            // notification (rsbinder has no `~Service` hook), so — exactly
+            // as addService's replace path does — an explicit unlink is
+            // required. Otherwise every register→tryUnregister cycle (e.g.
+            // a lazy service idling and reactivating) leaks a kernel
+            // `BC_REQUEST_DEATH_NOTIFICATION` plus a `DeathRecipient` entry.
+            if arg_service.as_proxy().is_some() {
+                let recipient: Arc<dyn rsbinder::DeathRecipient> = inner.death_recipient.clone();
+                if let Err(e) = arg_service.unlink_to_death(Arc::downgrade(&recipient)) {
+                    log::warn!(
+                        "tryUnregisterService: failed to unlink death notification for '{name}': {e:?}"
+                    );
+                }
+            }
+
             inner.name_to_service.remove(name);
 
             Ok(())
@@ -1058,7 +1140,7 @@ impl IServiceManager for ServiceManager {
     ) -> rsbinder::status::Result<
         Vec<hub::android_16::android::os::ServiceDebugInfo::ServiceDebugInfo>,
     > {
-        let inner = self.inner.lock().unwrap();
+        let inner = lock_recover(&self.inner);
 
         let mut out = Vec::with_capacity(inner.name_to_service.len());
 
@@ -1083,7 +1165,7 @@ impl IServiceManager for ServiceManager {
         // match arms.
         let mut pending = Vec::new();
         let lookup = {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = lock_recover(&self.inner);
             inner.try_get_binder(name, false, &mut pending)?
         };
         fire_pending(pending);
@@ -1098,7 +1180,7 @@ impl IServiceManager for ServiceManager {
         // `classify_for_service_union`.
         let mut pending = Vec::new();
         let lookup = {
-            let mut inner = self.inner.lock().unwrap();
+            let mut inner = lock_recover(&self.inner);
             inner.try_get_binder(name, false, &mut pending)?
         };
         fire_pending(pending);

--- a/rsbinder/src/hub/servicemanager_10.rs
+++ b/rsbinder/src/hub/servicemanager_10.rs
@@ -53,20 +53,41 @@ impl BpServiceManager {
 
 /// Retrieve an existing service, blocking for a few seconds if it doesn't yet
 /// exist.
+///
+/// The Android 10 C service manager's `GET_SERVICE` transaction is itself
+/// **non-blocking** (it answers immediately whether or not the service is
+/// registered). AOSP's libbinder provides the documented "block a few
+/// seconds for a not-yet-registered service" behavior entirely client-side,
+/// by polling roughly once per second for ~5s
+/// (`BpServiceManager::getService`). This mirrors that so early-boot
+/// lookups of a service that is about to register don't spuriously return
+/// `None` — matching the API 30+ path and stock Android 10.
 pub fn get_service(sm: &BpServiceManager, name: &str) -> Option<SIBinder> {
-    let result = (|| -> Result<Option<SIBinder>> {
-        let mut data = sm.proxy().prepare_transact(true)?;
-        data.write(name)?;
-        sm.transact(GET_SERVICE, &data)?.read()
-    })();
+    // ~5s total: one immediate attempt plus up to 5 once-per-second retries.
+    const RETRIES: u32 = 5;
+    for attempt in 0..=RETRIES {
+        let result = (|| -> Result<Option<SIBinder>> {
+            let mut data = sm.proxy().prepare_transact(true)?;
+            data.write(name)?;
+            sm.transact(GET_SERVICE, &data)?.read()
+        })();
 
-    match result {
-        Ok(binder) => binder,
-        Err(err) => {
-            log::error!("Failed to get service {name}: {err:?}");
-            None
+        match result {
+            Ok(Some(binder)) => return Some(binder),
+            // Not yet registered (the C SM's not-found reply also surfaces
+            // here as a short read). Retry. Logged at debug so a benign
+            // boot-time miss doesn't flood logcat across all attempts.
+            Ok(None) => {}
+            Err(err) => {
+                log::debug!("get_service({name}) attempt {attempt} failed, retrying: {err:?}");
+            }
+        }
+
+        if attempt < RETRIES {
+            std::thread::sleep(std::time::Duration::from_secs(1));
         }
     }
+    None
 }
 
 /// Retrieve an existing service called @a name from the service

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -1062,14 +1062,22 @@ impl Parcel {
         // SAFETY: `reserve(pos + padded)` above guarantees the destination
         // has at least `pos + padded` bytes of capacity, so `add(pos)` and
         // the `size`-byte copy (size <= padded) stay in-bounds and the
-        // ranges do not overlap (distinct allocations). `set_len` only grows
-        // up to the just-reserved capacity over now-initialized `u8` bytes.
+        // ranges do not overlap (distinct allocations). The 0-3 trailing pad
+        // bytes are then zeroed so that `set_len` exposes only initialized
+        // memory: `reserve` allocates but does not initialize, and the pad is
+        // transmitted (it is counted in `data_size`), so without this we would
+        // both hit UB and leak uninitialized process memory to the peer. AOSP
+        // masks the pad to zero as well. `set_len` only grows up to the
+        // just-reserved capacity over now-initialized `u8` bytes.
         unsafe {
             std::ptr::copy_nonoverlapping::<u8>(
                 parcelable.as_ptr() as _,
                 self.data.as_mut_ptr().add(pos),
                 size,
             );
+            if padded > size {
+                std::ptr::write_bytes(self.data.as_mut_ptr().add(pos + size), 0, padded - size);
+            }
             if self.data.len() < pos + padded {
                 self.data.set_len(pos + padded);
             }
@@ -1128,14 +1136,24 @@ impl Parcel {
         // SAFETY: `reserve(pos + aligned)` guarantees capacity for `add(pos)`
         // and the `unaligned`-byte copy (unaligned <= aligned). Source `data`
         // and the parcel buffer are distinct allocations (non-overlapping).
-        // `set_len` only grows up to the reserved capacity over `u8` bytes
-        // just initialized by the copy.
+        // The 0-3 trailing pad bytes are zeroed before `set_len`: `reserve`
+        // does not initialize, and the pad is transmitted (counted in
+        // `data_size`), so leaving it uninitialized is both UB and an
+        // info-leak to the peer. AOSP masks the pad to zero too. `set_len`
+        // only grows up to the reserved capacity over now-initialized `u8`.
         unsafe {
             std::ptr::copy_nonoverlapping::<u8>(
                 data.as_ptr(),
                 self.data.as_mut_ptr().add(pos),
                 unaligned,
             );
+            if aligned > unaligned {
+                std::ptr::write_bytes(
+                    self.data.as_mut_ptr().add(pos + unaligned),
+                    0,
+                    aligned - unaligned,
+                );
+            }
             if pos + aligned > self.data.len() {
                 self.data.set_len(pos + aligned);
             }
@@ -1451,6 +1469,29 @@ mod tests {
         // proving the returned `&mut [T]` actually aliases the
         // underlying storage (not a copy).
         assert_eq!(pd.as_slice(), &[99u8, 1, 2, 200][..]);
+    }
+
+    #[test]
+    fn write_array_zeroes_trailing_pad() {
+        // A byte array whose length is not a multiple of 4 leaves 1-3
+        // trailing pad bytes inside the (4-byte aligned) parcel slot. That
+        // pad is part of the transmitted payload (it is counted in
+        // `data_size`), so it must be zeroed — matching AOSP — otherwise
+        // `reserve`+`set_len` would mark uninitialized/leftover memory as
+        // initialized (UB) and leak it to the peer.
+        let mut parcel = Parcel::new();
+        // Poison the first 8 bytes with 0xFF so a missing zero-fill is
+        // observable as leftover bytes rather than incidental zeros.
+        parcel.write(&(-1i32)).unwrap();
+        parcel.write(&(-1i32)).unwrap();
+        parcel.set_data_position(0);
+
+        // 1-byte payload -> [i32 len=1][1 data byte][3 pad bytes].
+        let payload: &[u8] = &[0xAB];
+        SerializeArray::serialize_array(payload, &mut parcel).unwrap();
+
+        let bytes = parcel.data.as_slice();
+        assert_eq!(&bytes[4..8], &[0xAB, 0x00, 0x00, 0x00]);
     }
 
     #[test]

--- a/rsbinder/src/parcelable_holder.rs
+++ b/rsbinder/src/parcelable_holder.rs
@@ -225,7 +225,13 @@ impl Deserialize for ParcelableHolder {
 
 impl Parcelable for ParcelableHolder {
     fn write_to_parcel(&self, parcel: &mut Parcel) -> Result<()> {
-        parcel.write(&(self.stability as i32))?;
+        // AOSP serializes the stability Level *bitmask* (0/3/12/63 via
+        // `From<Stability> for i32`), not the enum discriminant. Using
+        // `as i32` here wrote 0/1/2/3, so any non-Local holder (e.g. Vintf
+        // wrote 3 instead of 63) was rejected with BAD_VALUE by a real
+        // peer. Mirror the `.into()` used on the SIBinder path.
+        let stability: i32 = self.stability.into();
+        parcel.write(&stability)?;
 
         let mut data = self.data.lock().expect("Parcelable holder lock poisoned");
         match *data {
@@ -261,7 +267,8 @@ impl Parcelable for ParcelableHolder {
 
     fn read_from_parcel(&mut self, parcel: &mut Parcel) -> Result<()> {
         let wire_stability: i32 = parcel.read()?;
-        if self.stability as i32 != wire_stability {
+        let local_stability: i32 = self.stability.into();
+        if local_stability != wire_stability {
             log::error!(
                 "ParcelableHolder::read_from_parcel: parcelable stability mismatch: {:?} != {:?}",
                 self.stability,
@@ -306,5 +313,32 @@ impl Parcelable for ParcelableHolder {
         parcel.set_data_position(data_end);
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_holder_serializes_stability_bitmask_not_discriminant() {
+        // A Vintf holder must serialize the AOSP Level bitmask (63), not
+        // the enum discriminant (3). An empty holder writes the stability
+        // followed by a 0 length; a real peer rejects a wrong stability
+        // value with BAD_VALUE, so this guards wire compatibility.
+        let holder = ParcelableHolder::new(Stability::Vintf);
+        let mut parcel = Parcel::new();
+        holder.write_to_parcel(&mut parcel).unwrap();
+
+        parcel.set_data_position(0);
+        let wire_stability: i32 = parcel.read().unwrap();
+        assert_eq!(wire_stability, 0b111111, "Vintf must serialize as 63");
+        let expected: i32 = Stability::Vintf.into();
+        assert_eq!(wire_stability, expected);
+
+        // And the round-trip back into a same-stability holder accepts it.
+        parcel.set_data_position(0);
+        let mut dst = ParcelableHolder::new(Stability::Vintf);
+        dst.read_from_parcel(&mut parcel).unwrap();
     }
 }

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -262,6 +262,28 @@ pub(crate) struct PublishedNative {
     /// `BR_DECREFS` decrement (deferred via `pending_*_derefs`,
     /// processed FIFO).
     pub(crate) kernel_refs: u32,
+    /// Number of `publish_native` dedup hits whose matching
+    /// `acquire` (`incref_publish`) has not landed yet. A dedup
+    /// returns an existing id but `publish_count` is only bumped by
+    /// the immediately-following `acquire`; without this reservation
+    /// a concurrent `decref_publish`/`deref_native_kernel` that drives
+    /// the counters to zero in that gap would remove the entry, and
+    /// the pending `acquire` would then ship a `binder` id the kernel
+    /// can no longer resolve. Bumped under the write lock on dedup,
+    /// consumed by the next `incref_publish`, and required to be zero
+    /// before any removal.
+    ///
+    /// Best-effort: the reservation is keyed by id, not by the specific
+    /// dedup, so an `append_from`-clone `acquire` on the same id can
+    /// consume it. That closes the common window (a `decref`/`deref`
+    /// racing a dedup) but not the pathological one where a clone's entire
+    /// `acquire`..`release` lifetime nests inside a single dedup's
+    /// `publish_native`..`acquire` gap — that gap is two adjacent
+    /// statements with no blocking call, so it is not reachable in
+    /// practice. Fully closing it would require threading "is-dedup" into
+    /// `flat_binder_object::acquire` (a `binder_object.rs` protocol
+    /// change); deferred.
+    pub(crate) pending_reservations: u32,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -896,10 +918,12 @@ impl ProcessState {
     /// encoding (replacing the data half of the old fat-pointer pair).
     ///
     /// Dedup is by `Arc::ptr_eq` against existing `binder_pin` entries —
-    /// publishing the same `Arc` twice returns the same id without any
-    /// counter side effects, matching Android's behavior where a single
-    /// `binder_node` is allocated per `weakref_type*` regardless of how
-    /// many times it is sent.
+    /// publishing the same `Arc` twice returns the same id, matching
+    /// Android's behavior where a single `binder_node` is allocated per
+    /// `weakref_type*` regardless of how many times it is sent. A dedup
+    /// hit bumps `pending_reservations` (the only counter side effect)
+    /// to pin the entry against a concurrent removal until the matching
+    /// `acquire` lands; see that field's doc.
     ///
     /// On a fresh insert, `RefCounter.strong` is driven 0→1 via
     /// `SIBinder::from_arc` (which calls `inc_strong` once on the inner
@@ -923,8 +947,14 @@ impl ProcessState {
             .published_natives
             .write()
             .expect("Published natives lock poisoned");
-        for (existing_id, entry) in map.iter() {
+        for (existing_id, entry) in map.iter_mut() {
             if Arc::ptr_eq(entry.binder_pin.as_arc(), &arc) {
+                // Reserve the entry against a concurrent removal until
+                // the matching `acquire` (incref_publish) lands; see
+                // `PublishedNative::pending_reservations`. `saturating_add`
+                // for symmetry with every decrement in this file (a wrap
+                // to 0 would defeat the reservation).
+                entry.pending_reservations = entry.pending_reservations.saturating_add(1);
                 return *existing_id;
             }
         }
@@ -945,6 +975,7 @@ impl ProcessState {
                 binder_pin,
                 publish_count: 0,
                 kernel_refs: 0,
+                pending_reservations: 0,
             },
         );
         id
@@ -966,6 +997,12 @@ impl ProcessState {
         match map.get_mut(&id) {
             Some(entry) => {
                 entry.publish_count += 1;
+                // Consume one outstanding reservation if any. The reservation
+                // is keyed by id, not by a specific dedup, so this closes the
+                // common window (a `decref`/`deref` racing a dedup before its
+                // acquire) but is best-effort: see the residual note on
+                // `PublishedNative::pending_reservations`.
+                entry.pending_reservations = entry.pending_reservations.saturating_sub(1);
                 true
             }
             None => false,
@@ -999,7 +1036,9 @@ impl ProcessState {
                          flat_binder_object::release pairing)"
                     );
                     entry.publish_count = entry.publish_count.saturating_sub(1);
-                    entry.publish_count == 0 && entry.kernel_refs == 0
+                    entry.publish_count == 0
+                        && entry.kernel_refs == 0
+                        && entry.pending_reservations == 0
                 }
                 None => return false,
             }
@@ -1063,7 +1102,9 @@ impl ProcessState {
             // in multi-pair scenarios; left as a follow-up.
             entry.kernel_refs = entry.kernel_refs.saturating_sub(1);
             let arc = Arc::clone(entry.binder_pin.as_arc());
-            let trigger = entry.publish_count == 0 && entry.kernel_refs == 0;
+            let trigger = entry.publish_count == 0
+                && entry.kernel_refs == 0
+                && entry.pending_reservations == 0;
             (arc, trigger)
         };
         if trigger_remove {
@@ -1105,7 +1146,7 @@ impl ProcessState {
                 .expect("Published natives lock poisoned");
             let needs_remove = map
                 .get(&id)
-                .map(|e| e.publish_count == 0 && e.kernel_refs == 0)
+                .map(|e| e.publish_count == 0 && e.kernel_refs == 0 && e.pending_reservations == 0)
                 .unwrap_or(false);
             if !needs_remove {
                 return;
@@ -1674,6 +1715,44 @@ mod tests {
             process.lookup_native(id1).is_none(),
             "entry must be removed after the last release fires"
         );
+
+        drop(arc);
+    }
+
+    /// A dedup hit reserves the entry against a concurrent removal that
+    /// drives `publish_count` to zero before the dedup's matching
+    /// `acquire` lands. This replays the dangerous interleaving
+    /// deterministically: without `pending_reservations` the `decref`
+    /// below would remove the entry and the trailing `incref` would
+    /// fail (the kernel would be handed an unresolvable id).
+    #[test]
+    #[serial_test::serial(binder)]
+    fn test_native_dedup_reserves_against_concurrent_removal() {
+        let process = ProcessState::init_default().expect("init_default");
+        let arc: Arc<dyn IBinder> = Arc::new(MockNative);
+
+        // Thread A publishes and serializes (acquire): publish_count = 1.
+        let id = process.publish_native(Arc::clone(&arc));
+        assert!(process.incref_publish(id));
+
+        // Thread B publishes the same Arc (dedup) — its acquire is still
+        // pending at this point.
+        let id_b = process.publish_native(Arc::clone(&arc));
+        assert_eq!(id, id_b);
+
+        // Thread A's parcel is freed (release) -> publish_count = 0. The
+        // entry must NOT be removed, because B's dedup acquire is pending.
+        assert!(process.decref_publish(id));
+        assert!(
+            process.lookup_native(id).is_some(),
+            "dedup reservation must keep the entry alive across the acquire gap"
+        );
+
+        // Thread B's acquire finally lands, consuming the reservation.
+        assert!(process.incref_publish(id));
+        // Thread B's release -> now genuinely zero -> removed.
+        assert!(process.decref_publish(id));
+        assert!(process.lookup_native(id).is_none());
 
         drop(arc);
     }

--- a/rsbinder/src/proxy_count.rs
+++ b/rsbinder/src/proxy_count.rs
@@ -212,9 +212,15 @@ pub(crate) fn on_proxy_create(uid: u32) {
 
 /// Internal hook called from `ProxyHandle::drop`. Decrements the
 /// global counter and, if per-uid tracking is enabled, decrements the
-/// uid map entry and clears the watermark debounce flags as the count
-/// drops below `low` (`limit_fired`) and `warning` (`warning_fired`).
-/// Symmetric with [`on_proxy_create`].
+/// uid map entry and clears **both** watermark debounce flags together
+/// once the count falls to/below `low`. Symmetric with
+/// [`on_proxy_create`].
+///
+/// AOSP (`BpBinder.cpp`) resets `LIMIT_REACHED_MASK | WARNING_REACHED_MASK`
+/// jointly at `count <= low`. Clearing them at separate thresholds (warning
+/// at `< warning`, limit at `< low`) let the `Warning` callback re-fire on a
+/// `low <-> warning` oscillation, which AOSP never does — so we mirror the
+/// joint reset.
 pub(crate) fn on_proxy_drop(uid: u32) {
     PROXY_COUNT.fetch_sub(1, Ordering::Relaxed);
     if !COUNT_BY_UID_ENABLED.load(Ordering::Relaxed) {
@@ -222,13 +228,10 @@ pub(crate) fn on_proxy_drop(uid: u32) {
     }
     let mut state = STATE.lock().expect("proxy_count state poisoned");
     let low = state.low;
-    let warning = state.warning;
     if let Some(entry) = state.per_uid.get_mut(&uid) {
         entry.count = entry.count.saturating_sub(1);
-        if entry.count < low {
+        if entry.count <= low {
             entry.limit_fired = false;
-        }
-        if entry.count < warning {
             entry.warning_fired = false;
         }
         if entry.count == 0 {

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -170,6 +170,22 @@ impl RawAccepted {
         }
     }
 
+    /// Companion to [`set_read_timeout`](Self::set_read_timeout): bound the
+    /// pre-wrap handshake's *write* side too. A peer that completes enough
+    /// of the handshake to be admitted but then stops reading would stall
+    /// our blocking handshake-reply `write_all` once its receive window
+    /// fills, pinning this worker (and its admission slot) — symmetric to
+    /// the read-side Slowloris. Best-effort.
+    fn set_write_timeout(&self, timeout: Option<std::time::Duration>) -> std::io::Result<()> {
+        match self {
+            RawAccepted::Unix(s) => s.set_write_timeout(timeout),
+            #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
+            RawAccepted::Vsock(s) => s.set_write_timeout(timeout),
+            #[cfg(feature = "rpc-tls")]
+            RawAccepted::Tcp(s) => s.set_write_timeout(timeout),
+        }
+    }
+
     /// Wrap the raw stream as `RpcTransport`, on the
     /// worker thread. `tls_config = Some(cfg)` ⇒ drive a server-side
     /// TLS handshake via [`TlsTransport::accept_stream`] over the raw
@@ -664,7 +680,11 @@ impl RpcServer {
     /// [`set_max_connections`](RpcServer::set_max_connections) admission
     /// slot — without it, a few idle peers can exhaust the cap and wedge
     /// the accept loop. `None` disables the deadline (a hung peer may
-    /// then hold a slot indefinitely).
+    /// then hold a slot indefinitely). The deadline is armed on **both**
+    /// the read and write sides of the handshake, so a peer that is
+    /// admitted but then refuses to read our handshake reply (stalling our
+    /// blocking `write_all` once its receive window fills) is bounded too,
+    /// not just a peer that refuses to send.
     ///
     /// The deadline bounds **only** the handshake/first-contact phase. For
     /// the android-13+ profile it is cleared after the explicit handshake;
@@ -697,6 +717,12 @@ impl RpcServer {
     /// keepalive/timeouts are otherwise the only backstop. (Currently
     /// honored on the android-13+ serve path; the r34 profile already
     /// bounds its first frame via the handshake deadline.)
+    ///
+    /// The serve phase arms this value on the **write** side too, so a peer
+    /// that stops draining replies is evicted as well — but a consumer that
+    /// legitimately reads a large reply slower than `d` is also dropped
+    /// mid-send (the connection is torn down, not desynced). Size `d`
+    /// against the slowest acceptable consumer, not just the idle gap.
     pub fn set_idle_timeout(&self, timeout: Option<std::time::Duration>) {
         *self.idle_timeout.lock().expect("idle_timeout poisoned") = timeout;
     }
@@ -989,6 +1015,9 @@ impl RpcServer {
                 if let Err(e) = raw.set_read_timeout(Some(d)) {
                     log::debug!("RPC: failed to arm pre-wrap handshake read timeout: {e:?}");
                 }
+                if let Err(e) = raw.set_write_timeout(Some(d)) {
+                    log::debug!("RPC: failed to arm pre-wrap handshake write timeout: {e:?}");
+                }
             }
             let transport = match server.wrap_accepted(raw) {
                 Ok(t) => t,
@@ -1021,19 +1050,28 @@ impl RpcServer {
     }
 
     /// Transition a connection from the bounded handshake/admission phase
-    /// to the long-lived serving phase (best-effort). By default this
-    /// lifts the read deadline entirely (`None`), so an established
-    /// two-way session may idle between requests unbounded — byte-identical
-    /// to prior behavior. If [`set_idle_timeout`](Self::set_idle_timeout)
-    /// was called, the serve loop instead inherits that idle read deadline,
-    /// so a peer that completes the handshake and then goes silent (a
+    /// to the long-lived serving phase (best-effort), arming **both** the
+    /// read and write deadlines. By default both are lifted (`None`), so an
+    /// established two-way session may idle between requests unbounded —
+    /// byte-identical to prior behavior. If
+    /// [`set_idle_timeout`](Self::set_idle_timeout) was called, the serve
+    /// loop inherits that value on each side, so a peer that completes the
+    /// handshake and then goes silent (or stops reading our replies) — a
     /// post-handshake Slowloris that would otherwise pin a
     /// [`set_max_connections`](Self::set_max_connections) admission slot
-    /// forever) surfaces as a serve-loop read error and is evicted.
-    fn arm_serve_read_timeout(&self, transport: &dyn RpcTransport) {
+    /// forever — surfaces as a serve-loop error and is evicted.
+    fn arm_serve_timeouts(&self, transport: &dyn RpcTransport) {
         let idle = *self.idle_timeout.lock().expect("idle_timeout poisoned");
         if let Err(e) = transport.set_read_timeout(idle) {
             log::debug!("RPC: failed to set serve-phase read timeout: {e:?}");
+        }
+        // Mirror the deadline onto the write side so a peer that idles
+        // *and* stops reading can't pin the worker via a blocked reply
+        // send. `None` (the default) leaves writes unbounded — byte-
+        // identical to prior behavior; a configured idle timeout now
+        // bounds both directions.
+        if let Err(e) = transport.set_write_timeout(idle) {
+            log::debug!("RPC: failed to set serve-phase write timeout: {e:?}");
         }
     }
 
@@ -1066,7 +1104,7 @@ impl RpcServer {
         // Bound the pre-serve handshake/first-contact phase so a
         // connected-but-silent peer can't pin its `Arc<RpcServer>` +
         // admission slot forever. Transitioned to the serve-phase deadline
-        // by `arm_serve_read_timeout` before any long-lived serve (`None`
+        // by `arm_serve_timeouts` before any long-lived serve (`None`
         // ⇒ idle unbounded, or the configured `set_idle_timeout`).
         // Best-effort: a set failure just means no deadline.
         if let Some(d) = *server
@@ -1076,6 +1114,9 @@ impl RpcServer {
         {
             if let Err(e) = transport.set_read_timeout(Some(d)) {
                 log::debug!("RPC: failed to arm handshake read timeout: {e:?}");
+            }
+            if let Err(e) = transport.set_write_timeout(Some(d)) {
+                log::debug!("RPC: failed to arm handshake write timeout: {e:?}");
             }
         }
         let a13_max = *server
@@ -1112,7 +1153,7 @@ impl RpcServer {
                 // serve-phase deadline — `None` (default, unbounded idle) or
                 // the configured `set_idle_timeout` so a post-handshake
                 // silent peer is evicted instead of pinning its slot.
-                server.arm_serve_read_timeout(transport.as_ref());
+                server.arm_serve_timeouts(transport.as_ref());
                 if incoming {
                     // Attach + incoming (`server_accept` already
                     // rejected new + incoming): resolve the session,
@@ -1377,6 +1418,31 @@ impl RpcServer {
                     // whole server down for all future clients.
                     log::warn!("transient accept error, continuing: {e}");
                     std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(e)
+                    if matches!(
+                        e.raw_os_error(),
+                        Some(code)
+                            if code == libc::EMFILE
+                                || code == libc::ENFILE
+                                || code == libc::ENOMEM
+                                || code == libc::ENOBUFS
+                    ) =>
+                {
+                    // Resource exhaustion: the process or system fd table
+                    // is full (EMFILE/ENFILE) or the kernel is out of
+                    // memory/buffers (ENOMEM/ENOBUFS). A peer that churns
+                    // connections can drive us to RLIMIT_NOFILE, at which
+                    // point `accept` returns EMFILE. These map to
+                    // `ErrorKind::Uncategorized`/`OutOfMemory`, so without
+                    // this arm they fall through to the fatal branch and
+                    // kill the listener for ALL future clients — turning a
+                    // transient overload into a permanent outage. The
+                    // condition is self-healing as in-flight sessions close
+                    // their fds, so back off (longer than the EINTR case to
+                    // give descriptors time to free) and keep serving.
+                    log::warn!("accept resource exhaustion, backing off: {e}");
+                    std::thread::sleep(std::time::Duration::from_millis(50));
                 }
                 Err(e) => {
                     // Fatal (e.g. the listener was closed): surface it.

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -416,6 +416,18 @@ impl ConnGuard<'_> {
 
 impl Drop for ConnGuard<'_> {
     fn drop(&mut self) {
+        if self.reentrant {
+            // A reentrant guard reused the outer frame's slot *and* its
+            // `DRIVING` marker — it pushed neither the marker nor claimed
+            // `exclusive_tid`, so it must remove neither. Removing a
+            // `DRIVING` entry here would delete the OUTER frame's marker
+            // (the key (session, slot) matches), so a later same-thread
+            // nested call would no longer see it, re-claim the slot as
+            // non-reentrant, and on *its* drop clear an `exclusive_tid`
+            // the outer frame still owns — corrupting exclusivity on
+            // multi-slot sessions.
+            return;
+        }
         let key = (self.inner as *const _ as usize, self.slot_id);
         DRIVING.with(|d| {
             let mut v = d.borrow_mut();
@@ -423,7 +435,7 @@ impl Drop for ConnGuard<'_> {
                 v.remove(pos);
             }
         });
-        if !self.reentrant {
+        {
             // Release exclusive ownership and wake waiters. We use
             // `notify_all` to match [`add_slot_inner`] / [`remove_slot`]:
             // a slot release benefits (a) `find_conn` any-available
@@ -842,6 +854,23 @@ impl RpcSessionInner {
             if let Err(e) = t.set_read_timeout(None) {
                 log::debug!("RPC: failed to clear first-frame read deadline: {e:?}");
             }
+        }
+    }
+
+    /// Lift any read/write deadlines on every slot transport
+    /// (best-effort). Used after a bounded handshake (e.g. an
+    /// Accessor-supplied preconnected fd) so the established session
+    /// reverts to the normal blocking-with-per-call-deadline behavior
+    /// rather than inheriting the handshake's sticky `SO_RCVTIMEO`/
+    /// `SO_SNDTIMEO`.
+    fn clear_handshake_timeouts(&self) {
+        let transports: Vec<Arc<dyn RpcTransport>> = {
+            let st = self.conn_state.lock().expect("conn_state poisoned");
+            st.slots.iter().map(|s| Arc::clone(&s.transport)).collect()
+        };
+        for t in transports {
+            let _ = t.set_read_timeout(None);
+            let _ = t.set_write_timeout(None);
         }
     }
 
@@ -2803,16 +2832,33 @@ impl RpcSession {
             }
         };
 
-        // (c) Run the android-13+ versioned handshake. No FD-over-RPC —
+        // (c) Bound the handshake. The fd comes from an Accessor returned
+        //     by the service manager (`resolve_accessor`), i.e. a peer we
+        //     do not trust. After clearing `O_NONBLOCK` above the handshake
+        //     `read`/`write_all` are fully blocking, so a peer that accepts
+        //     the connection but never sends (or never reads) the handshake
+        //     would otherwise hang `getService`/`get_root` forever — there
+        //     is no `SO_RCVTIMEO` here (the per-call session timeout only
+        //     applies inside `client_transact`). Arm a deadline on both
+        //     directions for the handshake, then clear it on the
+        //     established session so steady-state I/O is unbounded as
+        //     before. Best-effort: a set failure just means no deadline.
+        const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+        let _ = transport.set_read_timeout(Some(HANDSHAKE_TIMEOUT));
+        let _ = transport.set_write_timeout(Some(HANDSHAKE_TIMEOUT));
+
+        // (d) Run the android-13+ versioned handshake. No FD-over-RPC —
         //     the Accessor-fd carries no fd-mode metadata of its own and
         //     the consumer (the eventual proxy returned by `get_root`)
         //     drives any later FD passing through the negotiated wire
         //     directly.
-        RpcSession::connect_android13plus_fd(
+        let session = RpcSession::connect_android13plus_fd(
             transport,
             max_version,
             FileDescriptorTransportMode::None,
-        )
+        )?;
+        session.inner.clear_handshake_timeouts();
+        Ok(session)
     }
 
     /// Test/diagnostic: live local-node count (leak check).

--- a/rsbinder/src/rpc/transport/mod.rs
+++ b/rsbinder/src/rpc/transport/mod.rs
@@ -95,6 +95,19 @@ pub trait RpcTransport: Send + Sync {
         Ok(())
     }
 
+    /// Set a write deadline for subsequent sends. `None` clears it. The
+    /// default is a no-op for backends with no write-timeout notion
+    /// (`mem`'s send never blocks on a peer); socket-backed transports
+    /// (`unix` / `vsock` / `tcp_debug` / `tls`) override it. This bounds
+    /// the reply-send phase so a peer that completes the handshake/
+    /// admission and then stops reading cannot pin its worker thread (and,
+    /// under [`set_max_connections`](super::server::RpcServer::set_max_connections),
+    /// its admission slot) forever by stalling our blocking `write_all`
+    /// once the kernel send buffer fills.
+    fn set_write_timeout(&self, _timeout: Option<std::time::Duration>) -> RpcResult<()> {
+        Ok(())
+    }
+
     /// Send one frame plus passed file descriptors out-of-band (opt-in
     /// `FileDescriptorTransportMode::Unix`).
     ///

--- a/rsbinder/src/rpc/transport/tcp_debug.rs
+++ b/rsbinder/src/rpc/transport/tcp_debug.rs
@@ -145,6 +145,11 @@ impl RpcTransport for TcpDebugTransport {
         self.stream.set_read_timeout(timeout)?;
         Ok(())
     }
+
+    fn set_write_timeout(&self, timeout: Option<std::time::Duration>) -> RpcResult<()> {
+        self.stream.set_write_timeout(timeout)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/rsbinder/src/rpc/transport/tls.rs
+++ b/rsbinder/src/rpc/transport/tls.rs
@@ -75,6 +75,8 @@ pub trait TlsStream: Send + Sync {
     fn flush(&self) -> std::io::Result<()>;
     /// Set the read deadline for subsequent `read`s (`None` = blocking).
     fn set_read_timeout(&self, t: Option<Duration>) -> std::io::Result<()>;
+    /// Set the write deadline for subsequent `write`s (`None` = blocking).
+    fn set_write_timeout(&self, t: Option<Duration>) -> std::io::Result<()>;
 }
 
 // All std stream types implement `Read`/`Write` for `&Stream`, so the
@@ -92,6 +94,9 @@ impl TlsStream for TcpStream {
     fn set_read_timeout(&self, t: Option<Duration>) -> std::io::Result<()> {
         TcpStream::set_read_timeout(self, t)
     }
+    fn set_write_timeout(&self, t: Option<Duration>) -> std::io::Result<()> {
+        TcpStream::set_write_timeout(self, t)
+    }
 }
 
 impl TlsStream for UnixStream {
@@ -106,6 +111,9 @@ impl TlsStream for UnixStream {
     }
     fn set_read_timeout(&self, t: Option<Duration>) -> std::io::Result<()> {
         UnixStream::set_read_timeout(self, t)
+    }
+    fn set_write_timeout(&self, t: Option<Duration>) -> std::io::Result<()> {
+        UnixStream::set_write_timeout(self, t)
     }
 }
 
@@ -122,6 +130,9 @@ impl TlsStream for vsock::VsockStream {
     }
     fn set_read_timeout(&self, t: Option<Duration>) -> std::io::Result<()> {
         vsock::VsockStream::set_read_timeout(self, t)
+    }
+    fn set_write_timeout(&self, t: Option<Duration>) -> std::io::Result<()> {
+        vsock::VsockStream::set_write_timeout(self, t)
     }
 }
 
@@ -409,6 +420,11 @@ impl RpcTransport for TlsTransport {
 
     fn set_read_timeout(&self, timeout: Option<std::time::Duration>) -> RpcResult<()> {
         self.stream.set_read_timeout(timeout)?;
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, timeout: Option<std::time::Duration>) -> RpcResult<()> {
+        self.stream.set_write_timeout(timeout)?;
         Ok(())
     }
 }

--- a/rsbinder/src/rpc/transport/unix.rs
+++ b/rsbinder/src/rpc/transport/unix.rs
@@ -244,7 +244,16 @@ impl RpcTransport for UnixTransport {
     /// of this (`wire_android13::read_aosp_message`).
     fn recv_raw(&self, buf: &mut [u8]) -> RpcResult<usize> {
         let mut r = &self.stream;
-        r.read(buf).map_err(RpcError::from)
+        match r.read(buf) {
+            Ok(n) => Ok(n),
+            // A read deadline (`SO_RCVTIMEO` via `set_read_timeout`)
+            // elapsed. Surface it as `Timeout` rather than a generic `Io`
+            // so the android-13+ reader (`read_exact_raw`) can honor the
+            // `Timeout`/`Truncated` contract and a caller matching
+            // `Timeout`/`StatusCode::TimedOut` sees it.
+            Err(e) if super::is_timeout(&e) => Err(RpcError::Timeout),
+            Err(e) => Err(RpcError::from(e)),
+        }
     }
 
     /// Raw, **unframed** write + `SCM_RIGHTS` (the android-13+ v1+
@@ -327,7 +336,17 @@ impl RpcTransport for UnixTransport {
                 Ok(r) => break r,
                 // EINTR retry, symmetric with read_header.
                 Err(rustix::io::Errno::INTR) => continue,
-                Err(e) => return Err(std::io::Error::from(e).into()),
+                Err(e) => {
+                    let io_err = std::io::Error::from(e);
+                    // A read deadline elapsed (EAGAIN/EWOULDBLOCK from
+                    // `SO_RCVTIMEO`): surface `Timeout` (the accumulating
+                    // reader downgrades to `Truncated` if it was already
+                    // mid-message), not a generic `Io`.
+                    if super::is_timeout(&io_err) {
+                        return Err(RpcError::Timeout);
+                    }
+                    return Err(io_err.into());
+                }
             }
         };
         for msg in anc.drain() {
@@ -355,6 +374,11 @@ impl RpcTransport for UnixTransport {
 
     fn set_read_timeout(&self, timeout: Option<std::time::Duration>) -> RpcResult<()> {
         self.stream.set_read_timeout(timeout)?;
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, timeout: Option<std::time::Duration>) -> RpcResult<()> {
+        self.stream.set_write_timeout(timeout)?;
         Ok(())
     }
 

--- a/rsbinder/src/rpc/transport/vsock.rs
+++ b/rsbinder/src/rpc/transport/vsock.rs
@@ -97,4 +97,9 @@ impl RpcTransport for VsockTransport {
         self.stream.set_read_timeout(timeout)?;
         Ok(())
     }
+
+    fn set_write_timeout(&self, timeout: Option<std::time::Duration>) -> RpcResult<()> {
+        self.stream.set_write_timeout(timeout)?;
+        Ok(())
+    }
 }

--- a/rsbinder/src/rpc/wire_android13.rs
+++ b/rsbinder/src/rpc/wire_android13.rs
@@ -742,15 +742,28 @@ fn read_exact_raw<R: Read>(r: &mut R, n: usize) -> RpcResult<Vec<u8>> {
     let mut buf = vec![0u8; n];
     let mut got = 0;
     while got < n {
-        match r.read(&mut buf[got..]).map_err(map_io)? {
-            0 => {
+        match r.read(&mut buf[got..]) {
+            Ok(0) => {
                 return Err(if got == 0 {
                     RpcError::PeerClosed
                 } else {
                     RpcError::Truncated
                 })
             }
-            k => got += k,
+            Ok(k) => got += k,
+            // A read deadline elapsed (`RawTransportIo` surfaces
+            // `recv_raw`'s `Timeout` as `ErrorKind::TimedOut`): a clean
+            // `Timeout` before any byte of this read, else mid-frame
+            // `Truncated` — honoring the `set_read_timeout` contract rather
+            // than collapsing to a generic `Io` via `map_io`.
+            Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut => {
+                return Err(if got == 0 {
+                    RpcError::Timeout
+                } else {
+                    RpcError::Truncated
+                });
+            }
+            Err(e) => return Err(map_io(e)),
         }
     }
     Ok(buf)
@@ -791,7 +804,15 @@ pub fn read_aosp_message<R: Read>(r: &mut R) -> RpcResult<Vec<u8>> {
     let mut out = Vec::with_capacity(WIRE_HEADER_LEN + body_size);
     out.extend_from_slice(&header);
     if body_size > 0 {
-        out.extend_from_slice(&read_exact_raw(r, body_size)?);
+        // The header is already consumed, so a deadline that elapses at the
+        // start of the body is mid-message, not frame-synchronized: report
+        // `Truncated`, not `Timeout` (matches `read_aosp_message_with_fds`,
+        // which carries `total_read` across header+body).
+        let body = read_exact_raw(r, body_size).map_err(|e| match e {
+            RpcError::Timeout => RpcError::Truncated,
+            other => other,
+        })?;
+        out.extend_from_slice(&body);
     }
     Ok(out)
 }
@@ -844,7 +865,20 @@ pub fn read_aosp_message_with_fds(
         let mut buf = vec![0u8; want];
         let mut got = 0;
         while got < want {
-            let (n, mut more) = t.recv_raw_with_fds(&mut buf[got..])?;
+            let (n, mut more) = match t.recv_raw_with_fds(&mut buf[got..]) {
+                Ok(v) => v,
+                // A read deadline elapsed: a clean `Timeout` only before any
+                // byte of the message was read; otherwise the message is
+                // mid-flight ⇒ `Truncated` (same split as the EOF case below).
+                Err(RpcError::Timeout) => {
+                    return Err(if total_read == 0 {
+                        RpcError::Timeout
+                    } else {
+                        RpcError::Truncated
+                    });
+                }
+                Err(e) => return Err(e),
+            };
             fds.append(&mut more);
             // Enforce the per-message `MAX_FDS_PER_FRAME` cap *across*
             // the multiple recvmsgs that read one message. The
@@ -1088,9 +1122,13 @@ pub struct RawTransportIo<'a>(pub &'a dyn super::transport::RpcTransport);
 
 impl Read for RawTransportIo<'_> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.0
-            .recv_raw(buf)
-            .map_err(|e| std::io::Error::other(e.to_string()))
+        self.0.recv_raw(buf).map_err(|e| match e {
+            // Preserve the timeout kind across the `Read` boundary so
+            // `read_exact_raw` can honor the `Timeout`/`Truncated`
+            // contract; other errors keep their string form.
+            RpcError::Timeout => std::io::Error::from(std::io::ErrorKind::TimedOut),
+            other => std::io::Error::other(other.to_string()),
+        })
     }
 }
 

--- a/rsbinder/src/status.rs
+++ b/rsbinder/src/status.rs
@@ -145,6 +145,13 @@ impl Deserialize for ExceptionCode {
 /// `Status` combines an exception code, status code, and optional message
 /// to provide comprehensive error information for binder transactions.
 /// It can represent both successful operations and various failure modes.
+///
+/// `Clone` is derived (every field is `Clone`) so callers can fan a
+/// failed result out to multiple handlers, copy it while logging, or
+/// re-surface it on retry — mirroring AOSP's copyable `Status`. `PartialEq`
+/// is a manual impl (it deliberately ignores `message`), so it is not part
+/// of the derive.
+#[derive(Clone)]
 pub struct Status {
     code: StatusCode,
     exception: ExceptionCode,


### PR DESCRIPTION
## Summary

A 26-reviewer multi-perspective pass over `rsbinder`, `rsbinder-aidl`, and `rsb_hub` (each subsystem viewed through several lenses) surfaced 50 findings; an independent per-finding adversarial verification confirmed 45 and deduped them. This PR addresses the **High (5) + Medium (21) = 26** tier (the Low tier is deferred). A follow-up `/review-rust` pass over this PR's own diff caught and fixed a few additional issues — most notably a fixed-size-array default-codegen gap.

The single memory-safety defect (parcel pad bytes) is fixed; the remaining themes are wire-format fidelity with AOSP and untrusted-boundary DoS resistance.

## Fixes

**Parcel / refcount (core)**
- Zero the 1–3 trailing pad bytes in `write_array`/`write_aligned_data` before `set_len` — previously UB and transmitted uninitialized process memory to the peer.
- Serialize `ParcelableHolder` stability as the AOSP Level bitmask (0/3/12/63), not the enum discriminant — a non-`Local` holder was rejected with `BAD_VALUE` by a real peer.
- Reserve published-native entries across the `publish_native` dedup → `acquire` gap, closing a TOCTOU that could ship the kernel a `binder` id it can no longer resolve.

**RPC**
- Treat `EMFILE`/`ENFILE`/`ENOMEM`/`ENOBUFS` in the accept loop as transient, not fatal — resource exhaustion no longer permanently kills the server.
- Arm a write deadline alongside the read deadline at the handshake/serve phases so a slow-reading peer cannot pin a worker and its `set_max_connections` admission slot.
- Bound the Accessor preconnected-fd handshake with read/write timeouts.
- Fix reentrant `ConnGuard` drop to leave the outer frame's `DRIVING` marker and `exclusive_tid` intact.
- Classify raw android-13+ read-deadline elapses as `Timeout`/`Truncated` (per the documented transport contract) rather than a generic `Io`.

**AIDL**
- Reject pathologically nested input before parsing (stack-overflow DoS guard) and warn on duplicate imports of the same simple name.
- Reject variable multi-dimensional arrays and arrays of `List`; emit `std::array::from_fn` defaults for fixed-size arrays longer than 32 (Rust's `Default` stops at length 32).
- Reject transaction codes in the reserved meta-method range (`> kMaxUserSetMethodId` = 16777114).
- Serialize non-nullable IBinder/FD/interface fields with `UNEXPECTED_NULL` instead of writing a null marker.
- Evaluate logical-not (`!`) as boolean negation, not bitwise; escape all control characters in generated `char` literals.
- Accept underscore digit separators, `u32`/`u64` suffixes, and decimal-less float literals (`5f`, `1e10`).

**rsb_hub**
- Recover from registry mutex poisoning instead of bricking the service manager; dedup and cap per-name callback registrations.
- `unlink_to_death` before removing a service in `tryUnregisterService` (avoids a kernel death-subscription leak per register/unregister cycle).
- Return `ServiceWithMetadata(None)` for a missing service so an AOSP client's injected-accessor fallback still fires.
- Block ~5s polling for a not-yet-registered service on Android 10 (matching libbinder's client-side behavior).

**Misc**
- Derive `Clone` on `Status`; clear proxy-count warning/limit watermarks jointly at `<= low` (AOSP parity).

## Tests

Regression tests added (hermetic): parcel pad-byte zeroing; `ParcelableHolder` Vintf stability bitmask; `publish_native` dedup reservation interleaving; AIDL nesting-depth guard, integer underscores + `u32`/`u64` suffixes, decimal-less floats, logical-not, fixed-array-`>32` default; reserved transaction-code rejection.

## Validation

- **macOS hermetic** (committed tree): `rsbinder-aidl` 192/0; RPC suites (`rpc_server` 28, `rpc_tls` 9, `rpc_scenarios` 7, `rpc_fd` 4, `rpc_e2e` 4) all green; clippy (default + rpc/tls/tcp-debug) + fmt clean; full workspace + AIDL-codegen build OK.
- **Linux, real `/dev/binder`** (zen kernel): lib 189/0, rpc lib 288/0, kernel 3-process e2e sync 136/0 + async 136/0, `death_recipient` 2/0, `mesh_kernel` 1/0.
- **Android 16 emulator** (real binder + real servicemanager): lib 183/0, rpc (no-tls) 282/0 — the kernel-binder tests that cannot run on macOS pass here.

## Deferred

- The `publish_native` dedup reservation closes the common removal-races-dedup window but is best-effort: it does not close a pathological interleaving where a concurrent `append_from` clone's entire `acquire`..`release` lifetime nests inside a single dedup's `publish_native`..`acquire` gap (two adjacent statements with no blocking call — not reachable in practice). Fully closing it needs threading "is-dedup" through `flat_binder_object::acquire` (a `binder_object.rs` protocol change); documented on the field and deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
