### PR TITLE
docs: prepare 0.10.0 release notes and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,15 @@ This changelog starts at 0.9.0. For earlier releases, see the
 
 ## [Unreleased]
 
-## [0.10.0] - 2026-07-08
+## [0.10.0] - 2026-07-11
 
 ### Changed
 
+- **rsbinder:** oneway transactions now propagate transport errors (e.g.
+  `DeadObject`) to the caller instead of swallowing them as `Ok(())`,
+  matching AOSP's generated Rust proxies. (#159)
+- Dropped the `downcast-rs` dependency (replaced by std `Arc` downcasting)
+  and trimmed unused `tera` builtins from rsbinder-aidl's dependency tree.
 - **rsbinder (breaking):** `AccessorSockAddr` gained the `UnixAbstract`
   variant. The enum is intentionally not `#[non_exhaustive]` (its shape is
   part of the documented contract), so downstream exhaustive `match`es
@@ -83,6 +88,30 @@ This changelog starts at 0.9.0. For earlier releases, see the
 
 ### Added
 
+- **hub:** Android 17 (SDK 37) service-manager support. SDK 37 shares
+  Android 16's service-manager wire format, so it is served by the existing
+  `android_16` / `android_16_plus` features — no new feature flag.
+  Validated against an API 37 emulator. (#158)
+- **hub:** event-driven service lookups matching AOSP `waitForService`:
+  `wait_for_service` / `wait_for_interface` (block until registered, via
+  `registerForNotifications` where available) and non-blocking
+  `check_interface`. (#159)
+- **hub:** error-preserving lookups `try_get_service` / `try_get_interface`
+  returning `Result<Option<_>>`, so "service not registered" (`Ok(None)`)
+  is distinguishable from a transport/service-manager failure (`Err`). (#159)
+- **hub:** `add_service` now accepts `impl Into<SIBinder>` (pass a
+  `Strong<dyn IFoo>` or a reference to one directly — no `.as_binder()`),
+  backed by new `From<Strong<I>>` / `TryFrom<SIBinder>` conversions; plus
+  public `register_client_callback` / `try_unregister_service` for lazy
+  services. (#159)
+- **rsbinder:** `include_aidl!` macro replacing the
+  `include!(concat!(env!("OUT_DIR"), …))` + re-export boilerplate;
+  `BinderResult<T>` alias with `From<std::io::Error>` /
+  `From<TryFromSliceError>` for `Status`;
+  `SIBinder::link_to_death_arc` / `unlink_to_death_arc` (no more manual
+  `Arc::downgrade` incantation); `ParcelFileDescriptor::try_clone` +
+  `AsFd` + `From<OwnedFd>` / `From<File>`; typed `Parcel` scalar
+  read/write helpers; `RpcSession::get_interface`. (#159)
 - **rsbinder-aidl:** string concatenation composes through the ordinary
   expression grammar: `CONST_A + "suffix"` and parenthesized chains
   (`("a" + "b")`) now parse; previously only a literal-first chain did.
@@ -161,6 +190,12 @@ This changelog starts at 0.9.0. For earlier releases, see the
 
 ### Deprecated / known gaps
 
+- **hub:** `get_service` / `get_interface` are now `#[deprecated]`: their
+  implicit wait behavior is inconsistent across Android versions. Migrate to
+  `wait_for_service` / `wait_for_interface` (blocking), `check_service` /
+  `check_interface` (non-blocking), or the error-preserving `try_*`
+  variants. The functions still work; upgrading surfaces a compile-time
+  deprecation warning. (#159)
 - **rsbinder-aidl:** an AIDL `/** @deprecated */` doc comment is not yet
   propagated to a Rust `#[deprecated]` attribute (AOSP does). No wire or
   correctness impact; downstream users of a deprecated AIDL member simply do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,15 +150,15 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -479,9 +479,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -493,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -559,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -798,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustix"
@@ -1235,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -1513,18 +1513,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ $ mdbook serve
 
 ## Current Development Status
 
-**rsbinder** is pre-1.0 — the API may still change before 1.0. Core binder, AIDL, RPC transport, and Android `libbinder` interop are exercised by CI across Android API 29–36 and a Linux native-kernel-binder host.
+**rsbinder** is pre-1.0 — the API may still change before 1.0. Core binder, AIDL, RPC transport, and Android `libbinder` interop are exercised by CI across Android API 29–36 and a Linux native-kernel-binder host; Android 17 (API 37) is validated on an emulator.
 
 ## Platform Support
 
 | Platform | Kernel binder (`/dev/binder`) | RPC transport (binder-over-socket) |
 |----------|:-----------------------------:|:----------------------------------:|
 | Linux    | ✅ (binderfs)                  | ✅                                  |
-| Android  | ✅ (API 29–36)                 | ✅ (`libbinder` RPC v1 / v2 interop) |
+| Android  | ✅ (API 29–37)                 | ✅ (`libbinder` RPC v1 / v2 interop) |
 | macOS    | —                             | ✅ (first-class)                    |
 
 The RPC transport requires no kernel module, no root, and no special device file — making rsbinder usable as a general cross-platform Rust IPC layer in addition to its Android role.
@@ -129,7 +129,7 @@ Please follow the [cargo-ndk](https://github.com/bbqsrc/cargo-ndk) guide.
 - **Memory Management** — compatible parcel serialization and shared-memory handling.
 
 ### Android Version Support
-**rsbinder** supports Android versions 10 through 16 (API levels 29–36). Android 10 uses the legacy C service manager protocol; APIs not implemented there (`is_declared`, `register_for_notifications`, `unregister_for_notifications`, `get_service_debug_info`) return an error or `false` so callers can detect the gap. CI exercises emulator API levels 29, 30, 32, 34, and 36.
+**rsbinder** supports Android versions 10 through 17 (API levels 29–37). Android 15 (SDK 35) and Android 17 (SDK 37) share the Android 14 / Android 16 service-manager wire format respectively, so they are covered by the `android_14` / `android_16` features — no dedicated feature flag is needed. Android 10 uses the legacy C service manager protocol; APIs not implemented there (`is_declared`, `register_for_notifications`, `unregister_for_notifications`, `get_service_debug_info`) return an error or `false` so callers can detect the gap. CI exercises emulator API levels 29, 30, 32, 34, and 36.
 
 ### AIDL Compatibility
 The **rsbinder-aidl** compiler generates Rust code that maintains compatibility with Android's AIDL:

--- a/book/src/aidl-annotations.md
+++ b/book/src/aidl-annotations.md
@@ -34,6 +34,8 @@ pub struct Point {
 | `PartialEq` | Enables equality comparison |
 | `Copy` | Enables bitwise copy (fixed-size types only) |
 
+These are the most common choices, but the list is not exhaustive: as in AOSP, the generator passes through any `Name=true` identifier as a derive, so other derivable traits (`Eq`, `Hash`, `PartialOrd`, `Ord`, ...) work the same way.
+
 ### Why Clone Is Not Derived by Default
 
 Generated types do **not** derive `Clone` by default. This is intentional because some AIDL types contain fields that cannot be cloned:
@@ -118,7 +120,7 @@ Apply `@nullable` to method parameters, return values, or struct fields:
 ```aidl
 interface IUserService {
     @nullable String getName();
-    void setValues(@nullable in int[] values);
+    void setValues(in @nullable int[] values);
 }
 ```
 
@@ -320,8 +322,8 @@ The following table provides a quick reference for all annotations covered in th
 | `@nullable(heap=true)` | field | AOSP-faithful syntax for recursive fields; rsbinder boxes self-referential fields automatically (parameter accepted but not required) |
 | `@utf8InCpp` | String | No effect in Rust (strings are always UTF-8) |
 | `@Descriptor` | interface | Overrides the wire descriptor string |
-| `@VintfStability` | parcelable, interface | Enforces VINTF stability rules |
-| `@FixedSize` | parcelable | Restricts fields to fixed-size types, enables `Copy` |
+| `@VintfStability` | parcelable, interface | Stamps `Stability::Vintf`; structural constraints not enforced |
+| `@FixedSize` | parcelable | Recognized; currently a no-op (`Copy` comes from `@RustDerive(Copy=true)`) |
 | `@EnforcePermission` | interface method | Generates a `PermissionManagerService` check (kernel-only; denied over RPC) |
 
 When writing AIDL files for rsbinder, the most commonly used annotations are `@RustDerive` (for ergonomic Rust types), `@Backing` (for enums), and `@nullable` (for optional values). The remaining annotations are important for interoperability with Android or for specific use cases like recursive types and interface migration.

--- a/book/src/aidl-data-types.md
+++ b/book/src/aidl-data-types.md
@@ -115,7 +115,7 @@ For input parameters, a nullable array becomes `Option<&[T]>`. For return values
 AIDL definition:
 
 ```aidl
-@nullable int[] RepeatNullableIntArray(@nullable in int[] input);
+@nullable int[] RepeatNullableIntArray(in @nullable int[] input);
 ```
 
 Rust service implementation:

--- a/book/src/aidl-parcelable.md
+++ b/book/src/aidl-parcelable.md
@@ -43,7 +43,7 @@ assert_eq!(default_profile.age, 0);
 
 ## Constants in Parcelable
 
-Parcelable types can define constants, including numeric values and bit flags. These are emitted as module-level `pub const` items inside the generated parcelable module. Because the module shares its name with the struct, you still reach them with the familiar `TypeName::CONSTANT` path. This pattern is commonly used for configuration values and flag fields.
+Parcelable types can define constants, including numeric values and bit flags. These are emitted as module-level `pub const` items inside the generated parcelable module — not as associated constants on the struct. The familiar-looking `TypeName::CONSTANT` path therefore resolves through the *module* name (which shares its name with the struct), so you must import the module, not the struct: `use ...::Config;` gives you both `Config::BIT_VERBOSE` (the constant) and `Config::Config` (the struct). Importing the struct directly (`use ...::Config::Config;`) shadows the module path and makes the constants unreachable through it. This pattern is commonly used for configuration values and flag fields.
 
 ```aidl
 @RustDerive(Clone=true, PartialEq=true)
@@ -58,12 +58,12 @@ parcelable Config {
 }
 ```
 
-In Rust, the constants are accessed through the type path:
+In Rust, the constants are accessed through the module path, and the struct through the module-qualified `Config::Config` spelling:
 
 ```rust
-use Config::Config;
+use com::example::Config;
 
-let mut cfg = Config::default();
+let mut cfg = Config::Config::default();
 assert_eq!(cfg.retryCount, 5);
 
 cfg.flags = Config::BIT_VERBOSE | Config::BIT_DEBUG;
@@ -74,14 +74,14 @@ This pattern mirrors how the Android test suite defines and uses bit flags withi
 
 ## Using Parcelable in Services
 
-Parcelable types are passed to and from service methods as regular parameters. A common pattern is to pass a mutable reference to a parcelable so that the service can fill in or modify its fields. This is based on the `FillOutStructuredParcelable` pattern used in the rsbinder test suite.
+Parcelable types are passed to and from service methods as regular parameters. A common pattern is to pass a mutable reference to a parcelable so that the service can fill in or modify its fields. This is based on the `FillOutStructuredParcelable` pattern used in the rsbinder test suite. As with the constants above, `StructuredParcelable` in the snippets below names the generated *module*: the struct is written module-qualified as `StructuredParcelable::StructuredParcelable`, while the bit constants (`StructuredParcelable::BIT0`, `StructuredParcelable::BIT2`) resolve through the module.
 
 Service implementation:
 
 ```rust
 fn FillOutStructuredParcelable(
     &self,
-    parcelable: &mut StructuredParcelable,
+    parcelable: &mut StructuredParcelable::StructuredParcelable,
 ) -> rsbinder::status::Result<()> {
     parcelable.shouldBeJerry = "Jerry".into();
     parcelable.shouldContainThreeFs = vec![parcelable.f, parcelable.f, parcelable.f];
@@ -94,7 +94,7 @@ fn FillOutStructuredParcelable(
 Client side:
 
 ```rust
-let mut parcelable = StructuredParcelable {
+let mut parcelable = StructuredParcelable::StructuredParcelable {
     f: 17,
     shouldSetBit0AndBit2: 0,
     ..Default::default()
@@ -119,7 +119,7 @@ The `@nullable` annotation allows a parcelable parameter or return type to be `N
 AIDL declaration:
 
 ```aidl
-@nullable Empty RepeatNullableParcelable(@nullable in Empty input);
+@nullable Empty RepeatNullableParcelable(in @nullable Empty input);
 ```
 
 Service implementation:
@@ -167,7 +167,7 @@ for n in 0..10 {
 let result = service.ReverseList(head.as_ref().unwrap())?;
 
 // Traverse the reversed list: [0, 1, ..., 9]
-let mut current: Option<&RecursiveList> = result.as_ref();
+let mut current: Option<&RecursiveList> = Some(&result);
 for n in 0..10 {
     assert_eq!(current.map(|inner| inner.value), Some(n));
     current = current.unwrap().next.as_ref().map(|n| n.as_ref());
@@ -270,4 +270,4 @@ Here are some practical guidelines when working with parcelable types in rsbinde
 
 - **Place each parcelable in its own `.aidl` file.** Following the AIDL convention, each parcelable type should be defined in a separate file whose name matches the type name (e.g., `UserProfile.aidl` for `parcelable UserProfile`).
 
-- **Constants are scoped to the parcelable.** When you define `const int MAX_VALUE = 100;` inside a parcelable, access it in Rust as `MyParcelable::MAX_VALUE`. This keeps related constants close to the data they describe.
+- **Constants are scoped to the parcelable's module.** When you define `const int MAX_VALUE = 100;` inside a parcelable, access it in Rust as `MyParcelable::MAX_VALUE`, where `MyParcelable` is the generated *module* (import the module, not the struct — the struct itself is `MyParcelable::MyParcelable`). This keeps related constants close to the data they describe.

--- a/book/src/android.md
+++ b/book/src/android.md
@@ -18,8 +18,9 @@ See: [Android Build Environment Setup](./android-build.md)
 - **Android 13 (API 33)**: `android_13` feature
 - **Android 14 (API 34)**: `android_14` feature
 - **Android 16 (API 36)**: `android_16` feature
+- **Android 17 (API 37)**: served by the `android_16` feature
 
-> **Note**: Android 12L (API 32) uses the same Binder protocol as Android 12, so both are covered by the `android_12` feature flag. Similarly, Android 15 (API 35) uses the same Binder protocol as Android 14, so it is covered by the `android_14` or `android_14_plus` feature flag. No separate `android_12l` or `android_15` feature is needed.
+> **Note**: Android 12L (API 32) uses the same Binder protocol as Android 12, so both are covered by the `android_12` feature flag. Similarly, Android 15 (API 35) uses the same Binder protocol as Android 14, so it is covered by the `android_14` or `android_14_plus` feature flag, and Android 17 (API 37) uses the same Binder protocol as Android 16, so it is covered by the `android_16` or `android_16_plus` feature flag. No separate `android_12l`, `android_15`, or `android_17` feature is needed.
 
 > **Android 10 caveat**: Android 10 uses the legacy C `IServiceManager` (the AIDL-based interface only landed in Android 11). The `android_10` dispatch supports `get_service`, `check_service`, `add_service`, and `list_services`. APIs introduced later — `is_declared`, `register_for_notifications`, `unregister_for_notifications`, and `get_service_debug_info` — return `false` or `StatusCode::UnknownTransaction` so callers can detect the gap rather than silently misbehave.
 
@@ -29,16 +30,16 @@ In your `Cargo.toml`, specify the Android versions you want to support:
 
 ```toml
 [dependencies]
-rsbinder = { version = "0.8", features = ["android_14_plus"] }
+rsbinder = { version = "0.10", features = ["android_14_plus"] }
 ```
 
 Available feature combinations:
-- `android_10_plus`: Supports Android 10 through 16
-- `android_11_plus`: Supports Android 11 through 16
-- `android_12_plus`: Supports Android 12 through 16
-- `android_13_plus`: Supports Android 13 through 16
-- `android_14_plus`: Supports Android 14 through 16
-- `android_16_plus`: Supports Android 16 only
+- `android_10_plus`: Supports Android 10 through 17
+- `android_11_plus`: Supports Android 11 through 17
+- `android_12_plus`: Supports Android 12 through 17
+- `android_13_plus`: Supports Android 13 through 17
+- `android_14_plus`: Supports Android 14 through 17
+- `android_16_plus`: Supports Android 16 and 17
 
 ### Protocol Compatibility
 

--- a/book/src/arch-linux.md
+++ b/book/src/arch-linux.md
@@ -71,15 +71,16 @@ $ cargo run --bin hello_client
 
 ## Persistent Configuration
 
-To automatically load binder modules on boot:
+The linux-zen kernel builds binder directly into the kernel
+(`CONFIG_ANDROID_BINDER_IPC=y`), so there is no module to load on boot —
+no `modules-load.d` or `modprobe` configuration is needed. The only
+non-persistent piece is the binderfs device itself: re-run
+`sudo rsb_device binder` after each reboot (see above).
 
-```bash
-# Create module loading configuration
-$ echo "binder_linux" | sudo tee /etc/modules-load.d/binder.conf
-
-# Set module parameters
-$ echo "options binder_linux devices=binder,hwbinder,vndbinder" | sudo tee /etc/modprobe.d/binder.conf
-```
+> **Note**: `binder_linux` is the out-of-tree Anbox DKMS module, not
+> part of the zen kernel. `modules-load.d` / `modprobe binder_linux`
+> instructions found elsewhere apply only to that third-party module
+> setup on kernels without built-in binder support.
 
 ## Troubleshooting
 
@@ -92,8 +93,8 @@ $ dmesg | grep -i binder
 # Verify zen kernel is running
 $ uname -r | grep zen
 
-# Check if modules loaded successfully
-$ sudo modprobe -v binder_linux
+# Verify binder is built into the kernel config
+$ zgrep -E "(ANDROID|BINDER)" /proc/config.gz
 ```
 
 ## References

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -48,14 +48,14 @@ flowchart BT
     - Supports both native services and async services with runtime integration.
 
 - **Binder Client**
-    - Use hub::get_interface() to obtain a strongly-typed proxy to the service.
+    - Use hub::wait_for_interface() to obtain a strongly-typed proxy to the service (or hub::check_interface() / hub::try_get_interface() for non-blocking lookup).
     - The generated proxy code handles all IPC marshalling/unmarshalling automatically.
     - Supports death notifications for service lifecycle management.
     - Can register service callbacks for service availability notifications.
     - Full type safety with compile-time interface validation.
 
 - **HUB (Service Manager)**
-    - In **rsbinder**, the service manager is referred to as **HUB**. The `hub` module in the rsbinder API provides a unified interface (`hub::add_service()`, `hub::get_interface()`, etc.) that works on both platforms.
+    - In **rsbinder**, the service manager is referred to as **HUB**. The `hub` module in the rsbinder API provides a unified interface (`hub::add_service()`, `hub::wait_for_interface()`, etc.) that works on both platforms.
     - **On Linux**: **rsbinder** provides **rsb_hub**, a standalone service manager that you run as a separate process. You must start `rsb_hub` before registering or discovering services.
     - **On Android**: The system already provides its own service manager (`servicemanager`). **rsbinder** connects to it automatically — no need to run `rsb_hub`.
     - Handles service registration, discovery, and lifecycle management.

--- a/book/src/async-service.md
+++ b/book/src/async-service.md
@@ -94,10 +94,12 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     runtime.block_on(async {
         // Create and register the async service (see next section).
+        // `add_service` accepts anything convertible into `SIBinder`, so
+        // the typed binder is passed directly — no `.as_binder()` needed.
         let service = BnMyService::new_async_binder(
             MyAsyncService::default(), rt(),
         );
-        hub::add_service("com.example.myservice", service.as_binder())
+        hub::add_service("com.example.myservice", &service)
             .expect("Could not register service");
 
         // Yield to the runtime. This keeps the process alive and

--- a/book/src/callbacks-and-interfaces.md
+++ b/book/src/callbacks-and-interfaces.md
@@ -233,7 +233,7 @@ impl INestedService::ICallback::ICallback for Callback {
 To create and pass a nested callback to the service:
 
 ```rust
-let service: rsbinder::Strong<dyn INestedService::INestedService> = hub::get_interface(
+let service: rsbinder::Strong<dyn INestedService::INestedService> = hub::wait_for_interface(
     <INestedService::BpNestedService as INestedService::INestedService>::descriptor(),
 )
 .expect("did not get binder service");
@@ -258,6 +258,8 @@ assert_eq!(*received, Some(ParcelableWithNested::Status::Status::OK));
 ```
 
 The key detail is the fully-qualified path for the nested callback's Binder node: `INestedService::ICallback::BnCallback`. This follows the Rust module hierarchy generated from the AIDL nesting structure.
+
+Note that a client passing a callback object to a service must run a binder thread pool — call `ProcessState::start_thread_pool()` (or park a thread in `join_thread_pool()`) — because the service's `done(..)` invocation arrives as an *inbound* transaction into the client process.
 
 ### Service-Side Nested Callback Handling
 
@@ -336,6 +338,8 @@ service
 The cast `recipient.clone() as Arc<dyn DeathRecipient>` is necessary to convert from the concrete type to the trait object before calling `Arc::downgrade`. The weak reference ensures that the death recipient does not keep the Binder object alive -- if all strong references are dropped, the Binder object can be cleaned up normally.
 
 Note that death notifications only work for **remote** Binder objects. Calling `link_to_death` on a local Binder object (one in the same process) will return an error because there is no remote process to monitor.
+
+Also note that `binder_died` is delivered as an inbound binder command: the process that links a death recipient must call `ProcessState::start_thread_pool()` (or park a thread in `join_thread_pool()`), or the notification never fires — even a client that otherwise only makes outbound calls.
 
 ## Tips
 

--- a/book/src/enable-binder-for-linux.md
+++ b/book/src/enable-binder-for-linux.md
@@ -1,7 +1,7 @@
 # Enable binder for Linux
 Most Linux distributions do not have Binder IPC enabled by default, so additional steps are required to use it.
 
-> **Note**: Binder IPC requires Linux kernel 4.17 or later for native binderfs support.
+> **Note**: The binder driver was mainlined in Linux kernel 4.17, but **binderfs** — which rsbinder's `rsb_device` tool uses to create binder devices — landed in kernel 5.0. In practice you need kernel 5.0 or later.
 
 If you are able to build the Linux kernel yourself, you can enable Binder IPC by adding the following kernel configuration options:
 ```

--- a/book/src/error-handling.md
+++ b/book/src/error-handling.md
@@ -17,7 +17,7 @@ Every AIDL-generated method returns this type:
 pub type Result<T> = std::result::Result<T, Status>;
 ```
 
-This is a standard `Result` whose error variant is a `Status`.
+This is a standard `Result` whose error variant is a `Status`. In generated code the alias is spelled `rsbinder::BinderResult<T>` — it is identical to `rsbinder::status::Result<T>`, so that is the name you will see in your generated files.
 
 > **Note — two `Result` aliases coexist in `rsbinder`.** AIDL methods use
 > `rsbinder::status::Result<T> = Result<T, Status>` (rich error with exception

--- a/book/src/hello-world.md
+++ b/book/src/hello-world.md
@@ -18,12 +18,12 @@ publish = false
 edition = "2021"
 
 [dependencies]
-rsbinder = "0.8"
+rsbinder = "0.10"
 async-trait = "0.1"
 env_logger = "0.11"
 
 [build-dependencies]
-rsbinder-aidl = "0.8"
+rsbinder-aidl = "0.10"
 ```
 Add rsbinder and async-trait to [dependencies], and add rsbinder-aidl to [build-dependencies].
 
@@ -78,14 +78,21 @@ For the Client and Service, create a library that includes the Rust code generat
 
 Create src/lib.rs and add the following content.
 ```rust
-// Include the code hello.rs generated from AIDL.
-include!(concat!(env!("OUT_DIR"), "/hello.rs"));
-
-// Set up to use the APIs provided in the code generated for Client and Service.
-pub use crate::hello::IHello::*;
+// Include the code hello.rs generated from AIDL and re-export the
+// IHello interface items (the trait, BnHello, BpHello, ...) so both
+// the client and the service can use them.
+rsbinder::include_aidl!("hello", crate::hello::IHello::*);
 
 // Define the name of the service to be registered in the HUB(service manager).
 pub const SERVICE_NAME: &str = "my.hello";
+```
+
+The `rsbinder::include_aidl!` macro is the one-call form of the manual
+include/re-export pair. The above is equivalent to:
+
+```rust
+include!(concat!(env!("OUT_DIR"), "/hello.rs"));
+pub use crate::hello::IHello::*;
 ```
 
 ## Create a service
@@ -113,7 +120,7 @@ impl Interface for IHelloService {
 // Implement the IHello interface for the IHelloService.
 impl IHello for IHelloService {
     // Implement the echo method.
-    fn echo(&self, echo: &str) -> rsbinder::status::Result<String> {
+    fn echo(&self, echo: &str) -> rsbinder::BinderResult<String> {
         Ok(echo.to_owned())
     }
 }
@@ -134,9 +141,10 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     println!("Creating service...");
     let service = BnHello::new_binder(IHelloService{});
 
-    // Add the service to binder service manager.
+    // Add the service to binder service manager. `add_service` takes anything
+    // convertible into `SIBinder`, so the typed handle goes in directly.
     println!("Adding service to hub...");
-    hub::add_service(SERVICE_NAME, service.as_binder())?;
+    hub::add_service(SERVICE_NAME, &service)?;
 
     // Join the thread pool.
     // This is a blocking call. It will return when the thread pool is terminated.
@@ -160,7 +168,7 @@ struct MyServiceCallback {}
 impl Interface for MyServiceCallback {}
 
 impl IServiceCallback for MyServiceCallback {
-    fn onRegistration(&self, name: &str, _service: &SIBinder) -> rsbinder::status::Result<()> {
+    fn onRegistration(&self, name: &str, _service: &SIBinder) -> rsbinder::BinderResult<()> {
         println!("MyServiceCallback: {name}");
         Ok(())
     }
@@ -189,14 +197,14 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let service_callback = BnServiceCallback::new_binder(MyServiceCallback {});
     hub::register_for_notifications(SERVICE_NAME, &service_callback)?;
 
-    // Create a Hello proxy from binder service manager.
-    let hello: rsbinder::Strong<dyn IHello> = hub::get_interface(SERVICE_NAME)
-        .unwrap_or_else(|_| panic!("Can't find {SERVICE_NAME}"));
+    // Block until the Hello service is registered, then cast it to the
+    // interface — the event-driven equivalent of AOSP's `waitForService`.
+    let hello: rsbinder::Strong<dyn IHello> = hub::wait_for_interface(SERVICE_NAME)?;
 
+    // `link_to_death_arc` takes the concrete `Arc<MyDeathRecipient>` directly.
+    // Keep `recipient` alive for the link's lifetime (the link holds only a weak ref).
     let recipient = Arc::new(MyDeathRecipient {});
-    hello
-        .as_binder()
-        .link_to_death(Arc::downgrade(&(recipient as Arc<dyn DeathRecipient>)))?;
+    hello.link_to_death_arc(&recipient)?;
 
     // Call echo method of Hello proxy.
     let echo = hello.echo("Hello World!")?;
@@ -274,7 +282,7 @@ If you encounter issues:
 
 1. **"ProcessState is not initialized!"** - `ProcessState::init_default()` (or `ProcessState::init()`) must be called in `main()` before using any other rsbinder APIs
 2. **"environment variable OUT_DIR not defined"** - `build.rs` must be placed in the project root directory (next to `Cargo.toml`), not inside `src/`
-3. **"Can't find my.hello"** - Ensure the service is running and registered
+3. **Client blocks without output** - `hub::wait_for_interface` waits until the service is registered; ensure the service is running
 4. **Permission errors** - Check that binder device has correct permissions (0666)
 5. **Service manager not found** - Verify `rsb_hub` is running
 6. **Build errors** - Ensure all dependencies are correctly specified in Cargo.toml
@@ -290,7 +298,7 @@ Inside a service method, you can identify the calling process using `CallingCont
 ```rust
 use rsbinder::thread_state::CallingContext;
 
-fn echo(&self, echo: &str) -> rsbinder::status::Result<String> {
+fn echo(&self, echo: &str) -> rsbinder::BinderResult<String> {
     let caller = CallingContext::default();
     let caller_uid = caller.uid;
     let caller_pid = caller.pid;
@@ -312,7 +320,7 @@ This is especially useful since **rsbinder** does not enforce any access control
 Services can return service-specific errors to clients using `Status::new_service_specific_error`:
 
 ```rust
-fn echo(&self, echo: &str) -> rsbinder::status::Result<String> {
+fn echo(&self, echo: &str) -> rsbinder::BinderResult<String> {
     if echo.is_empty() {
         return Err(rsbinder::Status::new_service_specific_error(-1, None));
     }

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -81,12 +81,12 @@ Add the following configuration to your Cargo.toml file:
 
 ```toml
 [dependencies]
-rsbinder = "0.8"
+rsbinder = "0.10"
 async-trait = "0.1"
 env_logger = "0.11"  # Optional: for logging
 
 [build-dependencies]
-rsbinder-aidl = "0.8"
+rsbinder-aidl = "0.10"
 ```
 
 ### Feature Flags
@@ -94,13 +94,13 @@ rsbinder-aidl = "0.8"
 
 ```toml
 [dependencies]
-rsbinder = "0.8"  # Default: includes tokio async runtime
+rsbinder = "0.10"  # Default: includes tokio async runtime
 # or
-rsbinder = { version = "0.8", features = ["async"] }  # Async trait support without tokio — use your own async runtime
+rsbinder = { version = "0.10", features = ["async"] }  # Async trait support without tokio — use your own async runtime
 # or
-rsbinder = { version = "0.8", default-features = false }  # Synchronous only (no async support)
+rsbinder = { version = "0.10", default-features = false }  # Synchronous only (no async support)
 # or — opt in to the binder-over-socket stack (see RPC Transport chapter)
-rsbinder = { version = "0.8", features = ["rpc"] }
+rsbinder = { version = "0.10", features = ["rpc"] }
 ```
 
 Available features:

--- a/book/src/parcel-file-descriptor.md
+++ b/book/src/parcel-file-descriptor.md
@@ -29,6 +29,11 @@ let read_pfd = rsbinder::ParcelFileDescriptor::new(reader);
 let write_pfd = rsbinder::ParcelFileDescriptor::new(writer);
 ```
 
+Since 0.10.0 `ParcelFileDescriptor` also implements `From<std::fs::File>`
+and `From<OwnedFd>`, so the common concrete cases work with plain
+conversions — `let pfd: ParcelFileDescriptor = file.into();`. The generic
+`new()` covers any other `Into<OwnedFd>` source.
+
 ## Sending a File Descriptor to a Service
 
 A typical pattern is to create a pipe, wrap one end in a `ParcelFileDescriptor`,
@@ -65,28 +70,21 @@ When a service receives a `ParcelFileDescriptor`, it usually needs to **duplicat
 the descriptor before returning it or storing it. This avoids ownership conflicts
 and ensures each side can close its handle independently.
 
-The idiomatic helper function looks like this:
-
-```rust
-use rsbinder::ParcelFileDescriptor;
-
-fn dup_fd(fd: &ParcelFileDescriptor) -> ParcelFileDescriptor {
-    ParcelFileDescriptor::new(fd.as_ref().try_clone().unwrap())
-}
-```
-
-`as_ref()` returns a reference to the inner `OwnedFd`, and `try_clone()` calls
-the underlying OS `dup` system call.
-
+Since 0.10.0 the type has a built-in `ParcelFileDescriptor::try_clone()`
+that duplicates the underlying descriptor with `fcntl(F_DUPFD_CLOEXEC)`
+(the duplicate is always close-on-exec, matching AOSP
+`ParcelFileDescriptor::dup`), so no hand-rolled `dup` helper is needed.
 A service method that repeats a file descriptor back to the caller is then
 straightforward:
 
 ```rust
+use rsbinder::ParcelFileDescriptor;
+
 fn RepeatParcelFileDescriptor(
     &self,
     read: &ParcelFileDescriptor,
 ) -> rsbinder::status::Result<ParcelFileDescriptor> {
-    Ok(dup_fd(read))
+    Ok(read.try_clone()?)
 }
 ```
 
@@ -94,7 +92,7 @@ fn RepeatParcelFileDescriptor(
 
 AIDL interfaces can accept and return arrays of `ParcelFileDescriptor`. The
 pattern for reversing an array -- a common test case -- illustrates how to
-combine `dup_fd` with iterator combinators:
+combine `try_clone()` with iterator combinators:
 
 ```rust
 fn ReverseParcelFileDescriptorArray(
@@ -103,8 +101,10 @@ fn ReverseParcelFileDescriptorArray(
     repeated: &mut Vec<Option<ParcelFileDescriptor>>,
 ) -> rsbinder::status::Result<Vec<ParcelFileDescriptor>> {
     repeated.clear();
-    repeated.extend(input.iter().map(dup_fd).map(Some));
-    Ok(input.iter().rev().map(dup_fd).collect())
+    for fd in input {
+        repeated.push(Some(fd.try_clone()?));
+    }
+    input.iter().rev().map(|fd| Ok(fd.try_clone()?)).collect()
 }
 ```
 
@@ -155,6 +155,20 @@ fn file_from_pfd(fd: &ParcelFileDescriptor) -> File {
 }
 ```
 
+## File Descriptors over RPC
+
+`ParcelFileDescriptor` also crosses the socket-based
+[RPC transport](./rpc-transport.md) (the `rpc` Cargo feature). Unlike
+kernel binder, FD passing over RPC is **opt-in and negotiated per
+connection**: the server declares the modes it accepts with
+`RpcServer::set_supported_fd_modes`, and the client requests one with
+`RpcSession::negotiate_fd_transport` (or the `fd_mode` knob on the
+`RpcUnixClientConfig` builder). Descriptors then travel out-of-band via
+`SCM_RIGHTS`, which requires a Unix-domain socket and the android-14+
+wire version. Service and client code using `ParcelFileDescriptor` is
+otherwise unchanged. See
+[RPC Transport](./rpc-transport.md#capabilities) for details.
+
 ## Tips and Best Practices
 
 - **Descriptors are duplicated during IPC.** When a `ParcelFileDescriptor` is
@@ -170,14 +184,16 @@ fn file_from_pfd(fd: &ParcelFileDescriptor) -> File {
   `File` (via `try_clone().into()`) to use those traits.
 
 - **Always duplicate before storing.** If your service needs to keep a
-  reference to a received descriptor, clone it with `dup_fd`. Returning or
-  forwarding the original reference without duplication can lead to
+  reference to a received descriptor, clone it with `try_clone()`. Returning
+  or forwarding the original reference without duplication can lead to
   use-after-close errors.
 
 - **`ParcelFileDescriptor` is not `Clone`.** Because it wraps an `OwnedFd`,
   which owns the underlying file descriptor, the type cannot derive `Clone`.
-  Use `dup_fd` (or `as_ref().try_clone()`) for explicit duplication.
+  Use the built-in `try_clone()` (a `fcntl(F_DUPFD_CLOEXEC)` duplication,
+  added in 0.10.0) for explicit duplication, and the `From<OwnedFd>` /
+  `From<std::fs::File>` impls for construction.
 
 - **Error handling.** `try_clone()` can fail if the process has exhausted its
-  file descriptor limit. In production code, consider propagating the error
-  rather than calling `unwrap()`.
+  file descriptor limit. Propagate the error with `?` (a `StatusCode`
+  converts into `Status` automatically) rather than calling `unwrap()`.

--- a/book/src/redhat-linux.md
+++ b/book/src/redhat-linux.md
@@ -131,23 +131,22 @@ $ sudo dnf update kernel
 $ grep -E "(ANDROID|BINDER)" /boot/config-$(uname -r)
 ```
 
-## Module Loading (After Kernel Build)
+## After Kernel Build
 
-Once you have a kernel with binder support:
+With the kernel built as described above, binder is compiled directly
+into the kernel (`CONFIG_ANDROID_BINDER_IPC=y` is a built-in option,
+not a module), so nothing needs to be loaded with `modprobe` or
+configured in `modules-load.d`:
 
 ```bash
-# Load binder modules
-$ sudo modprobe binder_linux devices="binder,hwbinder,vndbinder"
-
-# Verify modules are loaded
-$ lsmod | grep binder
-
-# Create persistent module loading
-$ echo "binder_linux" | sudo tee /etc/modules-load.d/binder.conf
-
-# Set module parameters
-$ echo "options binder_linux devices=binder,hwbinder,vndbinder" | sudo tee /etc/modprobe.d/binder.conf
+# Verify binder is built into the running kernel
+$ grep -E "(ANDROID|BINDER)" /boot/config-$(uname -r)
 ```
+
+> **Note**: `modprobe binder_linux` / `modules-load.d` instructions
+> found elsewhere refer to `binder_linux`, the out-of-tree Anbox DKMS
+> module for kernels without built-in binder support. They do not apply
+> to a kernel built with the options above.
 
 ## SELinux Considerations
 

--- a/book/src/rpc-transport.md
+++ b/book/src/rpc-transport.md
@@ -26,7 +26,7 @@ distinguish RPC from kernel binder.
 >
 > ```toml
 > [dependencies]
-> rsbinder = { version = "0.8", features = ["rpc"] }
+> rsbinder = { version = "0.10", features = ["rpc"] }
 > ```
 
 ## When to use RPC vs. kernel binder
@@ -99,7 +99,7 @@ Key points:
   pure-RPC process needs neither `ProcessState` nor `rsb_hub`.
 - **`set_root`** publishes the single root binder. The client fetches
   it back through `RpcSession::get_root` — this is the moral
-  equivalent of `hub::get_interface(name)` for kernel binder, just
+  equivalent of `hub::wait_for_interface(name)` for kernel binder, just
   without a service manager.
 - **`server.run()`** runs the accept loop until
   [`RpcServer::shutdown`] is called. Use
@@ -222,12 +222,60 @@ Add the matching feature in `Cargo.toml`:
 
 ```toml
 [dependencies]
-rsbinder = { version = "0.8", features = ["rpc", "rpc-vsock"] }
+rsbinder = { version = "0.10", features = ["rpc", "rpc-vsock"] }
 ```
 
 Each backend implements the
 [`RpcTransport`](https://docs.rs/rsbinder/latest/rsbinder/rpc/transport/trait.RpcTransport.html)
 trait — you can implement your own if you need a custom carrier.
+
+### Abstract Unix-domain sockets (Linux/Android)
+
+Since 0.10.0 the Unix backend can also bind the Linux **abstract socket
+namespace** — a kernel-namespace name with no filesystem entry, so there
+is no socket file to create, unlink, or leak:
+
+```rust
+// Server: no filesystem path, nothing to clean up on shutdown.
+let server = RpcServer::setup_unix_server_abstract(b"my.rpc.name")?;
+
+// Client, r34 wire:
+let session = RpcSession::setup_unix_client_abstract(b"my.rpc.name")?;
+
+// Client, android-13+ wire (negotiating up to v2):
+let session =
+    RpcSession::setup_unix_client_android13plus_abstract(b"my.rpc.name", 2)?;
+```
+
+These functions exist only on Linux and Android (the abstract namespace
+is a Linux kernel feature).
+
+For the android-13+ client there is also a builder,
+[`RpcUnixClientConfig`](https://docs.rs/rsbinder/latest/rsbinder/rpc/struct.RpcUnixClientConfig.html),
+consumed by `RpcSession::setup_unix_client_android13plus_with_config`.
+One config combines filesystem-path or abstract addressing with the
+optional knobs the positional helpers expose individually — attaching to
+an existing session by echoing its 32-byte id, an outgoing-connection
+fan-out, and the fd transport mode (session-id attach and fan-out are
+mutually exclusive):
+
+```rust
+use rsbinder::rpc::{FileDescriptorTransportMode, RpcSession, RpcUnixClientConfig};
+
+let session = RpcSession::setup_unix_client_android13plus_with_config(
+    RpcUnixClientConfig::abstract_name(b"my.rpc.name", 2)
+        .outgoing_connections(2)
+        .fd_mode(FileDescriptorTransportMode::Unix),
+)?;
+```
+
+> **Security.** An abstract socket has **no filesystem permissions**:
+> any process in the same network namespace can connect (subject only to
+> LSM policy such as SELinux), so the directory-mode access control a
+> path-bound socket can rely on does not apply. When exposure matters,
+> install an [`RpcServer::set_authorizer`] hook (see
+> [Security](#security)) and check the peer identity (uid/gid/pid) it
+> receives.
 
 ### TLS client
 
@@ -421,20 +469,24 @@ through the android-13+ handshake.
 
 rsbinder implements **both sides** of this pattern:
 
-- **Consume side** — `hub::get_service(name)` transparently follows
-  the `IAccessor` arm: if the service manager hands back an
+- **Consume side** — the shared `hub` lookup path (`hub::check_service`,
+  `hub::wait_for_service`, and the typed/`try_*` variants) transparently
+  follows the `IAccessor` arm: if the service manager hands back an
   `IAccessor` instead of a regular binder, rsbinder calls
   `addConnection()`, adopts the fd, runs the v2 handshake, and gives
   you back the RPC root. Your client code looks identical to a
-  regular `hub::get_service` call.
+  regular `hub::check_service` call.
 
 - **Register side** — `hub::android_16::create_accessor(instance,
   addr_provider)` builds a `LocalAccessor` `BnAccessor` you can
   publish via `hub::add_service`. The provider closure resolves an
   instance name to an
   [`AccessorSockAddr`](https://docs.rs/rsbinder/latest/rsbinder/hub/android_16/enum.AccessorSockAddr.html)
-  (`Unix(path)`, `Vsock { cid, port }`, or `Inet(addr)`), and the
-  accessor opens the connection on demand:
+  (`Unix(path)`, `UnixAbstract(name)` — added in 0.10.0 —
+  `Vsock { cid, port }`, or `Inet(addr)`), and the accessor opens the
+  connection on demand. The enum is intentionally exhaustive (not
+  `#[non_exhaustive]`), so downstream exhaustive `match`es need an arm
+  for the new `UnixAbstract` variant — see the 0.10.0 CHANGELOG:
 
   ```rust
   use rsbinder::hub::{self, android_16::{create_accessor, AccessorSockAddr}};
@@ -471,9 +523,9 @@ rsbinder implements **both sides** of this pattern:
 Use
 [`hub::android_16::add_accessor_provider`](https://docs.rs/rsbinder/latest/rsbinder/hub/android_16/fn.add_accessor_provider.html)
 when you want a **process-local** accessor — one that doesn't go
-through the system service manager. Lookups via `hub::get_service` in
-the same process fall back to the process-local registry when the
-service manager returns nothing.
+through the system service manager. Lookups via `hub::check_service` /
+`hub::wait_for_service` in the same process fall back to the
+process-local registry when the service manager returns nothing.
 
 Both sides of the Accessor pattern have been validated against real
 Android 16 `libbinder` on the emulator.

--- a/book/src/service-manager.md
+++ b/book/src/service-manager.md
@@ -43,8 +43,10 @@ use rsbinder::*;
 // Create the Binder service object
 let service = BnMyService::new_binder(MyServiceImpl);
 
-// Register it under a descriptive name
-hub::add_service("com.example.myservice", service.as_binder())?;
+// Register it under a descriptive name. `add_service` accepts anything
+// convertible into `SIBinder`, so the typed `Strong<dyn IMyService>` can
+// be passed directly — no `.as_binder()` needed.
+hub::add_service("com.example.myservice", &service)?;
 ```
 
 The name passed to `add_service` is the identifier that clients will use to
@@ -64,68 +66,88 @@ the IPC call rather than a local compile-time or pre-flight check.
   (`_`), hyphens (`-`), and forward slashes (`/`). Special characters such as
   `$` are not allowed.
 - **Non-empty**: An empty string is rejected.
-- **Overwrite permitted**: Registering a service with a name that is already
-  in use replaces the previous registration.
+- **Overwrite rules**: Re-registering the *same* binder under a name, or
+  replacing a registration from the *same UID* (e.g. a restarted service
+  process), is always allowed. However, `rsb_hub` **rejects** an attempt by a
+  different UID to overwrite an existing name with a different binder — a
+  likely service-name hijack — unless it was started with the opt-in
+  `--allow-cross-uid-overwrite` flag.
 
 ```rust
 let service = BnFoo::new_binder(FooImpl {});
 
 // Empty names are rejected
-assert!(hub::add_service("", service.as_binder()).is_err());
+assert!(hub::add_service("", &service).is_err());
 
 // Valid name
-assert!(hub::add_service("foo", service.as_binder()).is_ok());
+assert!(hub::add_service("foo", &service).is_ok());
 
 // Maximum length (127 characters)
 let long_name = "a".repeat(127);
-assert!(hub::add_service(&long_name, service.as_binder()).is_ok());
+assert!(hub::add_service(&long_name, &service).is_ok());
 
 // Too long (128 characters)
 let too_long = "a".repeat(128);
-assert!(hub::add_service(&too_long, service.as_binder()).is_err());
+assert!(hub::add_service(&too_long, &service).is_err());
 
 // Special characters are rejected
-assert!(hub::add_service("happy$foo$fo", service.as_binder()).is_err());
+assert!(hub::add_service("happy$foo$fo", &service).is_err());
 ```
 
 ## Looking Up Services
 
-rsbinder provides three ways to find a registered service, each suited to a
-different use case.
+rsbinder provides a family of lookup functions. They differ only in *how they
+wait* and *how they encode "not registered"* — pick by what your client needs:
 
-### Type-Safe Lookup with `get_interface`
+| Function | Waits? | Returns | Not registered |
+|---|---|---|---|
+| `wait_for_interface::<T>` | blocks until registered | `Result<Strong<T>>` | *blocks* |
+| `wait_for_service` | blocks until registered | `Option<SIBinder>` | *blocks* |
+| `check_interface::<T>` | no | `Result<Strong<T>>` | `Err(NameNotFound)` |
+| `check_service` | no | `Option<SIBinder>` | `None` |
+| `try_get_interface::<T>` | no | `Result<Option<Strong<T>>>` | `Ok(None)` |
+| `try_get_service` | no | `Result<Option<SIBinder>>` | `Ok(None)` |
 
-The most common approach is `hub::get_interface`, which retrieves the service
-and casts it to the expected AIDL interface type in one step:
+> **Deprecated**: `hub::get_service` and `hub::get_interface` are
+> `#[deprecated]` as of 0.10.0 because their wait behavior was inconsistent
+> across Android versions. Use `wait_for_service` / `wait_for_interface` to
+> block until the service appears, or `check_service` / `check_interface`
+> for a non-blocking lookup.
+
+### Blocking, Type-Safe Lookup with `wait_for_interface`
+
+The most common client pattern is `hub::wait_for_interface`, which blocks
+until the service is registered and casts it to the expected AIDL interface
+type in one step — the equivalent of AOSP's `waitForService`:
 
 ```rust
 let service: rsbinder::Strong<dyn IMyService::IMyService> =
-    hub::get_interface("com.example.myservice")?;
+    hub::wait_for_interface("com.example.myservice")?;
 
 // Now call methods directly on the typed proxy
 let result = service.some_method()?;
 ```
 
-If the service is not registered, `get_interface` returns an error.
+The wait is unbounded: it returns when the service appears, and fails only
+if the service manager itself is unreachable. The wait is event-driven
+(registration-callback based) when the process runs a binder thread pool
+(`ProcessState::start_thread_pool()`); without one it degrades gracefully to
+~1-second polling.
 
-### Raw Binder Lookup with `get_service`
-
-If you need the untyped `SIBinder` handle (for example, to inspect the
-descriptor or pass it to another API), use `hub::get_service`:
+`hub::wait_for_service` is the untyped variant — it returns
+`Option<SIBinder>` when you need the raw handle (for example, to inspect the
+descriptor or pass it to another API):
 
 ```rust
-let binder: Option<SIBinder> = hub::get_service("com.example.myservice");
-if let Some(binder) = binder {
+if let Some(binder) = hub::wait_for_service("com.example.myservice") {
     println!("Found service with descriptor: {}", binder.descriptor());
 }
 ```
 
-Returns `None` if the service is not registered.
+### Non-Blocking Check with `check_service` / `check_interface`
 
-### Non-Blocking Check with `check_service`
-
-`hub::check_service` behaves like `get_service` but is intended as a
-non-blocking availability check:
+`hub::check_service` returns immediately, with `None` if the service is not
+(yet) registered:
 
 ```rust
 let binder: Option<SIBinder> = hub::check_service("com.example.myservice");
@@ -133,6 +155,26 @@ if binder.is_some() {
     println!("Service is available");
 } else {
     println!("Service is not yet registered");
+}
+```
+
+The typed counterpart `hub::check_interface` casts in one step and returns
+`Err(StatusCode::NameNotFound)` immediately when the service is absent.
+
+### Error-Preserving Lookup with `try_get_service` / `try_get_interface`
+
+`check_service` folds "not registered" and "service manager unreachable"
+into the same `None`. When you must tell those apart, use
+`hub::try_get_service` (or the typed `hub::try_get_interface`), which
+returns `Result<Option<_>>`: `Ok(None)` means the service is not registered,
+while `Err(..)` means the lookup itself failed (transport or service-manager
+error):
+
+```rust
+match hub::try_get_service("com.example.myservice") {
+    Ok(Some(binder)) => println!("found: {}", binder.descriptor()),
+    Ok(None) => println!("service not registered"),
+    Err(err) => println!("service manager unreachable: {err:?}"),
 }
 ```
 
@@ -203,6 +245,12 @@ hub::unregister_for_notifications("com.example.myservice", &callback)?;
 The callback will be invoked each time a service matching the given name is
 registered, including if it is re-registered after a restart.
 
+> **Thread pool required.** `onRegistration` arrives as an *inbound* binder
+> transaction, so the client process must call
+> `ProcessState::start_thread_pool()` (or park a thread in
+> `join_thread_pool()`) — otherwise the callback never fires. This applies
+> to any client that receives inbound calls, not just services.
+
 ## Checking if a Service is Declared
 
 `hub::is_declared` checks whether a service name has been declared in the
@@ -265,7 +313,7 @@ API availability matrix:
 
 | API                                | Android 10 | Android 11 | Android 12+ |
 |------------------------------------|:---------:|:---------:|:-----------:|
-| `get_service` / `check_service`    |     ✓     |     ✓     |      ✓      |
+| `check_service` / `wait_for_service` |     ✓     |     ✓     |      ✓      |
 | `add_service`                      |     ✓     |     ✓     |      ✓      |
 | `list_services`                    |     ✓     |     ✓     |      ✓      |
 | `is_declared`                      |   false   |     ✓     |      ✓      |
@@ -284,7 +332,7 @@ Linux (no VINTF manifest).
 
 ## Using the ServiceManager Object Directly
 
-The convenience functions (`hub::add_service`, `hub::get_service`, etc.) use
+The convenience functions (`hub::add_service`, `hub::check_service`, etc.) use
 a global singleton `ServiceManager` under the hood. If you need more control,
 you can obtain the `ServiceManager` instance directly:
 
@@ -297,7 +345,7 @@ use rsbinder::hub;
 let sm = hub::default()?;
 
 // Use methods on the ServiceManager instance
-let service = sm.get_service("com.example.myservice");
+let service = sm.check_service("com.example.myservice");
 let services = sm.list_services(hub::DUMP_FLAG_PRIORITY_ALL);
 ```
 
@@ -314,17 +362,25 @@ service manager as a parameter or store it in a struct.
   (e.g., `com.example.myservice`) to avoid name collisions with other
   services.
 
-- **Register for notifications instead of polling.** If your client starts
-  before the service it depends on, use `register_for_notifications` rather
-  than repeatedly calling `get_service` in a loop.
+- **Wait, don't poll.** If your client starts before the service it depends
+  on, call `wait_for_interface` / `wait_for_service` rather than repeatedly
+  calling `check_service` in a loop — the wait is event-driven when a binder
+  thread pool is running. Use `register_for_notifications` when you need to
+  observe every (re-)registration over time, and remember that the
+  notification callback only fires if the process runs a thread pool.
+
+- **Avoid the deprecated `get_service` / `get_interface`.** Their wait
+  behavior differed across Android versions; the `wait_*`, `check_*`, and
+  `try_get_*` families make the blocking and error semantics explicit.
 
 - **Handle registration failures.** `add_service` can fail if the name is
   invalid or if the caller lacks permission (on Android with SELinux). Always
   check the result.
 
-- **Use `get_interface` for type safety.** Prefer `hub::get_interface` over
-  `hub::get_service` when you know the expected interface type. It returns a
-  strongly-typed proxy that provides compile-time guarantees.
+- **Prefer the typed `*_interface` variants.** `wait_for_interface`,
+  `check_interface`, and `try_get_interface` return a strongly-typed proxy
+  that provides compile-time guarantees; the `*_service` variants return the
+  raw `SIBinder`.
 
 - **Debug with `list_services` and `get_service_debug_info`.** When
   troubleshooting, list all registered services and inspect their debug

--- a/book/src/service-patterns.md
+++ b/book/src/service-patterns.md
@@ -69,8 +69,8 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // to surface device-open or initialization failures.
     ProcessState::init_default()?;
 
-    // Start additional threads for handling concurrent Binder transactions.
-    // Optional but recommended for services that handle multiple clients.
+    // Start the binder thread pool and enable kernel-driven thread
+    // spawning, so concurrent transactions are handled in parallel.
     ProcessState::start_thread_pool();
 
     // Create a Binder object from your service implementation.
@@ -79,7 +79,9 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     // Register the service with the service manager (hub).
     // The first argument is the service name used by clients to find it.
-    hub::add_service("com.example.myservice", service.as_binder())?;
+    // `add_service` accepts anything convertible into `SIBinder`, so the
+    // typed `Strong<dyn IMyService>` goes in directly — no `.as_binder()`.
+    hub::add_service("com.example.myservice", &service)?;
 
     // Block the main thread and process incoming Binder transactions.
     // This call does not return under normal operation.
@@ -91,9 +93,10 @@ Each function in this lifecycle serves a specific purpose:
 
 - **`ProcessState::init_default()`** opens the Binder device (typically `/dev/binderfs/binder`)
   and sets up process-wide state for Binder communication.
-- **`ProcessState::start_thread_pool()`** spawns additional threads so the process can
-  handle multiple concurrent transactions. Without this call, only one thread handles
-  all incoming requests.
+- **`ProcessState::start_thread_pool()`** spawns a binder worker thread and enables
+  kernel-driven spawning of further workers. Without this call, transactions are
+  served only by threads that explicitly call `join_thread_pool()`, so the process
+  is effectively single-threaded.
 - **`BnMyService::new_binder()`** wraps your implementation struct in a Binder-compatible
   object. The `Bn` prefix stands for "Binder native" (the server-side stub).
 - **`hub::add_service()`** registers your service with the service manager so that clients
@@ -238,9 +241,12 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     ProcessState::init_default()?;
 
     // Obtain a strongly-typed proxy for the service.
-    // hub::get_interface returns a Strong<dyn IMyService> on success.
+    // hub::wait_for_interface blocks until the service is registered and
+    // returns a Strong<dyn IMyService> on success. Use hub::check_interface
+    // instead for a non-blocking probe that fails immediately with
+    // NameNotFound when the service is absent.
     let service: rsbinder::Strong<dyn IMyService::IMyService> =
-        hub::get_interface("com.example.myservice")?;
+        hub::wait_for_interface("com.example.myservice")?;
 
     // Call service methods through the proxy.
     let result = service.echo("hello")?;
@@ -249,6 +255,11 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+
+A purely-outbound client like this one needs no binder thread pool. As soon
+as the client *receives* inbound calls — a callback object it passed to the
+service, a service-registration notification, or a death recipient — it must
+also call `ProcessState::start_thread_pool()` (see below).
 
 ### Listing Available Services
 
@@ -280,6 +291,10 @@ let callback = hub::BnServiceCallback::new_binder(MyServiceCallback);
 hub::register_for_notifications(SERVICE_NAME, &callback)?;
 ```
 
+Note: `onRegistration` is an *inbound* transaction into the client process,
+so the client must call `ProcessState::start_thread_pool()` (or park a thread
+in `join_thread_pool()`) — otherwise the notification never fires.
+
 ### Death Recipients
 
 Clients can monitor whether a remote service process is still alive by registering
@@ -303,12 +318,21 @@ service.as_binder().link_to_death(
 
 To stop receiving notifications, call `unlink_to_death` with the same weak reference.
 
+Note: `binder_died` is delivered as an inbound binder command, so a client
+that links a death recipient must call `ProcessState::start_thread_pool()`
+(or park a thread in `join_thread_pool()`) — otherwise `binder_died` never
+fires.
+
 ## Tips and Best Practices
 
 - **`ProcessState::init_default()` must be called before any Binder operations.**
   Failing to do so will result in a panic.
-- **`start_thread_pool()` is optional but recommended.** Without it, only a single
-  thread handles all Binder transactions, which can become a bottleneck under load.
+- **`start_thread_pool()` is required by any process that receives inbound
+  transactions.** That includes not just services, but also *clients* holding a
+  service-notification callback, a callback object passed to a service, or a death
+  recipient — without a thread pool (or a thread parked in `join_thread_pool()`),
+  those callbacks and `binder_died` never fire. Only a purely-outbound client that
+  makes synchronous calls and receives nothing back can skip it.
 - **Each process needs only one `ProcessState::init_default()` call.** Multiple calls
   are safe but unnecessary.
 - **`join_thread_pool()` blocks the calling thread.** Place it at the end of `main()`

--- a/book/src/stability-tiers.md
+++ b/book/src/stability-tiers.md
@@ -25,6 +25,10 @@ binder and is not expected to break.
   `FLAG_CLEAR_BUF`.
 - **Service manager (Android binder)** — `hub::add_service`,
   `hub::get_service`, `hub::check_service`, `hub::get_interface`.
+  (`hub::get_service` / `hub::get_interface` are deprecated as of 0.10.0 in
+  favor of `wait_for_*` / `check_interface` / `try_*` — deprecated-but-kept
+  still satisfies the no-breakage promise; the replacements start in
+  Provisional. See [Service Manager](service-manager.md).)
 - **AIDL compiler entry points** — `rsbinder_aidl::Builder::{new, source,
   output, version, generate}`.
 - **rsb_device** binary CLI (binderfs setup).
@@ -35,6 +39,12 @@ Implemented and validated, but the public-API shape is still under
 review for 1.0. Expect at most a single round of renames or signature
 tweaks; wire formats are already locked.
 
+- **Service-manager lookups (new in 0.10.0)** — `hub::wait_for_service`,
+  `wait_for_interface`, `check_interface`, `try_get_service`,
+  `try_get_interface`, `register_client_callback`,
+  `try_unregister_service`, and the `impl Into<SIBinder>` form of
+  `add_service`. Wire behavior matches AOSP `waitForService` /
+  `checkService`; only the Rust signatures are still settling.
 - **RPC transport** — `RpcServer`, `RpcSession`, `setup_unix_server`,
   `setup_unix_client*`, `from_preconnected_fd`, `set_root`, `get_root`,
   `set_android13plus`, `set_max_threads(N)` (both `N == 1` and

--- a/book/src/ubuntu-linux.md
+++ b/book/src/ubuntu-linux.md
@@ -67,13 +67,14 @@ $ sudo rsb_device binder
 
 1. **Module not found**: Ensure your kernel was built with binder support enabled
 2. **Permission denied**: Make sure you're using sudo for device creation
-3. **Kernel too old**: Binder support requires Linux kernel 4.17+ natively
+3. **Kernel too old**: The binder driver was mainlined in kernel 4.17, but binderfs (used by `rsb_device`) requires kernel 5.0+
 
 ### Getting Help:
 
 - Check dmesg for kernel messages: `dmesg | grep -i binder`
-- Verify module loading: `sudo modprobe -v binder_linux`
-- Check system logs: `journalctl -f` while loading modules
+- Verify binder is enabled in the kernel config: `grep -E "(ANDROID|BINDER)" /boot/config-$(uname -r)`
+  (note: `binder_linux` is the out-of-tree Anbox DKMS module — `modprobe binder_linux` does not apply to a kernel built with the options above)
+- Check system logs: `journalctl -f`
 
 ## References
 

--- a/rsbinder-aidl/Cargo.toml
+++ b/rsbinder-aidl/Cargo.toml
@@ -3,7 +3,7 @@ name = "rsbinder-aidl"
 version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-description = "This is a AIDL compiler for rsbinder."
+description = "An AIDL compiler for rsbinder — generates Rust Binder IPC code from .aidl files."
 homepage = { workspace = true }
 repository = { workspace = true }
 readme = "README.md"
@@ -11,6 +11,9 @@ rust-version = { workspace = true }
 keywords.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = []
 async = []

--- a/rsbinder-aidl/src/lib.rs
+++ b/rsbinder-aidl/src/lib.rs
@@ -46,6 +46,15 @@
 //! - [`Builder::set_async_support`] — also emit `.await`-able async
 //!   client/server traits (defaults to the crate's `async` feature).
 //!
+//! # Constants
+//!
+//! As of 0.10.0, constant names are emitted **verbatim** — `const int kFoo`
+//! becomes `r#kFoo`, with no case-normalization — and constant expressions
+//! are evaluated with AOSP-strict rules: integer overflow, lossy narrowing,
+//! circular constant references, and invalid shift amounts are compile
+//! errors rather than being silently wrapped or truncated. See the project
+//! CHANGELOG for migration notes if upgrading from an earlier release.
+//!
 //! Compatibility notes, supported AIDL constructs, and diagnostics examples
 //! live in the repository README and <https://hiking90.github.io/rsbinder/>.
 

--- a/rsbinder-tools/src/bin/rsb_hub.rs
+++ b/rsbinder-tools/src/bin/rsb_hub.rs
@@ -887,7 +887,7 @@ impl IServiceManager for ServiceManager {
                     let msg = format!(
                         "registerForNotifications: too many callbacks for {name} (max {MAX_CALLBACKS_PER_NAME})"
                     );
-                    log::warn!("{}", &msg);
+                    log::warn!("{}", msg);
                     return Err((ExceptionCode::IllegalState, msg.as_str()).into());
                 }
             }
@@ -898,7 +898,7 @@ impl IServiceManager for ServiceManager {
                 let msg = format!(
                     "registerForNotifications: name registry full (max {MAX_DISTINCT_NAMES})"
                 );
-                log::warn!("{}", &msg);
+                log::warn!("{}", msg);
                 return Err((ExceptionCode::IllegalState, msg.as_str()).into());
             }
 
@@ -1030,7 +1030,7 @@ impl IServiceManager for ServiceManager {
                 service
             } else {
                 let msg = format!("registerClientCallback could not find service {name}");
-                log::warn!("{}", &msg);
+                log::warn!("{}", msg);
                 return Err((ExceptionCode::IllegalArgument, msg.as_str()).into());
             };
 
@@ -1039,13 +1039,13 @@ impl IServiceManager for ServiceManager {
                     "{:?} Only a server can register for client callbacks (for {})",
                     service.context, name
                 );
-                log::warn!("{}", &msg);
+                log::warn!("{}", msg);
                 return Err((ExceptionCode::Security, msg.as_str()).into());
             }
 
             if service.binder != *arg_service {
                 let msg = format!("registerClientCallback called with wrong service {name}");
-                log::warn!("{}", &msg);
+                log::warn!("{}", msg);
                 return Err((ExceptionCode::IllegalArgument, msg.as_str()).into());
             }
 
@@ -1061,7 +1061,7 @@ impl IServiceManager for ServiceManager {
                     let msg = format!(
                         "registerClientCallback: too many callbacks for {name} (max {MAX_CALLBACKS_PER_NAME})"
                     );
-                    log::warn!("{}", &msg);
+                    log::warn!("{}", msg);
                     return Err((ExceptionCode::IllegalState, msg.as_str()).into());
                 }
             }
@@ -1074,7 +1074,7 @@ impl IServiceManager for ServiceManager {
                 let msg = format!(
                     "registerClientCallback: name registry full (max {MAX_DISTINCT_NAMES})"
                 );
-                log::warn!("{}", &msg);
+                log::warn!("{}", msg);
                 return Err((ExceptionCode::IllegalState, msg.as_str()).into());
             }
 
@@ -1139,7 +1139,7 @@ impl IServiceManager for ServiceManager {
                 let msg = format!(
                     "{context:?} Tried to unregister {name}, but that service wasn't registered to begin with."
                 );
-                log::warn!("{}", &msg);
+                log::warn!("{}", msg);
                 return Err((ExceptionCode::IllegalArgument, msg.as_str()).into());
             };
 
@@ -1148,13 +1148,13 @@ impl IServiceManager for ServiceManager {
                     "{:?} Only a server can register for client callbacks (for {})",
                     service.context, name
                 );
-                log::warn!("{}", &msg);
+                log::warn!("{}", msg);
                 return Err((ExceptionCode::Security, msg.as_str()).into());
             }
 
             if service.binder != *arg_service {
                 let msg = format!("{context:?} Tried to unregister {name}, but a different service is registered under this name.");
-                log::warn!("{}", &msg);
+                log::warn!("{}", msg);
                 return Err((ExceptionCode::IllegalArgument, msg.as_str()).into());
             }
 
@@ -1162,7 +1162,7 @@ impl IServiceManager for ServiceManager {
                 let msg = format!(
                     "{context:?} Tried to unregister {name}, but there is about to be a client."
                 );
-                log::warn!("{}", &msg);
+                log::warn!("{}", msg);
                 return Err((ExceptionCode::IllegalState, msg.as_str()).into());
             }
 
@@ -1187,7 +1187,7 @@ impl IServiceManager for ServiceManager {
                 .unwrap_or(true);
             if has_clients {
                 let msg = format!("{context:?} Tried to unregister {name}, but there are clients.");
-                log::warn!("{}", &msg);
+                log::warn!("{}", msg);
                 if let Some(service) = inner.name_to_service.get_mut(name) {
                     service.guarantee_client = true;
                 }

--- a/rsbinder/Cargo.toml
+++ b/rsbinder/Cargo.toml
@@ -3,7 +3,7 @@ name = "rsbinder"
 version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-description = "rsbinder provides crates implemented in pure Rust that make Binder IPC available on both Android and Linux."
+description = "Pure-Rust Binder IPC for Linux, Android, and macOS — kernel binder plus a libbinder-compatible RPC (binder-over-socket) transport."
 homepage = { workspace = true }
 repository = { workspace = true }
 readme = "README.md"
@@ -11,6 +11,12 @@ rust-version = { workspace = true }
 keywords.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+# docs.rs builds with default features only unless told otherwise — without
+# this, the entire feature-gated `rpc` surface is absent from the published
+# docs.
+[package.metadata.docs.rs]
+all-features = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -429,7 +429,7 @@ impl dyn IBinder {
 
     /// Generalized proxy dispatch: a kernel
     /// [`proxy::ProxyHandle`] **or** (with the `rpc` feature) an
-    /// [`rpc::RpcProxy`](crate::rpc::RpcProxy), as a single
+    /// `rpc::RpcProxy`, as a single
     /// [`RemoteProxy`] trait object. Lets one generated `Bp*` stub
     /// call either stack. `as_proxy()` is retained unchanged so the
     /// existing generated kernel code keeps working verbatim.

--- a/rsbinder/src/lib.rs
+++ b/rsbinder/src/lib.rs
@@ -14,7 +14,35 @@
 //! - **Proxy**: Client-side interface for remote services
 //! - **Native**: Server-side service implementation utilities
 //! - **ProcessState**: Process-level binder state management
-//! - **ServiceManager**: Service discovery and registration
+//! - **ServiceManager**: Service discovery and registration (the [`hub`] module)
+//! - **RPC transport**: binder-over-socket (`rpc` module, behind the `rpc`
+//!   feature) — a separate stack from the kernel binder path
+//! - **Service facade**: the [`service`] module — register/look up services
+//!   once, choosing kernel binder or RPC by construction
+//!
+//! # Feature flags
+//!
+//! - `tokio` *(default)* — full async/await support on the Tokio runtime
+//!   (implies `async`).
+//! - `async` — generic async-trait support, without committing to a
+//!   specific runtime.
+//! - `rpc` — master switch for the RPC transport (binder-over-socket), a
+//!   separate stack from the kernel binder path. Off by default; default
+//!   and `--no-default-features` builds carry zero RPC/networking cost.
+//! - `rpc-tcp-debug` — plaintext TCP backend (implies `rpc`). Debug and
+//!   interop bring-up **only**, never production — use `rpc-tls` for real
+//!   networks.
+//! - `rpc-vsock` — vsock backend for host↔VM channels (implies `rpc`;
+//!   Linux and Android targets only).
+//! - `rpc-tls` — TLS backend over rustls (implies `rpc`). rsbinder never
+//!   invents crypto; the caller supplies the `rustls` configuration.
+//! - `android_10` … `android_16`, plus the `android_*_plus` ranges (e.g.
+//!   `android_11_plus`) — select which Android service-manager protocol
+//!   versions to support. Android 10 uses the legacy C service-manager
+//!   protocol. Android 15 and 17 need no dedicated flag: their
+//!   service-manager wire format is identical to Android 14 and
+//!   Android 16 respectively, so they are served by `android_14` /
+//!   `android_16`.
 //!
 //! # Basic Usage
 //!
@@ -197,9 +225,10 @@ pub mod permission_controller;
 /// Async runtime implementations
 #[cfg(feature = "async")]
 mod rt;
-/// Cross-transport service facade (Plan 2-16 Phase D): register/look up
-/// services once, choosing kernel binder or RPC by construction. Additive
-/// layer over `ProcessState`/`hub`/`RpcServer`/`RpcSession`.
+// Cross-transport service facade — see the module's own docs. Kept as a
+// plain (non-doc) comment: an outer doc here would merge with the
+// module's inner `//!` docs and re-resolve their intra-doc links at the
+// crate root, breaking them.
 pub mod service;
 
 // Explicit re-exports: glob re-exports would silently leak every

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -943,7 +943,7 @@ impl Parcel {
     /// through this method as it reads each `next` node, so a hostile
     /// deeply-nested payload would recurse until the worker-thread stack
     /// overflows — a hard `SIGABRT`, not a recoverable [`StatusCode`]. The
-    /// nesting is capped at [`MAX_NESTED_READ_DEPTH`]; a payload exceeding it
+    /// nesting is capped at `MAX_NESTED_READ_DEPTH` (1000); a payload exceeding it
     /// is rejected with [`StatusCode::BadValue`]. This is defense-in-depth
     /// beyond AOSP (whose `Parcel` has no equivalent guard) and is set far
     /// above any legitimate AIDL nesting, so conforming traffic is unaffected.

--- a/rsbinder/src/permission_controller.rs
+++ b/rsbinder/src/permission_controller.rs
@@ -48,7 +48,7 @@ pub const SERVICE_NAME: &str = "permission";
 /// check ([`check_permission`]) — across kernel binder *and* RPC — and
 /// receives the transport-tagged [`Caller`] so it can apply the right rule
 /// per transport (Android permission for [`Caller::Kernel`]; a uid ACL,
-/// TLS-certificate allowlist, or token scope for [`Caller::Rpc`]).
+/// TLS-certificate allowlist, or token scope for `Caller::Rpc`).
 ///
 /// The core crate ships only this **slot**, never a policy: token/JWT
 /// formats, certificate→permission tables, and uid→permission maps are

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -564,7 +564,7 @@ impl RpcServer {
     /// `config` is the caller's `rustls::ServerConfig` (server cert
     /// chain + private key, optional mTLS client-cert verifier);
     /// rsbinder never invents crypto. Use
-    /// [`super::rustls`](super::rustls) (re-export of the linked
+    /// [`super::rustls`] (re-export of the linked
     /// `rustls` version) to construct the config.
     #[cfg(feature = "rpc-tls")]
     pub fn setup_unix_server_tls(
@@ -579,7 +579,7 @@ impl RpcServer {
     /// TCP server with TLS. The TCP backend is
     /// **TLS-only** by design (plain-text network RPC is never
     /// production-appropriate; see [`super`] module doc). Use
-    /// [`super::rustls`](super::rustls) to construct the config (server
+    /// [`super::rustls`] to construct the config (server
     /// cert chain + private key, optional mTLS).
     #[cfg(feature = "rpc-tls")]
     pub fn setup_tcp_server_tls(
@@ -701,7 +701,7 @@ impl RpcServer {
 
     /// Set (or disable) the **handshake/admission read deadline** applied
     /// to each accepted connection before it enters the blocking serve
-    /// loop. Default [`DEFAULT_HANDSHAKE_TIMEOUT`] (10s). `Some(d)` ⇒ a
+    /// loop. Default `DEFAULT_HANDSHAKE_TIMEOUT` (10s). `Some(d)` ⇒ a
     /// connected-but-silent peer that never sends its handshake is
     /// dropped after `d`, releasing both its `Arc<RpcServer>` (so the
     /// server's `Drop` cleanup can run) and its
@@ -1001,7 +1001,7 @@ impl RpcServer {
 
     /// Serve one already-connected transport on its own worker thread
     /// (used by in-memory tests and by [`super::session`] direct calls).
-    /// The accept loop uses [`serve_connection_raw`](Self::serve_connection_raw)
+    /// The accept loop uses the private `serve_connection_raw`
     /// to keep TLS handshake (if any) on the worker side.
     pub fn serve_connection(self: &Arc<Self>, transport: Box<dyn RpcTransport>) {
         let server = Arc::clone(self);

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -2959,7 +2959,7 @@ impl RpcSession {
     /// The fd's address family (`SO_DOMAIN`) selects the rsbinder
     /// transport — `AF_UNIX` → [`super::transport::UnixTransport`],
     /// `AF_VSOCK` → `VsockTransport` (feature `rpc-vsock`, Linux only),
-    /// `AF_INET`/`AF_INET6` → [`super::transport::TcpDebugTransport`]
+    /// `AF_INET`/`AF_INET6` → `TcpDebugTransport`
     /// (feature `rpc-tcp-debug`). Any other family is rejected as
     /// [`StatusCode::BadType`], paralleling AOSP's
     /// `IAccessor::ERROR_UNSUPPORTED_SOCKET_FAMILY`. The handshake then

--- a/rsbinder/src/service.rs
+++ b/rsbinder/src/service.rs
@@ -16,7 +16,7 @@
 //! and two typed host/broker pairs, one per transport:
 //!
 //! - [`kernel::Host`] / [`kernel::Broker`] — over `ProcessState` + `hub`.
-//! - [`rpc::Host`] / [`rpc::Broker`] — over `RpcServer` + `RpcSession`
+//! - `rpc::Host` / `rpc::Broker` — over `RpcServer` + `RpcSession`
 //!   (`#[cfg(feature = "rpc")]`).
 //!
 //! # This is additive, not a replacement
@@ -41,7 +41,7 @@
 //! Phase A), and [`crate::get_calling_uid`] returns the kernel-vouched
 //! peer uid over Unix RPC / a fail-closed sentinel on uid-less transports
 //! (Phase B). Authorization on RPC is the transport's own boundary
-//! (`PeerIdentity` + [`crate::rpc::RpcServer::set_authorizer`]).
+//! (`PeerIdentity` + `crate::rpc::RpcServer::set_authorizer`).
 //!
 //! # Why typed pairs, not one `Endpoint` enum
 //!
@@ -75,7 +75,7 @@ pub trait Registry {
     ///
     /// Kernel: delegates to [`crate::hub::add_service`] (the system service
     /// manager). RPC: delegates to
-    /// [`crate::rpc::RpcServer::add_service`] (an in-process directory the
+    /// `crate::rpc::RpcServer::add_service` (an in-process directory the
     /// session root resolves) — there is no system-wide RPC service
     /// manager, by design (mirrors AOSP).
     fn add_service(&self, name: &str, binder: SIBinder) -> Result<()>;
@@ -159,7 +159,7 @@ pub mod kernel {
     ///
     /// Construction is **idempotent** (`ProcessState` is process-wide);
     /// [`Host::serve`] joins the **process-wide** binder thread pool — it
-    /// is not a per-instance lifecycle. Contrast [`super::rpc::Host`],
+    /// is not a per-instance lifecycle. Contrast `super::rpc::Host`,
     /// whose `serve()` drives a single socket.
     pub struct Host {
         _priv: (),

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -170,8 +170,8 @@ fn rpc_calling() -> Option<(binder::uid_t, binder::pid_t)> {
 /// - [`Caller::Kernel`] — Android permissions (`@EnforcePermission` /
 ///   [`crate::permission_controller::check_permission`]), `uid`/`pid`
 ///   ACLs, or the SELinux `sid`.
-/// - [`Caller::Rpc`] — the transport's own trust boundary: a Unix
-///   [`PeerIdentity::Local`](crate::rpc::PeerIdentity) uid ACL, a TLS
+/// - `Caller::Rpc` (with the `rpc` feature) — the transport's own trust
+///   boundary: a Unix `PeerIdentity::Local` uid ACL, a TLS
 ///   `Certificate` subject/fingerprint allowlist, etc.
 ///   `@EnforcePermission` is **denied** over RPC (Plan 2-16 Phase A).
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Documentation review pass for the **0.10.0** release. Covers the book, README, CHANGELOG, and API (rustdoc) docs. No product code changes — the `rsbinder/src` edits are rustdoc-only.

## CHANGELOG
- Record the previously-missing **Android 17 (SDK 37)** service-manager support (#158) and the **#159 API-ergonomics batch**: event-driven / error-preserving hub lookups (`wait_for_*`, `check_interface`, `try_get_*`), `add_service` taking `impl Into<SIBinder>`, `include_aidl!`, `link_to_death_arc`, `ParcelFileDescriptor::try_clone`.
- Document the oneway transport-error propagation change, the `get_service` / `get_interface` deprecation, and the `downcast-rs` drop.
- Set the release date to 2026-07-11.

## Packaging / docs.rs
- Add `[package.metadata.docs.rs] all-features = true` to `rsbinder` and `rsbinder-aidl` so the feature-gated `rpc` surface is actually documented on docs.rs (it was absent under the default-features build).
- Refresh the crates.io descriptions.

## rustdoc
- Add a `# Feature flags` section to the crate docs; fix broken intra-doc links and private/rpc-gated link warnings.
- **Zero warnings** across default / `--features rpc` / `--all-features` doc builds (was 14 / 10 / 11).

## book
- Bump dependency snippets from `0.8` to `0.10`.
- Fix AIDL examples that failed the generator (`@nullable in` → `in @nullable`) and the parcelable constant-access examples (module-qualified paths), verified against the live generator.
- Migrate deprecated `get_interface` usage to `wait_for_interface` / `try_*`.
- Document abstract Unix-domain sockets and the `RpcUnixClientConfig` builder.
- Correct the `binder_linux` module instructions for built-in kernels (Arch/Ubuntu/RedHat guides).

## Verification
- `mdbook build book` succeeds.
- `cargo doc` clean across all feature configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)