### PR TITLE
fix: address multi-perspective review findings (parcel wire, AIDL codegen, hub)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -120,8 +120,7 @@ jobs:
         run: |
           RUST_LOG=info nohup target/debug/test_service > test_service.log 2>&1 &
           echo $! > test_service.pid
-          sleep 2
-          kill -0 "$(cat test_service.pid)" || { echo "::error::test_service failed to start"; cat test_service.log; exit 1; }
+          bash scripts/ci_wait_test_service_ready.sh test_service.log test_service.pid
 
       - name: Run rsbinder unit tests (slow-path / hardening regression gate)
         run: |
@@ -206,8 +205,7 @@ jobs:
           sleep 1
           RUST_LOG=info nohup target/debug/test_service_async > test_service_async.log 2>&1 &
           echo $! > test_service.pid
-          sleep 2
-          kill -0 "$(cat test_service.pid)" || { echo "::error::test_service_async failed to start"; cat test_service_async.log; exit 1; }
+          bash scripts/ci_wait_test_service_ready.sh test_service_async.log test_service.pid
 
       - name: Run cargo test (async) — 1 iteration
         run: |
@@ -259,8 +257,7 @@ jobs:
           sleep 1
           RUST_LOG=info nohup target/debug/test_service > test_service.log 2>&1 &
           echo $! > test_service.pid
-          sleep 2
-          kill -0 "$(cat test_service.pid)" || { echo "::error::test_service failed to restart"; cat test_service.log; exit 1; }
+          bash scripts/ci_wait_test_service_ready.sh test_service.log test_service.pid
 
       - name: Run test_death_recipient (destructive)
         run: |
@@ -268,7 +265,16 @@ jobs:
           # callback + post-obituary unlink_to_death returning
           # DeadObject. Wired into CI here as part of the cache-pin
           # follow-up so its coverage is no longer manual-only.
-          RUST_BACKTRACE=1 cargo test --package tests -- --ignored \
+          #
+          # `--exact` is REQUIRED here: the filter `test_death_recipient` is a
+          # prefix of `test_death_recipient_panic_does_not_starve_others`, so a
+          # substring match would run BOTH in one process. Both are destructive
+          # (each kills the shared test_service), so running them together is an
+          # order-dependent race — whichever kills the service first leaves the
+          # other unable to resolve it ("did not get binder service"). That was
+          # the intermittent CI flake. Each destructive test must run alone
+          # against its own freshly-restarted, registration-verified service.
+          RUST_BACKTRACE=1 cargo test --package tests -- --ignored --exact \
             test_client::test_death_recipient
 
       - name: Restart test_service for test_wibinder_upgrade_after_obituary
@@ -277,8 +283,7 @@ jobs:
           sleep 1
           RUST_LOG=info nohup target/debug/test_service > test_service.log 2>&1 &
           echo $! > test_service.pid
-          sleep 2
-          kill -0 "$(cat test_service.pid)" || { echo "::error::test_service failed to restart"; cat test_service.log; exit 1; }
+          bash scripts/ci_wait_test_service_ready.sh test_service.log test_service.pid
 
       - name: Run test_wibinder_upgrade_after_obituary (destructive)
         run: |
@@ -286,7 +291,7 @@ jobs:
           # coverage on a real obituary path. The exact-path filter
           # (test_client::test_wibinder_upgrade_after_obituary) avoids
           # cargo's substring matching from picking up unrelated tests.
-          RUST_BACKTRACE=1 cargo test --package tests -- --ignored \
+          RUST_BACKTRACE=1 cargo test --package tests -- --ignored --exact \
             test_client::test_wibinder_upgrade_after_obituary
 
       - name: Restart test_service for test_death_recipient_panic_does_not_starve_others
@@ -295,8 +300,7 @@ jobs:
           sleep 1
           RUST_LOG=info nohup target/debug/test_service > test_service.log 2>&1 &
           echo $! > test_service.pid
-          sleep 2
-          kill -0 "$(cat test_service.pid)" || { echo "::error::test_service failed to restart"; cat test_service.log; exit 1; }
+          bash scripts/ci_wait_test_service_ready.sh test_service.log test_service.pid
 
       - name: Run test_death_recipient_panic_does_not_starve_others (destructive)
         run: |
@@ -306,7 +310,7 @@ jobs:
           # `proxy.rs` covers the dispatch-loop in isolation, this
           # one verifies the same guarantee end-to-end through the
           # kernel BR_DEAD_BINDER handshake.
-          RUST_BACKTRACE=1 cargo test --package tests -- --ignored \
+          RUST_BACKTRACE=1 cargo test --package tests -- --ignored --exact \
             test_client::test_death_recipient_panic_does_not_starve_others
 
       - name: Restart test_service for test_unlink_to_death_single_remove_via_obituary
@@ -315,8 +319,7 @@ jobs:
           sleep 1
           RUST_LOG=info nohup target/debug/test_service > test_service.log 2>&1 &
           echo $! > test_service.pid
-          sleep 2
-          kill -0 "$(cat test_service.pid)" || { echo "::error::test_service failed to restart"; cat test_service.log; exit 1; }
+          bash scripts/ci_wait_test_service_ready.sh test_service.log test_service.pid
 
       - name: Run test_unlink_to_death_single_remove_via_obituary (destructive)
         run: |
@@ -325,7 +328,7 @@ jobs:
           # `BpBinder::unlinkToDeath`'s `removeAt(i)`. Register the
           # same recipient twice, unlink once, then verify exactly
           # one `binder_died` fires after killService.
-          RUST_BACKTRACE=1 cargo test --package tests -- --ignored \
+          RUST_BACKTRACE=1 cargo test --package tests -- --ignored --exact \
             test_client::test_unlink_to_death_single_remove_via_obituary
 
       - name: Restart test_service for test_dump_fast_fails_on_dead_proxy_closes_fd
@@ -334,8 +337,7 @@ jobs:
           sleep 1
           RUST_LOG=info nohup target/debug/test_service > test_service.log 2>&1 &
           echo $! > test_service.pid
