### PR TITLE
fix: preserve empty Binder arrays

### DIFF
--- a/rsbinder/src/macros.rs
+++ b/rsbinder/src/macros.rs
@@ -505,9 +505,11 @@ macro_rules! impl_deserialize_for_parcelable {
                 let status: i32 = parcel.read()?;
                 if status == $crate::NULL_PARCELABLE_FLAG {
                     Err($crate::StatusCode::UnexpectedNull.into())
-                } else {
+                } else if status == $crate::NON_NULL_PARCELABLE_FLAG {
                     use $crate::Parcelable;
                     self.read_from_parcel(parcel)
+                } else {
+                    Err($crate::StatusCode::UnexpectedNull.into())
                 }
             }
         }
@@ -528,10 +530,12 @@ macro_rules! impl_deserialize_for_parcelable {
                 if status == $crate::NULL_PARCELABLE_FLAG {
                     *this = None;
                     Ok(())
-                } else {
+                } else if status == $crate::NON_NULL_PARCELABLE_FLAG {
                     use $crate::Parcelable;
                     this.get_or_insert_with(Self::default)
                         .read_from_parcel(parcel)
+                } else {
+                    Err($crate::StatusCode::UnexpectedNull.into())
                 }
             }
         }

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -977,10 +977,13 @@ impl Parcel {
         let len: i32 = self.read()?;
         if len < -1 {
             log::error!("Parcel: bad array length: {len}");
-            return Err(StatusCode::BadValue);
+            return Err(StatusCode::UnexpectedNull);
         }
-        if len <= 0 {
+        if len == -1 {
             return Ok(None);
+        }
+        if len == 0 {
+            return Ok(Some(Vec::new()));
         }
 
         // Checked arithmetic — protects 32-bit `usize` targets (armv7
@@ -1037,10 +1040,13 @@ impl Parcel {
         let len: i32 = self.read()?;
         if len < -1 {
             log::error!("Parcel: bad array length: {len}");
-            return Err(StatusCode::BadValue);
+            return Err(StatusCode::UnexpectedNull);
         }
-        if len <= 0 {
+        if len == -1 {
             return Ok(None);
+        }
+        if len == 0 {
+            return Ok(Some(Vec::new()));
         }
 
         // See `read_array` — checked arithmetic guards 32-bit `usize`
@@ -1770,6 +1776,32 @@ mod tests {
         assert_eq!(array, res.unwrap());
         let res = parcel.read_array::<u8>().unwrap();
         assert_eq!(reverse, res.unwrap());
+    }
+
+    #[test]
+    fn parcel_array_empty_is_not_null() {
+        let mut parcel = Parcel::new();
+        parcel.write_array::<u8>(&[]).unwrap();
+        parcel.write_array_char::<u16>(&[]).unwrap();
+        parcel.set_data_position(0);
+
+        assert_eq!(parcel.read_array::<u8>(), Ok(Some(Vec::new())));
+        assert_eq!(parcel.read_array_char::<u16>(), Ok(Some(Vec::new())));
+    }
+
+    #[test]
+    fn vec_deserialize_rejects_null_but_accepts_empty() {
+        let mut parcel = Parcel::new();
+        parcel.write(&-1i32).unwrap();
+        parcel.write(&0i32).unwrap();
+        parcel.write(&0i32).unwrap();
+        parcel.write(&-2i32).unwrap();
+        parcel.set_data_position(0);
+
+        assert_eq!(parcel.read::<Vec<u8>>(), Err(StatusCode::UnexpectedNull));
+        assert_eq!(parcel.read::<Vec<u8>>(), Ok(Vec::new()));
+        assert_eq!(parcel.read::<Option<Vec<u8>>>(), Ok(Some(Vec::<u8>::new())));
+        assert_eq!(parcel.read::<Vec<u8>>(), Err(StatusCode::UnexpectedNull));
     }
 
     #[test]

--- a/rsbinder/src/parcelable.rs
+++ b/rsbinder/src/parcelable.rs
@@ -762,10 +762,13 @@ pub trait DeserializeArray: Deserialize {
         let len: i32 = parcel.read()?;
         if len < -1 {
             log::error!("Negative array size given in parcel: {len}");
-            return Err(StatusCode::BadValue);
+            return Err(StatusCode::UnexpectedNull);
         }
-        if len <= 0 {
+        if len == -1 {
             return Ok(None);
+        }
+        if len == 0 {
+            return Ok(Some(Vec::new()));
         }
         // Cap the *speculative* pre-allocation at the bytes still left
         // in the parcel: every element consumes >= 1 wire byte, so a
@@ -816,7 +819,7 @@ impl<T: SerializeArray> SerializeOption for Vec<T> {
 
 impl<T: DeserializeArray> Deserialize for Vec<T> {
     fn deserialize(parcel: &mut Parcel) -> Result<Self> {
-        DeserializeArray::deserialize_array(parcel).map(|v| v.unwrap_or_default())
+        DeserializeArray::deserialize_array(parcel)?.ok_or(StatusCode::UnexpectedNull)
     }
 }
 

--- a/rsbinder/src/parcelable.rs
+++ b/rsbinder/src/parcelable.rs
@@ -412,6 +412,10 @@ impl DeserializeOption for String {
     fn deserialize_option(parcel: &mut Parcel) -> Result<Option<Self>> {
         let len = parcel.read::<i32>()?;
 
+        if len == -1 {
+            return Ok(None);
+        }
+
         if (0..i32::MAX).contains(&len) {
             // String16 wire = `len + 1` UTF-16 code units (the trailing
             // NUL terminator is sent too). Route the byte count through
@@ -440,10 +444,10 @@ impl DeserializeOption for String {
                 StatusCode::BadValue
             })?;
 
-            Ok(Some(res))
-        } else {
-            Ok(None)
+            return Ok(Some(res));
         }
+
+        Err(StatusCode::UnexpectedNull)
     }
 }
 
@@ -631,10 +635,10 @@ pub trait DeserializeOption: Deserialize {
     /// Deserialize an Option of this type from the given parcel.
     fn deserialize_option(parcel: &mut Parcel) -> Result<Option<Self>> {
         let null: i32 = parcel.read()?;
-        if null == NULL_PARCELABLE_FLAG {
-            Ok(None)
-        } else {
-            parcel.read().map(Some)
+        match null {
+            NULL_PARCELABLE_FLAG => Ok(None),
+            NON_NULL_PARCELABLE_FLAG => parcel.read().map(Some),
+            _ => Err(StatusCode::UnexpectedNull),
         }
     }
 
@@ -886,12 +890,13 @@ mod tests {
     /// panic.)
     #[test]
     fn hostile_string16_length_returns_err_not_panic() {
-        let mut p = Parcel::new();
-        // Near-`i32::MAX` declared length with no following payload.
-        p.write::<i32>(&(i32::MAX - 1)).unwrap();
-        p.set_data_position(0);
-        let r = <String as DeserializeOption>::deserialize_option(&mut p);
-        assert!(r.is_err());
+        for len in [-2, i32::MAX - 1, i32::MAX] {
+            let mut p = Parcel::new();
+            p.write::<i32>(&len).unwrap();
+            p.set_data_position(0);
+            let r = <String as DeserializeOption>::deserialize_option(&mut p);
+            assert!(r.is_err(), "len {len} returned {r:?}");
+        }
     }
 
     /// A normal string still round-trips byte-identically.

--- a/rsbinder/src/parcelable_holder.rs
+++ b/rsbinder/src/parcelable_holder.rs
@@ -206,10 +206,12 @@ impl Deserialize for ParcelableHolder {
         if status == NULL_PARCELABLE_FLAG {
             log::error!("ParcelableHolder::deserialize: unexpected null");
             Err(StatusCode::UnexpectedNull)
-        } else {
+        } else if status == NON_NULL_PARCELABLE_FLAG {
             let mut parcelable = ParcelableHolder::default();
             parcelable.read_from_parcel(parcel)?;
             Ok(parcelable)
+        } else {
+            Err(StatusCode::UnexpectedNull)
         }
     }
 
@@ -224,8 +226,10 @@ impl Deserialize for ParcelableHolder {
         if status == NULL_PARCELABLE_FLAG {
             log::error!("ParcelableHolder::deserialize_from: unexpected null");
             Err(StatusCode::UnexpectedNull)
-        } else {
+        } else if status == NON_NULL_PARCELABLE_FLAG {
             self.read_from_parcel(parcel)
+        } else {
+            Err(StatusCode::UnexpectedNull)
         }
     }
 }

--- a/rsbinder/src/status.rs
+++ b/rsbinder/src/status.rs
@@ -362,7 +362,7 @@ fn read_check_header_size(parcel: &mut Parcel) -> error::Result<()> {
     // Check for negative values first
     if header_size < 0 {
         log::error!("0x534e4554:132650049 Negative header_size({header_size}).");
-        return Err(StatusCode::BadValue);
+        return Err(StatusCode::Unknown);
     }
 
     // Safe conversion after negativity check
@@ -373,13 +373,13 @@ fn read_check_header_size(parcel: &mut Parcel) -> error::Result<()> {
         log::error!(
             "0x534e4554:132650049 Invalid header_size({header_size}) exceeds available({header_avail})."
         );
-        return Err(StatusCode::BadValue);
+        return Err(StatusCode::Unknown);
     }
 
     // Prevent integer overflow in position calculation
     let new_position = header_start.checked_add(header_size_usize).ok_or_else(|| {
         log::error!("0x534e4554:132650049 Position overflow with header_size({header_size})");
-        StatusCode::BadValue
+        StatusCode::Unknown
     })?;
 
     parcel.set_data_position(new_position);
@@ -430,7 +430,7 @@ impl Deserialize for Status {
                 log::error!(
                     "0x534e4554:132650049 Negative remote_stack_trace_header_size({remote_stack_trace_header_size})."
                 );
-                return Err(StatusCode::BadValue);
+                return Err(StatusCode::Unknown);
             }
 
             // Safe conversion after negativity check
@@ -442,7 +442,7 @@ impl Deserialize for Status {
                 log::error!(
                     "0x534e4554:132650049 Invalid remote_stack_trace_header_size({remote_stack_trace_header_size}) exceeds available({header_avail})."
                 );
-                return Err(StatusCode::BadValue);
+                return Err(StatusCode::Unknown);
             }
 
             if trace_size_usize != 0 {
@@ -451,7 +451,7 @@ impl Deserialize for Status {
                     log::error!(
                         "0x534e4554:132650049 Position overflow with remote_stack_trace_header_size({remote_stack_trace_header_size})"
                     );
-                    StatusCode::BadValue
+                    StatusCode::Unknown
                 })?;
 
                 parcel.set_data_position(new_position);

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -761,6 +761,10 @@ fn wait_for_response(until: UntilResponse) -> Result<Option<Parcel>> {
                         break;
                     }
                 }
+                binder::BR_TRANSACTION_PENDING_FROZEN => {
+                    log::warn!("Sending oneway calls to frozen process.");
+                    break;
+                }
                 binder::BR_DEAD_REPLY => {
                     return Err(StatusCode::DeadObject);
                 }
@@ -1392,7 +1396,7 @@ fn talk_with_driver(do_receive: bool) -> Result<()> {
                 Ok(_) => break,
                 Err(errno) if errno != rustix::io::Errno::INTR => {
                     log::error!("binder::write_read() error : {errno}");
-                    return Err(StatusCode::Errno(errno.raw_os_error()));
+                    return Err(StatusCode::from(errno));
                 }
                 _ => {}
             }
@@ -1728,7 +1732,7 @@ pub(crate) fn join_thread_pool(is_main: bool) -> Result<()> {
                         break;
                     }
                     StatusCode::Errno(errno)
-                        if errno == (rustix::io::Errno::CONNREFUSED.raw_os_error()) =>
+                        if errno == -(rustix::io::Errno::CONNREFUSED.raw_os_error()) =>
                     {
                         result = e;
                         break;
@@ -2172,11 +2176,12 @@ pub fn get_current_scheduler_policy() -> Result<i32> {
         // on a library or kernel bug, so prefer `EINVAL` over `0`
         // (which is itself a valid "success" errno and would mislead
         // the caller).
-        return Err(StatusCode::Errno(
-            std::io::Error::last_os_error()
-                .raw_os_error()
-                .unwrap_or(libc::EINVAL),
-        ));
+        let errno = std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or(libc::EINVAL);
+        return Err(StatusCode::from(rustix::io::Errno::from_raw_os_error(
+            errno,
+        )));
     }
     Ok(raw)
 }
@@ -2242,7 +2247,7 @@ pub fn get_extended_error() -> Result<ExtendedError> {
             // Pre-Android-12 driver — feature unavailable.
             StatusCode::InvalidOperation
         } else {
-            StatusCode::Errno(errno.raw_os_error())
+            StatusCode::from(errno)
         }
     })?;
     Ok(ExtendedError {


### PR DESCRIPTION
Binder encodes null arrays as length -1 and empty arrays as length 0. rsbinder treated all non-positive array lengths as null when reading arrays. This made nullable empty arrays deserialize as None and let non-null Vec<T> values accept null as an empty vector.

Split the -1 and 0 cases in the primitive and generic array readers, and make Vec<T> reject null with UnexpectedNull.

off topic:
just curious, when we can get next update, 0.9.0 is still not support android 17 yet, which has officially released.