### PR TITLE
chore(release): abstract-UDS follow-ups (#166) and bump to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,20 @@ This changelog starts at 0.9.0. For earlier releases, see the
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-08
+
 ### Changed
 
+- **rsbinder (breaking):** `AccessorSockAddr` gained the `UnixAbstract`
+  variant. The enum is intentionally not `#[non_exhaustive]` (its shape is
+  part of the documented contract), so downstream exhaustive `match`es
+  need a new arm. (#166)
+- **rpc (AOSP alignment):** additional outgoing connections opened by
+  `add_outgoing_connection_android13plus` now carry the session's fd
+  transport mode in the connection header (previously hardcoded to none),
+  matching AOSP `RpcSession::setupOneSocketConnection`; the session id is
+  also validated as exactly 32 bytes up front (`BadValue`) instead of
+  being sent malformed. (#166)
 - **rsbinder-aidl (breaking, AOSP alignment):** expression precedence now
   matches AOSP's C-style grammar — bitwise `|`/`^`/`&` bind looser than
   `==`/`!=` and relational operators. An unparenthesized expression mixing
@@ -100,6 +112,20 @@ This changelog starts at 0.9.0. For earlier releases, see the
   constants render as `&[&str]` (the previous `&[String]` type did not
   accept string-literal initializers); crate-level rustdoc and README
   updated.
+- **rpc:** abstract Unix-domain socket support (Linux/Android):
+  `RpcServer::setup_unix_server_abstract`,
+  `RpcSession::setup_unix_client_abstract` (R34 wire),
+  `setup_unix_client_android13plus_abstract`, and the
+  `AccessorSockAddr::UnixAbstract` variant for accessor addressing.
+  Abstract sockets have no filesystem entry (nothing to unlink) — and no
+  filesystem permissions; see the `setup_unix_server_abstract` rustdoc
+  for the `set_authorizer` guidance. (#166, thanks @qwq233)
+- **rpc:** `RpcUnixClientConfig` builder plus
+  `RpcSession::setup_unix_client_android13plus_with_config` /
+  `add_outgoing_connection_android13plus_with_config`: a single client
+  entry point combining path or abstract addressing, session-id attach,
+  fan-out (`outgoing_connections`), and fd transport mode. The existing
+  `with_id` / `fan_out` helpers delegate to it (wire-identical). (#166)
 
 ### Fixed
 
@@ -248,5 +274,6 @@ A large body of correctness work from multiple review and audit rounds
 - Addressed RUSTSEC-2025-0134 by replacing `rustls-pemfile` with
   `rustls-pki-types`.
 
-[Unreleased]: https://github.com/hiking90/rsbinder/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/hiking90/rsbinder/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/hiking90/rsbinder/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/hiking90/rsbinder/compare/v0.8.0...v0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "example-hello"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "env_logger",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "rsbinder"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "env_logger",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "rsbinder-aidl"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "convert_case",
  "miette",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "rsbinder-tools"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anstyle",
  "clap",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Jeff Kim <hiking90@gmail.com>"]
@@ -26,13 +26,13 @@ rust-version = "1.85"
 keywords = ["android", "binder", "aidl", "linux"]
 
 [workspace.dependencies]
-rsbinder = { version = "0.9.0", path = "rsbinder" }
+rsbinder = { version = "0.10.0", path = "rsbinder" }
 log = "0.4"
 env_logger = "0.11"
 anstyle = "1.0"
 tokio = { version = "1.52", default-features = false }
 async-trait = "0.1"
-rsbinder-aidl = { version = "0.9.0", path = "rsbinder-aidl" }
+rsbinder-aidl = { version = "0.10.0", path = "rsbinder-aidl" }
 pest = "2.8"
 pest_derive = "2.8"
 convert_case = "0.11"

--- a/rsbinder-aidl/README.md
+++ b/rsbinder-aidl/README.md
@@ -5,10 +5,10 @@ This is an AIDL compiler for **rsbinder**.
 Add dependencies to Cargo.toml (check crates.io for the latest version):
 ```toml
 [dependencies]
-rsbinder = "0.9"
+rsbinder = "0.10"
 
 [build-dependencies]
-rsbinder-aidl = { version = "0.9", features = ["async"] }
+rsbinder-aidl = { version = "0.10", features = ["async"] }
 ```
 
 Create a build.rs file:
@@ -51,10 +51,10 @@ rsbinder::include_aidl!("my_service", crate::IMyService::*);
 For environments without async runtime:
 ```toml
 [dependencies]
-rsbinder = { version = "0.9", default-features = false }
+rsbinder = { version = "0.10", default-features = false }
 
 [build-dependencies]
-rsbinder-aidl = "0.9"
+rsbinder-aidl = "0.10"
 ```
 
 ## Error Reporting

--- a/rsbinder/src/hub/accessor_register.rs
+++ b/rsbinder/src/hub/accessor_register.rs
@@ -66,6 +66,12 @@ pub enum AccessorSockAddr {
     Unix(PathBuf),
     /// AF_UNIX abstract name. Variant is always present for enum-shape
     /// stability; connect is supported only on Linux / Android.
+    ///
+    /// **Security**: the abstract namespace has no filesystem
+    /// permissions — any same-network-namespace process can bind a name
+    /// first and impersonate the server (path-bound sockets can rely on
+    /// directory modes to prevent this). Trust in the peer must come
+    /// from elsewhere, e.g. LSM policy or post-connect verification.
     UnixAbstract(Vec<u8>),
     /// AF_VSOCK `(cid, port)`. Only usable when the binary was built
     /// with the `rpc-vsock` feature; otherwise the connect helper

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -78,6 +78,7 @@ enum ServerListener {
 /// kernel reclaims the bind on `Drop` of the listener fd itself).
 enum BindAddress {
     Unix(PathBuf),
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     UnixAbstract,
     #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
     Vsock {
@@ -471,6 +472,15 @@ impl RpcServer {
     /// Bind + listen on a Linux/Android abstract Unix-domain socket.
     /// Abstract sockets have no filesystem entry, so there is no stale
     /// path to remove and no drop-time unlink.
+    ///
+    /// **Security**: unlike a path-bound socket, an abstract socket has
+    /// no filesystem permissions — *any* process in the same network
+    /// namespace can connect (subject only to LSM policy such as
+    /// SELinux). A path-bound [`setup_unix_server`](Self::setup_unix_server)
+    /// can rely on directory modes for access control; an abstract
+    /// server cannot. When exposure matters, install a
+    /// [`set_authorizer`](Self::set_authorizer) hook and check the
+    /// peer identity (uid/gid/pid) it receives.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn setup_unix_server_abstract(name: &[u8]) -> Result<Arc<RpcServer>> {
         let addr = UnixSocketAddr::from_abstract_name(name)?;
@@ -1509,6 +1519,7 @@ impl RpcServer {
     pub fn path(&self) -> Option<&Path> {
         match &self.bind {
             BindAddress::Unix(p) => Some(p.as_path()),
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             BindAddress::UnixAbstract => None,
             #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
             BindAddress::Vsock { .. } => None,
@@ -1540,6 +1551,7 @@ impl RpcServer {
         match &self.bind {
             BindAddress::Tcp(addr) => Some(*addr),
             BindAddress::Unix(_) => None,
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             BindAddress::UnixAbstract => None,
             #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
             BindAddress::Vsock { .. } => None,
@@ -1578,6 +1590,7 @@ impl Drop for RpcServer {
                 // on the same path doesn't see a stale ENOENT/EADDRINUSE.
                 let _ = std::fs::remove_file(p);
             }
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             BindAddress::UnixAbstract => {}
             #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
             BindAddress::Vsock { .. } => {

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -51,7 +51,23 @@ enum RpcUnixAddr<'a> {
     Abstract(&'a [u8]),
 }
 
-/// Unix-domain android-13+ RPC client configuration.
+/// Unix-domain android-13+ RPC client configuration — the builder
+/// consumed by
+/// [`RpcSession::setup_unix_client_android13plus_with_config`] and
+/// [`RpcSession::add_outgoing_connection_android13plus_with_config`].
+///
+/// One config expresses everything the per-shape convenience helpers
+/// (`setup_unix_client_android13plus{,_abstract,_with_id,_fan_out}`)
+/// take positionally: the address (filesystem path or Linux/Android
+/// abstract name), the highest wire version to offer, and the optional
+/// session-id attach / fan-out / fd-transport-mode knobs. The defaults
+/// (`session_id = empty`, `outgoing_connections = 1`, `fd_mode = None`)
+/// reproduce the plain single-connection
+/// [`RpcSession::setup_unix_client_android13plus`] byte-for-byte.
+///
+/// `session_id` and `outgoing_connections > 1` are mutually exclusive
+/// (attaching joins an existing session; fan-out mints a new one) —
+/// the consuming setup call rejects the combination with `BadValue`.
 pub struct RpcUnixClientConfig<'a> {
     addr: RpcUnixAddr<'a>,
     max_version: u32,
@@ -71,25 +87,38 @@ impl<'a> RpcUnixClientConfig<'a> {
         }
     }
 
+    /// Config for a filesystem-path Unix socket, offering at most wire
+    /// version `max_version` in the handshake.
     pub fn path(path: &'a Path, max_version: u32) -> Self {
         Self::new(RpcUnixAddr::Path(path), max_version)
     }
 
+    /// Config for a Linux/Android abstract Unix socket, offering at
+    /// most wire version `max_version` in the handshake.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub fn abstract_name(name: &'a [u8], max_version: u32) -> Self {
         Self::new(RpcUnixAddr::Abstract(name), max_version)
     }
 
+    /// Attach to an existing server session by echoing its 32-byte id
+    /// (AOSP `RpcSession::setupClient` follow-up connections). Empty
+    /// (the default) requests a brand-new session.
     pub fn session_id(mut self, session_id: &'a [u8]) -> Self {
         self.session_id = session_id;
         self
     }
 
+    /// Ask for an `n`-connection outgoing pool (AOSP `setupClient`
+    /// fan-out): the setup call negotiates `min(n, server max)` and
+    /// opens that many connections. Default 1 = founding connection
+    /// only, skipping negotiation entirely.
     pub fn outgoing_connections(mut self, n: u32) -> Self {
         self.outgoing_connections = n;
         self
     }
 
+    /// Request an fd transport mode in the connection header (AOSP
+    /// `setFileDescriptorTransportMode`). Default is no fd support.
     pub fn fd_mode(mut self, mode: FileDescriptorTransportMode) -> Self {
         self.fd_mode = Some(mode);
         self

--- a/rsbinder/tests/rpc_fd.rs
+++ b/rsbinder/tests/rpc_fd.rs
@@ -23,7 +23,6 @@ use std::thread;
 use rsbinder::rpc::transport::MemTransport;
 use rsbinder::rpc::{
     AddressSpace, FileDescriptorTransportMode as FdMode, RpcProxy, RpcServer, RpcSession,
-    RpcUnixClientConfig,
 };
 use rsbinder::{
     Binder, Interface, Parcel, ParcelFileDescriptor, Remotable, Result, SIBinder, Status,
@@ -368,6 +367,8 @@ fn fd_v1plus_aosp_roundtrip_both_directions() {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[test]
 fn fd_v1_abstract_unix_roundtrip_arg() {
+    use rsbinder::rpc::RpcUnixClientConfig;
+
     let name = format!("rsb_rpcfd_abs_{}", std::process::id()).into_bytes();
     let server = RpcServer::setup_unix_server_abstract(&name).expect("bind abstract fd");
     server.set_android13plus(1);

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -396,17 +396,29 @@ fn real_process_abstract_unix_socket_e2e() {
         std::process::exit(0);
     }
 
+    // Kill + reap the server child even when an assert below panics —
+    // its `server.run()` loop never exits on its own.
+    struct KillOnDrop(std::process::Child);
+    impl Drop for KillOnDrop {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
     let name = format!("rsb_rpc_abs_proc_{}", std::process::id());
     let exe = std::env::current_exe().expect("current_exe");
-    let mut child = std::process::Command::new(exe)
-        .args([
-            "--exact",
-            "real_process_abstract_unix_socket_e2e",
-            "--nocapture",
-        ])
-        .env("RSB_RPC_ABSTRACT_SERVER", &name)
-        .spawn()
-        .expect("spawn abstract server child");
+    let _child = KillOnDrop(
+        std::process::Command::new(exe)
+            .args([
+                "--exact",
+                "real_process_abstract_unix_socket_e2e",
+                "--nocapture",
+            ])
+            .env("RSB_RPC_ABSTRACT_SERVER", &name)
+            .spawn()
+            .expect("spawn abstract server child"),
+    );
 
     let client = 'connect: {
         for _ in 0..400 {
@@ -451,9 +463,6 @@ fn real_process_abstract_unix_socket_e2e() {
         t0.elapsed() < Duration::from_millis(420),
         "abstract fan-out across process must run 3 slow calls in parallel"
     );
-
-    child.kill().expect("kill abstract server child");
-    child.wait().expect("reap abstract server child");
 }
 
 // ---- concurrency: many threads, ONE shared session ----------------


### PR DESCRIPTION
Follow-ups for the abstract unix socket support merged in #166, plus the 0.10.0 release bump the breaking change requires.

## #166 follow-ups

- **macOS build warnings (would fail a `-D warnings` run):**
  - cfg-gate `BindAddress::UnixAbstract` to Linux/Android — its only constructor (`setup_unix_server_abstract`) is target-gated, so the unconditional variant tripped `dead_code` on macOS.
  - move the `RpcUnixClientConfig` import in `rpc_fd.rs` into the Linux-only test (`unused_imports` on macOS).
- **Security documentation:** the abstract namespace has no filesystem permissions — any same-network-namespace process can connect, and can bind a name first to impersonate a server. Documented on `setup_unix_server_abstract` (pointing at `set_authorizer` + peer identity checks) and on `AccessorSockAddr::UnixAbstract`.
- **Rustdoc:** flesh out `RpcUnixClientConfig` contract docs — defaults reproduce the single-connection helper byte-for-byte; `session_id` and `outgoing_connections > 1` are mutually exclusive (`BadValue`).
- **Test hygiene:** `real_process_abstract_unix_socket_e2e` now kills + reaps its server child via a drop guard, so a failed assert no longer leaks a forever-running child process.

## Release 0.10.0

`AccessorSockAddr` gained a variant in #166; the enum is intentionally not `#[non_exhaustive]`, so downstream exhaustive `match`es break — a semver-breaking change, hence 0.10.0 (pre-1.0 minor = breaking boundary).

- bump the workspace version and inter-crate dependencies; refresh rsbinder-aidl README snippets.
- CHANGELOG: record #166 under Added/Changed (breaking variant addition; AOSP-aligned fd-mode-in-header and 32-byte session-id validation changes in `add_outgoing_connection_android13plus`), and cut the `[0.10.0] - 2026-07-08` section.

## Verification

- macOS: `cargo fmt --check`, clippy clean on `rpc` and `rpc,rpc-tls,rpc-vsock`; `rpc_fd` 4/0, `rpc_server` 27/0, lib 281/0.
- Linux (Arch, kernel Rust binder box): clippy clean; `rpc_fd` 5/0, `rpc_server` 29/0 — including `abstract_unix_socket_e2e`, `real_process_abstract_unix_socket_e2e`, `fd_v1_abstract_unix_roundtrip_arg`, and the accessor abstract roundtrip.
- `cargo doc`: all intra-doc links added here resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
