### PR TITLE
feat(hub): support Android 17 (SDK 37) service manager dispatch

### DIFF
--- a/rsbinder/src/hub/mod.rs
+++ b/rsbinder/src/hub/mod.rs
@@ -265,6 +265,8 @@ pub use android_16::{
 /// Android SDK version constants
 #[cfg(target_os = "android")]
 pub mod sdk_versions {
+    /// Android 17 (API level 37)
+    pub const ANDROID_17: u32 = 37;
     /// Android 16 (API level 36)
     pub const ANDROID_16: u32 = 36;
     /// Android 15 (API level 35)
@@ -285,7 +287,7 @@ pub mod sdk_versions {
     /// Minimum supported Android SDK version
     pub const MIN_SUPPORTED: u32 = ANDROID_10;
     /// Maximum supported Android SDK version
-    pub const MAX_SUPPORTED: u32 = ANDROID_16;
+    pub const MAX_SUPPORTED: u32 = ANDROID_17;
 }
 
 /// ServiceManager provides a unified interface to interact with Android's Service Manager
@@ -342,7 +344,14 @@ pub fn default() -> Result<Arc<ServiceManager>> {
         }
 
         match sdk_version {
-            sdk_versions::ANDROID_16 => create_service_manager!(Android16, android_16),
+            // Android 17 (SDK 37) shares Android 16's service-manager wire
+            // format — the `android/os/*` AIDL is byte-identical between
+            // android-16.0.0_r4 and android-17.0.0_r1 (and the kernel binder
+            // UAPI is unchanged), so it is served by the `android_16` module,
+            // mirroring how Android 15 is served by `android_14`.
+            sdk_versions::ANDROID_16 | sdk_versions::ANDROID_17 => {
+                create_service_manager!(Android16, android_16)
+            }
             // Android 15 (SDK 35) shares Android 14's service-manager wire
             // format, so it is served by the `android_14` feature — there
             // is no separate `android_15` feature. A build that enables


### PR DESCRIPTION
## Summary

Adds Android 17 (API level 37) support to the runtime service-manager dispatch.

`hub::default()` previously capped at `ANDROID_16` (SDK 36). On an Android 17 device, `get_android_sdk_version()` returns 37, which fell through to the `_ => Err(StatusCode::InvalidOperation)` arm — so `hub::default()` failed on Android 17 even though the wire protocol is unchanged.

## Why no new feature flag / version module

A diff of AOSP `android-16.0.0_r4` → `android-17.0.0_r1` confirms the binder service-manager surface is **byte-identical** between the two releases (verified by git blob hashes):

| Surface | Result |
| --- | --- |
| Kernel binder UAPI (`linux/android/binder.h`) | identical blob |
| RPC wire format (`RpcWireFormat.h`), negotiated max version | identical (version still 2) |
| Meta-transaction codes (`IBinder.h`) | identical blob |
| Service-manager AIDL (`android/os/*.aidl`, 9 files) | identical blobs |

Android 17 is therefore served by the existing `android_16` module, mirroring how Android 15 (SDK 35) is served by `android_14` — no new `android_17` feature, `servicemanager_17.rs`, or hub module is needed.

## Changes

- Add `sdk_versions::ANDROID_17 = 37` and bump `MAX_SUPPORTED`.
- Route SDK 37 through the `android_16` dispatch arm (`ANDROID_16 | ANDROID_17`).

## Verification

- `cargo check` / `cargo clippy` for `aarch64-linux-android` with `--features android_10_plus` (exercises the changed `cfg(target_os = "android")` code and the full version match) — clean.
- Native macOS `cargo check` (non-Android path) — clean.
- `cargo fmt --check` — clean.

On-device STAGE3 emulator validation is deferred: Google has not yet published the API 37 `google_apis;x86_64` emulator system image (the catalog tops out at `android-36`), so the CI emulator matrix is left unchanged for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)