### PR TITLE
chore(deps): bump rsproperties to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,7 +492,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result",
 ]
 
@@ -1223,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "rsproperties"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7822263cfb0ee69f42277c46fe8f02143aaf31510278de8802f6d35d2f6e57a9"
+checksum = "878032a02f0dd5ec0fdd772e0141c50ef05d406c5a9f2ea79826285270fea168"
 dependencies = [
  "log",
  "pretty-hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ downcast-rs = "2.0"
 rustix = "1.1"
 libc = "0.2"
 clap = "4.6"
-rsproperties = "0.4"
+rsproperties = "0.5"
 miette = { version = "7.6", features = ["fancy"] }
 thiserror = "2"
 # dev-only: serializes the handful of rsbinder unit tests that share the

--- a/book/src/android.md
+++ b/book/src/android.md
@@ -67,7 +67,7 @@ println!("Running on Android {}", version);
 Add `rsproperties` to your dependencies:
 ```toml
 [dependencies]
-rsproperties = "0.3"
+rsproperties = "0.5"
 ```
 
 ### Using Android's Existing Binder Devices


### PR DESCRIPTION
rsproperties 0.5.0 was released. The only API rsbinder uses — `get_or<T>(name: &str, default: T) -> T` (`get_android_sdk_version`, android-gated) — is unchanged from 0.4, so this is a drop-in major bump. Also updates the `android.md` dependency example (was 0.3).

## Verification
- `cargo build --workspace` (host) — clean
- `cargo check -p rsbinder --target aarch64-linux-android` (exercises the android-only `rsproperties::get_or` call) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)