### PR TITLE
feat(rpc): support abstract unix sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,18 +119,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -143,12 +140,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -159,9 +156,9 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -229,15 +226,6 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -247,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -257,28 +245,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -290,13 +268,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.7"
+name = "defmt"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -305,9 +304,9 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -384,16 +383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,25 +429,25 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "ignore",
  "walkdir",
 ]
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "ignore"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -490,10 +479,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -503,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.28"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -638,7 +628,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -706,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -716,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
 dependencies = [
  "pest",
  "pest_generator",
@@ -726,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
 dependencies = [
  "pest",
  "pest_meta",
@@ -739,12 +729,11 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
 dependencies = [
  "pest",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -785,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -804,7 +793,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -866,7 +855,7 @@ dependencies = [
  "rustix",
  "rustls",
  "serial_test",
- "sha2 0.11.0",
+ "sha2",
  "tokio",
  "vsock",
 ]
@@ -924,7 +913,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -947,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -967,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -1059,24 +1048,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1402,12 +1380,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "vsock"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,18 +1513,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rsbinder-aidl/src/generator.rs
+++ b/rsbinder-aidl/src/generator.rs
@@ -1116,7 +1116,7 @@ pub mod {mod} {{
     #![allow(non_upper_case_globals, non_snake_case, dead_code)]
     pub type {name} = {rust_type};
 }}
-"#, mod = &decl.name, name = &decl.name, rust_type = &decl.rust_type);
+"#, mod = decl.name, name = decl.name, rust_type = decl.rust_type);
             return Ok(add_indent(indent, rendered.trim()));
         }
 

--- a/rsbinder/src/hub/accessor_register.rs
+++ b/rsbinder/src/hub/accessor_register.rs
@@ -17,20 +17,27 @@
 //! Cross-platform: the [`Unix`](AccessorSockAddr::Unix) variant is
 //! always present so macOS host hermetic tests can exercise the
 //! register-side path without `rpc-vsock` / `rpc-tcp-debug` features.
-//! `Vsock`/`Inet` variants are present in the type at all times for ABI
-//! stability; whether they can be *connected* is a runtime check
-//! inside the [`AccessorSockAddr::connect_owned_fd`] family of helpers
-//! — feature-disabled variants map to `ERROR_UNSUPPORTED_SOCKET_FAMILY`
-//! so an instance configured for a backend the binary wasn't built with
-//! surfaces as the same AOSP-faithful service-specific error a
-//! wrong-family `addConnection` returns.
+//! Abstract Unix, `Vsock`, and `Inet` variants are present in the type
+//! at all times for ABI stability; whether they can be *connected* is a
+//! runtime check inside the [`AccessorSockAddr::connect_owned_fd`]
+//! family of helpers — unavailable variants map to
+//! `ERROR_UNSUPPORTED_SOCKET_FAMILY` so an instance configured for a
+//! backend the binary/target cannot use surfaces as the same AOSP-
+//! faithful service-specific error a wrong-family `addConnection`
+//! returns.
 
 // cfg lives on the mod decl in super — duplicating here trips
 // clippy::duplicated_attributes.
 
 use std::io;
 use std::net::SocketAddrV4;
+#[cfg(target_os = "android")]
+use std::os::android::net::SocketAddrExt;
 use std::os::fd::OwnedFd;
+#[cfg(target_os = "linux")]
+use std::os::linux::net::SocketAddrExt;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::os::unix::net::SocketAddr as UnixSocketAddr;
 use std::path::PathBuf;
 
 use crate::error::Result;
@@ -41,11 +48,11 @@ use crate::error::Result;
 /// `sockaddr_vm` / `sockaddr_in`; this enum is the strongly-typed
 /// equivalent.
 ///
-/// All three variants exist regardless of build features so the enum's
-/// shape stays stable across feature flags (matching exhaustively in
+/// All variants exist regardless of build features so the enum's shape
+/// stays stable across feature flags (matching exhaustively in
 /// downstream `match` is therefore predictable). The
 /// `connect_*_owned_fd` helpers gate the *connect path* on the
-/// matching `rpc-vsock`/`rpc-tcp-debug` feature and return
+/// matching target or `rpc-vsock`/`rpc-tcp-debug` feature and return
 /// `ERROR_UNSUPPORTED_SOCKET_FAMILY` otherwise.
 ///
 /// `Debug`/`Clone` are provided so a provider closure can build the
@@ -57,6 +64,9 @@ use crate::error::Result;
 pub enum AccessorSockAddr {
     /// AF_UNIX path. Cross-platform — works on Linux + macOS host.
     Unix(PathBuf),
+    /// AF_UNIX abstract name. Variant is always present for enum-shape
+    /// stability; connect is supported only on Linux / Android.
+    UnixAbstract(Vec<u8>),
     /// AF_VSOCK `(cid, port)`. Only usable when the binary was built
     /// with the `rpc-vsock` feature; otherwise the connect helper
     /// returns `ERROR_UNSUPPORTED_SOCKET_FAMILY`.
@@ -75,6 +85,7 @@ impl AccessorSockAddr {
     pub fn family_str(&self) -> &'static str {
         match self {
             AccessorSockAddr::Unix(_) => "AF_UNIX",
+            AccessorSockAddr::UnixAbstract(_) => "AF_UNIX",
             AccessorSockAddr::Vsock { .. } => "AF_VSOCK",
             AccessorSockAddr::Inet(_) => "AF_INET",
         }
@@ -108,6 +119,7 @@ impl AccessorSockAddr {
     pub fn connect_owned_fd(&self) -> std::result::Result<OwnedFd, AccessorConnectError> {
         match self {
             AccessorSockAddr::Unix(path) => connect_unix_owned_fd(path),
+            AccessorSockAddr::UnixAbstract(name) => connect_unix_abstract_owned_fd(name),
             AccessorSockAddr::Vsock { cid, port } => connect_vsock_owned_fd(*cid, *port),
             AccessorSockAddr::Inet(addr) => connect_inet_owned_fd(*addr),
         }
@@ -127,7 +139,7 @@ impl AccessorSockAddr {
 pub enum AccessorConnectError {
     /// AOSP `ERROR_UNSUPPORTED_SOCKET_FAMILY` — the address family
     /// either isn't valid (none of `AF_UNIX/AF_VSOCK/AF_INET`) or the
-    /// crate wasn't built with the matching backend feature.
+    /// target / crate features cannot connect that backend.
     UnsupportedFamily,
     /// AOSP `ERROR_FAILED_TO_CREATE_SOCKET` — `socket(2)` failed
     /// before `connect(2)` was even attempted.
@@ -185,6 +197,29 @@ fn connect_unix_owned_fd(path: &PathBuf) -> std::result::Result<OwnedFd, Accesso
         // `socket(2)` is a distinct syscall the helper can inspect.
         Err(e) => Err(AccessorConnectError::ConnectFailed(e)),
     }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn connect_unix_abstract_owned_fd(
+    name: &[u8],
+) -> std::result::Result<OwnedFd, AccessorConnectError> {
+    use std::os::unix::net::UnixStream;
+    let addr =
+        UnixSocketAddr::from_abstract_name(name).map_err(AccessorConnectError::ConnectFailed)?;
+    match UnixStream::connect_addr(&addr) {
+        Ok(stream) => Ok(OwnedFd::from(stream)),
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            Err(AccessorConnectError::ConnectFailedEacces)
+        }
+        Err(e) => Err(AccessorConnectError::ConnectFailed(e)),
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn connect_unix_abstract_owned_fd(
+    _name: &[u8],
+) -> std::result::Result<OwnedFd, AccessorConnectError> {
+    Err(AccessorConnectError::UnsupportedFamily)
 }
 
 /// AF_VSOCK connect helper. Behind `rpc-vsock`; when the feature is
@@ -667,9 +702,11 @@ mod tests {
     #[test]
     fn family_str_covers_all_variants() {
         let unix = AccessorSockAddr::Unix(PathBuf::from("/tmp/rsbinder-test-2-14.sock"));
+        let unix_abstract = AccessorSockAddr::UnixAbstract(b"rsbinder-test-2-14".to_vec());
         let vsock = AccessorSockAddr::Vsock { cid: 2, port: 5555 };
         let inet = AccessorSockAddr::Inet("127.0.0.1:5555".parse().expect("addr"));
         assert_eq!(unix.family_str(), "AF_UNIX");
+        assert_eq!(unix_abstract.family_str(), "AF_UNIX");
         assert_eq!(vsock.family_str(), "AF_VSOCK");
         assert_eq!(inet.family_str(), "AF_INET");
     }
@@ -749,6 +786,38 @@ mod tests {
 
         server_handle.join().expect("server join");
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[test]
+    fn connect_owned_fd_unix_abstract_roundtrips() {
+        use std::io::{Read, Write};
+        #[cfg(target_os = "android")]
+        use std::os::android::net::SocketAddrExt;
+        #[cfg(target_os = "linux")]
+        use std::os::linux::net::SocketAddrExt;
+
+        let name = format!("rsb_a02_abs_{}", std::process::id()).into_bytes();
+        let addr = std::os::unix::net::SocketAddr::from_abstract_name(&name).expect("addr");
+        let listener = UnixListener::bind_addr(&addr).expect("bind");
+        let server_handle = std::thread::spawn(move || {
+            let (mut s, _) = listener.accept().expect("accept");
+            let mut buf = [0u8; 1];
+            s.read_exact(&mut buf).expect("read");
+            s.write_all(&buf).expect("write");
+        });
+
+        let fd = AccessorSockAddr::UnixAbstract(name)
+            .connect_owned_fd()
+            .expect("connect");
+        let mut stream = UnixStream::from(fd);
+        stream.write_all(&[0x42]).expect("client write");
+        let mut got = [0u8; 1];
+        stream.read_exact(&mut got).expect("client read");
+        assert_eq!(got, [0x42]);
+
+        drop(stream);
+        server_handle.join().expect("server join");
     }
 
     /// Unix path — connect to a non-existent path surfaces as

--- a/rsbinder/src/rpc/mod.rs
+++ b/rsbinder/src/rpc/mod.rs
@@ -97,7 +97,7 @@ pub use address::{AddressSpace, RpcAddress, SpecialTransaction, RPC_SESSION_ID_N
 pub use fd_mode::FileDescriptorTransportMode;
 pub use proxy::RpcProxy;
 pub use server::RpcServer;
-pub use session::RpcSession;
+pub use session::{RpcSession, RpcUnixClientConfig};
 pub use state::RpcState;
 pub use transport::{CertId, PeerIdentity, RpcTransport};
 

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -17,6 +17,12 @@
 use std::collections::HashMap;
 #[cfg(feature = "rpc-tls")]
 use std::net::{SocketAddr, TcpListener, TcpStream};
+#[cfg(target_os = "android")]
+use std::os::android::net::SocketAddrExt;
+#[cfg(target_os = "linux")]
+use std::os::linux::net::SocketAddrExt;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::os::unix::net::SocketAddr as UnixSocketAddr;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -67,11 +73,12 @@ enum ServerListener {
 }
 
 /// Backend-agnostic bind metadata. `Drop` branches on this for the
-/// per-backend cleanup: `Unix` removes the socket file, `Vsock`/`Tcp`
-/// have no filesystem cleanup (the kernel reclaims the bind on `Drop`
-/// of the listener fd itself).
+/// per-backend cleanup: path `Unix` removes the socket file;
+/// abstract Unix, `Vsock`, and `Tcp` have no filesystem cleanup (the
+/// kernel reclaims the bind on `Drop` of the listener fd itself).
 enum BindAddress {
     Unix(PathBuf),
+    UnixAbstract,
     #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
     Vsock {
         cid: u32,
@@ -459,6 +466,17 @@ impl RpcServer {
         // Non-blocking accept so the loop can observe `shutdown`.
         listener.set_nonblocking(true)?;
         Ok(Self::wrap(listener, BindAddress::Unix(path)))
+    }
+
+    /// Bind + listen on a Linux/Android abstract Unix-domain socket.
+    /// Abstract sockets have no filesystem entry, so there is no stale
+    /// path to remove and no drop-time unlink.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn setup_unix_server_abstract(name: &[u8]) -> Result<Arc<RpcServer>> {
+        let addr = UnixSocketAddr::from_abstract_name(name)?;
+        let listener = ServerListener::Unix(UnixListener::bind_addr(&addr)?);
+        listener.set_nonblocking(true)?;
+        Ok(Self::wrap(listener, BindAddress::UnixAbstract))
     }
 
     /// Bind + listen on a vsock `(cid, port)`. The
@@ -1491,6 +1509,7 @@ impl RpcServer {
     pub fn path(&self) -> Option<&Path> {
         match &self.bind {
             BindAddress::Unix(p) => Some(p.as_path()),
+            BindAddress::UnixAbstract => None,
             #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
             BindAddress::Vsock { .. } => None,
             #[cfg(feature = "rpc-tls")]
@@ -1506,6 +1525,7 @@ impl RpcServer {
         match &self.bind {
             BindAddress::Vsock { cid, port } => Some((*cid, *port)),
             BindAddress::Unix(_) => None,
+            BindAddress::UnixAbstract => None,
             #[cfg(feature = "rpc-tls")]
             BindAddress::Tcp(_) => None,
         }
@@ -1520,6 +1540,7 @@ impl RpcServer {
         match &self.bind {
             BindAddress::Tcp(addr) => Some(*addr),
             BindAddress::Unix(_) => None,
+            BindAddress::UnixAbstract => None,
             #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
             BindAddress::Vsock { .. } => None,
         }
@@ -1557,6 +1578,7 @@ impl Drop for RpcServer {
                 // on the same path doesn't see a stale ENOENT/EADDRINUSE.
                 let _ = std::fs::remove_file(p);
             }
+            BindAddress::UnixAbstract => {}
             #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
             BindAddress::Vsock { .. } => {
                 // vsock has no filesystem entry; the kernel reclaims the

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -15,6 +15,7 @@
 
 use std::cell::RefCell;
 use std::os::fd::{AsFd, OwnedFd};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Condvar, Mutex, Weak};
@@ -43,6 +44,66 @@ use super::{RpcError, RpcResult};
 /// mode, the client-supplied `session_id`, and the
 /// `RPC_CONNECTION_OPTION_INCOMING` flag.
 type Android13PlusAccept = (Box<dyn RpcTransport>, Android13PlusCodec, u8, Vec<u8>, bool);
+
+enum RpcUnixAddr<'a> {
+    Path(&'a Path),
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    Abstract(&'a [u8]),
+}
+
+/// Unix-domain android-13+ RPC client configuration.
+pub struct RpcUnixClientConfig<'a> {
+    addr: RpcUnixAddr<'a>,
+    max_version: u32,
+    session_id: &'a [u8],
+    outgoing_connections: u32,
+    fd_mode: Option<FileDescriptorTransportMode>,
+}
+
+impl<'a> RpcUnixClientConfig<'a> {
+    fn new(addr: RpcUnixAddr<'a>, max_version: u32) -> Self {
+        Self {
+            addr,
+            max_version,
+            session_id: &[],
+            outgoing_connections: 1,
+            fd_mode: None,
+        }
+    }
+
+    pub fn path(path: &'a Path, max_version: u32) -> Self {
+        Self::new(RpcUnixAddr::Path(path), max_version)
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn abstract_name(name: &'a [u8], max_version: u32) -> Self {
+        Self::new(RpcUnixAddr::Abstract(name), max_version)
+    }
+
+    pub fn session_id(mut self, session_id: &'a [u8]) -> Self {
+        self.session_id = session_id;
+        self
+    }
+
+    pub fn outgoing_connections(mut self, n: u32) -> Self {
+        self.outgoing_connections = n;
+        self
+    }
+
+    pub fn fd_mode(mut self, mode: FileDescriptorTransportMode) -> Self {
+        self.fd_mode = Some(mode);
+        self
+    }
+
+    fn connect(&self) -> Result<super::transport::UnixTransport> {
+        match &self.addr {
+            RpcUnixAddr::Path(path) => super::transport::UnixTransport::connect(path),
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            RpcUnixAddr::Abstract(name) => super::transport::UnixTransport::connect_abstract(name),
+        }
+        .map_err(StatusCode::from)
+    }
+}
 
 /// Which RPC wire profile a session speaks.
 ///
@@ -2663,13 +2724,45 @@ impl RpcSession {
         max_version: u32,
         session_id: &[u8],
     ) -> Result<RpcSession> {
-        let t = super::transport::UnixTransport::connect(path)?;
-        RpcSession::connect_android13plus_fd_with_id(
-            Box::new(t),
-            max_version,
-            FileDescriptorTransportMode::None,
-            session_id,
+        Self::setup_unix_client_android13plus_with_config(
+            RpcUnixClientConfig::path(path.as_ref(), max_version).session_id(session_id),
         )
+    }
+
+    /// Client: connect to a Unix-domain android-13+ server using a config object.
+    pub fn setup_unix_client_android13plus_with_config(
+        config: RpcUnixClientConfig,
+    ) -> Result<RpcSession> {
+        let local = config.outgoing_connections.max(1);
+        if local > 1 && !config.session_id.is_empty() {
+            return Err(StatusCode::BadValue);
+        }
+
+        let session = RpcSession::connect_android13plus_fd_with_id(
+            Box::new(config.connect()?),
+            config.max_version,
+            config.fd_mode.unwrap_or(FileDescriptorTransportMode::None),
+            config.session_id,
+        )?;
+        if local == 1 {
+            return Ok(session);
+        }
+
+        let negotiated = session.negotiate(local)?;
+        if negotiated <= 1 {
+            return Ok(session);
+        }
+        let session_id = session.get_session_id()?;
+        let fd_mode = session.fd_transport_mode();
+        for _ in 1..negotiated {
+            session.add_outgoing_connection_android13plus_transport(
+                || config.connect(),
+                config.max_version,
+                &session_id,
+                fd_mode,
+            )?;
+        }
+        Ok(session)
     }
 
     /// Client multi-outgoing: open one *additional*
@@ -2693,6 +2786,38 @@ impl RpcSession {
         max_version: u32,
         session_id: &[u8],
     ) -> Result<u64> {
+        self.add_outgoing_connection_android13plus_with_config(
+            RpcUnixClientConfig::path(path.as_ref(), max_version).session_id(session_id),
+        )
+    }
+
+    /// Client multi-outgoing using a [`RpcUnixClientConfig`].
+    pub fn add_outgoing_connection_android13plus_with_config(
+        &self,
+        config: RpcUnixClientConfig,
+    ) -> Result<u64> {
+        if config.outgoing_connections.max(1) != 1 || config.session_id.len() != 32 {
+            return Err(StatusCode::BadValue);
+        }
+        let fd_mode = self.fd_transport_mode();
+        if config.fd_mode.is_some_and(|mode| mode != fd_mode) {
+            return Err(StatusCode::BadValue);
+        }
+        self.add_outgoing_connection_android13plus_transport(
+            || config.connect(),
+            config.max_version,
+            config.session_id,
+            fd_mode,
+        )
+    }
+
+    fn add_outgoing_connection_android13plus_transport(
+        &self,
+        connect: impl FnOnce() -> Result<super::transport::UnixTransport>,
+        max_version: u32,
+        session_id: &[u8],
+        fd_mode: FileDescriptorTransportMode,
+    ) -> Result<u64> {
         // Profile uniformity (AOSP requires same version across a
         // session). Refuse R34 / a higher caller-supplied `max_version`
         // **before** the handshake so a mismatch doesn't burn a server
@@ -2713,10 +2838,15 @@ impl RpcSession {
             WireProfile::R34(_) => return Err(StatusCode::BadType),
         };
         let effective_max = max_version.min(session_version);
-        let t = super::transport::UnixTransport::connect(path)?;
+        let hdr_fd_mode = if fd_mode == FileDescriptorTransportMode::Unix {
+            FD_MODE_UNIX
+        } else {
+            FD_MODE_NONE
+        };
+        let t = connect()?;
         let codec = {
             let mut io = RawTransportIo(&t);
-            client_connect_with_id(&mut io, effective_max, false, FD_MODE_NONE, session_id)
+            client_connect_with_id(&mut io, effective_max, false, hdr_fd_mode, session_id)
                 .map_err(StatusCode::from)?
         };
         if codec.version() != session_version {
@@ -2771,36 +2901,10 @@ impl RpcSession {
         max_version: u32,
         local_max_outgoing: u32,
     ) -> Result<RpcSession> {
-        // Borrow the path once for the founding connect; clone to
-        // `PathBuf` to drive the fan-out loop without forcing
-        // `impl AsRef<Path> + Clone` on the caller (each
-        // `add_outgoing_connection_android13plus` takes a fresh
-        // `impl AsRef<Path>`).
-        let path: std::path::PathBuf = path.as_ref().to_owned();
-        let session = Self::setup_unix_client_android13plus(&path, max_version)?;
-        let local = local_max_outgoing.max(1);
-        if local == 1 {
-            // Single-connection: skip GET_MAX_THREADS entirely so the
-            // wire is bit-identical to the founding-only helper.
-            return Ok(session);
-        }
-        // `negotiate(local)` exchanges GET_MAX_THREADS, records the
-        // `min(local, remote)` on the session, and returns that exact
-        // value — which is AOSP `setupClient`'s `outgoingConnections`
-        // by construction (it computes the same `min` then mints the
-        // pool against it).
-        let negotiated = session.negotiate(local)?;
-        if negotiated <= 1 {
-            return Ok(session);
-        }
-        let session_id = session.get_session_id()?;
-        // `1..negotiated` ⇒ exactly `negotiated - 1` extras; the
-        // founding connection counts as the first slot. AOSP loop:
-        // `for (i = 0; i + 1 < outgoingConnections; i++)`.
-        for _ in 1..negotiated {
-            session.add_outgoing_connection_android13plus(&path, max_version, &session_id)?;
-        }
-        Ok(session)
+        Self::setup_unix_client_android13plus_with_config(
+            RpcUnixClientConfig::path(path.as_ref(), max_version)
+                .outgoing_connections(local_max_outgoing),
+        )
     }
 
     /// Client: connect to a Unix-domain android-13+ RPC server **with

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -2572,6 +2572,13 @@ impl RpcSession {
         RpcSession::new(Box::new(t), AddressSpace::Initiator).map_err(StatusCode::from)
     }
 
+    /// Client: connect to a Linux/Android abstract Unix-domain RPC server.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn setup_unix_client_abstract(name: &[u8]) -> Result<RpcSession> {
+        let t = super::transport::UnixTransport::connect_abstract(name)?;
+        RpcSession::new(Box::new(t), AddressSpace::Initiator).map_err(StatusCode::from)
+    }
+
     /// Client: connect to a Unix-domain RPC server speaking the
     /// **android-13+ versioned wire**. Connects
     /// the UDS, then runs the AOSP handshake via
@@ -2583,6 +2590,17 @@ impl RpcSession {
         max_version: u32,
     ) -> Result<RpcSession> {
         let t = super::transport::UnixTransport::connect(path)?;
+        RpcSession::connect_android13plus(Box::new(t), max_version)
+    }
+
+    /// Client: connect to a Linux/Android abstract Unix-domain RPC
+    /// server speaking the **android-13+ versioned wire**.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn setup_unix_client_android13plus_abstract(
+        name: &[u8],
+        max_version: u32,
+    ) -> Result<RpcSession> {
+        let t = super::transport::UnixTransport::connect_abstract(name)?;
         RpcSession::connect_android13plus(Box::new(t), max_version)
     }
 

--- a/rsbinder/src/rpc/transport/unix.rs
+++ b/rsbinder/src/rpc/transport/unix.rs
@@ -11,7 +11,13 @@
 //! tests, and a `connect(path)` convenience.
 
 use std::io::{Read, Write};
+#[cfg(target_os = "android")]
+use std::os::android::net::SocketAddrExt;
 use std::os::fd::OwnedFd;
+#[cfg(target_os = "linux")]
+use std::os::linux::net::SocketAddrExt;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::os::unix::net::SocketAddr as UnixSocketAddr;
 use std::os::unix::net::UnixStream;
 use std::path::Path;
 
@@ -96,6 +102,13 @@ impl UnixTransport {
         // `RpcError: From<std::io::Error>` — `?` does the conversion.
         let stream = UnixStream::connect(path)?;
         Self::from_stream(stream)
+    }
+
+    /// Connect to a Linux/Android abstract Unix socket.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn connect_abstract(name: &[u8]) -> RpcResult<Self> {
+        let addr = UnixSocketAddr::from_abstract_name(name)?;
+        Self::from_stream(UnixStream::connect_addr(&addr)?)
     }
 }
 

--- a/rsbinder/tests/rpc_fd.rs
+++ b/rsbinder/tests/rpc_fd.rs
@@ -23,6 +23,7 @@ use std::thread;
 use rsbinder::rpc::transport::MemTransport;
 use rsbinder::rpc::{
     AddressSpace, FileDescriptorTransportMode as FdMode, RpcProxy, RpcServer, RpcSession,
+    RpcUnixClientConfig,
 };
 use rsbinder::{
     Binder, Interface, Parcel, ParcelFileDescriptor, Remotable, Result, SIBinder, Status,
@@ -362,4 +363,39 @@ fn fd_v1plus_aosp_roundtrip_both_directions() {
         let _ = bg.join();
         let _ = std::fs::remove_file(&path);
     }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[test]
+fn fd_v1_abstract_unix_roundtrip_arg() {
+    let name = format!("rsb_rpcfd_abs_{}", std::process::id()).into_bytes();
+    let server = RpcServer::setup_unix_server_abstract(&name).expect("bind abstract fd");
+    server.set_android13plus(1);
+    server.set_max_threads(2);
+    server.set_supported_fd_modes(&[FdMode::Unix]);
+    server.set_root(Interface::as_binder(&Binder::new(BnFd(Box::new(FdSvc)))));
+    let bg = server.run_background();
+
+    let client = RpcSession::setup_unix_client_android13plus_with_config(
+        RpcUnixClientConfig::abstract_name(&name, 1)
+            .fd_mode(FdMode::Unix)
+            .outgoing_connections(2),
+    )
+    .expect("abstract fd connect");
+    assert_eq!(client.negotiated_max_threads(), 2);
+    let root = client.get_root().expect("get_root");
+
+    let mut tf = tempfile();
+    tf.write_all(b"abstract-fd").unwrap();
+    tf.rewind().unwrap();
+    let pfd = ParcelFileDescriptor::new(tf);
+    assert_eq!(
+        call_len_of(&root, &pfd).unwrap(),
+        "abstract-fd".len() as i32
+    );
+
+    drop(root);
+    drop(client);
+    server.shutdown();
+    let _ = bg.join();
 }

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -285,7 +285,7 @@ fn poll_until(mut f: impl FnMut() -> bool) -> bool {
 struct ServeCleanup {
     server: Arc<RpcServer>,
     bg: Option<std::thread::JoinHandle<()>>,
-    path: std::path::PathBuf,
+    path: Option<std::path::PathBuf>,
 }
 impl ServeCleanup {
     fn new(
@@ -296,7 +296,7 @@ impl ServeCleanup {
         Self {
             server,
             bg: Some(bg),
-            path,
+            path: Some(path),
         }
     }
 }
@@ -328,7 +328,9 @@ impl Drop for ServeCleanup {
             }
         }
         self.server.join_workers();
-        let _ = std::fs::remove_file(&self.path);
+        if let Some(path) = &self.path {
+            let _ = std::fs::remove_file(path);
+        }
     }
 }
 
@@ -766,6 +768,45 @@ fn android13plus_profile_e2e() {
         // is dropped here as the for-loop body scope ends, in the same
         // order the explicit shutdown/join/remove_file ran before.
     }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[test]
+fn abstract_unix_socket_e2e() {
+    let r34_name = format!("rsb_rpc_abs_r34_{}", std::process::id()).into_bytes();
+    let server = RpcServer::setup_unix_server_abstract(&r34_name).expect("bind abstract r34");
+    assert!(server.path().is_none());
+    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    let bg = server.run_background();
+    let _cu_r34 = ServeCleanup {
+        server: Arc::clone(&server),
+        bg: Some(bg),
+        path: None,
+    };
+
+    let client = RpcSession::setup_unix_client_abstract(&r34_name).expect("connect abstract r34");
+    let root = EchoProxy(client.get_root().expect("get_root"));
+    assert_eq!(root.echo("abstract-r34").unwrap(), "abstract-r34");
+
+    let a13_name = format!("rsb_rpc_abs_a13_{}", std::process::id()).into_bytes();
+    let server = RpcServer::setup_unix_server_abstract(&a13_name).expect("bind abstract a13");
+    assert!(server.path().is_none());
+    server.set_android13plus(2);
+    server.set_max_threads(2);
+    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    let bg = server.run_background();
+    let _cu_a13 = ServeCleanup {
+        server: Arc::clone(&server),
+        bg: Some(bg),
+        path: None,
+    };
+
+    let client = RpcSession::setup_unix_client_android13plus_abstract(&a13_name, 2)
+        .expect("connect abstract android13plus");
+    assert_eq!(client.wire_protocol_version(), Some(2));
+    assert_eq!(client.negotiate(8).expect("negotiate"), 2);
+    let root = EchoProxy(client.get_root().expect("get_root"));
+    assert_eq!(root.echo("abstract-a13").unwrap(), "abstract-a13");
 }
 
 /// The decoupled `TlsTransport`

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use rsbinder::rpc::{RpcProxy, RpcServer, RpcSession};
+use rsbinder::rpc::{RpcProxy, RpcServer, RpcSession, RpcUnixClientConfig};
 use rsbinder::{
     Binder, Interface, Parcel, Remotable, Result, SIBinder, Status, StatusCode, TransactionCode,
     FIRST_CALL_TRANSACTION,
@@ -358,6 +358,10 @@ fn real_process_e2e_and_negotiation() {
 
     {
         let client = RpcSession::setup_unix_client(&path).expect("connect");
+        assert!(matches!(
+            client.add_outgoing_connection_android13plus(tmp_sock("r34bad"), 1, &[0u8; 32]),
+            Err(StatusCode::BadType)
+        ));
         // Explicit negotiation, local=8, server advertises 2.
         assert_eq!(client.negotiate(8).expect("negotiate"), 2);
         assert_eq!(client.negotiated_max_threads(), 2);
@@ -378,6 +382,78 @@ fn real_process_e2e_and_negotiation() {
     child.kill().expect("kill server child");
     child.wait().expect("reap server child");
     let _ = std::fs::remove_file(&path);
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[test]
+fn real_process_abstract_unix_socket_e2e() {
+    if let Ok(name) = std::env::var("RSB_RPC_ABSTRACT_SERVER") {
+        let server = RpcServer::setup_unix_server_abstract(name.as_bytes()).expect("bind abstract");
+        server.set_android13plus(2);
+        server.set_max_threads(3);
+        server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+        let _ = server.run();
+        std::process::exit(0);
+    }
+
+    let name = format!("rsb_rpc_abs_proc_{}", std::process::id());
+    let exe = std::env::current_exe().expect("current_exe");
+    let mut child = std::process::Command::new(exe)
+        .args([
+            "--exact",
+            "real_process_abstract_unix_socket_e2e",
+            "--nocapture",
+        ])
+        .env("RSB_RPC_ABSTRACT_SERVER", &name)
+        .spawn()
+        .expect("spawn abstract server child");
+
+    let client = 'connect: {
+        for _ in 0..400 {
+            if let Ok(c) = RpcSession::setup_unix_client_android13plus_with_config(
+                RpcUnixClientConfig::abstract_name(name.as_bytes(), 2),
+            ) {
+                break 'connect c;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        panic!("connect abstract server child");
+    };
+
+    assert_eq!(client.wire_protocol_version(), Some(2));
+    assert_eq!(client.negotiate(8).expect("negotiate"), 3);
+    let sid = client.get_session_id().expect("get_session_id");
+    let attached = RpcSession::setup_unix_client_android13plus_with_config(
+        RpcUnixClientConfig::abstract_name(name.as_bytes(), 2).session_id(&sid),
+    )
+    .expect("attach abstract child session");
+    assert_eq!(attached.get_session_id().expect("attached id"), sid);
+    let root = EchoProxy(attached.get_root().expect("attached get_root"));
+    assert_eq!(root.echo("abstract-process").unwrap(), "abstract-process");
+
+    let fan = RpcSession::setup_unix_client_android13plus_with_config(
+        RpcUnixClientConfig::abstract_name(name.as_bytes(), 2).outgoing_connections(3),
+    )
+    .expect("abstract child fan-out");
+    assert_eq!(fan.negotiated_max_threads(), 3);
+    let root = Arc::new(EchoProxy(fan.get_root().expect("fan get_root")));
+    let t0 = std::time::Instant::now();
+    let handles: Vec<_> = (0..3)
+        .map(|_| {
+            let root = Arc::clone(&root);
+            std::thread::spawn(move || root.slow(150).expect("slow round-trip"))
+        })
+        .collect();
+    for h in handles {
+        h.join().expect("thread");
+    }
+    assert!(
+        t0.elapsed() < Duration::from_millis(420),
+        "abstract fan-out across process must run 3 slow calls in parallel"
+    );
+
+    child.kill().expect("kill abstract server child");
+    child.wait().expect("reap abstract server child");
 }
 
 // ---- concurrency: many threads, ONE shared session ----------------
@@ -807,6 +883,44 @@ fn abstract_unix_socket_e2e() {
     assert_eq!(client.negotiate(8).expect("negotiate"), 2);
     let root = EchoProxy(client.get_root().expect("get_root"));
     assert_eq!(root.echo("abstract-a13").unwrap(), "abstract-a13");
+
+    let sid = client.get_session_id().expect("get_session_id");
+    let sid_arr: [u8; 32] = sid.as_slice().try_into().expect("32-byte session id");
+    let attached = RpcSession::setup_unix_client_android13plus_with_config(
+        RpcUnixClientConfig::abstract_name(&a13_name, 2).session_id(&sid),
+    )
+    .expect("attach abstract android13plus");
+    assert_eq!(attached.get_session_id().expect("attached id"), sid);
+    assert!(
+        poll_until(|| server.session_slot_count(&sid_arr) == Some(2)),
+        "abstract with_id attach shares the founding session"
+    );
+
+    let fan_name = format!("rsb_rpc_abs_fan_{}", std::process::id()).into_bytes();
+    let fan_server = RpcServer::setup_unix_server_abstract(&fan_name).expect("bind fan-out");
+    fan_server.set_android13plus(2);
+    fan_server.set_max_threads(3);
+    fan_server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    let fan_bg = fan_server.run_background();
+    let _cu_fan = ServeCleanup {
+        server: Arc::clone(&fan_server),
+        bg: Some(fan_bg),
+        path: None,
+    };
+
+    let fan_client = RpcSession::setup_unix_client_android13plus_with_config(
+        RpcUnixClientConfig::abstract_name(&fan_name, 2).outgoing_connections(3),
+    )
+    .expect("abstract fan-out");
+    assert_eq!(fan_client.negotiated_max_threads(), 3);
+    let fan_sid = fan_client.get_session_id().expect("fan-out id");
+    let fan_sid_arr: [u8; 32] = fan_sid.as_slice().try_into().expect("32-byte session id");
+    assert!(
+        poll_until(|| fan_server.session_slot_count(&fan_sid_arr) == Some(3)),
+        "abstract fan-out created founding + 2 attached slots"
+    );
+    let fan_root = EchoProxy(fan_client.get_root().expect("fan get_root"));
+    assert_eq!(fan_root.echo("abstract-fan").unwrap(), "abstract-fan");
 }
 
 /// The decoupled `TlsTransport`
@@ -1364,6 +1478,10 @@ fn b2_fan_out_creates_n_outgoing_slots_when_local_max_outgoing_is_n() {
 
     let client = RpcSession::setup_unix_client_android13plus_fan_out(&path, 1, 3)
         .expect("setupClient fan-out");
+    assert!(matches!(
+        client.add_outgoing_connection_android13plus(tmp_sock("badid"), 1, b"bad"),
+        Err(StatusCode::BadValue)
+    ));
     // `negotiate` was the second step of the helper ⇒ negotiated value
     // is recorded on the session and equals the fan-out pool size.
     assert_eq!(
@@ -1372,6 +1490,14 @@ fn b2_fan_out_creates_n_outgoing_slots_when_local_max_outgoing_is_n() {
         "helper performed GET_MAX_THREADS and recorded min(local=3, server=3) = 3"
     );
     let sid = client.get_session_id().expect("get_session_id");
+    assert!(matches!(
+        client.add_outgoing_connection_android13plus_with_config(
+            RpcUnixClientConfig::path(&tmp_sock("badfd"), 1)
+                .session_id(&sid)
+                .fd_mode(rsbinder::rpc::FileDescriptorTransportMode::Unix),
+        ),
+        Err(StatusCode::BadValue)
+    ));
     let sid_arr: [u8; 32] = sid
         .as_slice()
         .try_into()


### PR DESCRIPTION
Add abstract Unix socket server/client support for RPC and Accessor addressing, covering both R34 and android-13+ RPC paths.

Validate direct abstract RPC with same-process and cross-process e2e tests, plus Accessor abstract fd roundtrip coverage.

Tested only on Android 16 devices (I only have two A16 phones), more tests needed. Please leave comments if there're any problems.