-          sleep 2
-          kill -0 "$(cat test_service.pid)" || { echo "::error::test_service failed to restart"; cat test_service.log; exit 1; }
+          bash scripts/ci_wait_test_service_ready.sh test_service.log test_service.pid
 
       - name: Run test_dump_fast_fails_on_dead_proxy_closes_fd (destructive)
         run: |
@@ -343,7 +345,7 @@ jobs:
           # must fast-fail with DeadObject before consuming the fd,
           # so the caller's fd is closed via RAII. Verified via pipe
           # EOF on the read end after `dump` drops the write end.
-          RUST_BACKTRACE=1 cargo test --package tests -- --ignored \
+          RUST_BACKTRACE=1 cargo test --package tests -- --ignored --exact \
             test_client::test_dump_fast_fails_on_dead_proxy_closes_fd
 
       - name: Stop background services

--- a/rsbinder-aidl/src/aidl.pest
+++ b/rsbinder-aidl/src/aidl.pest
@@ -214,7 +214,11 @@ FLOATVALUE = @{
 }
 // HEXVALUE = @{ hex_value ~ int_suffix? }
 // hex_value = @{ "0" ~ ("x" | "X") ~ (ASCII_DIGIT | 'a'..'f' | 'A'..'F')+ }
-C_STR = @{ "\"" ~ ( !("\"") ~ ANY | "\\" ~ ANY)* ~ "\"" }
+// Try the `\X` escape alternative first so an escaped quote `\"` is consumed
+// as one unit instead of the bare `\` being eaten and the following `"`
+// terminating the string early. (String-constant backslashes are rejected in
+// `parse_string_term`, but a clean tokenization yields a clear diagnostic.)
+C_STR = @{ "\"" ~ ( "\\" ~ ANY | !("\"") ~ ANY)* ~ "\"" }
 
 LOGICAL_OR = { "||" }
 LOGICAL_AND = { "&&" }

--- a/rsbinder-aidl/src/const_expr.rs
+++ b/rsbinder-aidl/src/const_expr.rs
@@ -446,8 +446,32 @@ impl ValueType {
                     format!("\"{}\".into()", self.to_value_string())
                 }
             }
