### PR TITLE
docs: add CHANGELOG with 0.9.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,124 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+While the project is pre-1.0, minor releases may add features and occasionally
+change APIs; patch releases are backward-compatible fixes.
+
+This changelog starts at 0.9.0. For earlier releases, see the
+[Git tags](https://github.com/hiking90/rsbinder/tags) and
+[GitHub releases](https://github.com/hiking90/rsbinder/releases).
+
+## [Unreleased]
+
+## [0.9.0] - 2026-06-15
+
+The headline of this release is a complete **RPC transport** (binder over
+sockets) — a separate, opt-in stack alongside the existing kernel binder
+support — together with first-class macOS support, a substantially expanded
+Android compatibility surface, AIDL compiler improvements, and a large body of
+correctness work from several review and audit rounds.
+
+### Added
+
+#### RPC transport (binder-over-socket) — new opt-in subsystem
+
+A pure-Rust binder-over-socket stack, wire-compatible with Android's
+`libbinder` RPC and kept entirely separate from the kernel binder path. It is
+off by default and zero-cost when disabled, enabled via the `rpc` master
+feature with per-backend opt-ins (`rpc-tcp-debug`, `rpc-vsock`, `rpc-tls`).
+
+- `RpcServer` / `RpcSession`: multi-session serving, threading, version
+  negotiation, and oneway / nested-call / timeout handling, plus
+  `RpcServer::set_max_connections`.
+- Transports: Unix socket, in-memory, debug TCP, vsock, and TLS (rustls) —
+  including server-side TLS over unix/TCP/vsock and client mTLS.
+- Wire compatibility: android-13+ versioned wire and android-16 RPC v2,
+  validated against real `libbinder`.
+- FD-over-RPC (`FileDescriptorTransportMode`), AOSP-faithful.
+- Multi-connection session pool with per-node async ordering and AOSP
+  `timesSent` / excess-`DEC_STRONG` accounting.
+- RPC Accessor (`IAccessor`): both the client (consume) and registration
+  sides, plus VINTF accessor integration in `rsb_hub`.
+- Cross-transport calling identity and authorization: an injectable
+  `PermissionAuthority`, a transport-tagged `Caller`, and a cross-transport
+  service facade.
+- RPC death notification and an async-over-RPC adapter.
+
+#### Platform support
+
+- First-class **macOS** support for the RPC stack (peer-credential authorizer,
+  target-gated platform code). Kernel-binder-only APIs return
+  `InvalidOperation` on macOS.
+
+#### Android compatibility
+
+- Calling identity: `get_calling_sid` / `get_calling_uid` / `get_calling_pid`,
+  `clear_calling_identity` / `restore_calling_identity`, strict-mode policy,
+  and `android.os.IPermissionController` (`check_permission`).
+- `@EnforcePermission` code generation (`Single` / `AllOf` / `AnyOf`).
+- Extended error reporting (`binder_extended_error` via `get_extended_error`),
+  `FLAG_UPDATE_TXN`, and AppOps reply-header handling.
+- Real-time priority inheritance (`FLAT_BINDER_FLAG_INHERIT_RT`, opt-in via
+  `BinderFeatures`).
+- Proxy-count infrastructure (global and per-uid counters with watermark
+  callbacks).
+- `Binder::attach_object` / `find_object` / `detach_object`,
+  `LazyServiceRegistrar`, and an `IMemory` skeleton.
+- Freeze-notification kernel UAPI baseline.
+
+#### AIDL compiler (rsbinder-aidl)
+
+- Generated `getInterfaceVersion()` / `getInterfaceHash()` meta methods
+  (AIDL `--version` / `--hash`).
+- `@Backing` type validation with AOSP-faithful diagnostics.
+- Richer miette diagnostics (e.g. dedicated direction/primitive errors) and an
+  AOSP fixture sweep.
+
+#### Service manager (rsb_hub)
+
+- Lazy-service poller and client-callback support.
+- Accessor registration and VINTF integration.
+
+### Changed
+
+- Replaced the unmaintained `rustls-pemfile` with `rustls-pki-types`
+  `PemObject`.
+- Reduced redundant clones across the binder hot paths.
+- Bumped `rsproperties` to 0.5, plus `log`, `similar`, and the dependabot
+  `rust-major` / `rust-minor` dependency groups.
+- Extensive documentation work: mdBook overhaul, API-doc sync, and
+  cross-transport / RPC-TLS guides.
+
+### Fixed
+
+A large body of correctness work from multiple review and audit rounds
+(PRs #147–#155). Highlights:
+
+- `Parcel::append_from` no longer double-closes a file descriptor or
+  underflows a refcount on an error path, and parcel write paths never read or
+  transmit uninitialized bytes.
+- `wait_for_response` no longer hangs the caller on a malformed `BR_REPLY`
+  (`TF_STATUS_CODE` with an OK status).
+- RPC: roll back `timesSent` and the oneway `async_number` reservation when a
+  send fails; reject truncated `SCM_RIGHTS` fd batches (`MSG_CTRUNC`) instead
+  of silently dropping fds.
+- AIDL: reject operator-chain input that would overflow the parser stack,
+  unresolvable constant references, and out-of-range shifts; `r#`-escape
+  type-level names that are Rust keywords.
+- `rsb_hub`: bound per-name registries and de-duplicate callback death links.
+- `proxy_count`: decide per-object whether to track a proxy so toggling
+  tracking no longer desyncs the count.
+- Migrated `getrandom::getrandom` to `getrandom::fill` for getrandom 0.4.
+- Various test fixes (WIBinder upgrade after obituary, process-wide thread-pool
+  counter, RPC lifecycle flake).
+
+### Security
+
+- Addressed RUSTSEC-2025-0134 by replacing `rustls-pemfile` with
+  `rustls-pki-types`.
+
+[Unreleased]: https://github.com/hiking90/rsbinder/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/hiking90/rsbinder/compare/v0.8.0...v0.9.0


### PR DESCRIPTION
Adds a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)-formatted \`CHANGELOG.md\` (the project had none). Prep for the 0.9.0 release.

The **[0.9.0]** entry summarizes the 134 commits since v0.8.0, grouped into Added / Changed / Fixed / Security:

- **Added** — the new opt-in **RPC transport** (binder-over-socket: Unix/mem/TCP/vsock/TLS, android-13+/v2 wire with real-libbinder interop, FD-over-RPC, multi-connection pool, RPC Accessor, cross-transport calling identity/authz, death notify, async adapter); first-class **macOS** support; expanded **Android compatibility** (calling identity, @EnforcePermission codegen, extended error, RT inherit, proxy-count, attachObject/LazyServiceRegistrar/IMemory); **AIDL** interface version/hash + @Backing validation; **rsb_hub** lazy-service poller + accessor integration.
- **Changed** — rustls-pemfile → rustls-pki-types, clone reduction, rsproperties 0.5 + dependency bumps, docs/mdBook overhaul.
- **Fixed** — correctness work from review/audit rounds (PRs #147-#155).
- **Security** — RUSTSEC-2025-0134 (rustls-pemfile replaced).

Content is limited to changes actually merged to master (verified the Android-compat modules and public APIs are present); no in-progress/unmerged work is listed. Earlier releases are referenced via Git tags / GitHub releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)