### PR TITLE
fix: 13 findings from multi-agent source review

### DIFF
--- a/rsbinder-aidl/src/const_expr.rs
+++ b/rsbinder-aidl/src/const_expr.rs
@@ -323,12 +323,20 @@ impl ValueType {
                     Some(expr) => {
                         let calculated = expr.calculate()?;
                         if let ValueType::Name(_) = calculated.value {
+                            // Still a name after resolution ⇒ a circular
+                            // reference broke the cycle (tested graceful
+                            // degradation); fold to a neutral value.
                             Ok(false)
                         } else {
                             calculated.to_bool()
                         }
                     }
-                    None => Ok(false),
+                    // Genuinely unresolvable (typo / missing import). AOSP
+                    // rejects this at build time; surface a diagnostic instead
+                    // of fabricating `false`.
+                    None => Err(ConstExprError::new(format!(
+                        "cannot resolve constant reference '{name}'"
+                    ))),
                 }
             }
             ValueType::Expr { .. } | ValueType::Unary { .. } => {
@@ -365,7 +373,10 @@ impl ValueType {
                             calculated.to_f64()
                         }
                     }
-                    None => Ok(0.0),
+                    // See `to_bool`: unresolvable reference ⇒ diagnostic, not 0.
+                    None => Err(ConstExprError::new(format!(
+                        "cannot resolve constant reference '{name}'"
+                    ))),
                 }
             }
             ValueType::Expr { .. } | ValueType::Unary { .. } => {
@@ -404,7 +415,10 @@ impl ValueType {
                             calculated.to_i64()
                         }
                     }
-                    None => Ok(0),
+                    // See `to_bool`: unresolvable reference ⇒ diagnostic, not 0.
+                    None => Err(ConstExprError::new(format!(
+                        "cannot resolve constant reference '{name}'"
+                    ))),
                 }
             }
             ValueType::Reference { value, .. } => Ok(*value),
@@ -673,6 +687,24 @@ impl ValueType {
                 } else {
                     rhs_value as _
                 };