-            ValueType::Float(_) => format!("{}f32", self.to_value_string()),
-            ValueType::Double(_) => format!("{}f64", self.to_value_string()),
+            // A non-finite fold (e.g. `1.0e400` parses to infinity) would emit
+            // `inff32` / `NaNf64` — not valid Rust. Emit the proper float
+            // constant instead; finite values keep the suffixed-decimal form.
+            ValueType::Float(v) => {
+                let f = *v as f32;
+                if f.is_finite() {
+                    format!("{f}f32")
+                } else if f.is_nan() {
+                    "f32::NAN".to_owned()
+                } else if f > 0.0 {
+                    "f32::INFINITY".to_owned()
+                } else {
+                    "f32::NEG_INFINITY".to_owned()
+                }
+            }
+            ValueType::Double(v) => {
+                if v.is_finite() {
+                    format!("{v}f64")
+                } else if v.is_nan() {
+                    "f64::NAN".to_owned()
+                } else if *v > 0.0 {
+                    "f64::INFINITY".to_owned()
+                } else {
+                    "f64::NEG_INFINITY".to_owned()
+                }
+            }
             ValueType::Char(_) => format!("'{}' as u16", self.to_value_string()),
             ValueType::Name(_) => self.to_value_string(),
             ValueType::Reference {

--- a/rsbinder-aidl/src/const_expr.rs
+++ b/rsbinder-aidl/src/const_expr.rs
@@ -484,7 +484,15 @@ impl ValueType {
                     "vec![".to_owned()
                 };
                 for v in v {
-                    let init_str = v.value.to_init(param.clone());
+                    let init_str = match &v.value {
+                        // AOSP `aidl_to_rust.cpp` re-emits a byte inside an array
+                        // as its unsigned `u8` representation (e.g. -1 -> 255):
+                        // the array's Rust element type is `u8` (i8 maps to u8 via
+                        // `array_type_name`), and Rust rejects a negated literal in
+                        // a `u8` array. Positive bytes are unchanged by the cast.
+                        ValueType::Byte(b) => (*b as u8).to_string(),
+                        _ => v.value.to_init(param.clone()),
+                    };
 
                     let some_str = if let ValueType::Array(_) = v.value {
                         init_str

--- a/rsbinder-aidl/src/parser.rs
+++ b/rsbinder-aidl/src/parser.rs
@@ -1377,13 +1377,33 @@ fn parse_expression(mut pairs: pest::iterators::Pairs<Rule>) -> Result<ConstExpr
     Ok(lhs)
 }
 
-fn parse_string_term(pair: pest::iterators::Pair<Rule>) -> ConstExpr {
+fn parse_string_term(pair: pest::iterators::Pair<Rule>) -> Result<ConstExpr, AidlError> {
     match pair.as_rule() {
         Rule::C_STR => {
-            let string = pair.as_str();
-            ConstExpr::new(ValueType::String(string[1..string.len() - 1].into()))
+            let span = pair.as_span();
+            let raw = pair.as_str();
+            let inner = &raw[1..raw.len() - 1];
+            // The string is emitted verbatim into a generated Rust `"..."`.
+            // rsbinder intentionally allows non-ASCII (UTF-8) here — e.g.
+            // `const String MSG = "한글";` — because it round-trips as a valid
+            // Rust string literal (more lenient than AOSP `isValidLiteralChar`,
+            // which rejects non-ASCII). But a control byte or a backslash would
+            // be emitted verbatim and fail to compile (a raw `\X` is not
+            // necessarily a valid Rust escape; rsbinder does not decode string
+            // escapes). Reject only those at parse time.
+            if let Some(bad) = inner.bytes().find(|&b| b < 0x20 || b == 0x7f || b == b'\\') {
+                return Err(make_parse_error(
+                    format!(
+                        "invalid byte 0x{bad:02x} in string literal: control characters and \
+                         backslash escapes are not allowed (non-ASCII text is permitted)"
+                    ),
+                    span.start(),
+                    span.end(),
+                ));
+            }
+            Ok(ConstExpr::new(ValueType::String(inner.into())))
         }
-        Rule::qualified_name => ConstExpr::new(ValueType::Name(pair.as_str().into())),
+        Rule::qualified_name => Ok(ConstExpr::new(ValueType::Name(pair.as_str().into()))),
         _ => unreachable!("Unexpected rule in Rule::parse_string_term: {}", pair),
     }
 }
@@ -1394,7 +1414,7 @@ fn parse_string_expr(pairs: pest::iterators::Pairs<Rule>) -> Result<ConstExpr, A
     for pair in pairs {
         match pair.as_rule() {
             Rule::string_term => {
-                let term = parse_string_term(pair.into_inner().next().unwrap());
+                let term = parse_string_term(pair.into_inner().next().unwrap())?;
                 expr = match expr {
                     Some(expr) => Some(ConstExpr::new_expr(expr, "+", term)),
                     None => Some(term),
@@ -1450,8 +1470,13 @@ fn parse_const_expr(pair: pest::iterators::Pair<Rule>) -> Result<ConstExpr, Aidl
                     .chars()
                     .next()
                     .ok_or_else(|| make_parse_error("empty char escape", start, end))?;
-                // Map the common C/AIDL escape sequences to their actual code
+                // Map the supported C/AIDL escape sequences to their actual code
                 // points (e.g. `'\n'` becomes newline, not the literal 'n').
+                // rsbinder intentionally supports these (more lenient than AOSP,
+                // which only allows `'\0'`). An unrecognized escape used to fall
+                // through to the post-backslash char verbatim — silently
+                // producing the wrong code point (`'\a'` -> 'a' = 97, not bell).
+                // Reject it instead.
                 match esc {
                     'n' => '\n',
                     't' => '\t',
@@ -1460,7 +1485,13 @@ fn parse_const_expr(pair: pest::iterators::Pair<Rule>) -> Result<ConstExpr, Aidl
                     '\\' => '\\',
                     '\'' => '\'',
                     '"' => '"',
-                    other => other,
+                    other => {
+                        return Err(make_parse_error(
+                            format!("unsupported char escape '\\{other}'"),
+                            start,
+                            end,
+                        ))
+                    }
                 }
             } else {
                 inner

--- a/rsbinder-aidl/tests/test_parse_errors.rs
+++ b/rsbinder-aidl/tests/test_parse_errors.rs
@@ -118,3 +118,60 @@ fn test_error_span_points_to_correct_location() {
         panic!("Expected AidlError::Parse, got: {err:?}");
     }
 }
+
+// AIDL-3 / AIDL-5: a backslash or control byte in a String constant would be
+// emitted verbatim into the generated Rust `"..."` and fail to compile (a raw
+// `\X` is not necessarily a valid Rust escape; rsbinder does not decode string
+// escapes). They are rejected at parse time. Non-ASCII (UTF-8) text stays
+// valid — rsbinder is intentionally more lenient than AOSP there.
+#[test]
+fn test_string_constant_backslash_or_control_rejected() {
+    for src in [
+        r#"parcelable P { const String S = "a\nb"; }"#, // backslash-n (not decoded)
+        r#"parcelable P { const String S = "a\\b"; }"#, // literal backslash
+        r#"parcelable P { const String S = "a\"b"; }"#, // escaped quote (AIDL-5 grammar)
+    ] {
+        let err = expect_parse_error(src, "test.aidl");
+        assert!(matches!(&err, AidlError::Parse(_)), "src: {src}");
+    }
+    // Non-ASCII text and plain ASCII stay valid.
+    for src in [
+        r#"parcelable P { const String S = "한글 테스트"; }"#,
+        r#"parcelable P { const String S = "plain ascii"; }"#,
+    ] {
+        let ctx = SourceContext::new("test.aidl", src);
+        assert!(
+            parse_document(&ctx).is_ok(),
+            "string constant must still parse: {src}"
+        );
+    }
+}
+
+// AIDL-4: an unsupported char escape used to fall through to the post-backslash
+// char verbatim, silently producing the wrong code point (`'\a'` -> 'a' = 97,
+// not bell = 7). It is now rejected. The supported escapes still decode and a
+// plain char still parses.
+#[test]
+fn test_char_constant_unknown_escape_rejected() {
+    for src in [
+        r#"interface I { const char C = '\a'; }"#,
+        r#"interface I { const char C = '\f'; }"#,
+        r#"interface I { const char C = '\v'; }"#,
+        r#"interface I { const char C = '\b'; }"#,
+    ] {
+        let err = expect_parse_error(src, "test.aidl");
+        assert!(matches!(&err, AidlError::Parse(_)), "src: {src}");
+    }
+    for src in [
+        r#"interface I { const char C = '\n'; }"#,
+        r#"interface I { const char C = '\t'; }"#,
+        r#"interface I { const char C = '\0'; }"#,
+        r#"interface I { const char C = 'A'; }"#,
+    ] {
+        let ctx = SourceContext::new("test.aidl", src);
+        assert!(
+            parse_document(&ctx).is_ok(),
+            "supported char literal must still parse: {src}"
+        );
+    }
+}

--- a/rsbinder-aidl/tests/test_review_regressions.rs
+++ b/rsbinder-aidl/tests/test_review_regressions.rs
@@ -119,3 +119,32 @@ fn negative_byte_array_default_emits_unsigned() {
         "no negated literal may remain in a u8 byte array (got: {packed})"
     );
 }
+
+/// AIDL-2: a float/double field default that folds to a non-finite value
+/// (e.g. `1.0e400` parses to infinity) must emit a valid Rust float constant
+/// (`f64::INFINITY` / `f32::INFINITY` / `NAN`), not `inff64` / `NaNf32` which
+/// do not compile. Finite defaults keep the suffixed-decimal form.
+#[test]
+fn non_finite_float_default_emits_valid_constant() {
+    let out =
+        generate_str("parcelable P { double d = 1.0e400; float f = 1.0e400; double n = 1.0; }")
+            .expect("must generate");
+    let packed = out.replace([' ', '\n'], "");
+    assert!(
+        packed.contains("f64::INFINITY"),
+        "double infinity default must emit f64::INFINITY (got: {packed})"
+    );
+    assert!(
+        packed.contains("f32::INFINITY"),
+        "float infinity default must emit f32::INFINITY (got: {packed})"
+    );
+    assert!(
+        !packed.contains("inff64") && !packed.contains("inff32"),
+        "no `inff64`/`inff32` token may remain (got: {packed})"
+    );
+    // A finite default is untouched.
+    assert!(
+        packed.contains("1f64") || packed.contains("1.0f64") || packed.contains("1f64"),
+        "finite double default keeps suffixed-decimal form (got: {packed})"
+    );
+}

--- a/rsbinder-aidl/tests/test_review_regressions.rs
+++ b/rsbinder-aidl/tests/test_review_regressions.rs
@@ -8,12 +8,18 @@
 
 /// Returns `true` only when BOTH parsing and code generation succeed.
 fn generate_ok(input: &str) -> bool {
+    generate_str(input).is_some()
+}
+
+/// Returns the generated Rust source (the `.1` of `Generator::document`) when
+/// parse + generation both succeed. NOTE: the generator does not type-check its
+/// output, so this succeeding does not prove the emitted Rust *compiles* — use
+/// it to assert on the emitted text directly.
+fn generate_str(input: &str) -> Option<String> {
     let ctx = rsbinder_aidl::SourceContext::new("test.aidl", input);
-    let Ok(document) = rsbinder_aidl::parse_document(&ctx) else {
-        return false;
-    };
+    let document = rsbinder_aidl::parse_document(&ctx).ok()?;
     let gen = rsbinder_aidl::Generator::new(false, false);
-    gen.document(&document).is_ok()
+    gen.document(&document).ok().map(|(_, rust)| rust)
 }
 
 /// M-6: a `List<T[]>` (list-of-array) is grammar-valid but used to hit the
@@ -87,5 +93,29 @@ fn empty_brace_initializer_is_rejected_not_panicked() {
     assert!(
         generate_ok("parcelable P { int[] x = {}; }"),
         "a legitimate empty-array initializer must still generate"
+    );
+}
+
+/// AIDL-1: a negative byte literal inside an array default must be re-emitted
+/// as its unsigned `u8` representation (AOSP `aidl_to_rust.cpp`). The array's
+/// Rust element type is `u8` (i8 maps to u8 via `array_type_name`), which
+/// cannot hold a negated literal, so the previous `[-1, ...]` / `vec![-1, ...]`
+/// output did not compile. Positive bytes are unchanged.
+#[test]
+fn negative_byte_array_default_emits_unsigned() {
+    let out = generate_str("parcelable P { byte[] a = {-1, -2, 3}; byte[2] f = {-1, 127}; }")
+        .expect("must generate");
+    let packed = out.replace([' ', '\n'], "");
+    assert!(
+        packed.contains("vec![255,254,3,]"),
+        "Vec<u8> byte default must reinterpret negatives as u8 (got: {packed})"
+    );
+    assert!(
+        packed.contains("[255,127,]"),
+        "[u8; N] byte default must reinterpret negatives as u8 (got: {packed})"
+    );
+    assert!(
+        !packed.contains("vec![-1,") && !packed.contains("[-1,"),
+        "no negated literal may remain in a u8 byte array (got: {packed})"
     );
 }

--- a/rsbinder-tools/src/bin/rsb_hub.rs
+++ b/rsbinder-tools/src/bin/rsb_hub.rs
@@ -120,6 +120,24 @@ fn lock_recover<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 /// legitimate caller hits it.
 const MAX_CALLBACKS_PER_NAME: usize = 256;
 
+/// Upper bound on the number of *distinct service names* held in each registry
+/// map (`name_to_service`, `name_to_registration_callbacks`,
+/// `name_to_client_callbacks`). `MAX_CALLBACKS_PER_NAME` caps callbacks per
+/// name but not the number of names, so without this a single client could
+/// loop over distinct names (`addService("svc.{i}")`,
+/// `registerForNotifications("svc.{i}")`, ...) and grow the heap without bound.
+/// Like `MAX_CALLBACKS_PER_NAME`, this is the defense in place of the
+/// SELinux/uid admission AOSP relies on and rsb_hub lacks. Generous enough that
+/// no real device (a few hundred services) hits it.
+const MAX_DISTINCT_NAMES: usize = 10_000;
+
+/// True when inserting `name` would add a *new* distinct key to a registry
+/// `map` that already holds `MAX_DISTINCT_NAMES` names. Overwriting an existing
+/// key never grows the map, so it is always allowed. Factored out for testing.
+fn distinct_name_cap_exceeded<V>(map: &HashMap<String, V>, name: &str) -> bool {
+    !map.contains_key(name) && map.len() >= MAX_DISTINCT_NAMES
+}
+
 struct Inner {
     death_recipient: Arc<DeathRecipientWrapper>,
     name_to_service: HashMap<String, Service>,
@@ -668,6 +686,17 @@ impl IServiceManager for ServiceManager {
             let mut inner = lock_recover(&self.inner);
             let recipient: Arc<dyn rsbinder::DeathRecipient> = inner.death_recipient.clone();
 
+            // distinct-name DoS cap: refuse a *new* service name once the
+            // registry is full (overwriting an existing name never grows the
+            // map, so it is still allowed). See `MAX_DISTINCT_NAMES`.
+            if distinct_name_cap_exceeded(&inner.name_to_service, name) {
+                log::warn!(
+                    "addService: service registry full (max {MAX_DISTINCT_NAMES} names), \
+                     rejecting new name '{name}'"
+                );
+                return Err(ExceptionCode::IllegalState.into());
+            }
+
             let mut prev_clients = false;
             // `SIBinder: PartialEq` is `Arc::ptr_eq`, so this is binder
             // identity: is the *same* object being re-registered under this
@@ -863,6 +892,16 @@ impl IServiceManager for ServiceManager {
                 }
             }
 
+            // distinct-name DoS cap (orthogonal to the per-name cap above):
+            // refuse a *new* name once the map is full. See `MAX_DISTINCT_NAMES`.
+            if distinct_name_cap_exceeded(&inner.name_to_registration_callbacks, name) {
+                let msg = format!(
+                    "registerForNotifications: name registry full (max {MAX_DISTINCT_NAMES})"
+                );
+                log::warn!("{}", &msg);
+                return Err((ExceptionCode::IllegalState, msg.as_str()).into());
+            }
+
             arg_callback.as_binder().link_to_death(Arc::downgrade(
                 &(inner.death_recipient.clone() as Arc<dyn rsbinder::DeathRecipient>),
             ))?;
@@ -1004,6 +1043,18 @@ impl IServiceManager for ServiceManager {
                     log::warn!("{}", &msg);
                     return Err((ExceptionCode::IllegalState, msg.as_str()).into());
                 }
+            }
+
+            // distinct-name DoS cap. Defense-in-depth: client callbacks require
+            // a registered service (checked above), so this map's names are
+            // already a subset of the service-name map, which is itself capped —
+            // but bound it explicitly to stay robust. See `MAX_DISTINCT_NAMES`.
+            if distinct_name_cap_exceeded(&inner.name_to_client_callbacks, name) {
+                let msg = format!(
+                    "registerClientCallback: name registry full (max {MAX_DISTINCT_NAMES})"
+                );
+                log::warn!("{}", &msg);
+                return Err((ExceptionCode::IllegalState, msg.as_str()).into());
             }
 
             arg_callback.as_binder().link_to_death(Arc::downgrade(
@@ -1351,5 +1402,35 @@ mod tests {
         // Non-ASCII (Unicode lowercase letters not in `[a-z]`).
         assert!(!ServiceManager::is_valid_service_name("테스트"));
         assert!(!ServiceManager::is_valid_service_name("café"));
+    }
+
+    /// HUB-1: the distinct-name cap rejects a *new* name once a registry map is
+    /// full, but always allows overwriting an existing name (which does not
+    /// grow the map). Bounds the unbounded heap growth a client could cause by
+    /// looping over distinct service names — the per-name cap does not cover
+    /// the distinct-name axis.
+    #[test]
+    fn distinct_name_cap_rejects_new_but_allows_existing() {
+        // Below capacity: any name is allowed.
+        let mut small: HashMap<String, ()> = HashMap::new();
+        small.insert("a".to_owned(), ());
+        assert!(!distinct_name_cap_exceeded(&small, "a"));
+        assert!(!distinct_name_cap_exceeded(&small, "brand-new"));
+
+        // Fill exactly to capacity with distinct names.
+        let mut full: HashMap<String, ()> = HashMap::new();
+        for i in 0..MAX_DISTINCT_NAMES {
+            full.insert(format!("svc.{i}"), ());
+        }
+        assert_eq!(full.len(), MAX_DISTINCT_NAMES);
+
+        // A new name is rejected once full...
+        assert!(distinct_name_cap_exceeded(&full, "one-too-many"));
+        // ...but overwriting an existing name is still allowed.
+        assert!(!distinct_name_cap_exceeded(&full, "svc.0"));
+        assert!(!distinct_name_cap_exceeded(
+            &full,
+            &format!("svc.{}", MAX_DISTINCT_NAMES - 1)
+        ));
     }
 }

--- a/rsbinder/src/binder_object.rs
+++ b/rsbinder/src/binder_object.rs
@@ -32,9 +32,14 @@ impl flat_binder_object {
             hdr: binder_object_header {
                 type_: BINDER_TYPE_FD,
             },
-            flags: 0x7F | FLAT_BINDER_FLAG_ACCEPTS_FDS,
-            // Init via the 8-byte `binder` field (not the u32 `handle`) so the upper bytes are zeroed:
-            // mirrors AOSP Parcel.cpp `obj.binder = 0; obj.handle = fd;`, avoids leaking uninit stack to the remote.
+            // AOSP `Parcel::writeFileDescriptor` (kernel arm) sets `obj.flags = 0`
+            // for a `BINDER_TYPE_FD` object: it bypasses `flattenBinder`, so neither
+            // schedBits nor `ACCEPTS_FDS` apply. The kernel ignores this field for FD
+            // objects (it rewrites the object on delivery), but match AOSP exactly.
+            flags: 0,
+            // Init via the 8-byte `binder` field (not the u32 `handle`) so the upper bytes
+            // are zeroed: mirrors AOSP `obj.binder = 0; obj.handle = fd;`, avoids leaking
+            // uninit stack to the remote.
             __bindgen_anon_1: flat_binder_object__bindgen_ty_1 {
                 binder: (fd as u32) as u64,
             },
@@ -203,6 +208,9 @@ impl From<&SIBinder> for flat_binder_object {
                 hdr: binder_object_header {
                     type_: BINDER_TYPE_HANDLE,
                 },
+                // AOSP-correct: `flattenBinder`'s HANDLE arm sets `obj.flags = 0`,
+                // then applies `obj.flags |= schedBits` after both arms, so the
+                // final value is `0 | schedBits` == `sched_bits`. Do not "fix" to 0.
                 flags: sched_bits,
                 __bindgen_anon_1: flat_binder_object__bindgen_ty_1 {
                     handle: proxy.handle(),
@@ -303,45 +311,36 @@ pub(crate) fn write_flat_binder(
 mod tests {
     use super::*;
 
-    /// Regression guard for the `new_with_fd` construction fix.
+    /// Regression guard for `new_with_fd`.
     ///
-    /// Two distinct defects were present before the fix:
+    /// `flags` must be `0`: AOSP `Parcel::writeFileDescriptor` (kernel arm)
+    /// writes `obj.flags = 0` for a `BINDER_TYPE_FD` object — it bypasses
+    /// `flattenBinder`, so no schedBits / `ACCEPTS_FDS`. An earlier change set
+    /// `0x7F | ACCEPTS_FDS` (= `0x17F`) and this test asserted it as
+    /// "byte-identical to AOSP" — it was not. The kernel ignores the field for
+    /// FD objects so nothing broke functionally, but it diverged on the wire.
+    /// Like the ParcelableHolder stability case, an rsbinder<->rsbinder round
+    /// trip cannot catch a wrong-but-symmetric flags value, so this asserts the
+    /// AOSP golden byte (`0`) directly.
     ///
-    ///  1. `flags: 0x7F & FLAT_BINDER_FLAG_ACCEPTS_FDS` — a bitwise AND
-    ///     between disjoint bit ranges (`0x7F` vs `0x100`) is always 0,
-    ///     so every FD object went on the wire with `flags == 0`. The
-    ///     fix is `0x7F | FLAT_BINDER_FLAG_ACCEPTS_FDS`, byte-identical
-    ///     to AOSP `Parcel::writeFileDescriptor`.
-    ///  2. The union was initialized via the u32 `handle` variant, so
-    ///     the upper 4 bytes of the 8-byte `binder` field were left
-    ///     uninitialized and leaked uninitialized stack to the remote
-    ///     (Rust UB). The fix initializes the full-width `binder` field
-    ///     so the upper bytes are guaranteed zero.
+    /// Also guards the full-width union init: the 8-byte `binder` field must be
+    /// written (not the u32 `handle` variant) so the upper 4 bytes are zero and
+    /// no uninitialized stack leaks to the remote.
     #[test]
-    fn new_with_fd_flags_and_full_width_init() {
+    fn new_with_fd_flags_zero_and_full_width_init() {
         let fd: i32 = 7;
         let obj = flat_binder_object::new_with_fd(fd, false);
 
         assert_eq!(obj.header_type(), BINDER_TYPE_FD, "must be a FD object");
 
-        // Defect 1: flags must be the OR (0x7F | 0x100 == 0x17F), never 0.
+        // AOSP writeFileDescriptor sets flags = 0 for FD objects.
         assert_eq!(
-            obj.flags,
-            0x7F | FLAT_BINDER_FLAG_ACCEPTS_FDS,
-            "flags must be 0x7F | FLAT_BINDER_FLAG_ACCEPTS_FDS (regression: was 0x7F & ... == 0)"
-        );
-        assert_ne!(
             obj.flags, 0,
-            "AND-instead-of-OR regression: flags collapsed to 0"
-        );
-        assert_eq!(
-            obj.flags & FLAT_BINDER_FLAG_ACCEPTS_FDS,
-            FLAT_BINDER_FLAG_ACCEPTS_FDS,
-            "ACCEPTS_FDS bit must be set"
+            "FD object flags must be 0 (AOSP Parcel::writeFileDescriptor)"
         );
 
-        // Defect 2: the full 8-byte union must equal exactly `fd` with a
-        // zeroed upper half — no uninitialized stack bytes leaked.
+        // The full 8-byte union must equal exactly `fd` with a zeroed upper
+        // half — no uninitialized stack bytes leaked.
         assert_eq!(
             obj.pointer(),
             fd as u32 as u64,

--- a/rsbinder/src/parcelable_holder.rs
+++ b/rsbinder/src/parcelable_holder.rs
@@ -208,10 +208,10 @@ impl Deserialize for ParcelableHolder {
 
     /// Read ONTO `self`, preserving its already-set stability. Plain
     /// `deserialize()` constructs a fresh `Local` holder, which then rejects a
-    /// higher wire stability — losing the `@VintfStability` (or vendor/system)
-    /// level a generated parcelable's `Default` assigned to a holder field.
-    /// Generated `read_from_parcel` reads holder fields via `read_onto` so this
-    /// override runs; mirrors AOSP's `field.readFromParcel(parcel)`.
+    /// `@VintfStability` wire stability — losing the level a generated
+    /// parcelable's `Default` assigned to a holder field. Generated
+    /// `read_from_parcel` reads holder fields via `read_onto` so this override
+    /// runs; mirrors AOSP's `field.readFromParcel(parcel)`.
     fn deserialize_from(&mut self, parcel: &mut Parcel) -> Result<()> {
         let status: i32 = parcel.read()?;
         if status == NULL_PARCELABLE_FLAG {
@@ -223,14 +223,31 @@ impl Deserialize for ParcelableHolder {
     }
 }
 
+/// Encode a holder's stability as AOSP's `Parcelable::Stability` enum
+/// (`STABILITY_LOCAL = 0`, `STABILITY_VINTF = 1`).
+///
+/// This is a *different* wire value from the binder-object
+/// `internal::Stability::Level` bitmask (0/3/12/63 via `From<Stability> for
+/// i32`) used on the `writeStrongBinder` path, and it is version-independent:
+/// `frameworks/native/libs/binder/ParcelableHolder.cpp` writes
+/// `writeInt32(static_cast<int32_t>(getStability()))` unchanged on every
+/// Android version (verified byte-identical between android-12 and android-16),
+/// with no `Category` repr or Android-12 `0x0c000000` adjustment. The AIDL
+/// `@VintfStability` annotation maps a holder field to `STABILITY_VINTF`
+/// (`system/tools/aidl` `generate_cpp.cpp`); everything else is
+/// `STABILITY_LOCAL`. Reusing the binder-object encoding here put 63 (and
+/// `0x0c00003f` on Android 12) on the wire where a real libbinder peer expects
+/// 1, so any `@VintfStability` holder field was rejected with `BAD_VALUE`.
+fn parcelable_stability_repr(stability: Stability) -> i32 {
+    match stability {
+        Stability::Vintf => 1, // STABILITY_VINTF
+        _ => 0,                // STABILITY_LOCAL
+    }
+}
+
 impl Parcelable for ParcelableHolder {
     fn write_to_parcel(&self, parcel: &mut Parcel) -> Result<()> {
-        // AOSP serializes the stability Level *bitmask* (0/3/12/63 via
-        // `From<Stability> for i32`), not the enum discriminant. Using
-        // `as i32` here wrote 0/1/2/3, so any non-Local holder (e.g. Vintf
-        // wrote 3 instead of 63) was rejected with BAD_VALUE by a real
-        // peer. Mirror the `.into()` used on the SIBinder path.
-        let stability: i32 = self.stability.into();
+        let stability = parcelable_stability_repr(self.stability);
         parcel.write(&stability)?;
 
         let mut data = self.data.lock().expect("Parcelable holder lock poisoned");
@@ -267,7 +284,7 @@ impl Parcelable for ParcelableHolder {
 
     fn read_from_parcel(&mut self, parcel: &mut Parcel) -> Result<()> {
         let wire_stability: i32 = parcel.read()?;
-        let local_stability: i32 = self.stability.into();
+        let local_stability = parcelable_stability_repr(self.stability);
         if local_stability != wire_stability {
             log::error!(
                 "ParcelableHolder::read_from_parcel: parcelable stability mismatch: {:?} != {:?}",
@@ -321,24 +338,52 @@ mod tests {
     use super::*;
 
     #[test]
-    fn empty_holder_serializes_stability_bitmask_not_discriminant() {
-        // A Vintf holder must serialize the AOSP Level bitmask (63), not
-        // the enum discriminant (3). An empty holder writes the stability
-        // followed by a 0 length; a real peer rejects a wrong stability
-        // value with BAD_VALUE, so this guards wire compatibility.
-        let holder = ParcelableHolder::new(Stability::Vintf);
-        let mut parcel = Parcel::new();
-        holder.write_to_parcel(&mut parcel).unwrap();
+    fn holder_serializes_parcelable_stability_not_binder_level_bitmask() {
+        // A `ParcelableHolder` writes AOSP's `Parcelable::Stability` enum
+        // (`STABILITY_LOCAL = 0`, `STABILITY_VINTF = 1`), NOT the binder-object
+        // `internal::Stability::Level` bitmask (0/3/12/63). A `@VintfStability`
+        // holder therefore puts `1` on the wire; a real libbinder peer rejects
+        // any other value (the old 63, or `0x0c00003f` on Android 12) with
+        // BAD_VALUE. Golden values verified against android-12 and android-16
+        // `frameworks/native/libs/binder/ParcelableHolder.cpp` + `Parcelable.h`
+        // and `system/tools/aidl` `generate_cpp.cpp` (vintf holder field init).
+        //
+        // This cannot be caught by rsbinder<->rsbinder round trips: both ends
+        // share the same encoding, so a wrong-but-symmetric value always
+        // agrees. Only a fixed golden byte (or real-libbinder interop) detects
+        // it — hence the explicit `== 1` / `== 0` assertions below.
+        let vintf = ParcelableHolder::new(Stability::Vintf);
+        let mut vp = Parcel::new();
+        vintf.write_to_parcel(&mut vp).unwrap();
+        vp.set_data_position(0);
+        let vintf_wire: i32 = vp.read().unwrap();
+        assert_eq!(
+            vintf_wire, 1,
+            "Vintf holder must serialize as STABILITY_VINTF (1)"
+        );
 
-        parcel.set_data_position(0);
-        let wire_stability: i32 = parcel.read().unwrap();
-        assert_eq!(wire_stability, 0b111111, "Vintf must serialize as 63");
-        let expected: i32 = Stability::Vintf.into();
-        assert_eq!(wire_stability, expected);
+        let local = ParcelableHolder::default();
+        let mut lp = Parcel::new();
+        local.write_to_parcel(&mut lp).unwrap();
+        lp.set_data_position(0);
+        let local_wire: i32 = lp.read().unwrap();
+        assert_eq!(
+            local_wire, 0,
+            "Local holder must serialize as STABILITY_LOCAL (0)"
+        );
 
-        // And the round-trip back into a same-stability holder accepts it.
-        parcel.set_data_position(0);
+        // Round-trip back into a same-stability holder accepts it.
+        vp.set_data_position(0);
         let mut dst = ParcelableHolder::new(Stability::Vintf);
-        dst.read_from_parcel(&mut parcel).unwrap();
+        dst.read_from_parcel(&mut vp).unwrap();
+
+        // The stability-mismatch guard still holds: a fresh Local holder must
+        // reject a Vintf (1) wire value with BadValue.
+        vp.set_data_position(0);
+        let mut local_dst = ParcelableHolder::default();
+        assert!(matches!(
+            local_dst.read_from_parcel(&mut vp),
+            Err(StatusCode::BadValue)
+        ));
     }
 }

--- a/scripts/ci_wait_test_service_ready.sh
+++ b/scripts/ci_wait_test_service_ready.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Wait until test_service[_async] has finished registering all of its services.
+#
+# The integration suite restarts the service immediately before each destructive
+# test. Checking only that the process is alive (`kill -0`) races with the
+# service's asynchronous `addService` calls, so a fail-fast `getService` in the
+# test can resolve nothing and panic ("did not get binder service"). The service
+# prints `TEST_SERVICE_READY` to stderr once every service is registered; poll
+# the (redirected) log for it, failing fast if the process dies or the marker
+# never shows up.
+#
+# Usage: ci_wait_test_service_ready.sh <service-log> <pid-file>
+set -u
+
+log="${1:?usage: $0 <service-log> <pid-file>}"
+pid_file="${2:?usage: $0 <service-log> <pid-file>}"
+marker="TEST_SERVICE_READY"
+deadline=$((SECONDS + 15))
+
+while ! grep -q "$marker" "$log" 2>/dev/null; do
+    if ! kill -0 "$(cat "$pid_file" 2>/dev/null)" 2>/dev/null; then
+        echo "::error::test service process died before registering"
+        cat "$log" 2>/dev/null || true
+        exit 1
+    fi
+    if [ "$SECONDS" -ge "$deadline" ]; then
+        echo "::error::test service did not register within 15s"
+        cat "$log" 2>/dev/null || true
+        exit 1
+    fi
+    sleep 0.1
+done
+
+echo "test service ready (all services registered)"

--- a/tests/src/bin/test_service.rs
+++ b/tests/src/bin/test_service.rs
@@ -884,5 +884,13 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     )
     .expect("Could not register service");
 
+    // Readiness signal for the integration harness: every service is now
+    // registered, so a client `getService` will resolve. Printed to stderr
+    // (unbuffered) so it reaches a redirected log immediately — `join_thread_pool`
+    // below never returns, so a buffered stdout line might never flush. CI
+    // restart steps poll for this marker instead of merely checking the process
+    // is alive, closing the restart→query race that fail-fast tests would lose.
+    eprintln!("TEST_SERVICE_READY: all services registered");
+
     Ok(ProcessState::join_thread_pool()?)
 }

--- a/tests/src/bin/test_service_async.rs
+++ b/tests/src/bin/test_service_async.rs
@@ -917,6 +917,11 @@ fn main() {
         hub::add_service(fixed_size_array_service_name, fixed_size_array_service.as_binder())
         .expect("Could not register service");
 
+        // Readiness signal for the integration harness (see test_service.rs):
+        // all services registered; stderr is unbuffered so it reaches a
+        // redirected log before `pending().await` blocks forever.
+        eprintln!("TEST_SERVICE_READY: all services registered");
+
         // By awaiting `pending`, we yield to the runtime. This results in the current-thread
         // runtime being driven by the current thread (the main thread in this case). E.g., this
         // means that anything spawned with `tokio::spawn` will run on this thread.


### PR DESCRIPTION
Multi-perspective source review (2026-06-07) of `rsbinder`, `rsbinder-aidl`, and `rsb_hub`. Each finding was confirmed against the AOSP source before fixing, and the batch is verified across macOS (hermetic), REMOTE_LINUX (kernel Rust binder e2e), and Android 16/12 emulators. One commit per finding.

## Parcel / wire compatibility

- **WP-1 — `ParcelableHolder` stability.** The holder serialized the binder-object `internal::Stability::Level` bitmask (`Vintf` = 63, plus the Android-12 `0x0c000000` repr) where AOSP `ParcelableHolder` writes the unrelated, version-independent `Parcelable::Stability` enum (`LOCAL` = 0, `VINTF` = 1). A `@VintfStability` holder therefore put 63 on the wire where a real libbinder peer expects 1 and rejected it with `BAD_VALUE`. Invisible to the suite because every holder test is rsbinder↔rsbinder (both ends shared the wrong-but-symmetric value); the old self-test even asserted 63. Now decoupled onto a holder-only 0/1 mapping with a golden byte-assert.
- **WP-2 — kernel FD object flags.** `new_with_fd` set `flags = 0x7F | ACCEPTS_FDS` (0x17F); AOSP `writeFileDescriptor` sets `0` for a `BINDER_TYPE_FD` object (it bypasses `flattenBinder`, so no schedBits/ACCEPTS_FDS). Functionally inert (the kernel ignores the field for FD objects) but a wire divergence, and the regression test again asserted the wrong value as "byte-identical". Now writes `0`. (The proxy HANDLE arm's `sched_bits` was checked and is already AOSP-correct — `flattenBinder` applies `|= schedBits` after both arms — so it is left as-is with a clarifying comment.)

## AIDL code generation (non-compiling output on accepted input)

- **AIDL-1 — negative byte array defaults.** `byte[] a = {-1}` emitted `vec![-1]: Vec<u8>` (E0600). Re-emit negatives as their unsigned `u8` representation (`-1` → `255`), mirroring AOSP `aidl_to_rust.cpp`.
- **AIDL-2 — non-finite float defaults.** A default folding to infinity/NaN (e.g. `double d = 1.0e400;`) emitted `inff64`/`NaNf32`. Now emits `f64::INFINITY` / `NEG_INFINITY` / `NAN` (and f32 variants).
- **AIDL-3/4/5 — string/char literal content.** Reject only content that yields non-compiling Rust: backslashes/control bytes in `String` constants, and unsupported char escapes (`\a \f \v \b`, which used to silently produce the wrong code point). The `C_STR` grammar is reordered so an escaped quote tokenizes cleanly. rsbinder's intentional extensions over AOSP are preserved — non-ASCII string constants (`"한글"`) and the supported `\n \t \r \0 \\ \' \"` char escapes still work.

## Service manager (`rsb_hub`)

- **HUB-1 — distinct-name registry cap.** `MAX_CALLBACKS_PER_NAME` bounded callbacks per name but not the number of distinct names, so one client could loop over distinct names and grow the hub's heap without bound (the hub is the single point of failure for device IPC, and Linux has no SELinux/uid admission). Add `MAX_DISTINCT_NAMES` (10,000) to `name_to_service`, `name_to_registration_callbacks`, and `name_to_client_callbacks`: a *new* name is rejected once the map is full, while overwriting an existing name (restarts, re-registration) stays allowed.

## Verification

- **macOS hermetic:** workspace `fmt`/`clippy` clean; `rsbinder-aidl`, `rsbinder-tools` (incl. the cap unit test), and `binder_object` tests all pass.
- **REMOTE_LINUX (kernel Rust binder):** `rsbinder` lib 189/0; `tests` crate kernel-binder e2e 138/0 + 6 ignored (including `test_repeat_extendable_parcelable_vintf` over real kernel binder, and a live `rsb_hub` confirming HUB-1 is non-regressive); `death_recipient` 2/0.
- **Emulator:** Android 16 (SDK 36) and Android 12 (SDK 31) `binder_object` 5/0 — the SDK 31 run confirms the WP-1 fix removed the Android-12 stability-repr entanglement from the holder path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)