+
+                // The shift is computed in `i64` below but stored in the
+                // promoted operand type. AOSP rejects a shift amount
+                // `>= sizeof(T)*8` as "Constant expression computation
+                // overflows"; computing in i64 and truncating to the operand
+                // type instead silently miscompiles (e.g. `1 << 40` folds to
+                // 0). Reject an out-of-range amount up front to match AOSP.
+                let bits: u32 = match &promoted {
+                    ValueType::Int64(_) | ValueType::Reference { .. } => 64,
+                    // Int32 / Byte both integral-promote to `int` for the shift.
+                    _ => 32,
+                };
+                if rhs_value >= bits {
+                    return Err(ConstExprError::new(format!(
+                        "shift amount {rhs_value} out of range for operator '{operator}' \
+                         (operand width {bits} bits)"
+                    )));
+                }
 
                 let value = if is_shl {
                     lhs_value.wrapping_shl(rhs_value)

--- a/rsbinder-aidl/src/generator.rs
+++ b/rsbinder-aidl/src/generator.rs
@@ -1037,8 +1037,12 @@ impl Generator {
 
         let mut context = self.new_context();
 
-        context.insert("mod", &decl.name);
-        context.insert("name", &decl.name);
+        // Escape a Rust-keyword interface name (AIDL permits it) so the
+        // generated `pub mod` / `pub trait` compiles. `bn_name`/`bp_name` are
+        // `Bn`/`Bp`-prefixed and thus never keywords.
+        let escaped_name = crate::escape_rust_keyword(&decl.name);
+        context.insert("mod", &escaped_name);
+        context.insert("name", &escaped_name);
         context.insert("namespace", &namespace);
         context.insert("const_members", &const_members);
         context.insert("fn_members", &fn_members);
@@ -1173,8 +1177,11 @@ pub mod {mod} {{
 
         let mut context = self.new_context();
 
-        context.insert("mod", &decl.name);
-        context.insert("name", &decl.name);
+        // Escape a Rust-keyword parcelable name so `pub mod` / `pub struct`
+        // compiles.
+        let escaped_name = crate::escape_rust_keyword(&decl.name);
+        context.insert("mod", &escaped_name);
+        context.insert("name", &escaped_name);
         context.insert("derive", &parser::rust_derive_list(&decl.annotation_list));
         context.insert("namespace", &namespace);
         context.insert("members", &members);
@@ -1257,7 +1264,9 @@ pub mod {mod} {{
 
         let mut context = self.new_context();
 
-        context.insert("mod", &decl.name);
+        // The enum *name* is `r#`-escaped in the template; escape the module
+        // name (which is not) for a Rust-keyword enum name.
+        context.insert("mod", &crate::escape_rust_keyword(&decl.name));
         context.insert("enum_name", &decl.name);
         context.insert(
             "enum_type",
@@ -1340,7 +1349,9 @@ pub mod {mod} {{
 
         let mut context = self.new_context();
 
-        context.insert("mod", &decl.name);
+        // The union *name* is `r#`-escaped in the template; escape the module
+        // name (which is not) for a Rust-keyword union name.
+        context.insert("mod", &crate::escape_rust_keyword(&decl.name));
         context.insert("union_name", &decl.name);
         context.insert("derive", &parser::rust_derive_list(&decl.annotation_list));
         context.insert("namespace", &namespace);

--- a/rsbinder-aidl/src/lib.rs
+++ b/rsbinder-aidl/src/lib.rs
@@ -67,7 +67,15 @@ impl Namespace {
         curr_ns.drain(0..index_to_remove);
         target_ns.drain(0..index_to_remove);
 
-        "super::".repeat(curr_ns.len()) + &target_ns.join(Self::RUST)
+        // Escape any path segment that is a Rust keyword (an AIDL type used as
+        // a module here, e.g. a parcelable named `match`) so the reference
+        // compiles; non-keyword segments are unchanged.
+        let target_path = target_ns
+            .iter()
+            .map(|seg| escape_rust_keyword(seg))
+            .collect::<Vec<_>>()
+            .join(Self::RUST);
+        "super::".repeat(curr_ns.len()) + &target_path
     }
 }
 
@@ -81,6 +89,34 @@ impl Namespace {
 /// import still surfaces as `ResolutionError::ImportNotFound`.
 pub(crate) fn is_builtin_aidl_type(fqcn: &str) -> bool {
     matches!(fqcn, "android.os.ParcelFileDescriptor")
+}
+
+/// Wrap `ident` as a Rust raw identifier (`r#ident`) iff it is a Rust keyword
+/// that would otherwise fail to compile as a plain identifier.
+///
+/// AIDL's identifier grammar permits type and member names that are Rust
+/// keywords (`type`, `loop`, `match`, `move`, `impl`, …); the generated
+/// `mod` / `struct` / `trait` declarations and the `::`-joined reference paths
+/// that name them must escape those, exactly as AOSP's Rust backend does
+/// (`pub struct r#<Name>`, `::r#<segment>`). `crate`, `self`, `Self` and
+/// `super` cannot be raw identifiers — and are meaningful path keywords — so
+/// they are returned unchanged. Non-keyword identifiers are returned unchanged,
+/// so generated output for ordinary names is byte-for-byte identical.
+pub(crate) fn escape_rust_keyword(ident: &str) -> std::borrow::Cow<'_, str> {
+    // Strict + reserved Rust 2021 keywords, minus `crate`/`self`/`Self`/`super`
+    // (invalid as raw identifiers; never need escaping in our output).
+    const KEYWORDS: &[&str] = &[
+        "as", "async", "await", "break", "const", "continue", "dyn", "else", "enum", "extern",
+        "false", "fn", "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut",
+        "pub", "ref", "return", "static", "struct", "trait", "true", "type", "unsafe", "use",
+        "where", "while", "abstract", "become", "box", "do", "final", "macro", "override", "priv",
+        "typeof", "unsized", "virtual", "yield", "try",
+    ];
+    if KEYWORDS.contains(&ident) {
+        std::borrow::Cow::Owned(format!("r#{ident}"))
+    } else {
+        std::borrow::Cow::Borrowed(ident)
+    }
 }
 
 pub fn indent_space(step: usize) -> String {

--- a/rsbinder-aidl/src/parser.rs
+++ b/rsbinder-aidl/src/parser.rs
@@ -2259,6 +2259,15 @@ fn calculate_namespace(
 /// [`check_nesting_depth`].
 const MAX_NESTING_DEPTH: usize = 256;
 
+/// Maximum number of operator tokens accepted in a single statement/element
+/// (reset at `; , ( ) [ ] { }`). A const expression made of a long operator
+/// chain — `~~~~…~5` or `1+1+…+1` — contains no brackets, so it slips past the
+/// bracket/angle guard yet still drives one parser/walker recursion per
+/// operator and overflows the stack. This bounds that chain length: far above
+/// any legitimate expression (a few dozen OR'd flags at most), far below the
+/// multi-thousand recursion depth that aborts the process.
+const MAX_OPERATOR_RUN: usize = 1024;
+
 /// Pre-parse denial-of-service guard. pest's recursive-descent parser and
 /// the recursive AST walkers recurse once per nesting level, so deeply
 /// nested input (`((((...))))` or `List<List<...>>`) would overflow the
@@ -2276,6 +2285,7 @@ fn check_nesting_depth(source: &str) -> Option<usize> {
     let mut i = 0;
     let mut bracket_depth: usize = 0; // () [] {}
     let mut angle_depth: usize = 0; // <> generics
+    let mut op_run: usize = 0; // operator tokens in the current statement/element
     let next = |i: usize| bytes.get(i + 1).copied();
     while i < bytes.len() {
         match bytes[i] {
@@ -2309,24 +2319,49 @@ fn check_nesting_depth(source: &str) -> Option<usize> {
                 i += 2;
                 continue;
             }
-            b'(' | b'[' | b'{' => bracket_depth += 1,
-            b')' | b']' | b'}' => bracket_depth = bracket_depth.saturating_sub(1),
+            // A bracket / element / statement boundary begins a fresh
+            // sub-expression, so the operator run restarts here.
+            b'(' | b'[' | b'{' => {
+                bracket_depth += 1;
+                op_run = 0;
+            }
+            b')' | b']' | b'}' => {
+                bracket_depth = bracket_depth.saturating_sub(1);
+                op_run = 0;
+            }
+            b',' => op_run = 0,
             // `<<` shift / `<=` are not generic openers.
             b'<' if matches!(next(i), Some(b'<') | Some(b'=')) => {
+                if bytes[i + 1] == b'<' {
+                    op_run += 1; // `<<` drives one shift-recursion level
+                }
                 i += 2;
                 continue;
             }
             b'<' => angle_depth += 1,
             // `>>` shift / `>=` are not generic closers.
             b'>' if matches!(next(i), Some(b'>') | Some(b'=')) => {
+                if bytes[i + 1] == b'>' {
+                    op_run += 1;
+                }
                 i += 2;
                 continue;
             }
             b'>' => angle_depth = angle_depth.saturating_sub(1),
-            b';' => angle_depth = 0,
+            b';' => {
+                angle_depth = 0;
+                op_run = 0;
+            }
+            // Unary / binary operator tokens. Each drives one
+            // parser/walker recursion level, so a long unbracketed chain
+            // would overflow the stack — bound it via `op_run`.
+            b'+' | b'-' | b'*' | b'/' | b'%' | b'&' | b'|' | b'^' | b'!' | b'~' => op_run += 1,
             _ => {}
         }
-        if bracket_depth > MAX_NESTING_DEPTH || angle_depth > MAX_NESTING_DEPTH {
+        if bracket_depth > MAX_NESTING_DEPTH
+            || angle_depth > MAX_NESTING_DEPTH
+            || op_run > MAX_OPERATOR_RUN
+        {
             return Some(i);
         }
         i += 1;

--- a/rsbinder-aidl/src/type_generator.rs
+++ b/rsbinder-aidl/src/type_generator.rs
@@ -262,15 +262,16 @@ impl TypeGenerator {
             .expect("type must be resolved during code generation");
         let curr_ns = current_namespace();
         let ns = curr_ns.relative_mod(&lookup_decl.ns);
+        // Escape the simple type name if it is a Rust keyword (AIDL allows it)
+        // so the generated path / `Strong<dyn …>` / `Box<…>` compiles. The
+        // `relative_mod` module path is already keyword-escaped.
+        let simple = crate::escape_rust_keyword(lookup_decl.name.ns.last().unwrap());
         let name = if !ns.is_empty() {
-            format!("{}::{}", ns, lookup_decl.name.ns.last().unwrap())
+            format!("{ns}::{simple}")
+        } else if curr_ns.ns.last().unwrap() == lookup_decl.name.ns.last().unwrap().as_str() {
+            format!("Box<{simple}>") // To avoid, recursive type issue.
         } else {
-            let name: String = lookup_decl.name.ns.last().unwrap().to_owned();
-            if curr_ns.ns.last().unwrap() == name.as_str() {
-                format!("Box<{name}>") // To avoid, recursive type issue.
-            } else {
-                name
-            }
+            simple.into_owned()
         };
 
         match lookup_decl.decl {
@@ -1009,23 +1010,36 @@ impl TypeGenerator {
         }
 
         let scalar_param = param.with_fixed_array(false).with_nullable(false);
-        Ok(match expr.calculate() {
-            Ok(calculated) => match &calculated.value {
-                // An enum reference whose target is the enum type keeps the
-                // symbolic member; a primitive target (e.g. int) takes its value.
-                ValueType::Reference { value, .. } => {
-                    if matches!(&self.value_type, ValueType::UserDefined(_)) {
-                        calculated.value.to_init(scalar_param)
-                    } else {
-                        ValueType::Int64(*value).to_init(scalar_param)
-                    }
+        // Propagate an evaluation failure (an unresolvable reference inside a
+        // sub-expression, an overflowing shift, too-deep nesting) as a
+        // diagnostic instead of silently emitting a `0` default — AOSP rejects
+        // these at build time.
+        let calculated = expr
+            .calculate()
+            .map_err(|e| make_type_error(e.message, self.type_span))?;
+        // A value that is *still* a bare name means the reference does not
+        // resolve at all (typo / missing import); diagnose rather than baking a
+        // fabricated constant into the generated IPC code.
+        if let ValueType::Name(name) = &calculated.value {
+            return Err(make_type_error(
+                format!("cannot resolve constant reference '{name}'"),
+                self.type_span,
+            ));
+        }
+        Ok(match &calculated.value {
+            // An enum reference whose target is the enum type keeps the
+            // symbolic member; a primitive target (e.g. int) takes its value.
+            ValueType::Reference { value, .. } => {
+                if matches!(&self.value_type, ValueType::UserDefined(_)) {
+                    calculated.value.to_init(scalar_param)
+                } else {
+                    ValueType::Int64(*value).to_init(scalar_param)
                 }
-                _ => match calculated.convert_to(&self.value_type) {
-                    Ok(converted) => converted.value.to_init(scalar_param),
-                    Err(_) => calculated.value.to_init(scalar_param),
-                },
+            }
+            _ => match calculated.convert_to(&self.value_type) {
+                Ok(converted) => converted.value.to_init(scalar_param),
+                Err(_) => calculated.value.to_init(scalar_param),
             },
-            Err(_) => ValueType::Void.to_init(scalar_param),
         })
     }
 

--- a/rsbinder-aidl/tests/test_safety_fixes.rs
+++ b/rsbinder-aidl/tests/test_safety_fixes.rs
@@ -285,6 +285,116 @@ fn test_unknown_type_is_diagnostic_not_panic() {
 }
 
 #[test]
+fn test_operator_chain_rejected_before_stack_overflow() {
+    // A long *unbracketed* operator chain bypasses the bracket/angle nesting
+    // guard yet still drives one parser/walker recursion per operator. It must
+    // be rejected as an ordinary diagnostic, never overflow the stack (the
+    // chains here stay under the stack-overflow threshold but exceed
+    // `MAX_OPERATOR_RUN`, so the pre-parse guard rejects them).
+    let unary = "~".repeat(4000);
+    let unary_input = format!("package test.dos;\ninterface IFoo {{ const int X = {unary}5; }}");
+    assert!(
+        test_aidl_generation(&unary_input).is_err(),
+        "long unary operator chain must be rejected"
+    );
+
+    let binary = "1+".repeat(4000);
+    let binary_input = format!("package test.dos;\ninterface IFoo {{ const int X = {binary}1; }}");
+    assert!(
+        test_aidl_generation(&binary_input).is_err(),
+        "long binary operator chain must be rejected"
+    );
+
+    // A short chain still generates fine.
+    let ok =
+        test_aidl_generation("package test.dos;\ninterface IFoo { const int Y = 1 + 2 + 3 + 4; }")
+            .expect("short expression should generate");
+    assert!(ok.contains("r#Y"));
+}
+
+#[test]
+fn test_unresolvable_const_reference_is_diagnostic() {
+    // A typo'd / missing constant reference must surface a diagnostic instead
+    // of silently folding to 0 (AOSP hard-fails with "Can't find <name>").
+    // Covers both a bare reference and one inside an arithmetic expression.
+    for input in [
+        "package test.u;\ninterface IFoo { const int A = TYPO_NAME; }",
+        "package test.u;\ninterface IFoo { const int A = TYPO_NAME + 1; }",
+    ] {
+        assert!(
+            test_aidl_generation(input).is_err(),
+            "unresolvable const reference must error, input: {input}"
+        );
+    }
+
+    // A *circular* reference is still handled gracefully (it resolves to a
+    // neutral 0 via cycle-breaking, not a hard error) — distinct code path.
+    let circular = test_aidl_generation(
+        "package test.c;\ninterface IFoo { const int A = B; const int B = A; }",
+    );
+    assert!(
+        circular.is_ok(),
+        "circular reference must degrade gracefully, got: {circular:?}"
+    );
+}
+
+#[test]
+fn test_overflowing_shift_is_diagnostic() {
+    // `1 << 40` overflows the int32 shift operand type and is rejected by
+    // AOSP; rsbinder must not silently truncate it to 0. The declared `long`
+    // does not widen the shift (operands promote to int independently).
+    assert!(
+        test_aidl_generation("package test.s;\ninterface IFoo { const long C = 1 << 40; }")
+            .is_err(),
+        "out-of-range shift in a long const must error"
+    );
+    assert!(
+        test_aidl_generation("package test.s;\ninterface IFoo { const int A = 1 << 40; }").is_err(),
+        "out-of-range shift in an int const must error"
+    );
+
+    // An in-range shift still generates the correct value.
+    let ok = test_aidl_generation("package test.s;\ninterface IFoo { const int B = 1 << 4; }")
+        .expect("in-range shift should generate");
+    assert!(ok.contains("r#B"));
+    // `1L << 40` is valid (64-bit operand) and must keep working.
+    let wide = test_aidl_generation("package test.s;\ninterface IFoo { const long D = 1L << 40; }")
+        .expect("64-bit shift should generate");
+    assert!(wide.contains("r#D"));
+}
+
+#[test]
+fn test_rust_keyword_type_names_are_escaped() {
+    // AIDL permits type names that are Rust keywords (`type`, `loop`,
+    // `match`, …); the generated mod/struct/trait declarations AND the
+    // reference paths that name them must `r#`-escape so the output compiles
+    // (AOSP's Rust backend does the same). Previously only member names were
+    // escaped, so a keyword-named type emitted non-compiling Rust.
+    let parc = test_aidl_generation("package test.kw;\nparcelable type { int a; }")
+        .expect("keyword parcelable should generate");
+    assert!(parc.contains("pub mod r#type"), "got:\n{parc}");
+    assert!(parc.contains("pub struct r#type"), "got:\n{parc}");
+
+    let iface = test_aidl_generation("package test.kw;\ninterface loop { void foo(); }")
+        .expect("keyword interface should generate");
+    assert!(iface.contains("pub mod r#loop"), "got:\n{iface}");
+    assert!(iface.contains("pub trait r#loop"), "got:\n{iface}");
+
+    // Cross-reference: a field typed as a keyword-named parcelable must
+    // produce a fully `r#`-escaped path, never a bare keyword path.
+    let xref = test_aidl_generation(
+        "package test.kw;\nparcelable match { int a; }\nparcelable Holder { match m; }",
+    )
+    .expect("cross-reference to keyword type should generate");
+    assert!(
+        xref.contains("super::r#match::r#match"),
+        "cross-reference path not escaped, got:\n{xref}"
+    );
+    // An ordinary (non-keyword) name is untouched — no spurious escaping.
+    assert!(xref.contains("pub mod Holder"), "got:\n{xref}");
+}
+
+#[test]
 fn test_enum_array_default_initializers() {
     // Characterization: no golden test covered `init_enum_array_value` (enum
     // array field defaults). Pins both the non-nullable and nullable forms so

--- a/rsbinder-tools/src/bin/rsb_hub.rs
+++ b/rsbinder-tools/src/bin/rsb_hub.rs
@@ -902,9 +902,30 @@ impl IServiceManager for ServiceManager {
                 return Err((ExceptionCode::IllegalState, msg.as_str()).into());
             }
 
-            arg_callback.as_binder().link_to_death(Arc::downgrade(
-                &(inner.death_recipient.clone() as Arc<dyn rsbinder::DeathRecipient>),
-            ))?;
+            // Death-link dedup. rsb_hub links every accepted registration to a
+            // single shared `death_recipient`, and `ProxyHandle::link_to_death`
+            // does not dedup recipients, so linking the same callback binder
+            // under K distinct names would stack K identical death
+            // subscriptions and fire `binder_died` K times on death — K full
+            // O(maps) cleanup sweeps in the single death thread (a self-DoS
+            // bounded only by `MAX_DISTINCT_NAMES`). Link at most once per
+            // distinct callback binder; the per-name list still records it
+            // under every name, so cleanup still finds and removes all entries.
+            // The scan short-circuits on the first match, so the amplification
+            // case (one binder, many names) stays O(1) per registration after
+            // the initial link. Mirrors the `same_binder` relink guard in
+            // `addService`.
+            let cb_binder = arg_callback.as_binder();
+            let already_linked = inner
+                .name_to_registration_callbacks
+                .values()
+                .flatten()
+                .any(|c| c.as_binder() == cb_binder);
+            if !already_linked {
+                cb_binder.link_to_death(Arc::downgrade(
+                    &(inner.death_recipient.clone() as Arc<dyn rsbinder::DeathRecipient>),
+                ))?;
+            }
 
             inner
                 .name_to_registration_callbacks
@@ -1057,9 +1078,21 @@ impl IServiceManager for ServiceManager {
                 return Err((ExceptionCode::IllegalState, msg.as_str()).into());
             }
 
-            arg_callback.as_binder().link_to_death(Arc::downgrade(
-                &(inner.death_recipient.clone() as Arc<dyn rsbinder::DeathRecipient>),
-            ))?;
+            // Death-link dedup, same rationale as `registerForNotifications`:
+            // link the shared `death_recipient` at most once per distinct
+            // callback binder so registering one binder across K service names
+            // cannot stack K death subscriptions (K cleanup sweeps on death).
+            let cb_binder = arg_callback.as_binder();
+            let already_linked = inner
+                .name_to_client_callbacks
+                .values()
+                .flatten()
+                .any(|c| c.as_binder() == cb_binder);
+            if !already_linked {
+                cb_binder.link_to_death(Arc::downgrade(
+                    &(inner.death_recipient.clone() as Arc<dyn rsbinder::DeathRecipient>),
+                ))?;
+            }
 
             if service.has_clients {
                 pending.push(PendingCallback::Clients {

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -209,13 +209,6 @@ impl<T: Clone + Default> ParcelData<T> {
         }
     }
 
-    fn resize(&mut self, len: usize) {
-        match self {
-            ParcelData::Vec(v) => v.resize_with(len, Default::default),
-            _ => panic!("&[u8] can't support resize()."),
-        }
-    }
-
     fn capacity(&self) -> usize {
         match self {
             ParcelData::Vec(v) => v.capacity(),
@@ -306,6 +299,13 @@ struct RpcFields {
     /// recorded by the session directly (it owns the profile); only
     /// the FD path needs this Parcel-side flag.
     record_fd_positions: bool,
+    /// Session addresses of local binders that bumped their `timesSent`
+    /// (`RpcState::on_binder_leaving`) while being flattened into this
+    /// outgoing parcel. If the send then fails, the session rolls each back
+    /// (`cancel_binder_leaving`) so the unreceived binder's node does not leak.
+    /// Write-only on the success path (the peer's DEC balances the bumps), so
+    /// the wire is byte-unchanged.
+    leaving_addrs: Vec<crate::rpc::RpcAddress>,
 }
 
 /// The behaviour of the RPC serialization state lives here so that the
@@ -571,6 +571,26 @@ impl Parcel {
         if let Some(rpc) = self.rpc.as_mut() {
             rpc.object_positions = positions;
         }
+    }
+
+    /// Record that flattening a local binder into this outgoing RPC parcel
+    /// bumped its `timesSent` for the address `addr`, so a later send failure
+    /// can roll the bump back. No-op kernel-side.
+    #[cfg(feature = "rpc")]
+    pub(crate) fn rpc_record_leaving_addr(&mut self, addr: crate::rpc::RpcAddress) {
+        if let Some(rpc) = self.rpc.as_mut() {
+            rpc.leaving_addrs.push(addr);
+        }
+    }
+
+    /// The local-binder addresses whose `timesSent` this parcel bumped while
+    /// serializing (see [`Parcel::rpc_record_leaving_addr`]). Empty kernel-side
+    /// or when no local binder was flattened.
+    #[cfg(feature = "rpc")]
+    pub(crate) fn rpc_leaving_addrs(&self) -> &[crate::rpc::RpcAddress] {
+        self.rpc
+            .as_ref()
+            .map_or(&[], |r| r.leaving_addrs.as_slice())
     }
 
     /// AOSP `Parcel::unflattenBinder` v2 strict check: a binder may
@@ -1070,6 +1090,14 @@ impl Parcel {
         // masks the pad to zero as well. `set_len` only grows up to the
         // just-reserved capacity over now-initialized `u8` bytes.
         unsafe {
+            // Zero any `[len..pos]` gap left by a forward `set_data_position`
+            // before `set_len`, so an uninitialized hole is never exposed via
+            // `as_slice()` / transmitted to the peer (UB + info-leak). See
+            // `write_aligned_data` for the full rationale.
+            let old_len = self.data.len();
+            if pos > old_len {
+                std::ptr::write_bytes(self.data.as_mut_ptr().add(old_len), 0, pos - old_len);
+            }
             std::ptr::copy_nonoverlapping::<u8>(
                 parcelable.as_ptr() as _,
                 self.data.as_mut_ptr().add(pos),
@@ -1142,6 +1170,16 @@ impl Parcel {
         // info-leak to the peer. AOSP masks the pad to zero too. `set_len`
         // only grows up to the reserved capacity over now-initialized `u8`.
         unsafe {
+            // If the write cursor sits past the current end (a forward
+            // `set_data_position`), the skipped `[len..pos]` bytes were never
+            // initialized; zero them before `set_len` marks the region
+            // initialized, otherwise `as_slice()` / `data_size()` would expose
+            // uninitialized heap to the peer (UB + info-leak). AOSP `growData`
+            // zero-fills grown capacity the same way.
+            let old_len = self.data.len();
+            if pos > old_len {
+                std::ptr::write_bytes(self.data.as_mut_ptr().add(old_len), 0, pos - old_len);
+            }
             std::ptr::copy_nonoverlapping::<u8>(
                 data.as_ptr(),
                 self.data.as_mut_ptr().add(pos),
@@ -1303,6 +1341,13 @@ impl Parcel {
         // are distinct parcels (non-overlapping). `set_len` only grows up to
         // the reserved capacity over the `u8` bytes just copied.
         unsafe {
+            // Zero any `[len..pos]` gap from a forward `set_data_position`
+            // before `set_len` so an uninitialized hole is never exposed /
+            // transmitted (UB + info-leak). See `write_aligned_data`.
+            let old_len = self.data.len();
+            if self.pos > old_len {
+                std::ptr::write_bytes(self.data.as_mut_ptr().add(old_len), 0, self.pos - old_len);
+            }
             std::ptr::copy_nonoverlapping::<u8>(
                 other.data.as_slice()[offset..offset + size].as_ptr(),
                 self.data.as_mut_ptr().add(self.pos),
@@ -1324,26 +1369,43 @@ impl Parcel {
         let skip_objects = false;
 
         if num_objects > 0 && !skip_objects {
-            let start = self.objects.len();
-            self.objects.resize(start + (num_objects as usize));
+            self.objects.reserve(num_objects as usize);
 
             // Recompute each offset from the SOURCE table position
-            // (`other.objects`), then store the relocated offset into the
-            // destination table. AOSP: `off = pos - offset + startPos`.
+            // (`other.objects`). AOSP: `off = pos - offset + startPos`.
+            //
+            // Commit the relocated offset into `self.objects` only AFTER the
+            // object is fully acquired and (for FDs) dup'd + rewritten with the
+            // destination's own fd. If `acquire()` or the FD dup fails, the
+            // offset is never committed, so this parcel's `Drop`
+            // (`release_objects`) only ever iterates fully-acquired entries.
+            // Committing first (as before) left a half-built entry that still
+            // held the SOURCE's fd/handle bytes; on the drop that follows the
+            // `?` it would `release()` the source's still-owned fd
+            // (double-close) or decrement a refcount that was never incremented
+            // (underflow). AOSP's `appendFrom` is double-close-safe because it
+            // never aborts the loop; this push-after-success ordering achieves
+            // the same invariant by construction.
             let src_objects = other.objects.as_slice();
-            let dst_objects = self.objects.as_mut_slice();
-            for (idx, i) in (start..).zip(first_idx..=last_idx) {
+            for i in first_idx..=last_idx {
                 let off = src_objects[i as usize] as usize - offset + start_pos;
-                dst_objects[idx] = off as _;
                 let mut flat = read_flat_binder(self.data.as_slice(), off)?;
                 flat.acquire()?;
                 if flat.header_type() == BINDER_TYPE_FD {
-                    flat.set_handle(
-                        rustix::io::fcntl_dupfd_cloexec(flat.borrowed_fd(), 0)?.into_raw_fd() as _,
-                    );
+                    let newfd = match rustix::io::fcntl_dupfd_cloexec(flat.borrowed_fd(), 0) {
+                        Ok(newfd) => newfd,
+                        Err(e) => {
+                            // FD `acquire()` is a no-op, so nothing to undo; the
+                            // source's fd at `off` stays owned by the source
+                            // parcel (no double-close). Offset not committed.
+                            return Err(std::io::Error::from(e).into());
+                        }
+                    };
+                    flat.set_handle(newfd.into_raw_fd() as _);
                     flat.set_cookie(1);
                     write_flat_binder(self.data.as_mut_slice(), off, &flat)?;
                 }
+                self.objects.push(off as _);
             }
         }
 

--- a/rsbinder/src/proxy.rs
+++ b/rsbinder/src/proxy.rs
@@ -87,6 +87,12 @@ pub struct ProxyHandle {
     /// (`synthetic_proxy`) and by the construction-failure path where
     /// `inc_strong_handle` errored before the counter was bumped.
     count_acquired: AtomicBool,
+    /// True iff `on_proxy_create` incremented the per-uid tracking map for
+    /// this proxy (i.e. tracking was enabled at construction). `Drop` uses
+    /// this — not the live `COUNT_BY_UID_ENABLED` flag — to decide whether to
+    /// decrement the per-uid map, so toggling tracking off while the proxy is
+    /// live cannot desync the count (AOSP `BpBinder::mTrackedUid`).
+    counted_by_uid: AtomicBool,
     stability: Stability,
     /// Set once when `send_obituary` runs to publish "this proxy is
     /// dead" to all observers.
@@ -135,12 +141,13 @@ impl ProxyHandle {
         // a proxy that never reached `on_proxy_create`. The
         // `count_acquired` guard below is how `Drop` knows.
         thread_state::inc_strong_handle(handle)?;
-        crate::proxy_count::on_proxy_create(tracked_uid);
+        let counted_by_uid = crate::proxy_count::on_proxy_create(tracked_uid);
         Ok(Arc::new(Self {
             handle,
             descriptor,
             tracked_uid,
             count_acquired: AtomicBool::new(true),
+            counted_by_uid: AtomicBool::new(counted_by_uid),
             stability,
             obituary_sent: AtomicBool::new(false),
             recipients: RwLock::new(Vec::new()),
@@ -415,7 +422,10 @@ impl Drop for ProxyHandle {
         // and the `inc_strong_handle`-failure path leave the guard
         // `false`, so the proxy_count globals never see a phantom drop.
         if self.count_acquired.load(Ordering::Relaxed) {
-            crate::proxy_count::on_proxy_drop(self.tracked_uid);
+            crate::proxy_count::on_proxy_drop(
+                self.tracked_uid,
+                self.counted_by_uid.load(Ordering::Relaxed),
+            );
         }
     }
 }
@@ -671,6 +681,7 @@ mod tests {
             // `proxy_count::on_proxy_drop`, matching this constructor's
             // skip of `new_acquired`'s `on_proxy_create`.
             count_acquired: AtomicBool::new(false),
+            counted_by_uid: AtomicBool::new(false),
             stability: Stability::Local,
             obituary_sent: AtomicBool::new(obituary_sent),
             recipients: RwLock::new(Vec::new()),

--- a/rsbinder/src/proxy_count.rs
+++ b/rsbinder/src/proxy_count.rs
@@ -173,12 +173,18 @@ pub fn clear_count_by_uid() {
 /// the global counter (lock-free) and, if per-uid tracking is enabled,
 /// updates the uid map under the state mutex.
 ///
+/// Returns `true` iff the per-uid map was incremented (tracking was
+/// enabled at create time). The caller records this on the proxy so its
+/// `Drop` decrements the per-uid map iff this create did — binding the
+/// decision per-object (AOSP `mTrackedUid`) rather than re-reading the
+/// global flag, which would desync if tracking is toggled mid-flight.
+///
 /// Watermark callbacks fire after the mutex is dropped to support
 /// reentrant callback bodies (AOSP `postTask` discipline).
-pub(crate) fn on_proxy_create(uid: u32) {
+pub(crate) fn on_proxy_create(uid: u32) -> bool {
     PROXY_COUNT.fetch_add(1, Ordering::Relaxed);
     if !COUNT_BY_UID_ENABLED.load(Ordering::Relaxed) {
-        return;
+        return false;
     }
     let event = {
         let mut state = STATE.lock().expect("proxy_count state poisoned");
@@ -208,22 +214,29 @@ pub(crate) fn on_proxy_create(uid: u32) {
     if let Some((cb, event)) = event {
         cb(event);
     }
+    true
 }
 
 /// Internal hook called from `ProxyHandle::drop`. Decrements the
-/// global counter and, if per-uid tracking is enabled, decrements the
-/// uid map entry and clears **both** watermark debounce flags together
-/// once the count falls to/below `low`. Symmetric with
-/// [`on_proxy_create`].
+/// global counter and, iff this proxy's `on_proxy_create` incremented the
+/// per-uid map (`counted_by_uid`), decrements that entry and clears **both**
+/// watermark debounce flags together once the count falls to/below `low`.
+/// Symmetric with [`on_proxy_create`].
+///
+/// `counted_by_uid` is captured per-proxy at create time rather than
+/// re-reading `COUNT_BY_UID_ENABLED` here: if tracking is toggled off while a
+/// proxy is live, re-reading the live flag would skip the matching decrement
+/// and permanently inflate the uid's count (and latch its watermark). AOSP
+/// avoids this by deciding per-object via `BpBinder::mTrackedUid`.
 ///
 /// AOSP (`BpBinder.cpp`) resets `LIMIT_REACHED_MASK | WARNING_REACHED_MASK`
 /// jointly at `count <= low`. Clearing them at separate thresholds (warning
 /// at `< warning`, limit at `< low`) let the `Warning` callback re-fire on a
 /// `low <-> warning` oscillation, which AOSP never does — so we mirror the
 /// joint reset.
-pub(crate) fn on_proxy_drop(uid: u32) {
+pub(crate) fn on_proxy_drop(uid: u32, counted_by_uid: bool) {
     PROXY_COUNT.fetch_sub(1, Ordering::Relaxed);
-    if !COUNT_BY_UID_ENABLED.load(Ordering::Relaxed) {
+    if !counted_by_uid {
         return;
     }
     let mut state = STATE.lock().expect("proxy_count state poisoned");
@@ -270,10 +283,10 @@ mod tests {
         on_proxy_create(1000);
         on_proxy_create(2000);
         assert_eq!(get_binder_proxy_count(), 3);
-        on_proxy_drop(1000);
+        on_proxy_drop(1000, false);
         assert_eq!(get_binder_proxy_count(), 2);
-        on_proxy_drop(1000);
-        on_proxy_drop(2000);
+        on_proxy_drop(1000, false);
+        on_proxy_drop(2000, false);
         assert_eq!(get_binder_proxy_count(), 0);
     }
 
@@ -287,8 +300,8 @@ mod tests {
         assert_eq!(get_binder_proxy_count(), 2);
         assert_eq!(get_binder_proxy_count_for_uid(1000), 0);
         assert_eq!(get_binder_proxy_counts_by_uid(), vec![]);
-        on_proxy_drop(1000);
-        on_proxy_drop(2000);
+        on_proxy_drop(1000, false);
+        on_proxy_drop(2000, false);
     }
 
     #[test]
@@ -305,9 +318,9 @@ mod tests {
         let mut snap = get_binder_proxy_counts_by_uid();
         snap.sort_by_key(|(uid, _)| *uid);
         assert_eq!(snap, vec![(1000, 2), (2000, 1)]);
-        on_proxy_drop(1000);
-        on_proxy_drop(1000);
-        on_proxy_drop(2000);
+        on_proxy_drop(1000, true);
+        on_proxy_drop(1000, true);
+        on_proxy_drop(2000, true);
         // All counts at 0 → map entries removed.
         assert_eq!(get_binder_proxy_counts_by_uid(), vec![]);
     }
@@ -338,7 +351,7 @@ mod tests {
 
         // Drop to below low=2 → debounce clears; next climb fires again.
         for _ in 0..6 {
-            on_proxy_drop(1000);
+            on_proxy_drop(1000, true);
         }
         assert_eq!(get_binder_proxy_count_for_uid(1000), 1);
         on_proxy_create(1000); // 2
@@ -348,11 +361,11 @@ mod tests {
         let snap: Vec<_> = fired.lock().unwrap().clone();
         assert_eq!(snap.len(), 4, "re-fire after below-low reset: {snap:?}");
 
-        on_proxy_drop(1000);
-        on_proxy_drop(1000);
-        on_proxy_drop(1000);
-        on_proxy_drop(1000);
-        on_proxy_drop(1000);
+        on_proxy_drop(1000, true);
+        on_proxy_drop(1000, true);
+        on_proxy_drop(1000, true);
+        on_proxy_drop(1000, true);
+        on_proxy_drop(1000, true);
     }
 
     #[test]
@@ -370,8 +383,8 @@ mod tests {
         })));
         on_proxy_create(1000);
         on_proxy_create(1000); // should not deadlock
-        on_proxy_drop(1000);
-        on_proxy_drop(1000);
+        on_proxy_drop(1000, true);
+        on_proxy_drop(1000, true);
     }
 
     #[test]
@@ -387,7 +400,43 @@ mod tests {
         // Global counter is unaffected — it tracks live `ProxyHandle`s,
         // not the per-uid statistic.
         assert_eq!(get_binder_proxy_count(), 2);
-        on_proxy_drop(1000);
-        on_proxy_drop(2000);
+        on_proxy_drop(1000, true);
+        on_proxy_drop(2000, true);
+    }
+
+    #[test]
+    fn per_uid_count_survives_tracking_toggled_off_while_live() {
+        // Regression: `on_proxy_drop` must mirror what the proxy's
+        // `on_proxy_create` did (captured per-object), not re-read the live
+        // `COUNT_BY_UID_ENABLED`. Toggling tracking off while a counted proxy
+        // is alive previously skipped its decrement and permanently inflated
+        // the uid's count.
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_for_test();
+
+        enable_count_by_uid(true);
+        // Two proxies created while enabled → each captures counted_by_uid=true.
+        let c1 = on_proxy_create(1000);
+        let c2 = on_proxy_create(1000);
+        assert!(c1 && c2);
+        assert_eq!(get_binder_proxy_count_for_uid(1000), 2);
+
+        // Tracking turned off while both proxies are still live.
+        enable_count_by_uid(false);
+
+        // A proxy created *now* captures counted_by_uid=false.
+        let c3 = on_proxy_create(1000);
+        assert!(!c3);
+
+        // Drop all three using each proxy's captured decision. The two
+        // enabled-era proxies decrement the per-uid map even though tracking
+        // is now off; the disabled-era proxy does not touch it.
+        on_proxy_drop(1000, c3); // disabled-era: no per-uid effect
+        on_proxy_drop(1000, c2);
+        on_proxy_drop(1000, c1);
+
+        // Count is back to exactly 0 (entry removed) — no inflation.
+        assert_eq!(get_binder_proxy_count_for_uid(1000), 0);
+        assert_eq!(get_binder_proxy_counts_by_uid(), vec![]);
     }
 }

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -1152,12 +1152,18 @@ impl RpcSessionInner {
                     // reuse its existing address (no new local node).
                     rp.address()
                 } else {
-                    // A local object leaving this process.
-                    self.shared
+                    // A local object leaving this process: `on_binder_leaving`
+                    // bumps its `timesSent`. Record the address so a send
+                    // failure can roll the bump back (`cancel_binder_leaving`)
+                    // — the unreceived binder is never DEC'd by the peer.
+                    let addr = self
+                        .shared
                         .state
                         .lock()
                         .expect("rpc state poisoned")
-                        .on_binder_leaving(b)?
+                        .on_binder_leaving(b)?;
+                    parcel.rpc_record_leaving_addr(addr);
+                    addr
                 };
                 // AOSP `Parcel::flattenBinder`: `dataPos = mDataPos`
                 // is captured **before** `writeInt32(TYPE_BINDER)` —
@@ -1277,6 +1283,22 @@ impl RpcSessionInner {
     /// Client outbound transaction. Returns the reply parcel (or `None`
     /// for oneway). Applies any interleaved `DEC_STRONG` and loops to
     /// the matching `REPLY`.
+    /// Undo the reservations a failed outgoing transaction took before the
+    /// send actually happened: the per-node oneway `async_number` (when
+    /// `oneway_addr` is `Some((addr, consumed))`) and every local-binder
+    /// `timesSent` bump recorded in `data` while it was serialized. Invoked
+    /// only on an encode/send error, so the success path is untouched and the
+    /// wire is byte-unchanged.
+    fn rollback_outgoing(&self, data: &Parcel, oneway_addr: Option<(RpcAddress, u64)>) {
+        let mut state = self.shared.state.lock().expect("rpc state poisoned");
+        if let Some((addr, consumed)) = oneway_addr {
+            state.cancel_send_async_number(addr, consumed);
+        }
+        for &addr in data.rpc_leaving_addrs() {
+            state.cancel_binder_leaving(&addr);
+        }
+    }
+
     pub(crate) fn client_transact(
         &self,
         addr: RpcAddress,
@@ -1316,10 +1338,27 @@ impl RpcSessionInner {
             // wire when empty.
             object_positions: data.rpc_object_positions().to_vec(),
         };
-        let frame = self.profile.codec().encode_transact(&txn)?;
+        // From here the request has consumed reservations (a oneway
+        // `async_number`, and each local binder's `timesSent` bump recorded
+        // while `data` was serialized). If the encode or send fails, roll them
+        // back: the peer never received the transaction, and — unlike AOSP —
+        // rsbinder does not tear the (possibly multi-connection) session down
+        // on a send failure, so without rollback the reservations would leak
+        // (a stranded local node, a permanent oneway-ordering gap).
+        let rollback = || self.rollback_outgoing(data, oneway.then_some((addr, async_number)));
+        let frame = match self.profile.codec().encode_transact(&txn) {
+            Ok(frame) => frame,
+            Err(e) => {
+                rollback();
+                return Err(e.into());
+            }
+        };
         // Out-of-band fds collected while serializing the request
         // (empty unless `Unix` fd-mode).
-        self.send_msg(transport, &frame, data.rpc_out_fds())?;
+        if let Err(e) = self.send_msg(transport, &frame, data.rpc_out_fds()) {
+            rollback();
+            return Err(e.into());
+        }
         if oneway {
             return Ok(None);
         }
@@ -1719,12 +1758,22 @@ impl RpcSessionInner {
             return Ok(());
         }
         match result {
-            Ok(()) => self.send_reply(
-                0,
-                reply.rpc_data_bytes(),
-                reply.rpc_object_positions(),
-                reply.rpc_out_fds(),
-            ),
+            Ok(()) => {
+                let sent = self.send_reply(
+                    0,
+                    reply.rpc_data_bytes(),
+                    reply.rpc_object_positions(),
+                    reply.rpc_out_fds(),
+                );
+                if sent.is_err() {
+                    // The reply (with any binders the handler returned) never
+                    // reached the peer; roll back their `timesSent` bumps so the
+                    // returned local nodes do not leak. No oneway counter here —
+                    // a reply is always twoway.
+                    self.rollback_outgoing(&reply, None);
+                }
+                sent
+            }
             Err(e) => self.send_reply(e.into(), &[], &[], &[]),
         }
     }

--- a/rsbinder/src/rpc/state.rs
+++ b/rsbinder/src/rpc/state.rs
@@ -228,6 +228,25 @@ impl RpcState {
         self.local_nodes.get(addr).map(|n| n.binder.clone())
     }
 
+    /// Roll back one `on_binder_leaving` strong bump for `addr` when the
+    /// transaction that would have carried the binder fails to send (AOSP
+    /// `cancelBinderLeaving`). The peer never received the binder, so it will
+    /// never send the matching `DEC_STRONG`; without this the node (and the
+    /// strong `SIBinder` it pins) would leak for the rest of a multi-connection
+    /// session, which — unlike AOSP — rsbinder does not tear down on a send
+    /// failure. The bump and this rollback are a commutative ±1 on a count, so
+    /// this is safe even if another thread concurrently sends the same binder.
+    /// Drops the node once the count reaches 0, exactly like an inbound DEC.
+    pub fn cancel_binder_leaving(&mut self, addr: &RpcAddress) {
+        if let Some(node) = self.local_nodes.get_mut(addr) {
+            node.strong -= 1;
+            if node.strong <= 0 {
+                self.local_nodes.remove(addr);
+                self.local_by_ptr.retain(|_, a| a != addr);
+            }
+        }
+    }
+
     /// Apply an inbound `DEC_STRONG` for `addr`. Drops the node (and
     /// its strong `SIBinder`) once the count reaches 0 — no leak.
     /// Returns `true` if the node was removed.
@@ -347,6 +366,24 @@ impl RpcState {
             warn_async_wrap(&addr);
         }
         n
+    }
+
+    /// Roll back a `next_send_async_number(addr)` reservation when the oneway
+    /// transaction that consumed it fails to send. The peer's receive-side
+    /// counter expects a contiguous sequence, so a consumed-but-never-sent
+    /// number leaves a permanent gap that parks every later oneway to `addr`
+    /// in the peer's `async_todo` (rsbinder, unlike AOSP, does not tear the
+    /// session down on a send failure). Unlike the strong-count rollback this
+    /// is an *ordering* sequence, so only roll back when we were the last
+    /// consumer (`counter == consumed + 1`); if another thread already reserved
+    /// the next number, rolling back would hand it out twice, so we leave the
+    /// gap (the existing `ASYNC_TODO_TERMINATE_LEVEL` watermark is the backstop).
+    pub fn cancel_send_async_number(&mut self, addr: RpcAddress, consumed: u64) {
+        if let Some(counter) = self.remote_send_async_counters.get_mut(&addr) {
+            if *counter == consumed.wrapping_add(1) {
+                *counter = consumed;
+            }
+        }
     }
 
     /// Decide whether to dispatch an inbound oneway now
@@ -543,6 +580,61 @@ mod tests {
         assert!(st.lookup_local(&a).is_none());
         // DEC_STRONG on an unknown address is safe (idempotent).
         assert!(!st.dec_strong_local(&a));
+    }
+
+    /// A send failure rolls back exactly one `on_binder_leaving` bump; the
+    /// node survives while other sends still reference it and is removed only
+    /// when the last bump is cancelled (no leak, no double-free).
+    #[test]
+    fn cancel_binder_leaving_rolls_back_one_bump() {
+        let mut st = RpcState::new(AddressSpace::Acceptor);
+        let b = SIBinder::new(Arc::new(Dummy)).unwrap();
+        let a = st.on_binder_leaving(&b).unwrap(); // strong 1
+        let a2 = st.on_binder_leaving(&b).unwrap(); // strong 2 (resend)
+        assert_eq!(a, a2);
+        assert_eq!(st.local_node_count(), 1);
+
+        st.cancel_binder_leaving(&a);
+        assert_eq!(
+            st.local_node_count(),
+            1,
+            "still referenced by the other send"
+        );
+        assert!(st.lookup_local(&a).is_some());
+
+        st.cancel_binder_leaving(&a);
+        assert_eq!(st.local_node_count(), 0, "last bump cancelled → node freed");
+        assert!(st.lookup_local(&a).is_none());
+
+        // Cancel on an unknown / already-freed address is safe.
+        st.cancel_binder_leaving(&a);
+    }
+
+    /// A oneway send failure rolls back its reserved `async_number` only when
+    /// it was the last reservation; if another send already advanced past it,
+    /// rolling back would hand the same number out twice, so it must not.
+    #[test]
+    fn cancel_send_async_number_only_when_last_consumer() {
+        let mut st = RpcState::new(AddressSpace::Acceptor);
+        let b = SIBinder::new(Arc::new(Dummy)).unwrap();
+        let a = st.on_binder_leaving(&b).unwrap();
+
+        assert_eq!(st.next_send_async_number(a), 0);
+        let consumed = st.next_send_async_number(a); // 1
+        assert_eq!(consumed, 1);
+        // We were the last consumer → rollback; the number is handed out again.
+        st.cancel_send_async_number(a, consumed);
+        assert_eq!(st.next_send_async_number(a), 1, "rolled back");
+
+        // Now simulate a concurrent send advancing past us before we cancel.
+        let consumed2 = st.next_send_async_number(a); // 2
+        let _other = st.next_send_async_number(a); // 3 (another in-flight send)
+        st.cancel_send_async_number(a, consumed2);
+        assert_eq!(
+            st.next_send_async_number(a),
+            4,
+            "no rollback when not the last consumer"
+        );
     }
 
     /// The android-13+ wire encodes only the low 32 bits of the address

--- a/rsbinder/src/rpc/transport/unix.rs
+++ b/rsbinder/src/rpc/transport/unix.rs
@@ -318,7 +318,7 @@ impl RpcTransport for UnixTransport {
     /// fds across those `recvmsg`s (AOSP
     /// `RpcTransportRaw::interruptableReadFully`).
     fn recv_raw_with_fds(&self, buf: &mut [u8]) -> RpcResult<(usize, Vec<std::os::fd::OwnedFd>)> {
-        use rustix::net::{RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags};
+        use rustix::net::{RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags, ReturnFlags};
         use std::io::IoSliceMut;
         use std::mem::MaybeUninit;
 
@@ -349,6 +349,17 @@ impl RpcTransport for UnixTransport {
                 }
             }
         };
+        // The kernel sets `MSG_CTRUNC` when an SCM_RIGHTS batch did not fit
+        // the ancillary buffer: it installs as many fds as fit and silently
+        // drops the rest. Continuing would leave the parcel's fd object table
+        // referencing fds we never received, so fail the connection instead —
+        // matching AOSP `OS_unix_base.cpp` which rejects truncation with EPIPE
+        // rather than proceeding with a half-delivered message.
+        if r.flags.contains(ReturnFlags::CTRUNC) {
+            return Err(RpcError::Protocol(
+                "SCM_RIGHTS control message truncated (too many fds in one message)",
+            ));
+        }
         for msg in anc.drain() {
             if let RecvAncillaryMessage::ScmRights(iter) = msg {
                 for fd in iter {
@@ -443,7 +454,7 @@ impl RpcTransport for UnixTransport {
     /// Connections in `Unix` fd-mode use this for *every* frame, so
     /// `recvmsg` and `Read` are never mixed on one fd.
     fn recv_frame_with_fds(&self) -> RpcResult<(Vec<u8>, Vec<std::os::fd::OwnedFd>)> {
-        use rustix::net::{RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags};
+        use rustix::net::{RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags, ReturnFlags};
         use std::io::IoSliceMut;
         use std::mem::MaybeUninit;
 
@@ -498,6 +509,16 @@ impl RpcTransport for UnixTransport {
                     }
                 }
             };
+            // `MSG_CTRUNC` ⇒ the kernel dropped surplus fds that did not fit
+            // the ancillary buffer; the frame's fd indices would then point at
+            // fds we never received. Reject rather than proceed, matching AOSP
+            // `OS_unix_base.cpp` (EPIPE on truncation). Same guard as
+            // `recv_raw_with_fds`.
+            if r.flags.contains(ReturnFlags::CTRUNC) {
+                return Err(RpcError::Protocol(
+                    "SCM_RIGHTS control message truncated (too many fds in one message)",
+                ));
+            }
             for msg in anc.drain() {
                 if let RecvAncillaryMessage::ScmRights(iter) = msg {
                     for fd in iter {

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -848,6 +848,17 @@ fn wait_for_response(until: UntilResponse) -> Result<Option<Parcel>> {
                                 log::warn!("binder::BR_REPLY ({status})");
                                 return Err(status);
                             }
+                            // AOSP `IPCThreadState::waitForResponse` ends the
+                            // status-code branch with an unconditional `goto
+                            // finish` (`return err`, even for NO_ERROR), so a
+                            // `TF_STATUS_CODE` reply carrying status 0 yields a
+                            // successful empty reply — it never loops. Falling
+                            // through here instead would re-enter the outer
+                            // `loop` and block in `talk_with_driver` waiting for
+                            // a command a conforming peer never sends, hanging
+                            // (potentially the main thread) on a malformed or
+                            // hostile reply. Return the empty reply to match.
+                            return Ok(Some(Parcel::new()));
                         }
                     } else {
                         free_buffer(


### PR DESCRIPTION
## Summary

A two-pass review — parallel per-area reviewers followed by an adversarial verification pass on each finding — of `rsbinder`, `rsbinder-aidl`, and `rsb_hub`. It surfaced 29 candidate issues; **13 were confirmed** against the current code and AOSP (`android-16.0.0_r4`) and are fixed here. The other 16 were refuted (intentional designs, AOSP-faithful behavior, or unreachable paths) and left untouched.

## Fixes

### rsbinder (core)
| Sev | Area | Fix |
|---|---|---|
| High | `parcel::append_from` | Commit a relocated object offset only **after** `acquire()`/FD-dup succeed, so an error path can no longer double-close the source fd or underflow a refcount. |
| Low | `parcel` write paths | Zero-fill the `[len..pos]` gap left by a forward `set_data_position` before `set_len` (`write_array`/`write_aligned_data`/`append_from`), so uninitialized heap is never read or transmitted (UB + info leak). |
| Med | `thread_state` | A `BR_REPLY` carrying `TF_STATUS_CODE` with `status==Ok` now returns an empty reply instead of looping into a blocking `talk_with_driver`, so a malformed/hostile peer cannot hang the caller (AOSP `waitForResponse`). |
| Med | `rpc/state`,`rpc/session` | Roll back `on_binder_leaving` (`timesSent`) and the oneway `async_number` reservation when an outbound transaction fails to send — a multi-connection session no longer leaks a local node or permanently desyncs per-node oneway ordering. |
| Med | `rpc/transport/unix` | Reject `SCM_RIGHTS` receives flagged `MSG_CTRUNC` instead of silently dropping surplus fds (AOSP rejects with `EPIPE`). |
| Low | `proxy_count` | Decide per-proxy at create time whether to decrement the per-uid map, instead of re-reading the live `COUNT_BY_UID_ENABLED` flag — toggling tracking off while a proxy is live no longer desyncs the count (AOSP `mTrackedUid`). |

### rsbinder-aidl
| Sev | Area | Fix |
|---|---|---|
| High | `parser::check_nesting_depth` | Bound the operator-chain length so a long unbracketed const expression (`~~~5`, `1+1+...`) cannot overflow the parser stack (uncatchable `SIGABRT`). |
| High | `const_expr`/`type_generator` | An unresolvable constant reference now produces a diagnostic instead of silently folding to `0`; circular-reference graceful degradation is preserved. |
| Med | `const_expr` | Reject an out-of-range shift amount instead of computing in `i64` and truncating (e.g. `1 << 40` silently became `0`). |
| Med | `generator`/`lib`/`type_generator` | `r#`-escape type-level names (`mod`/`struct`/`trait` and reference paths) when they are Rust keywords, so a keyword-named AIDL type emits compiling Rust (AOSP Rust backend parity). |

### rsb_hub
| Sev | Area | Fix |
|---|---|---|
| Low | `rsb_hub` | Link a callback binder's death notification at most once per distinct callback binder, so registering one callback across K names cannot amplify into K `binder_died` cleanup sweeps. |

## Tests
New regression tests: rsbinder-aidl (operator-chain DoS, unresolvable-const diagnostic, shift overflow, keyword type names) and rsbinder (`proxy_count` toggle, `RpcState` rollback).

## Validation
- **macOS hermetic**: rsbinder lib, rsbinder-aidl (incl. AOSP fixture sweep), rsbinder-tools, RPC integration — green; `clippy` (default + rpc) and `fmt` clean.
- **REMOTE_LINUX** (kernel with Rust binder): rsbinder-aidl ~199/0, RPC (lib 69 + e2e/fd/scenarios/server) 0 fail, rsbinder lib on real binder 198/0, **kernel-binder 3-process e2e 136/0**. Zero panics, zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
