### PR TITLE
fix(rsbinder): harden kernel and RPC binder paths from full source review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ This changelog starts at 0.9.0. For earlier releases, see the
 
 ## [Unreleased]
 
+### Changed
+
+- **rsbinder (AOSP alignment):** `FLAG_PRIVATE_VENDOR` is now `0x10000000`
+  (AOSP `IBinder.h`) instead of `0`. Code passing this flag to `transact`
+  now sets bit 28 on the wire. `FLAG_PRIVATE_LOCAL` is unchanged (`0`).
+
 ## [0.10.0] - 2026-07-11
 
 ### Changed

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -67,9 +67,13 @@ pub type TransactionFlags = u32;
 pub const FLAG_ONEWAY: TransactionFlags = sys::transaction_flags_TF_ONE_WAY;
 /// Corresponds to TF_CLEAR_BUF -- clear transaction buffers after call is made.
 pub const FLAG_CLEAR_BUF: TransactionFlags = sys::transaction_flags_TF_CLEAR_BUF;
-/// Set to the vendor flag if we are building for the VNDK, 0 otherwise
+/// `FLAG_PRIVATE_LOCAL` — the vendor flag on a VNDK build, `0` otherwise
+/// (AOSP `IBinder.h`). rsbinder targets the system side, so it is `0`; this is
+/// the flag the AIDL codegen emits on outgoing transactions.
 pub const FLAG_PRIVATE_LOCAL: TransactionFlags = 0;
-pub const FLAG_PRIVATE_VENDOR: TransactionFlags = FLAG_PRIVATE_LOCAL;
+/// `FLAG_PRIVATE_VENDOR` (`0x10000000`, AOSP `IBinder.h`) — unconditional,
+/// unlike [`FLAG_PRIVATE_LOCAL`]. Marks a transaction as vendor-private.
+pub const FLAG_PRIVATE_VENDOR: TransactionFlags = 0x10000000;
 /// `TF_UPDATE_TXN` (0x40). Set together with
 /// [`FLAG_ONEWAY`] on a `transact()` to ask the Android 12+ driver to
 /// replace any pending async transaction with the same `(target, code)`
@@ -470,7 +474,12 @@ pub fn __rpc_stamp_descriptor(_binder: &SIBinder, _descriptor: &str) {}
 
 impl std::fmt::Debug for dyn IBinder {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:?}", self.as_any())
+        // `as_any()` formats as the useless `Any { .. }`; surface the fields a
+        // reader actually needs from a bare `&dyn IBinder` instead.
+        f.debug_struct("dyn IBinder")
+            .field("descriptor", &self.descriptor())
+            .field("remote", &self.is_remote())
+            .finish()
     }
 }
 
@@ -602,6 +611,23 @@ impl Stability {
     }
 }
 
+/// AOSP `Stability::kBinderWireFormatVersion` (`Stability.cpp:31`) — the wire
+/// version stamped into an android-12 `Category`.
+const BINDER_WIRE_FORMAT_VERSION: i32 = 1;
+
+/// android-12 `Stability::Category::repr()` for a raw `Level`.
+///
+/// AOSP-12 `Category { uint8_t version; uint8_t reserved[2]; Level level; }`
+/// with `currentFromLevel` = `{ version: 1, reserved: 0, level }`, so on
+/// little-endian `repr() == (level << 24) | version`
+/// (`frameworks/native/libs/binder/{include/binder/Stability.h,Stability.cpp}`,
+/// android-12.0.0_r34).
+// Only reachable in the `target_os = "android"` encode branch (and unit tests).
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+const fn android12_category_repr(level: i32) -> i32 {
+    (level << 24) | BINDER_WIRE_FORMAT_VERSION
+}
+
 // Android 12 version uses "Category" as the stability format for passed on the wire lines,
 // whereas other versions do not. Therefore, we can use the android_properties crate
 // to determine the Android version and perform different handling accordingly.
@@ -613,7 +639,7 @@ impl From<Stability> for i32 {
     fn from(stability: Stability) -> i32 {
         use Stability::*;
 
-        let stability = match stability {
+        let level = match stability {
             Local => 0,
             Vendor => 0b000011,
             System => 0b001100,
@@ -624,13 +650,13 @@ impl From<Stability> for i32 {
         {
             let android_sdk_version = crate::get_android_sdk_version();
             if android_sdk_version == 31 || android_sdk_version == 32 {
-                stability | 0x0c000000
+                android12_category_repr(level)
             } else {
-                stability
+                level
             }
         }
         #[cfg(not(target_os = "android"))]
-        stability
+        level
     }
 }
 
@@ -639,14 +665,26 @@ impl TryFrom<i32> for Stability {
     fn try_from(stability: i32) -> Result<Stability> {
         use Stability::*;
 
-        // Try matching as raw Level value first (Android 11, 13+)
-        let level = if stability <= 0xFF {
-            stability
-        } else {
-            // Try extracting level from Category repr format (Android 12).
-            // Category struct on little-endian: { version: u8, reserved: [u8; 2], level: u8 }
-            // repr() = (level << 24) | version
+        // A stability field arrives in one of two on-wire encodings:
+        //   * Raw `Level` (android-11, android-13+, and the non-android
+        //     build): the level value itself in the low byte (0/3/12/63),
+        //     high bytes zero.
+        //   * android-12 `Category::repr()` = `(level << 24) | version`, i.e.
+        //     the level in the high byte with a nonzero wire-format version in
+        //     the low byte.
+        // If any bit above the low byte is set it is a Category (a
+        // nonzero-level Category decodes by level whatever its version byte).
+        // Otherwise the low byte is the raw level — except the bare android-12
+        // wire-format version `0x0000_0001` (Category with level 0), which
+        // decodes to `Local`. A level-0 Category with any other version byte
+        // is byte-ambiguous with a raw level and cannot be distinguished;
+        // AOSP-12 only ever writes version 1.
+        let level = if stability & !0xFF != 0 {
             (stability >> 24) & 0xFF
+        } else if stability == BINDER_WIRE_FORMAT_VERSION {
+            0
+        } else {
+            stability
         };
 
         match level {
@@ -1359,10 +1397,35 @@ mod stability_tests {
     // === Wire value tests ===
     #[test]
     fn test_stability_wire_values() {
-        assert_eq!(Into::<i32>::into(Stability::Local), 0);
-        assert_eq!(Into::<i32>::into(Stability::Vendor), 0b000011);
-        assert_eq!(Into::<i32>::into(Stability::System), 0b001100);
-        assert_eq!(Into::<i32>::into(Stability::Vintf), 0b111111);
+        // On a real android SDK 31/32 device the wire form is the Category
+        // repr `(level << 24) | 1`; on every other target it is the raw level.
+        // Assert the exact bytes for whichever encoding is active, and that
+        // the decoder round-trips it back.
+        for (s, level) in [
+            (Stability::Local, 0),
+            (Stability::Vendor, 0b000011),
+            (Stability::System, 0b001100),
+            (Stability::Vintf, 0b111111),
+        ] {
+            let wire: i32 = s.into();
+            #[cfg(target_os = "android")]
+            let expected = {
+                let sdk = crate::get_android_sdk_version();
+                if sdk == 31 || sdk == 32 {
+                    android12_category_repr(level)
+                } else {
+                    level
+                }
+            };
+            #[cfg(not(target_os = "android"))]
+            let expected = level;
+            assert_eq!(wire, expected, "wire encoding for {s:?}");
+            assert_eq!(
+                Stability::try_from(wire).unwrap(),
+                s,
+                "round-trip for {s:?}"
+            );
+        }
     }
 
     // === TryFrom round-trip tests ===
@@ -1381,40 +1444,43 @@ mod stability_tests {
 
     #[test]
     fn test_stability_category_format() {
-        // Android 12 Category repr: level in byte 3 (big end on little-endian)
-        // Category{version=1, reserved=[0,0], level} → repr = (level << 24) | version
-        let category = |level: i32, version: i32| -> i32 { (level << 24) | version };
+        // android-12 Category repr = (level << 24) | version(1), byte-exact to
+        // AOSP-12.0.0_r34 Stability::Category::currentFromLevel.
+        assert_eq!(super::android12_category_repr(0), 0x0000_0001);
+        assert_eq!(super::android12_category_repr(0b000011), 0x0300_0001);
+        assert_eq!(super::android12_category_repr(0b001100), 0x0c00_0001);
+        assert_eq!(super::android12_category_repr(0b111111), 0x3f00_0001);
 
-        assert_eq!(
-            Stability::try_from(category(0b000011, 1)).unwrap(),
-            Stability::Vendor
-        );
-        assert_eq!(
-            Stability::try_from(category(0b001100, 1)).unwrap(),
-            Stability::System
-        );
-        assert_eq!(
-            Stability::try_from(category(0b111111, 1)).unwrap(),
-            Stability::Vintf
-        );
+        // Decode every Category repr back to its level — including the
+        // Local/UNDECLARED case (0x0000_0001).
+        assert_eq!(Stability::try_from(0x0000_0001).unwrap(), Stability::Local);
+        assert_eq!(Stability::try_from(0x0300_0001).unwrap(), Stability::Vendor);
+        assert_eq!(Stability::try_from(0x0c00_0001).unwrap(), Stability::System);
+        assert_eq!(Stability::try_from(0x3f00_0001).unwrap(), Stability::Vintf);
 
-        // Different version values should also work
+        // A nonzero-level Category with a different (future) version byte
+        // still decodes by level (AOSP reads only Category.level).
         assert_eq!(
-            Stability::try_from(category(0b001100, 12)).unwrap(),
+            Stability::try_from((0b001100 << 24) | 12).unwrap(),
             Stability::System
         );
 
-        // rsbinder's own Android 12 format: level | 0x0c000000
-        assert_eq!(
-            Stability::try_from(0b001100 | 0x0c000000_i32).unwrap(),
-            Stability::System
-        );
+        // Raw-level encoding (android-11 / android-13+) still decodes.
+        assert_eq!(Stability::try_from(0).unwrap(), Stability::Local);
+        assert_eq!(Stability::try_from(0b000011).unwrap(), Stability::Vendor);
+        assert_eq!(Stability::try_from(0b001100).unwrap(), Stability::System);
+        assert_eq!(Stability::try_from(0b111111).unwrap(), Stability::Vintf);
     }
 
     #[test]
     fn test_stability_invalid_value() {
         assert_eq!(Stability::try_from(0x7F).unwrap_err(), StatusCode::BadValue);
-        assert_eq!(Stability::try_from(0x01).unwrap_err(), StatusCode::BadValue);
+        // A low-byte value that is neither a valid raw level nor the android-12
+        // wire-format version tag is rejected.
+        assert_eq!(Stability::try_from(0x05).unwrap_err(), StatusCode::BadValue);
+        // 0x01 is the android-12 Local/UNDECLARED Category repr — it decodes
+        // to Local, not BadValue.
+        assert_eq!(Stability::try_from(0x01).unwrap(), Stability::Local);
     }
 
     // === Bitmask verification tests ===

--- a/rsbinder/src/file_descriptor.rs
+++ b/rsbinder/src/file_descriptor.rs
@@ -273,10 +273,13 @@ impl DeserializeOption for ParcelFileDescriptor {
             return Ok(None);
         }
 
+        // AOSP `ParcelFileDescriptor.writeToParcel` (frameworks/base
+        // core/java/android/os/ParcelFileDescriptor.java): `writeInt(hasComm)`,
+        // then `writeFileDescriptor(mFd)`, then `writeFileDescriptor(mCommFd)`
+        // when `hasComm != 0` (a Java `createReliablePipe()` /
+        // `createReliableSocketPair()` PFD). Read the main fd object first,
+        // regardless of `hasComm`.
         let has_comm = parcel.read::<i32>()?;
-        if has_comm != 0 {
-            return Err(StatusCode::BadValue);
-        }
 
         let obj = parcel.read_object(true)?;
 
@@ -293,6 +296,16 @@ impl DeserializeOption for ParcelFileDescriptor {
         }
 
         let fd = rustix::io::fcntl_dupfd_cloexec(obj.borrowed_fd(), 0)?;
+
+        // Reliable-PFD comm channel: consume the second fd object so the
+        // parcel cursor stays aligned; rsbinder has no comm channel, so drop
+        // it (the parcel owns it and closes it on `BC_FREE_BUFFER`).
+        if has_comm != 0 {
+            let comm = parcel.read_object(true)?;
+            if comm.header_type() != crate::sys::BINDER_TYPE_FD {
+                return Err(StatusCode::BadType);
+            }
+        }
 
         Ok(Some(ParcelFileDescriptor::new(fd)))
     }

--- a/rsbinder/src/hub/accessor_16.rs
+++ b/rsbinder/src/hub/accessor_16.rs
@@ -77,9 +77,11 @@ pub use android::os::IAccessor::{IAccessorAsync, IAccessorAsyncService};
 /// wrapper is transparent to consumers. The inner proxy is the only
 /// concrete `IBinder` anyone outside this module needs to recognise.
 pub(crate) struct AccessorRoot {
-    /// The RPC root `SIBinder` returned by `RpcSession::get_root`. Owns
-    /// an `Arc<RpcProxy>` (one of two: the other is cached inside
-    /// `RpcSessionInner.state` and dies with the session).
+    /// The RPC root `SIBinder` returned by `RpcSession::get_root`. This is,
+    /// via its `Arc<RpcProxy>`, what keeps the proxy alive: the session-side
+    /// cache in `RpcSessionInner.state` holds only a `Weak` (it dedups without
+    /// keeping proxies alive), so dropping `inner` is what fires
+    /// `RpcProxy::drop`.
     inner: SIBinder,
     /// **Load-bearing**: must drop *after* `inner` (Rust drops fields in
     /// declaration order). Dropping `session` first kills the
@@ -306,7 +308,7 @@ pub fn accessor_error_name(code: i32) -> &'static str {
     }
 }
 
-/// Fuzz hook: feed an arbitrary big-endian i32
+/// Fuzz hook: feed an arbitrary little-endian i32
 /// byte payload into [`accessor_error_name`] and assert it never
 /// panics, allocates indefinitely, or returns a non-`'static str`. The
 /// returned string is intentionally consumed via `std::hint::black_box`

--- a/rsbinder/src/hub/servicemanager_10.rs
+++ b/rsbinder/src/hub/servicemanager_10.rs
@@ -6,13 +6,12 @@ use crate::*;
 // Interface descriptor for the Android 10 C service manager.
 pub const SERVICE_MANAGER_DESCRIPTOR: &str = "android.os.IServiceManager";
 
-// Re-export the priority flags from the hub root so values can never drift
-// from the AIDL-generated constants used by API 30+.
+// Re-export the priority/proto flags from the hub root so values can never
+// drift from the AIDL-generated constants used by API 30+.
 pub use crate::hub::{
     DUMP_FLAG_PRIORITY_ALL, DUMP_FLAG_PRIORITY_CRITICAL, DUMP_FLAG_PRIORITY_DEFAULT,
-    DUMP_FLAG_PRIORITY_HIGH, DUMP_FLAG_PRIORITY_NORMAL,
+    DUMP_FLAG_PRIORITY_HIGH, DUMP_FLAG_PRIORITY_NORMAL, DUMP_FLAG_PROTO,
 };
-pub const DUMP_FLAG_PROTO: i32 = 1 << 4;
 
 // `addService` allow_isolated argument; the C service manager treats any
 // non-zero value as true.
@@ -126,7 +125,12 @@ pub fn check_service(sm: &BpServiceManager, name: &str) -> Option<SIBinder> {
     match result {
         Ok(binder) => binder,
         Err(err) => {
-            log::error!("Failed to check service {name}: {err}");
+            // The legacy C service manager signals "not found" as a single
+            // `u32 0` (no flat object), which surfaces here as a short-read
+            // `Err`. That is the normal absent-service path, not an error —
+            // log at `debug` like `get_service`/`try_get_service` (and unlike
+            // API 11+, where it is a silent `Ok(None)`).
+            log::debug!("check_service({name}): not found or read error: {err}");
             None
         }
     }

--- a/rsbinder/src/lazy_service.rs
+++ b/rsbinder/src/lazy_service.rs
@@ -133,29 +133,45 @@ impl LazyServiceRegistrar {
         }
     }
 
-    /// Attempt to unregister all services whose last `onClients` was
-    /// `false` (no current clients). AOSP
+    /// Attempt to unregister **every** service, all-or-nothing. AOSP
     /// [`LazyServiceRegistrar::tryUnregisterLocked`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=193).
     ///
-    /// **Returns** `true` if every clientless service successfully
-    /// flipped to `registered = false`; `false` if `force_persist` is
-    /// engaged or no candidates were eligible. The hub-integrated
-    /// version owed by the caller (see module docs) is the place where
-    /// the actual `tryUnregisterService` IPC happens — this skeleton
-    /// only mutates internal state.
+    /// AOSP's caller (`maybeTryShutdownLocked`) only reaches this when
+    /// `mNumConnectedServices == 0`, and `tryUnregisterLocked` then
+    /// unregisters *all* services (rolling back on the first failure). A
+    /// `true` return means "no service is registered any more → the process is
+    /// safe to exit". A per-entry flip (leaving client-holding services
+    /// registered while others go down) would let a caller following the
+    /// AOSP idiom `if try_unregister() { exit }` terminate with live-client
+    /// services still registered.
+    ///
+    /// **Returns** `true` iff every service was flipped to
+    /// `registered = false` (there is no service with clients, and
+    /// `force_persist` is not engaged); `false` otherwise — in which case
+    /// nothing is changed. A registrar with no services returns `false`:
+    /// there is nothing to unregister, so it never signals "safe to exit"
+    /// (AOSP cannot reach this state — its shutdown check only runs from an
+    /// `onClients` callback of a registered service). The hub-integrated
+    /// version owed by the caller (see module docs) is where the actual
+    /// `tryUnregisterService` IPC happens; this skeleton only mutates
+    /// internal state.
     pub fn try_unregister(&self) -> bool {
         if self.force_persist.load(Ordering::Acquire) {
             return false;
         }
         let mut inner = self.inner.lock().expect("lazy_service inner poisoned");
-        let mut any_eligible = false;
-        for entry in inner.services.values_mut() {
-            if !entry.has_clients && entry.registered {
-                entry.registered = false;
-                any_eligible = true;
-            }
+        if inner.services.is_empty() {
+            return false;
         }
-        any_eligible
+        // Global gate: if any service still has clients, unregister nothing and
+        // report "not safe to shut down" (AOSP all-or-nothing).
+        if inner.services.values().any(|e| e.has_clients) {
+            return false;
+        }
+        for entry in inner.services.values_mut() {
+            entry.registered = false;
+        }
+        true
     }
 
     /// Re-register every previously-unregistered service. AOSP
@@ -246,23 +262,44 @@ mod tests {
         assert_eq!(reg.registered_count(), 1);
     }
 
-    /// `try_unregister` flips `registered` to
-    /// false **only** for entries with `has_clients == false`. AOSP
-    /// `tryUnregisterLocked` eligibility predicate.
+    /// `try_unregister` is all-or-nothing: if ANY service still has clients it
+    /// unregisters nothing and returns `false`; only once every service is
+    /// clientless does it flip them all and return `true`. AOSP
+    /// `tryUnregisterLocked` (gated by the caller on `mNumConnectedServices ==
+    /// 0`).
     #[test]
-    fn try_unregister_only_flips_clientless_entries() {
+    fn try_unregister_is_all_or_nothing() {
         let reg = LazyServiceRegistrar::new();
         reg.register_service("a", fresh_binder()).unwrap();
         reg.register_service("b", fresh_binder()).unwrap();
-        // `a` still has clients; `b` lost theirs.
+        // `a` still has clients; `b` lost theirs → not safe to unregister
+        // anything, and nothing is changed.
         reg.on_clients("b", false);
-        assert!(reg.try_unregister(), "any eligible -> true");
+        assert!(!reg.try_unregister(), "a still has clients -> false, no-op");
         let snap = reg.snapshot();
-        let a = snap.iter().find(|(n, _, _)| n == "a").unwrap();
-        let b = snap.iter().find(|(n, _, _)| n == "b").unwrap();
-        assert!(a.2, "`a` still has clients, stays registered");
-        assert!(!b.2, "`b` clientless and unregistered");
-        assert_eq!(reg.registered_count(), 1);
+        assert!(
+            snap.iter().find(|(n, _, _)| n == "a").unwrap().2,
+            "`a` stays registered"
+        );
+        assert!(
+            snap.iter().find(|(n, _, _)| n == "b").unwrap().2,
+            "`b` also stays registered"
+        );
+        assert_eq!(reg.registered_count(), 2);
+
+        // Now `a` also loses its clients → all clientless → unregister all.
+        reg.on_clients("a", false);
+        assert!(reg.try_unregister(), "all clientless -> true");
+        let snap = reg.snapshot();
+        assert!(
+            !snap.iter().find(|(n, _, _)| n == "a").unwrap().2,
+            "`a` unregistered"
+        );
+        assert!(
+            !snap.iter().find(|(n, _, _)| n == "b").unwrap().2,
+            "`b` unregistered"
+        );
+        assert_eq!(reg.registered_count(), 0);
     }
 
     /// `force_persist(true)` short-circuits `try_unregister`

--- a/rsbinder/src/lib.rs
+++ b/rsbinder/src/lib.rs
@@ -284,8 +284,10 @@ pub use process_state::ProcessState;
 // From `proxy` — client-side handle types.
 pub use proxy::{Proxy, ProxyHandle};
 
+// Explicit (not glob) so a newly-added `pub` item in `rt` can't silently leak
+// to the crate root without semver review — the policy stated above.
 #[cfg(feature = "tokio")]
-pub use rt::*;
+pub use rt::{get_interface, Tokio, TokioRuntime};
 pub use status::{BinderResult, ExceptionCode, Status};
 
 /// Default path to the binder control device

--- a/rsbinder/src/macros.rs
+++ b/rsbinder/src/macros.rs
@@ -119,7 +119,7 @@ macro_rules! __declare_binder_interface {
                                     // the cast now rather than panic in `as_async()` at
                                     // the first method call (AOSP returns `BadType` too).
                                     if native.0.try_as_async().is_some() {
-                                        Ok($crate::Strong::new(Box::new(native.clone())))
+                                        Ok($crate::Strong::new(Box::new(native)))
                                     } else {
                                         Err($crate::StatusCode::BadType)
                                     }
@@ -438,7 +438,7 @@ macro_rules! declare_binder_interface {
                     Some(proxy) => Ok($crate::Strong::new(Box::new(proxy))),
                     None => {
                         match $crate::native::Binder::<$native>::try_from(binder) {
-                            Ok(native) => Ok($crate::Strong::new(Box::new(native.clone()))),
+                            Ok(native) => Ok($crate::Strong::new(Box::new(native))),
                             Err(err) => Err(err),
                         }
                     }
@@ -528,6 +528,9 @@ macro_rules! impl_deserialize_for_parcelable {
                     use $crate::Parcelable;
                     self.read_from_parcel(parcel)
                 } else {
+                    // Any flag other than NON_NULL is UNEXPECTED_NULL, matching
+                    // AOSP C++ `Parcel::readData` and `DeserializeOption`'s
+                    // default path.
                     Err($crate::StatusCode::UnexpectedNull.into())
                 }
             }
@@ -554,6 +557,9 @@ macro_rules! impl_deserialize_for_parcelable {
                     this.get_or_insert_with(Self::default)
                         .read_from_parcel(parcel)
                 } else {
+                    // Any flag other than NULL/NON_NULL is UNEXPECTED_NULL,
+                    // matching AOSP C++ `Parcel::readData` and
+                    // `DeserializeOption`'s default path.
                     Err($crate::StatusCode::UnexpectedNull.into())
                 }
             }

--- a/rsbinder/src/native.rs
+++ b/rsbinder/src/native.rs
@@ -184,6 +184,9 @@ fn stability_from_tag(tag: u8) -> Stability {
     }
 }
 
+// Must stay crate-private and never be embedded by value in another type:
+// `try_from`'s Arc reinterpret cast relies on an `Inner<B>` at an Arc's data
+// address being the Arc's own pointee.
 struct Inner<T: Remotable + Send + Sync> {
     remotable: T,
     /// `AtomicU8` storing a [`Stability`] tag (see `STABILITY_TAG_*`).
@@ -461,8 +464,11 @@ impl<T: Remotable> Transactable for Inner<T> {
                 if (FIRST_CALL_TRANSACTION..=LAST_CALL_TRANSACTION).contains(&code)
                     && !(thread_state::check_interface(reader, T::descriptor())?)
                 {
-                    reply.write(&StatusCode::BadType)?;
-                    return Ok(());
+                    // BAD_TYPE as the transaction *status* (the dispatcher
+                    // emits a TF_STATUS_CODE reply), matching AOSP NDK
+                    // `ABBinder::onTransact` — never as reply payload, which
+                    // clients would parse as a success.
+                    return Err(StatusCode::BadType);
                 }
 
                 match self.remotable.on_transact(code, reader, reply) {
@@ -650,17 +656,35 @@ impl<B: Remotable + 'static> TryFrom<SIBinder> for Binder<B> {
             return Err(StatusCode::BadType);
         }
 
-        if ibinder.as_any().downcast_ref::<Inner<B>>().is_some() {
-            // SAFETY: `downcast_ref::<Inner<B>>` confirmed the
-            // underlying allocation is `Inner<B>`. The trait-object
-            // Arc's data pointer addresses that `Inner<B>` value
-            // directly, so casting `*const dyn IBinder` to
-            // `*const Inner<B>` is layout-correct. Cloning the
-            // trait-object Arc and consuming it via `Arc::into_raw`
-            // leaks one strong ref; `Arc::from_raw` on the cast
-            // pointer reclaims that ref as `Arc<Inner<B>>`, conserving
-            // the total strong count after `ibinder` drops at the end
-            // of this function.
+        if let Some(inner_ref) = ibinder.as_any().downcast_ref::<Inner<B>>() {
+            // Soundness guard for a caller-supplied `IBinder`: the cast below
+            // reinterprets the trait-object Arc's *data* allocation as
+            // `Inner<B>`. `downcast_ref` only proves that `as_any()`'s return
+            // is *an* `Inner<B>` — an external impl that delegates `as_any()`/
+            // `descriptor()` to a wrapped inner object would pass both checks
+            // while its Arc points at the *wrapper* allocation, making the
+            // reinterpret (and the refcount ops on it) UB. Require that
+            // `as_any()` returned this Arc's own data before casting.
+            let data_ptr = Arc::as_ptr(ibinder.as_arc()) as *const u8;
+            let any_ptr = inner_ref as *const Inner<B> as *const u8;
+            if !std::ptr::eq(data_ptr, any_ptr) {
+                log::error!(
+                    "binder cast to `{}`: as_any() is not the Arc's own data (delegating IBinder impl?)",
+                    B::descriptor()
+                );
+                return Err(StatusCode::BadValue);
+            }
+            // SAFETY: `downcast_ref::<Inner<B>>` confirmed the underlying value
+            // is `Inner<B>`, and the pointer-identity check above confirms the
+            // trait-object Arc's data pointer addresses that same `Inner<B>`,
+            // which can only be the Arc's own pointee because `Inner<T>` is
+            // crate-private and never embedded by value (a wrapper with an
+            // `Inner<B>` first field could otherwise pass both checks), so
+            // casting `*const dyn IBinder` to `*const Inner<B>` is
+            // layout-correct. Cloning the trait-object Arc and consuming it via
+            // `Arc::into_raw` leaks one strong ref; `Arc::from_raw` on the cast
+            // pointer reclaims that ref as `Arc<Inner<B>>`, conserving the total
+            // strong count after `ibinder` drops at the end of this function.
             let arc_dyn = Arc::clone(ibinder.as_arc());
             let raw_dyn = Arc::into_raw(arc_dyn);
             let inner_raw = raw_dyn as *const Inner<B>;
@@ -668,10 +692,13 @@ impl<B: Remotable + 'static> TryFrom<SIBinder> for Binder<B> {
 
             Ok(Self { inner })
         } else {
+            // Descriptor matched (checked above) but the object is not a local
+            // `Binder<B>` — a remote proxy for the same interface, or a
+            // different `Remotable` type sharing the descriptor. Logging both
+            // descriptors would just print the same string twice.
             log::error!(
-                "Downcast failed: expected {}, got {}",
-                B::descriptor(),
-                ibinder.descriptor()
+                "cast to local Binder<{}> failed: not a local binder (remote proxy or different Remotable)",
+                B::descriptor()
             );
             Err(StatusCode::BadValue)
         }
@@ -880,11 +907,11 @@ mod stability_mutation_tests {
         b.inner.mark_vintf().expect("not parceled yet");
         assert_eq!(b.inner.stability(), Stability::Vintf);
         let wire: i32 = b.inner.stability().into();
-        // Bottom 6 bits are the level; higher bits may carry the
-        // Android-12 `0x0c000000` overlay on a real Android target —
-        // mask before comparing so the host-tree hermetic test stays
-        // build-independent.
-        assert_eq!(wire & 0xFF, 0b111111);
+        // Decode independent of the wire format — raw level (off-android /
+        // SDK ≠ 31,32) puts the level in the low byte, the android-12 Category
+        // repr puts it in the high byte — so round-trip through the decoder
+        // rather than masking a fixed byte.
+        assert_eq!(Stability::try_from(wire).unwrap(), Stability::Vintf);
     }
 
     /// `force_downgrade_to_vendor_stability` flips the

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -226,7 +226,7 @@ impl<T: Clone + Default> ParcelData<T> {
     fn push(&mut self, other: T) {
         match self {
             ParcelData::Vec(v) => v.push(other),
-            _ => panic!("extend_from_slice() is only available for ParcelData::Vec."),
+            _ => panic!("push() is only available for ParcelData::Vec."),
         }
     }
 }
@@ -1180,7 +1180,10 @@ impl Parcel {
 
     pub(crate) fn write_array<S: Serialize + Sized>(&mut self, parcelable: &[S]) -> Result<()> {
         let len = parcelable.len();
-        self.write::<i32>(&(len as _))?;
+        // The wire length word is an `i32`; a slice too large to fit is a
+        // `BadValue`, not a silently truncated (possibly negative) count.
+        let len_i32: i32 = len.try_into().or(Err(StatusCode::BadValue))?;
+        self.write::<i32>(&len_i32)?;
 
         if len == 0 {
             return Ok(());
@@ -1190,17 +1193,24 @@ impl Parcel {
         let padded = pad_size(size);
         let pos = self.pos;
 
-        self.data.reserve(pos + padded);
-        // SAFETY: `reserve(pos + padded)` above guarantees the destination
-        // has at least `pos + padded` bytes of capacity, so `add(pos)` and
-        // the `size`-byte copy (size <= padded) stay in-bounds and the
-        // ranges do not overlap (distinct allocations). The 0-3 trailing pad
-        // bytes are then zeroed so that `set_len` exposes only initialized
-        // memory: `reserve` allocates but does not initialize, and the pad is
-        // transmitted (it is counted in `data_size`), so without this we would
-        // both hit UB and leak uninitialized process memory to the peer. AOSP
-        // masks the pad to zero as well. `set_len` only grows up to the
-        // just-reserved capacity over now-initialized `u8` bytes.
+        // See `write_aligned_data`: keep the end position within `i32::MAX`
+        // and reject rather than overflow the reserve/copy arithmetic.
+        let end = pos
+            .checked_add(padded)
+            .filter(|&e| e <= i32::MAX as usize)
+            .ok_or(StatusCode::BadValue)?;
+
+        self.data.reserve(end);
+        // SAFETY: `reserve(end)` above guarantees the destination has at least
+        // `end` bytes of capacity, so `add(pos)` and the `size`-byte copy
+        // (size <= padded) stay in-bounds and the ranges do not overlap
+        // (distinct allocations). The 0-3 trailing pad bytes are then zeroed
+        // so that `set_len` exposes only initialized memory: `reserve`
+        // allocates but does not initialize, and the pad is transmitted (it is
+        // counted in `data_size`), so without this we would both hit UB and
+        // leak uninitialized process memory to the peer. AOSP masks the pad to
+        // zero as well. `set_len` only grows up to the just-reserved capacity
+        // over now-initialized `u8` bytes.
         unsafe {
             // Zero any `[len..pos]` gap left by a forward `set_data_position`
             // before `set_len`, so an uninitialized hole is never exposed via
@@ -1218,24 +1228,33 @@ impl Parcel {
             if padded > size {
                 std::ptr::write_bytes(self.data.as_mut_ptr().add(pos + size), 0, padded - size);
             }
-            if self.data.len() < pos + padded {
-                self.data.set_len(pos + padded);
+            if self.data.len() < end {
+                self.data.set_len(end);
             }
         }
 
-        self.set_data_position(pos + padded);
+        self.set_data_position(end);
 
         Ok(())
     }
 
     pub(crate) fn write_array_char<S: CharType>(&mut self, parcelable: &[S]) -> Result<()> {
         let len = parcelable.len();
-        self.write::<i32>(&(len as _))?;
+        // Length word is an `i32`, and `4 * len` must not overflow `usize`.
+        let len_i32: i32 = len.try_into().or(Err(StatusCode::BadValue))?;
+        self.write::<i32>(&len_i32)?;
 
-        let size = 4 * len;
+        let size = len.checked_mul(4).ok_or(StatusCode::BadValue)?;
         let padded = pad_size(size);
 
-        self.data.reserve(self.pos + padded);
+        // See `write_aligned_data`: keep the end position within `i32::MAX`
+        // and reject rather than overflow the reserve arithmetic.
+        let end = self
+            .pos
+            .checked_add(padded)
+            .filter(|&e| e <= i32::MAX as usize)
+            .ok_or(StatusCode::BadValue)?;
+        self.data.reserve(end);
         for c in parcelable {
             self.write(&c.as_i32())?;
         }
@@ -1262,7 +1281,7 @@ impl Parcel {
         }
     }
 
-    pub(crate) fn write_aligned<T>(&mut self, val: &T) {
+    pub(crate) fn write_aligned<T>(&mut self, val: &T) -> Result<()> {
         let unaligned = std::mem::size_of::<T>();
         // SAFETY: `val` is a live `&T`, so its `size_of::<T>()` bytes are
         // valid to read as `u8` for the borrow's duration. The resulting
@@ -1270,23 +1289,34 @@ impl Parcel {
         let val_bytes: &[u8] =
             unsafe { std::slice::from_raw_parts(val as *const T as *const u8, unaligned) };
 
-        self.write_aligned_data(val_bytes);
+        self.write_aligned_data(val_bytes)
     }
 
-    pub(crate) fn write_aligned_data(&mut self, data: &[u8]) {
+    pub(crate) fn write_aligned_data(&mut self, data: &[u8]) -> Result<()> {
         let unaligned = data.len();
         let aligned = pad_size(unaligned);
         let pos = self.pos;
 
-        self.data.reserve(pos + aligned);
-        // SAFETY: `reserve(pos + aligned)` guarantees capacity for `add(pos)`
-        // and the `unaligned`-byte copy (unaligned <= aligned). Source `data`
-        // and the parcel buffer are distinct allocations (non-overlapping).
-        // The 0-3 trailing pad bytes are zeroed before `set_len`: `reserve`
-        // does not initialize, and the pad is transmitted (counted in
-        // `data_size`), so leaving it uninitialized is both UB and an
-        // info-leak to the peer. AOSP masks the pad to zero too. `set_len`
-        // only grows up to the reserved capacity over now-initialized `u8`.
+        // A valid parcel never exceeds `i32::MAX` bytes (wire offsets are
+        // int32), so the end position must fit in that range. A larger `pos`
+        // can only come from moving the write cursor there via a misuse of
+        // the public `set_data_position`; reject it rather than overflow
+        // `pos + aligned` into a wild `reserve`/`write_bytes`. Mirrors AOSP
+        // `Parcel::growData` returning `BAD_VALUE` for `len > INT32_MAX`.
+        let end = pos
+            .checked_add(aligned)
+            .filter(|&e| e <= i32::MAX as usize)
+            .ok_or(StatusCode::BadValue)?;
+
+        self.data.reserve(end);
+        // SAFETY: `reserve(end)` guarantees capacity for `add(pos)` and the
+        // `unaligned`-byte copy (unaligned <= aligned). Source `data` and the
+        // parcel buffer are distinct allocations (non-overlapping). The 0-3
+        // trailing pad bytes are zeroed before `set_len`: `reserve` does not
+        // initialize, and the pad is transmitted (counted in `data_size`), so
+        // leaving it uninitialized is both UB and an info-leak to the peer.
+        // AOSP masks the pad to zero too. `set_len` only grows up to the
+        // reserved capacity over now-initialized `u8`.
         unsafe {
             // If the write cursor sits past the current end (a forward
             // `set_data_position`), the skipped `[len..pos]` bytes were never
@@ -1310,12 +1340,13 @@ impl Parcel {
                     aligned - unaligned,
                 );
             }
-            if pos + aligned > self.data.len() {
-                self.data.set_len(pos + aligned);
+            if end > self.data.len() {
+                self.data.set_len(end);
             }
         }
 
-        self.set_data_position(pos + aligned);
+        self.set_data_position(end);
+        Ok(())
     }
 
     pub(crate) fn write_object(&mut self, obj: &flat_binder_object, null_meta: bool) -> Result<()> {
@@ -1327,12 +1358,12 @@ impl Parcel {
         // `is_for_rpc == false`.
         #[cfg(feature = "rpc")]
         if self.rpc.is_some() {
-            self.write_aligned(obj);
+            self.write_aligned(obj)?;
             return Ok(());
         }
 
         let data_pos = self.pos;
-        self.write_aligned(obj);
+        self.write_aligned(obj)?;
 
         if null_meta || obj.pointer() != 0 {
             obj.acquire()?;
@@ -1451,13 +1482,22 @@ impl Parcel {
 
         let num_objects = last_idx - first_idx + 1;
 
-        self.data.reserve(self.pos + size);
+        // See `write_aligned_data`: bound the end position to `i32::MAX` and
+        // reject rather than overflow the reserve/copy arithmetic when the
+        // write cursor was moved to a nonsensical position.
+        let end = self
+            .pos
+            .checked_add(size)
+            .filter(|&e| e <= i32::MAX as usize)
+            .ok_or(StatusCode::BadValue)?;
+
+        self.data.reserve(end);
         // SAFETY: the source range `other.data[offset..offset + size]` is
         // bounds-checked by the slice index above (panics if out of range),
-        // and `reserve(self.pos + size)` guarantees the destination has
-        // capacity for `add(self.pos)` plus `size` bytes. `other` and `self`
-        // are distinct parcels (non-overlapping). `set_len` only grows up to
-        // the reserved capacity over the `u8` bytes just copied.
+        // and `reserve(end)` guarantees the destination has capacity for
+        // `add(self.pos)` plus `size` bytes. `other` and `self` are distinct
+        // parcels (non-overlapping). `set_len` only grows up to the reserved
+        // capacity over the `u8` bytes just copied.
         unsafe {
             // Zero any `[len..pos]` gap from a forward `set_data_position`
             // before `set_len` so an uninitialized hole is never exposed /
@@ -1471,11 +1511,11 @@ impl Parcel {
                 self.data.as_mut_ptr().add(self.pos),
                 size,
             );
-            if self.pos + size > self.data.len() {
-                self.data.set_len(self.pos + size);
+            if end > self.data.len() {
+                self.data.set_len(end);
             }
         }
-        self.set_data_position(self.pos + size);
+        self.set_data_position(end);
 
         // An RPC-mode parcel carries no `flat_binder_object`s, so the
         // offset recompute / re-acquire / FD-dup below is kernel-only.
@@ -2218,7 +2258,7 @@ mod tests {
         let pos = p.data_position();
         expect.push(pos as u32);
         p.write(&1i32).unwrap(); // present/TYPE_BINDER
-        p.write_aligned_data(&[0u8; 8]); // 8B RpcWireAddress
+        p.write_aligned_data(&[0u8; 8]).unwrap(); // 8B RpcWireAddress
         p.write(&0x0Ci32).unwrap(); // stability
         p.rpc_record_object_position(pos);
 
@@ -2235,7 +2275,7 @@ mod tests {
         let pos = p.data_position();
         expect.push(pos as u32);
         p.write(&1i32).unwrap();
-        p.write_aligned_data(&[0u8; 8]);
+        p.write_aligned_data(&[0u8; 8]).unwrap();
         p.write(&0x0Ci32).unwrap();
         p.rpc_record_object_position(pos);
 

--- a/rsbinder/src/parcelable.rs
+++ b/rsbinder/src/parcelable.rs
@@ -100,8 +100,7 @@ macro_rules! impl_parcelable {
     {Serialize, $ty:ty} => {
         impl Serialize for $ty {
             fn serialize(&self, parcel: &mut Parcel) -> Result<()> {
-                parcel.write_aligned(self);
-                Ok(())
+                parcel.write_aligned(self)
             }
         }
     };
@@ -156,8 +155,7 @@ macro_rules! impl_parcelable_ex {
         impl Serialize for $ty {
             fn serialize(&self, parcel: &mut Parcel) -> Result<()> {
                 let val: $to_ty = *self as _;
-                parcel.write_aligned(&val);
-                Ok(())
+                parcel.write_aligned(&val)
             }
         }
     };
@@ -287,8 +285,7 @@ impl DeserializeArray for bool {}
 impl Serialize for bool {
     fn serialize(&self, parcel: &mut Parcel) -> Result<()> {
         let val: i32 = *self as _;
-        parcel.write_aligned(&val);
-        Ok(())
+        parcel.write_aligned(&val)
     }
 }
 
@@ -319,7 +316,7 @@ impl SerializeOption for str {
                         utf16.as_ptr() as *const u8,
                         utf16.len() * std::mem::size_of::<u16>(),
                     )
-                });
+                })?;
 
                 Ok(())
             }
@@ -336,8 +333,7 @@ impl Deserialize for StatusCode {
 impl Serialize for StatusCode {
     fn serialize(&self, parcel: &mut Parcel) -> Result<()> {
         let val: i32 = i32::from(*self);
-        parcel.write_aligned(&val);
-        Ok(())
+        parcel.write_aligned(&val)
     }
 }
 
@@ -363,8 +359,7 @@ macro_rules! impl_parcelable_struct {
     {Serialize, $ty:ty} => {
         impl Serialize for $ty {
             fn serialize(&self, parcel: &mut Parcel) -> Result<()> {
-                parcel.write_aligned(self);
-                Ok(())
+                parcel.write_aligned(self)
             }
         }
     };
@@ -747,7 +742,11 @@ impl<T: SerializeOption> SerializeArray for Option<T> {}
 pub trait SerializeArray: Serialize + Sized {
     /// Serialize an array of this type into the given parcel.
     fn serialize_array(slice: &[Self], parcel: &mut Parcel) -> Result<()> {
-        parcel.write::<i32>(&(slice.len() as i32))?;
+        // The wire length word is an `i32`; a slice too large to fit is a
+        // `BadValue`, not a silently truncated (possibly negative) count.
+        // Matches AOSP's Rust `SerializeArray` (`try_into().or(BAD_VALUE)`).
+        let len: i32 = slice.len().try_into().or(Err(StatusCode::BadValue))?;
+        parcel.write::<i32>(&len)?;
 
         for s in slice {
             parcel.write(s)?;
@@ -992,6 +991,8 @@ mod tests {
 
         assert_eq!(p.read::<Tiny>(), Ok(Tiny { x: 7 }));
         assert_eq!(p.read::<Option<Tiny>>(), Ok(None));
+        // Any non-{0,1} flag is UNEXPECTED_NULL, matching AOSP C++
+        // `Parcel::readData` and the `DeserializeOption` default path.
         assert_eq!(p.read::<Option<Tiny>>(), Err(StatusCode::UnexpectedNull));
     }
 }

--- a/rsbinder/src/parcelable_holder.rs
+++ b/rsbinder/src/parcelable_holder.rs
@@ -167,7 +167,7 @@ impl ParcelableHolder {
                 }
             }
             ParcelableHolderData::Parcel(ref mut parcel) => {
-                // Safety: 0 should always be a valid position.
+                // Position 0 (rewind to start) is always valid.
                 parcel.set_data_position(0);
 
                 let name: String = parcel.read()?;
@@ -276,12 +276,12 @@ impl Parcelable for ParcelableHolder {
                 parcelable.write_to_parcel(parcel)?;
 
                 let end = parcel.data_position();
-                // Safety: we got the position from `data_position`.
+                // The position came from `data_position`, so it is in range.
                 parcel.set_data_position(length_start);
 
                 assert!(end >= data_start);
                 parcel.write(&((end - data_start) as i32))?;
-                // Safety: we got the position from `data_position`.
+                // The position came from `data_position`, so it is in range.
                 parcel.set_data_position(end);
 
                 Ok(())
@@ -334,7 +334,7 @@ impl Parcelable for ParcelableHolder {
             .get_mut()
             .expect("Parcelable holder lock poisoned") = ParcelableHolderData::Parcel(new_parcel);
 
-        // Safety: `append_from` checks if `data_size` overflows
+        // `append_from` checks whether `data_size` overflows
         // `parcel` and returns `BAD_VALUE` if that happens. We also
         // explicitly check for negative and zero `data_size` above,
         // so `data_end` is guaranteed to be greater than `data_start`.

--- a/rsbinder/src/permission_controller.rs
+++ b/rsbinder/src/permission_controller.rs
@@ -133,8 +133,8 @@ pub fn default() -> Result<Strong<dyn IPermissionController>> {
 ///
 /// Returns `false` when:
 /// - The transaction arrived over RPC (see above).
-/// - The current thread is not handling a binder transaction
-///   (`get_calling_uid()` / `get_calling_pid()` both `0`).
+/// - The current thread is not handling a binder transaction (explicit
+///   deny before uid/pid are read or PMS is consulted).
 /// - The `permission` service is unreachable (`system_server` absent or
 ///   the binder driver is not initialized).
 /// - The remote `checkPermission` call returns an error.
@@ -171,6 +171,14 @@ pub fn check_permission(reader: &Parcel, permission_name: &str) -> bool {
     // an RPC parcel), so it is independent of Plan 2-16 Phase B uid wiring.
     if reader.is_for_rpc() {
         warn_enforce_permission_over_rpc();
+        return false;
+    }
+    // Kernel default path. Outside a live binder transaction the calling
+    // uid/pid read as `0`, and PermissionManagerService unconditionally grants
+    // root (uid 0) — so a call made outside a transaction would return `true`,
+    // inverting the documented "fail closed when not handling a transaction"
+    // contract. Deny explicitly before reading uid/pid or reaching PMS.
+    if !crate::is_handling_transaction() {
         return false;
     }
     let calling_pid = crate::get_calling_pid();
@@ -227,10 +235,10 @@ mod tests {
     }
 
     /// Plan 2-16 Phase A unit-level proof: `check_permission` denies for
-    /// an RPC parcel **before** consulting PMS. A kernel parcel falls
-    /// through to the PMS path (which returns `false` here only because
-    /// `system_server` is unreachable in this hermetic build) — the RPC
-    /// arm is the new transport gate this asserts.
+    /// an RPC parcel **before** consulting PMS. A kernel parcel outside a
+    /// live transaction is denied at the `is_handling_transaction` gate
+    /// before PMS is ever consulted — the RPC arm is the transport gate
+    /// this asserts.
     //
     // `serial(authority)`: `AUTHORITY` is a process global, so this default
     // test must not run concurrently with the authority-delegation test.

--- a/rsbinder/src/process_state.rs
+++ b/rsbinder/src/process_state.rs
@@ -304,10 +304,17 @@ struct MemoryMap {
     size: usize,
 }
 // SAFETY: `ptr` is a PROT_READ binder mapping owned for the whole
-// ProcessState lifetime. It is never written through and never read as
-// Rust data (the binder driver manages the pages); the only use is the
-// single `munmap(ptr, size)` in ProcessState::drop. No data race is
-// possible, so the handle is safe to send and share across threads.
+// ProcessState lifetime. Accesses *through this handle* are limited to the
+// single `munmap(ptr, size)` in ProcessState::drop. The region itself is the
+// kernel-delivered transaction-buffer area and *is* read as Rust data
+// elsewhere (thread_state reads inbound `BR_TRANSACTION`/`BR_REPLY` buffers
+// and `calling_sid` out of it), but that access is synchronized by the binder
+// driver's buffer-lifetime protocol (a buffer stays valid until
+// `BC_FREE_BUFFER`), not by this handle — and it goes through the kernel
+// pointers in the transaction, not `ptr`. Because the mapping lives for the
+// singleton's whole lifetime (the init-race loser never serviced a
+// transaction), no such read is outstanding at drop. No data race is possible
+// through this handle, so it is safe to send and share across threads.
 unsafe impl Sync for MemoryMap {}
 unsafe impl Send for MemoryMap {}
 
@@ -504,7 +511,12 @@ impl ProcessState {
         Self::init(path, 0)
     }
 
-    /// Get binder service manager.
+    /// Register `binder` as this process's binder context manager
+    /// (`BINDER_SET_CONTEXT_MGR`). First-wins: a second call is a no-op — the
+    /// process can only be the context manager for one object, and the kernel
+    /// registers the *process*, not a specific binder — so a second call with
+    /// a different binder is logged and the passed binder dropped rather than
+    /// silently believed to have taken effect.
     pub fn become_context_manager(
         &self,
         binder: SIBinder,
@@ -514,22 +526,24 @@ impl ProcessState {
             .write()
             .expect("Context manager lock poisoned");
 
-        if context_manager.is_none() {
-            let obj = binder::flat_binder_object::new_binder_with_flags(
-                binder::FLAT_BINDER_FLAG_ACCEPTS_FDS,
+        if context_manager.is_some() {
+            log::warn!(
+                "become_context_manager called again; keeping the first registration (no-op)"
             );
-
-            if binder::set_context_mgr_ext(&self.driver, obj).is_err() {
-                //     android_errorWriteLog(0x534e4554, "121035042");
-                // let unused: i32 = 0;
-                if let Err(e) = binder::set_context_mgr(&self.driver, 0) {
-                    return Err(
-                        format!("Binder ioctl to become context manager failed: {e}").into(),
-                    );
-                }
-            }
-            *context_manager = Some(binder);
+            return Ok(());
         }
+
+        let obj =
+            binder::flat_binder_object::new_binder_with_flags(binder::FLAT_BINDER_FLAG_ACCEPTS_FDS);
+
+        if binder::set_context_mgr_ext(&self.driver, obj).is_err() {
+            //     android_errorWriteLog(0x534e4554, "121035042");
+            // let unused: i32 = 0;
+            if let Err(e) = binder::set_context_mgr(&self.driver, 0) {
+                return Err(format!("Binder ioctl to become context manager failed: {e}").into());
+            }
+        }
+        *context_manager = Some(binder);
 
         Ok(())
     }
@@ -713,6 +727,12 @@ impl ProcessState {
         stability: Stability,
         ready: SlowPathReady,
     ) -> Result<SIBinder> {
+        // Declared BEFORE the write lock so it drops AFTER (reverse order):
+        // any watermark callback that `new_acquired` → `proxy_count::
+        // on_proxy_create` would fire is queued and only runs once this lock
+        // is released, so a callback re-entering the proxy cache can't
+        // deadlock against the write lock this thread still holds.
+        let _proxy_count_defer = crate::proxy_count::CallbackDeferGuard::new();
         let mut handle_to_proxy = self
             .handle_to_proxy
             .write()
@@ -1163,7 +1183,12 @@ impl ProcessState {
         // guaranteed no further BR_* will reference this id (kernel_refs
         // was 0 to reach this branch).
         let arc_for_weak = Arc::clone(entry.binder_pin.as_arc());
-        let _ = arc_for_weak.dec_weak();
+        if let Err(e) = arc_for_weak.dec_weak() {
+            // Symmetric with `publish_native`'s `inc_weak` (which is loud on
+            // failure); a discarded error here would hide a RefCounter.weak
+            // underflow / leak.
+            log::error!("unpublish_native: dec_weak failed for id {id}: {e:?}");
+        }
         drop(entry.binder_pin);
     }
 
@@ -1246,18 +1271,28 @@ impl ProcessState {
         if self.thread_pool_started.load(Ordering::Relaxed) {
             let name = self.make_binder_thread_name();
             log::info!("Spawning new pooled thread, name={name}");
-            let _ = thread::Builder::new()
+            match thread::Builder::new()
                 .name(name)
-                .spawn(move || thread_state::join_thread_pool(is_main));
-
-            // Account into the per-origin counter so tests can verify
-            // the `start_thread_pool` spawn contract without racing
-            // kernel-driven `BR_SPAWN_LOOPER` spawns. See the field
-            // docs on `main_thread_spawned` / `kernel_started_threads`.
-            if is_main {
-                self.main_thread_spawned.fetch_add(1, Ordering::SeqCst);
-            } else {
-                self.kernel_started_threads.fetch_add(1, Ordering::SeqCst);
+                .spawn(move || thread_state::join_thread_pool(is_main))
+            {
+                Ok(_) => {
+                    // Account into the per-origin counter so tests can verify
+                    // the `start_thread_pool` spawn contract without racing
+                    // kernel-driven `BR_SPAWN_LOOPER` spawns. See the field
+                    // docs on `main_thread_spawned` / `kernel_started_threads`.
+                    // Only on success — a failed spawn must not desync the
+                    // counter, and on a `BR_SPAWN_LOOPER` request the kernel
+                    // would otherwise wait forever for a looper that never
+                    // registered.
+                    if is_main {
+                        self.main_thread_spawned.fetch_add(1, Ordering::SeqCst);
+                    } else {
+                        self.kernel_started_threads.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+                Err(e) => {
+                    log::error!("failed to spawn pooled binder thread: {e}");
+                }
             }
         }
         // AOSP's late-startThreadPool desync TODO can't arise here: BC_REGISTER_LOOPER is
@@ -1328,13 +1363,20 @@ fn open_driver(
 
 impl Drop for ProcessState {
     fn drop(self: &mut ProcessState) {
-        let mmap = self.mmap.read().expect("Mmap lock poisoned");
+        // This `Drop` runs on the `init` race loser too; a `munmap` failure is
+        // not worth aborting the process (a `Drop` panic while unwinding
+        // aborts immediately). A poisoned lock still yields usable data —
+        // `ptr`/`size` are a POD pair a panicking reader cannot leave
+        // inconsistent — so unmap anyway rather than leak the mapping.
+        let mmap = self.mmap.read().unwrap_or_else(|e| e.into_inner());
         // SAFETY: `mmap.ptr`/`mmap.size` are exactly the address and length
         // returned by the `mmap` call in `ProcessState::new`. This runs only
         // in `Drop`, so the mapping is still live and is unmapped exactly
         // once; no references into the region outlive `ProcessState`.
         unsafe {
-            rustix::mm::munmap(mmap.ptr, mmap.size).expect("Failed to unmap memory");
+            if let Err(e) = rustix::mm::munmap(mmap.ptr, mmap.size) {
+                log::error!("ProcessState::drop: munmap failed: {e}");
+            }
         }
     }
 }

--- a/rsbinder/src/proxy.rs
+++ b/rsbinder/src/proxy.rs
@@ -86,13 +86,18 @@ pub struct ProxyHandle {
     /// `new_acquired`; left `false` by test-only construction helpers
     /// (`synthetic_proxy`) and by the construction-failure path where
     /// `inc_strong_handle` errored before the counter was bumped.
-    count_acquired: AtomicBool,
+    ///
+    /// Plain `bool`, not atomic: written once at construction (before the
+    /// `Arc<ProxyHandle>` is shared) and read only in `Drop` (`&mut self`);
+    /// the `Arc` refcount's release/acquire supplies the happens-before.
+    count_acquired: bool,
     /// True iff `on_proxy_create` incremented the per-uid tracking map for
     /// this proxy (i.e. tracking was enabled at construction). `Drop` uses
     /// this — not the live `COUNT_BY_UID_ENABLED` flag — to decide whether to
     /// decrement the per-uid map, so toggling tracking off while the proxy is
-    /// live cannot desync the count (AOSP `BpBinder::mTrackedUid`).
-    counted_by_uid: AtomicBool,
+    /// live cannot desync the count (AOSP `BpBinder::mTrackedUid`). Plain
+    /// `bool` for the same reason as `count_acquired`.
+    counted_by_uid: bool,
     stability: Stability,
     /// Set once when `send_obituary` runs to publish "this proxy is
     /// dead" to all observers.
@@ -146,8 +151,8 @@ impl ProxyHandle {
             handle,
             descriptor,
             tracked_uid,
-            count_acquired: AtomicBool::new(true),
-            counted_by_uid: AtomicBool::new(counted_by_uid),
+            count_acquired: true,
+            counted_by_uid,
             stability,
             obituary_sent: AtomicBool::new(false),
             recipients: RwLock::new(Vec::new()),
@@ -386,7 +391,7 @@ impl ProxyHandle {
 
 impl Debug for ProxyHandle {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Inner")
+        f.debug_struct("ProxyHandle")
             .field("handle", &self.handle)
             .field("descriptor", &self.descriptor)
             .field("stability", &self.stability)
@@ -421,11 +426,8 @@ impl Drop for ProxyHandle {
         // `on_proxy_create`. Test-only `synthetic_proxy`
         // and the `inc_strong_handle`-failure path leave the guard
         // `false`, so the proxy_count globals never see a phantom drop.
-        if self.count_acquired.load(Ordering::Relaxed) {
-            crate::proxy_count::on_proxy_drop(
-                self.tracked_uid,
-                self.counted_by_uid.load(Ordering::Relaxed),
-            );
+        if self.count_acquired {
+            crate::proxy_count::on_proxy_drop(self.tracked_uid, self.counted_by_uid);
         }
     }
 }
@@ -465,11 +467,15 @@ impl IBinder for ProxyHandle {
         // 2. Remote query (EXTENSION_TRANSACTION)
         let data = Parcel::new();
         let ext: Option<SIBinder> = match self.submit_transact(EXTENSION_TRANSACTION, &data, 0) {
-            Ok(Some(mut reply)) => match DeserializeOption::deserialize_option(&mut reply) {
-                Ok(ext) => ext,
-                Err(_) => return Ok(None),
-            },
-            _ => return Ok(None),
+            Ok(Some(mut reply)) => DeserializeOption::deserialize_option(&mut reply)?,
+            Ok(None) => None,
+            // A server predating extensions reports `UnknownTransaction`;
+            // treat that as "no extension". Every other error (notably
+            // `DeadObject`, and reply-corruption) propagates — matching AOSP
+            // `BpBinder::getExtension`, which returns the transact status
+            // rather than collapsing all failures to "none".
+            Err(StatusCode::UnknownTransaction) => None,
+            Err(e) => return Err(e),
         };
 
         // 3. Classify and cache. Strong unless the extension's handle
@@ -680,8 +686,8 @@ mod tests {
             // `count_acquired = false` means `Drop` skips
             // `proxy_count::on_proxy_drop`, matching this constructor's
             // skip of `new_acquired`'s `on_proxy_create`.
-            count_acquired: AtomicBool::new(false),
-            counted_by_uid: AtomicBool::new(false),
+            count_acquired: false,
+            counted_by_uid: false,
             stability: Stability::Local,
             obituary_sent: AtomicBool::new(obituary_sent),
             recipients: RwLock::new(Vec::new()),
@@ -719,7 +725,7 @@ mod tests {
         let debug_str = format!("{handle:?}");
         assert_eq!(
             debug_str,
-            "Inner { handle: 1, descriptor: \"test\", stability: Local, obituary_sent: false }"
+            "ProxyHandle { handle: 1, descriptor: \"test\", stability: Local, obituary_sent: false }"
         );
 
         std::mem::forget(handle);

--- a/rsbinder/src/proxy_count.rs
+++ b/rsbinder/src/proxy_count.rs
@@ -20,6 +20,7 @@
 //! are debounced (a uid only fires `Limit` once until it drops below `low`,
 //! and `Warning` once until it drops below `warning`).
 
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
@@ -44,11 +45,13 @@ pub enum ProxyCountEvent {
     Limit { uid: u32, count: u64 },
 }
 
-/// Callback type for [`ProxyCountEvent`] notifications. Invoked from
-/// the proxy create/drop hot path **outside** the internal mutex, so
-/// the callback may freely re-enter `proxy_count` APIs (but must not
-/// itself block indefinitely — every proxy create/drop on every thread
-/// is gated on that callback returning).
+/// Callback type for [`ProxyCountEvent`] notifications. Invoked **outside**
+/// the internal `proxy_count` mutex, and — on the proxy-create path — after
+/// the process-wide `ProcessState::handle_to_proxy` cache lock is released
+/// (via [`CallbackDeferGuard`]). The callback may therefore freely re-enter
+/// both `proxy_count` APIs and the binder proxy cache (`get_service`,
+/// resolving/creating proxies). It must not block indefinitely — every proxy
+/// create/drop on the firing thread is gated on it returning.
 pub type ProxyCountCallback = Arc<dyn Fn(ProxyCountEvent) + Send + Sync>;
 
 /// Process-global proxy count. Lock-free hot path: every
@@ -93,6 +96,54 @@ static STATE: LazyLock<Mutex<State>> = LazyLock::new(|| {
         per_uid: HashMap::new(),
     })
 });
+
+thread_local! {
+    /// While set, `on_proxy_create` queues watermark callbacks instead of
+    /// firing them inline. Set by [`CallbackDeferGuard`] around the
+    /// proxy-cache create path so the callback never runs with the caller's
+    /// `ProcessState::handle_to_proxy` write lock still held.
+    static CALLBACK_DEFER: Cell<bool> = const { Cell::new(false) };
+    /// Watermark callbacks queued while [`CALLBACK_DEFER`] was set, fired by
+    /// the outermost [`CallbackDeferGuard`] on drop (after the cache lock is
+    /// released).
+    static PENDING_CALLBACKS: RefCell<Vec<(ProxyCountCallback, ProxyCountEvent)>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+/// RAII guard that defers watermark callbacks on the current thread until it
+/// drops. `ProcessState::slow_path_p3` creates it **before** taking the
+/// `handle_to_proxy` write lock and drops it **after** that lock is released
+/// (declaration order), so a user callback that re-enters the proxy cache
+/// (`get_service`, creating a proxy, …) cannot deadlock against the lock the
+/// creating thread still holds. Nested guards keep deferring until the
+/// outermost one drops. AOSP defers via `postTask`; this is the equivalent.
+pub(crate) struct CallbackDeferGuard {
+    was_deferring: bool,
+}
+
+impl CallbackDeferGuard {
+    pub(crate) fn new() -> Self {
+        let was_deferring = CALLBACK_DEFER.with(|d| d.replace(true));
+        Self { was_deferring }
+    }
+}
+
+impl Drop for CallbackDeferGuard {
+    fn drop(&mut self) {
+        CALLBACK_DEFER.with(|d| d.set(self.was_deferring));
+        if self.was_deferring {
+            // A nested guard is still active — keep deferring.
+            return;
+        }
+        // Outermost guard: fire everything queued while deferral was active.
+        // `CALLBACK_DEFER` is already cleared, so a callback that creates a
+        // proxy fires its own watermark inline (the cache lock is released).
+        let pending: Vec<_> = PENDING_CALLBACKS.with(|p| std::mem::take(&mut *p.borrow_mut()));
+        for (cb, event) in pending {
+            cb(event);
+        }
+    }
+}
 
 /// Snapshot of the process-global proxy count.
 ///
@@ -212,7 +263,14 @@ pub(crate) fn on_proxy_create(uid: u32) -> bool {
         }
     };
     if let Some((cb, event)) = event {
-        cb(event);
+        // Defer to after the proxy-cache lock is released when a
+        // `CallbackDeferGuard` is active on this thread (the create path);
+        // otherwise fire inline (already outside the internal `STATE` mutex).
+        if CALLBACK_DEFER.with(|d| d.get()) {
+            PENDING_CALLBACKS.with(|p| p.borrow_mut().push((cb, event)));
+        } else {
+            cb(event);
+        }
     }
     true
 }
@@ -257,6 +315,8 @@ pub(crate) fn on_proxy_drop(uid: u32, counted_by_uid: bool) {
 pub(crate) fn reset_for_test() {
     PROXY_COUNT.store(0, Ordering::Relaxed);
     COUNT_BY_UID_ENABLED.store(false, Ordering::Relaxed);
+    CALLBACK_DEFER.with(|d| d.set(false));
+    PENDING_CALLBACKS.with(|p| p.borrow_mut().clear());
     let mut state = STATE.lock().expect("proxy_count state poisoned");
     state.high = DEFAULT_HIGH_WATERMARK;
     state.low = DEFAULT_LOW_WATERMARK;

--- a/rsbinder/src/ref_counter.rs
+++ b/rsbinder/src/ref_counter.rs
@@ -5,7 +5,15 @@ use std::sync::atomic::{AtomicI32, Ordering};
 
 use crate::error::*;
 
-pub(crate) const INITIAL_STRONG_VALUE: i32 = i32::MAX as _;
+// Matches AOSP `RefBase.cpp` (`#define INITIAL_STRONG_VALUE (1<<28)`) exactly.
+// The value must be positive so that the transient `fetch_add(1)` in `inc`
+// (before the sentinel is subtracted) stays positive: a concurrent
+// `attempt_inc` that observes the intermediate value must see a normal
+// positive count, never a negative one. `i32::MAX` here would wrap to
+// `i32::MIN` on that first increment and open a window where the count reads
+// negative (spurious `attempt_inc` failure in release, `debug_assert` panic
+// in debug). `1<<28` leaves ~2^28 headroom above and below.
+pub(crate) const INITIAL_STRONG_VALUE: i32 = 1 << 28;
 
 /// Thread-safe reference counter used for binder objects.
 ///
@@ -105,6 +113,12 @@ impl RefCounter {
                 // Use Relaxed to match Android's implementation
                 curr_count = self.count.fetch_add(1, Ordering::Relaxed);
                 if curr_count != 0 && curr_count != INITIAL_STRONG_VALUE {
+                    // Lost the revive race. Undo BOTH the strong bump we just
+                    // made and the weak ref (`dec_func`); a bare `dec_func`
+                    // would leak the `fetch_add(1)` above. Diverges from AOSP
+                    // `RefBase::attemptIncStrong`, which keeps the ref and
+                    // returns true here (OBJECT_LIFETIME_WEAK arm).
+                    self.count.fetch_sub(1, Ordering::Relaxed);
                     dec_func();
                     return false;
                 }
@@ -123,6 +137,7 @@ impl RefCounter {
         // Use Release ordering to ensure all our writes are visible before the decrement.
         // This matches Android's RefBase::decStrong implementation.
         let c = self.count.fetch_sub(1, Ordering::Release);
+        debug_assert!(c >= 1, "RefCounter::dec underflow (double decStrong)");
         if c == 1
             && self
                 .count

--- a/rsbinder/src/rpc/lifecycle.rs
+++ b/rsbinder/src/rpc/lifecycle.rs
@@ -165,11 +165,15 @@ impl SessionLifecycle {
     pub(crate) fn drop_connection(&self) -> bool {
         let mut v = self.inner.load(Ordering::SeqCst);
         loop {
-            debug_assert_eq!(
-                v >> STATE_SHIFT,
-                STATE_LIVE_TAG,
-                "drop_connection called from non-Live state"
-            );
+            if v >> STATE_SHIFT != STATE_LIVE_TAG {
+                // Contract violation (double `drop_connection`, or a call from
+                // Dying/Dead). In release, refuse rather than let `v - 1`
+                // underflow the tag/count and *resurrect* a torn-down session —
+                // the exact invariant this type exists to protect. No obituary
+                // edge is reported. In debug this still trips the assertion.
+                debug_assert!(false, "drop_connection called from non-Live state");
+                return false;
+            }
             let count = v & COUNT_MASK;
             debug_assert!(count >= 1, "Live state with count == 0");
             let (new_v, was_last) = if count == 1 {
@@ -190,12 +194,16 @@ impl SessionLifecycle {
     /// Transition `Dying → Dead`. The caller MUST have just fired
     /// session obituaries (the only path that reaches `Dying`).
     pub(crate) fn mark_dead(&self) {
-        let prev = self.inner.swap(encode_dead(), Ordering::SeqCst);
-        debug_assert_eq!(
-            prev >> STATE_SHIFT,
-            STATE_DYING_TAG,
-            "mark_dead called from non-Dying state"
+        // Only `Dying → Dead`. An unconditional `swap` would clobber a `Live`
+        // state (silently killing a live session in release if called out of
+        // order); the CAS makes any out-of-order call a no-op instead.
+        let res = self.inner.compare_exchange(
+            encode_dying(),
+            encode_dead(),
+            Ordering::SeqCst,
+            Ordering::SeqCst,
         );
+        debug_assert!(res.is_ok(), "mark_dead called from non-Dying state");
     }
 }
 

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -125,31 +125,25 @@ impl ServerListener {
     /// (and any TLS handshake) runs in the worker thread spawned by
     /// [`RpcServer::serve_connection_raw`].
     fn accept_raw(&self) -> std::io::Result<RawAccepted> {
+        // Only `accept(2)` here — the per-stream setup (blocking mode, TCP
+        // nodelay) is deferred to the worker via `prepare_for_worker`, so a
+        // setup failure on one connection (e.g. a peer that RST between SYN
+        // and our `setsockopt`, which can surface as ECONNRESET or even
+        // EINVAL) drops only that connection instead of propagating into the
+        // accept loop's error match and killing the whole server.
         match self {
             ServerListener::Unix(l) => {
                 let (stream, _addr) = l.accept()?;
-                // The listener is non-blocking so the accept loop can
-                // poll `shutdown`; the accepted connection must be
-                // blocking for the worker's `recv_frame` (and for the
-                // worker-side TLS handshake when applicable).
-                stream.set_nonblocking(false)?;
                 Ok(RawAccepted::Unix(stream))
             }
             #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
             ServerListener::Vsock(l) => {
                 let (stream, _addr) = l.accept()?;
-                stream.set_nonblocking(false)?;
                 Ok(RawAccepted::Vsock(stream))
             }
             #[cfg(feature = "rpc-tls")]
             ServerListener::Tcp(l) => {
                 let (stream, _addr) = l.accept()?;
-                stream.set_nonblocking(false)?;
-                // TCP-specific: `nodelay=true` matches the client-side
-                // `TlsTransport::connect`/`accept` (back-compat
-                // convenience). Small-frame RPC traffic ⇒ disable
-                // Nagle so handshake + first request don't coalesce.
-                stream.set_nodelay(true)?;
                 Ok(RawAccepted::Tcp(stream))
             }
         }
@@ -157,6 +151,26 @@ impl ServerListener {
 }
 
 impl RawAccepted {
+    /// Configure the accepted stream for its worker: switch it to blocking
+    /// (the listener is non-blocking only so the accept loop can poll
+    /// `shutdown`; the worker does blocking `recv_frame` and, for TLS, a
+    /// blocking handshake), and for TCP disable Nagle (small-frame RPC
+    /// traffic; matches the client-side `TlsTransport::connect`). Runs on the
+    /// *worker* thread so a failure drops only this connection — see
+    /// [`ServerListener::accept_raw`].
+    fn prepare_for_worker(&self) -> std::io::Result<()> {
+        match self {
+            RawAccepted::Unix(s) => s.set_nonblocking(false),
+            #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
+            RawAccepted::Vsock(s) => s.set_nonblocking(false),
+            #[cfg(feature = "rpc-tls")]
+            RawAccepted::Tcp(s) => {
+                s.set_nonblocking(false)?;
+                s.set_nodelay(true)
+            }
+        }
+    }
+
     /// Arm a read deadline on the raw stream *before* it is wrapped, so
     /// the pre-wrap TLS handshake (driven inside [`into_transport`],
     /// which performs blocking reads on this socket) is itself bounded.
@@ -1005,9 +1019,17 @@ impl RpcServer {
     /// to keep TLS handshake (if any) on the worker side.
     pub fn serve_connection(self: &Arc<Self>, transport: Box<dyn RpcTransport>) {
         let server = Arc::clone(self);
-        let handle = std::thread::spawn(move || {
-            Self::run_connection_in_worker(server, transport);
-        });
+        let handle = match std::thread::Builder::new()
+            .name("rpc-conn".into())
+            .spawn(move || {
+                Self::run_connection_in_worker(server, transport);
+            }) {
+            Ok(h) => h,
+            Err(e) => {
+                log::warn!("RPC: failed to spawn connection worker, dropping: {e}");
+                return;
+            }
+        };
         let mut workers = self.workers.lock().expect("workers poisoned");
         // Reap finished handles so `workers` is bounded by *concurrent*
         // (not cumulative) connections — same discipline as the accept
@@ -1027,35 +1049,54 @@ impl RpcServer {
     /// transports (UDS / vsock) skip the TLS branch and wrap natively.
     fn serve_connection_raw(self: &Arc<Self>, raw: RawAccepted) {
         let server = Arc::clone(self);
-        let handle = std::thread::spawn(move || {
-            // Bound the pre-wrap handshake phase on the raw socket before
-            // any blocking I/O. The TLS handshake runs inside
-            // `wrap_accepted` (below), *before* `run_connection_in_worker`
-            // arms its deadline, so a silent peer would otherwise pin this
-            // worker — and, with `set_max_connections`, the accept loop —
-            // forever. `run_connection_in_worker` re-arms (idempotent) and
-            // clears it before the long-lived serve.
-            if let Some(d) = *server
-                .handshake_timeout
-                .lock()
-                .expect("handshake_timeout poisoned")
-            {
-                if let Err(e) = raw.set_read_timeout(Some(d)) {
-                    log::debug!("RPC: failed to arm pre-wrap handshake read timeout: {e:?}");
-                }
-                if let Err(e) = raw.set_write_timeout(Some(d)) {
-                    log::debug!("RPC: failed to arm pre-wrap handshake write timeout: {e:?}");
-                }
-            }
-            let transport = match server.wrap_accepted(raw) {
-                Ok(t) => t,
-                Err(e) => {
-                    log::warn!("RPC transport wrap (TLS or native) failed: {e:?}");
+        let spawned = std::thread::Builder::new()
+            .name("rpc-conn".into())
+            .spawn(move || {
+                // Switch the accepted socket to blocking (+ TCP nodelay) on
+                // the worker so a per-connection setup failure drops just this
+                // connection, not the whole accept loop.
+                if let Err(e) = raw.prepare_for_worker() {
+                    log::warn!("RPC: failed to prepare accepted stream, dropping: {e:?}");
                     return;
                 }
-            };
-            Self::run_connection_in_worker(server, transport);
-        });
+                // Bound the pre-wrap handshake phase on the raw socket before
+                // any blocking I/O. The TLS handshake runs inside
+                // `wrap_accepted` (below), *before* `run_connection_in_worker`
+                // arms its deadline, so a silent peer would otherwise pin this
+                // worker — and, with `set_max_connections`, the accept loop —
+                // forever. `run_connection_in_worker` re-arms (idempotent) and
+                // clears it before the long-lived serve.
+                if let Some(d) = *server
+                    .handshake_timeout
+                    .lock()
+                    .expect("handshake_timeout poisoned")
+                {
+                    if let Err(e) = raw.set_read_timeout(Some(d)) {
+                        log::debug!("RPC: failed to arm pre-wrap handshake read timeout: {e:?}");
+                    }
+                    if let Err(e) = raw.set_write_timeout(Some(d)) {
+                        log::debug!("RPC: failed to arm pre-wrap handshake write timeout: {e:?}");
+                    }
+                }
+                let transport = match server.wrap_accepted(raw) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        log::warn!("RPC transport wrap (TLS or native) failed: {e:?}");
+                        return;
+                    }
+                };
+                Self::run_connection_in_worker(server, transport);
+            });
+        // Thread creation can fail on resource exhaustion (EAGAIN); dropping
+        // the connection is correct — the accept loop's EMFILE/ENOMEM back-off
+        // would be undone by a `spawn` panic here.
+        let handle = match spawned {
+            Ok(h) => h,
+            Err(e) => {
+                log::warn!("RPC: failed to spawn connection worker, dropping: {e}");
+                return;
+            }
+        };
         let mut workers = self.workers.lock().expect("workers poisoned");
         workers.retain(|h| !h.is_finished());
         workers.push(handle);
@@ -1410,11 +1451,14 @@ impl RpcServer {
             // a full server still shuts down promptly. `live_worker_
             // count()` reaps finished handles, so a freed slot is
             // observed here.
-            if let Some(max) = *self
+            // Copy the cap and drop the guard before `live_worker_count()`
+            // (which locks `workers`) and the sleep, so a `set_max_connections`
+            // caller is never blocked behind the accept loop's poll interval.
+            let max_connections = *self
                 .max_connections
                 .lock()
-                .expect("max_connections poisoned")
-            {
+                .expect("max_connections poisoned");
+            if let Some(max) = max_connections {
                 if self.live_worker_count() >= max {
                     std::thread::sleep(std::time::Duration::from_millis(5));
                     continue;
@@ -1437,13 +1481,25 @@ impl RpcServer {
                 Err(e)
                     if matches!(
                         e.kind(),
-                        std::io::ErrorKind::ConnectionAborted | std::io::ErrorKind::Interrupted
+                        std::io::ErrorKind::ConnectionAborted
+                            | std::io::ErrorKind::ConnectionReset
+                            | std::io::ErrorKind::Interrupted
+                    ) || matches!(
+                        e.raw_os_error(),
+                        Some(code)
+                            if code == libc::EPROTO
+                                || code == libc::ENETDOWN
+                                || code == libc::ENETUNREACH
+                                || code == libc::EHOSTUNREACH
+                                || code == libc::ETIMEDOUT
                     ) =>
                 {
                     // Transient: peer reset between SYN and accept()
-                    // (ECONNABORTED), or EINTR. A normal accept loop
-                    // continues past these — they must NOT take the
-                    // whole server down for all future clients.
+                    // (ECONNABORTED/ECONNRESET), EINTR, or a pending network
+                    // error that `accept(2)` documents as retry-like (EPROTO /
+                    // ENETDOWN / ENETUNREACH / EHOSTUNREACH / ETIMEDOUT). A
+                    // normal accept loop continues past these — they must NOT
+                    // take the whole server down for all future clients.
                     log::warn!("transient accept error, continuing: {e}");
                     std::thread::sleep(std::time::Duration::from_millis(10));
                 }
@@ -1475,8 +1531,10 @@ impl RpcServer {
                 Err(e) => {
                     // Fatal (e.g. the listener was closed): surface it.
                     // Never disguise a hard failure as `Ok(())`, which
-                    // would make `run_background` silently dead.
-                    log::debug!("accept loop ending (fatal): {e}");
+                    // would make `run_background` silently dead. Logged at
+                    // `error` because this terminates the whole accept loop —
+                    // higher severity than the transient (`warn`) arms above.
+                    log::error!("accept loop ending (fatal): {e}");
                     return Err(e.into());
                 }
             }
@@ -1488,7 +1546,11 @@ impl RpcServer {
     pub fn run_background(self: &Arc<Self>) -> JoinHandle<()> {
         let me = Arc::clone(self);
         std::thread::spawn(move || {
-            let _ = me.run();
+            // Surface a fatal accept-loop error instead of silently discarding
+            // it — otherwise the background server dies with no trace.
+            if let Err(e) = me.run() {
+                log::error!("RPC accept loop terminated with error: {e:?}");
+            }
         })
     }
 

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -243,10 +243,10 @@ fn consume_rpc_interface_token(reader: &mut Parcel, expected: &str) -> Result<()
     Ok(())
 }
 
-fn write_addr(p: &mut Parcel, addr: &RpcAddress) {
+fn write_addr(p: &mut Parcel, addr: &RpcAddress) -> Result<()> {
     // 32 bytes, already 4-aligned (no padding) — matches the r34
     // Parcel RPC binder encoding (i32 present flag handled by caller).
-    p.write_aligned_data(addr.as_wire_bytes().as_slice());
+    p.write_aligned_data(addr.as_wire_bytes().as_slice())
 }
 
 fn read_addr(p: &mut Parcel) -> Result<RpcAddress> {
@@ -752,11 +752,14 @@ impl RpcSessionInner {
         }) {
             let transport = {
                 let st = self.conn_state.lock().expect("conn_state poisoned");
-                st.slots
-                    .iter()
-                    .find(|s| s.id == slot_id)
-                    .map(|s| Arc::clone(&s.transport))
-                    .expect("DRIVING slot present")
+                match st.slots.iter().find(|s| s.id == slot_id) {
+                    Some(s) => Arc::clone(&s.transport),
+                    // The slot this thread was driving was retired
+                    // (`remove_slot` on a worker exit) between the `DRIVING`
+                    // push and this reentrant lookup. Surface a typed dead
+                    // error rather than panicking on the driver loop.
+                    None => return Err(StatusCode::DeadObject),
+                }
             };
             return Ok(ConnGuard {
                 inner: self,
@@ -801,17 +804,41 @@ impl RpcSessionInner {
 
     /// Non-blocking variant of [`find_conn`]
     /// for `RpcProxy::drop`'s fast path. Returns `None` instead of
-    /// waiting on `slot_cv` when the pool has no free slot. Does NOT
-    /// touch the reentrant `DRIVING` short-circuit (callers in Drop
-    /// context are by definition not the slot's driver).
+    /// waiting on `slot_cv` when the pool has no free slot.
+    ///
+    /// Like [`find_conn`], step (1) is the reentrant `DRIVING` pin: a
+    /// caller reaching here from `RpcProxy::drop` → `queue_dec_strong` can
+    /// be a server handler that dropped the last cached-proxy `SIBinder`
+    /// on its *own* dispatch thread — which is already driving one of this
+    /// session's slots. Reusing that slot (`reentrant: true`) is the
+    /// documented interleaved-DEC_STRONG path. The first-available scan
+    /// below claims **only** a genuinely free slot: claiming a slot this
+    /// thread already drives would, on this guard's drop, clear an
+    /// `exclusive_tid` the outer frame still owns and let another thread
+    /// race onto the same transport (wire interleaving / reply theft).
     fn try_find_conn(&self) -> Option<ConnGuard<'_>> {
         let tid = current_tid();
         let sess_ptr = self as *const RpcSessionInner as usize;
+        // (1) Reentrant pin — mirror `find_conn` step (1).
+        if let Some(slot_id) = DRIVING.with(|d| {
+            d.borrow()
+                .iter()
+                .rev()
+                .find_map(|&(sp, sid)| if sp == sess_ptr { Some(sid) } else { None })
+        }) {
+            let st = self.conn_state.lock().expect("conn_state poisoned");
+            let transport = Arc::clone(&st.slots.iter().find(|s| s.id == slot_id)?.transport);
+            drop(st);
+            return Some(ConnGuard {
+                inner: self,
+                slot_id,
+                transport,
+                reentrant: true,
+            });
+        }
+        // (3) First available — only a truly free slot.
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
-        let s = st
-            .slots
-            .iter_mut()
-            .find(|s| s.exclusive_tid == Some(tid) || s.exclusive_tid.is_none())?;
+        let s = st.slots.iter_mut().find(|s| s.exclusive_tid.is_none())?;
         s.exclusive_tid = Some(tid);
         let slot_id = s.id;
         let transport = Arc::clone(&s.transport);
@@ -889,11 +916,13 @@ impl RpcSessionInner {
         }) {
             let transport = {
                 let st = self.conn_state.lock().expect("conn_state poisoned");
-                st.slots
-                    .iter()
-                    .find(|s| s.id == want_slot_id)
-                    .map(|s| Arc::clone(&s.transport))
-                    .expect("pinned slot present")
+                match st.slots.iter().find(|s| s.id == want_slot_id) {
+                    Some(s) => Arc::clone(&s.transport),
+                    // Pinned slot retired between the `DRIVING` push and this
+                    // reentrant lookup — surface a typed dead error instead of
+                    // panicking on the driver loop.
+                    None => return Err(StatusCode::DeadObject),
+                }
             };
             return Ok(ConnGuard {
                 inner: self,
@@ -1040,15 +1069,14 @@ impl RpcSessionInner {
         Some(id)
     }
 
-    /// Remove a slot from the pool on its worker's
-    /// `serve_blocking_on` exit. Called by the slot's *own* worker
-    /// (self-remove), so `find_conn_pinned(slot_id)`'s
-    /// `panic!("removed from pool")` remains structurally unreachable
-    /// (the slot's exclusive holder is the dropping thread itself; no
-    /// other thread can be pinned on it). `notify_all` so any
-    /// `find_conn` (any-available) waiter re-evaluates against the
-    /// shrunk pool — and any `find_conn_pinned(slot_id)` waiter
-    /// surfaces the structural error (treated as a should-never panic).
+    /// Remove a slot from the pool. Two legitimate callers: the slot's
+    /// *own* worker on its `serve_blocking_on` exit (self-remove), and
+    /// `client_transact`'s stale-reply poison path (a non-reentrant slot
+    /// whose transport desynced mid-transaction). After a poison, the
+    /// slot's worker finds its slot gone and gets `DeadObject` from
+    /// `find_conn_pinned` — an expected exit signal, not a structural
+    /// bug. `notify_all` so any `find_conn` (any-available) waiter
+    /// re-evaluates against the shrunk pool.
     fn remove_slot(&self, slot_id: u64) {
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
         st.slots.retain(|s| s.id != slot_id);
@@ -1209,11 +1237,11 @@ impl RpcSessionInner {
     ///   `writeUint64(address)`. r34's 32-byte form here was rejected by
     ///   a real libbinder peer (`"unrecognized address … we should own
     ///   the creation of"`) — real-peer-pinned Parcel-body conformance.
-    fn wire_write_binder_addr(&self, p: &mut Parcel, addr: &RpcAddress) {
+    fn wire_write_binder_addr(&self, p: &mut Parcel, addr: &RpcAddress) -> Result<()> {
         match &self.profile {
             WireProfile::R34(_) => write_addr(p, addr),
             WireProfile::Android13Plus(_) => {
-                p.write_aligned_data(&Android13PlusCodec::encode_addr(addr));
+                p.write_aligned_data(&Android13PlusCodec::encode_addr(addr))
             }
         }
     }
@@ -1266,7 +1294,7 @@ impl RpcSessionInner {
                 // never grow a table.
                 let obj_pos = parcel.data_position();
                 parcel.write(&1i32)?;
-                self.wire_write_binder_addr(parcel, &addr);
+                self.wire_write_binder_addr(parcel, &addr)?;
                 if self.profile.records_binder_positions() {
                     parcel.rpc_record_object_position(obj_pos);
                 }
@@ -1458,9 +1486,38 @@ impl RpcSessionInner {
         // leaks onto the next call or a later recv on this connection.
         let deadline = *self.shared.timeout.lock().expect("timeout poisoned");
         let _deadline_guard = ReplyDeadlineGuard::arm(transport, deadline)?;
+        // The request has already been sent, so any transport/decode error
+        // below (timeout, truncation, peer close, malformed frame) leaves the
+        // reply in-flight on a now-desynced stream. `WireReply` carries no
+        // transaction id (AOSP-faithful), so the next transact on this slot
+        // would misread the stale reply as its own. Retire the slot on such an
+        // error so the desynced stream is never reused — AOSP tears the whole
+        // session down here; retiring one connection is the multi-connection
+        // analogue. A clean, fully-consumed reply frame that carries a non-zero
+        // application `status` does NOT desync the stream and must not poison.
+        // A reentrant guard does not own the slot (the outer frame does), so it
+        // never retires it.
+        let poison_slot = || {
+            if !conn.reentrant {
+                self.remove_slot(conn.slot_id);
+            }
+        };
         loop {
-            let (frame, in_fds) = self.recv_msg(transport)?;
-            match self.profile.codec().decode_message(&frame)? {
+            let (frame, in_fds) = match self.recv_msg(transport) {
+                Ok(v) => v,
+                Err(e) => {
+                    poison_slot();
+                    return Err(e.into());
+                }
+            };
+            let message = match self.profile.codec().decode_message(&frame) {
+                Ok(m) => m,
+                Err(e) => {
+                    poison_slot();
+                    return Err(e.into());
+                }
+            };
+            match message {
                 WireMessage::Reply(WireReply {
                     status,
                     data,
@@ -1503,7 +1560,10 @@ impl RpcSessionInner {
                     // leave the timeout desynchronized.
                     let _restore = NestedDeadlineGuard::lift(transport, deadline)?;
                     let peer = transport.peer_identity();
-                    self.dispatch_transact(t, in_fds, peer)?;
+                    if let Err(e) = self.dispatch_transact(t, in_fds, peer) {
+                        poison_slot();
+                        return Err(e);
+                    }
                 }
             }
         }
@@ -1874,11 +1934,10 @@ impl RpcSessionInner {
     /// via the `DRIVING` marker).
     /// `Ok(false)` ⇒ peer closed (stop).
     fn serve_once_on_slot(&self, slot_id: u64) -> Result<bool> {
-        // The worker drives its own slot — pinning to it must succeed
-        // (the slot was just added by `add_incoming_slot`/etc. and
-        // hasn't been removed yet because `remove_slot` only runs from
-        // this very call's `serve_blocking_on` exit). A `DeadObject`
-        // here would be a structural bug, propagated so the worker exits.
+        // The worker drives its own slot. Pinning normally succeeds, but a
+        // concurrent `client_transact` may have poisoned (removed) the slot
+        // after a stale-reply desync — `find_conn_pinned` then returns
+        // `DeadObject`, propagated so the worker exits cleanly.
         let conn = self.find_conn_pinned(slot_id)?;
         let transport = conn.transport();
         let (frame, in_fds) = match self.recv_msg(transport) {
@@ -1922,14 +1981,28 @@ impl RpcSessionInner {
                 let root = self.shared.root.lock().expect("root poisoned").clone();
                 let mut reply = Parcel::new();
                 reply.attach_rpc_ops(self.parcel_ops());
-                // SIBinder::serialize → RPC branch → write_binder.
-                match &root {
-                    Some(b) => reply.write(b)?,
-                    None => reply.write(&0i32)?,
+                // SIBinder::serialize → RPC branch → write_binder. A write
+                // failure after `write_binder`'s `timesSent` bump must roll
+                // back too, same as a send failure below.
+                let write_res = match &root {
+                    Some(b) => reply.write(b),
+                    None => reply.write(&0i32),
+                };
+                if let Err(e) = write_res {
+                    self.rollback_outgoing(&reply, None);
+                    return Err(e);
                 }
                 // GET_ROOT carries a binder-in-parcel: at v2 its
                 // position is in the object table.
-                self.send_reply(0, reply.rpc_data_bytes(), reply.rpc_object_positions(), &[])
+                let sent =
+                    self.send_reply(0, reply.rpc_data_bytes(), reply.rpc_object_positions(), &[]);
+                if sent.is_err() {
+                    // The reply carrying the root binder never reached the peer;
+                    // roll back its `timesSent` bump so the root node does not
+                    // leak. Symmetric with the twoway reply path.
+                    self.rollback_outgoing(&reply, None);
+                }
+                sent
             }
             Some(SpecialTransaction::GetMaxThreads) => {
                 let n = self.shared.max_threads.load(Ordering::SeqCst) as i32;
@@ -1969,7 +2042,21 @@ impl RpcSessionInner {
                         false
                     }
                 };
-                let agreed = if want_unix && self.shared.fd_unix_supported.load(Ordering::SeqCst) {
+                // FD transport is a v1+ feature. Gate GET_FD_MODE the same way
+                // the connection handshake does (`negotiated >= PROTOCOL_V1`),
+                // so a v0-negotiated android-13+ session cannot be flipped into
+                // `Unix` fd mode here — that would open a v0 wire to fd
+                // transport, bypassing the handshake's category-forbids-fd rule.
+                // R34 (android-12, `wire_version() == None`) has no versioned
+                // handshake; GET_FD_MODE *is* its native fd negotiation.
+                let fd_version_ok = match self.profile.wire_version() {
+                    None => true,
+                    Some(v) => v >= PROTOCOL_V1,
+                };
+                let agreed = if want_unix
+                    && fd_version_ok
+                    && self.shared.fd_unix_supported.load(Ordering::SeqCst)
+                {
                     FileDescriptorTransportMode::Unix
                 } else {
                     FileDescriptorTransportMode::None
@@ -2494,9 +2581,11 @@ impl RpcSession {
             )?
             .ok_or(StatusCode::UnexpectedNull)?;
         let mut reply = reply;
-        reply
-            .read::<SIBinder>()
-            .map_err(|_| StatusCode::UnexpectedNull)
+        // Propagate the real read error (v2 strict-position `BadValue`, a
+        // stability short-read, `UnexpectedNull` for an actually-null root)
+        // rather than squashing every failure into `UnexpectedNull`, which
+        // hides the diagnostic — matching `get_session_id`'s no-squash policy.
+        reply.read::<SIBinder>()
     }
 
     /// Server: process inbound messages until the peer closes.

--- a/rsbinder/src/rpc/transport/tls.rs
+++ b/rsbinder/src/rpc/transport/tls.rs
@@ -296,6 +296,9 @@ impl TlsTransport {
             match self.stream.write(&cipher[off..]) {
                 Ok(0) => return Err(RpcError::PeerClosed),
                 Ok(n) => off += n,
+                // EINTR: a signal interrupted the write — retry (matches the
+                // plain-socket backends).
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
                 Err(e) => return Err(e.into()),
             }
         }
@@ -332,7 +335,19 @@ impl TlsTransport {
     /// it into the crypto state. Returns `false` on a clean TCP EOF.
     fn pump_incoming(&self) -> RpcResult<bool> {
         let mut tmp = [0u8; TLS_READ_CHUNK];
-        let k = self.stream.read(&mut tmp)?;
+        let k = loop {
+            match self.stream.read(&mut tmp) {
+                Ok(k) => break k,
+                // EINTR: retry the interrupted blocking read.
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                // A read deadline elapsed mid-stream: surface as `Timeout` so
+                // the android-13+ frame path maps it to `TimedOut`/`Truncated`
+                // like the plain-socket backends (this transport's module doc
+                // lists android-13+-over-TLS as a supported profile).
+                Err(e) if super::is_timeout(&e) => return Err(RpcError::Timeout),
+                Err(e) => return Err(e.into()),
+            }
+        };
         if k == 0 {
             return Ok(false); // peer closed the socket
         }
@@ -343,8 +358,14 @@ impl TlsTransport {
             if n == 0 {
                 break;
             }
-            c.process_new_packets()
-                .map_err(|_| RpcError::Protocol("TLS record processing failed"))?;
+            c.process_new_packets().map_err(|e| {
+                // Log the rustls detail (bad_record_mac, alert kind, …) — it is
+                // otherwise lost behind the static `Protocol` message. rustls
+                // has queued any fatal alert; the next `send_raw`/`flush_control`
+                // drains it best-effort.
+                log::warn!("TLS record processing failed: {e}");
+                RpcError::Protocol("TLS record processing failed")
+            })?;
         }
         Ok(true)
     }
@@ -370,14 +391,29 @@ impl RpcTransport for TlsTransport {
         // reader's `pump_incoming` can still drain — no flow-control
         // deadlock).
         let _g = self.wlock.lock().expect("tls wlock poisoned");
-        let cipher = {
-            let mut c = self.conn.lock().expect("tls conn poisoned");
-            c.writer().write_all(buf)?;
-            let mut v = Vec::new();
-            c.write_tls(&mut v)?;
-            v
-        };
-        self.write_socket_locked(&cipher)
+        // rustls bounds its plaintext sendable buffer (`DEFAULT_BUFFER_LIMIT`,
+        // ~64 KiB); feeding a larger frame in a single `write_all` fails with
+        // `WriteZero`. Chunk the plaintext and interleave encrypt
+        // (`write_tls`) + transmit so any frame size (up to `MAX_FRAME_LEN` =
+        // 64 MiB) streams. The record order still equals the sequence order
+        // because the whole loop holds `wlock`.
+        debug_assert!(!buf.is_empty(), "send_raw with an empty frame");
+        let mut cipher = Vec::new();
+        let mut off = 0;
+        while off < buf.len() {
+            {
+                let mut c = self.conn.lock().expect("tls conn poisoned");
+                let n = c.writer().write(&buf[off..])?;
+                if n == 0 {
+                    return Err(RpcError::Protocol("rustls accepted no plaintext"));
+                }
+                off += n;
+                cipher.clear();
+                c.write_tls(&mut cipher)?;
+            }
+            self.write_socket_locked(&cipher)?;
+        }
+        Ok(())
     }
 
     /// Single-reader: one thread drives `recv_*` per connection (the RPC
@@ -440,6 +476,11 @@ impl Read for RawIo<'_> {
             // (`WouldBlock`/`TimedOut`) and clean-close handling stay
             // byte-for-byte the R34 behavior over a plain socket.
             Err(RpcError::Io(e)) => Err(e),
+            // A read-deadline timeout (mapped in `pump_incoming`) must keep the
+            // `TimedOut` io kind so `read_header`'s `is_timeout` still fires —
+            // otherwise it degrades to a generic `Other` and the frame path
+            // loses the Timeout/Truncated contract.
+            Err(RpcError::Timeout) => Err(std::io::ErrorKind::TimedOut.into()),
             Err(RpcError::PeerClosed) => Ok(0),
             Err(e) => Err(std::io::Error::other(e.to_string())),
         }

--- a/rsbinder/src/rpc/transport/unix.rs
+++ b/rsbinder/src/rpc/transport/unix.rs
@@ -463,9 +463,12 @@ impl RpcTransport for UnixTransport {
     }
 
     /// Receive one length-prefixed frame plus any `SCM_RIGHTS` fds.
-    /// Received fds are `O_CLOEXEC` (`RecvFlags::CMSG_CLOEXEC`).
-    /// Connections in `Unix` fd-mode use this for *every* frame, so
-    /// `recvmsg` and `Read` are never mixed on one fd.
+    /// Received fds are made `O_CLOEXEC` explicitly via `fcntl_setfd`
+    /// (`recvmsg` runs with `RecvFlags::empty()`; `MSG_CMSG_CLOEXEC` is
+    /// Linux-only, so the portable path sets the flag after receipt — same as
+    /// [`recv_raw_with_fds`](Self::recv_raw_with_fds)). Connections in `Unix`
+    /// fd-mode use this for *every* frame, so `recvmsg` and `Read` are never
+    /// mixed on one fd.
     fn recv_frame_with_fds(&self) -> RpcResult<(Vec<u8>, Vec<std::os::fd::OwnedFd>)> {
         use rustix::net::{RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags, ReturnFlags};
         use std::io::IoSliceMut;

--- a/rsbinder/src/rpc/wire_android13.rs
+++ b/rsbinder/src/rpc/wire_android13.rs
@@ -429,6 +429,12 @@ impl Android13PlusCodec {
             .get(A13_CONN_HEADER_LEN..end)
             .ok_or(RpcError::Protocol("session id truncated"))?
             .to_vec();
+        // Strict length: reject trailing bytes past the declared session id,
+        // matching `decode_message` / `decode_session_preamble` — a lenient
+        // decoder would silently desync a caller that framed this header.
+        if buf.len() != end {
+            return Err(RpcError::Protocol("RpcConnectionHeader length mismatch"));
+        }
         Ok((version, options, fd_mode, session_id))
     }
 
@@ -804,12 +810,15 @@ pub fn read_aosp_message<R: Read>(r: &mut R) -> RpcResult<Vec<u8>> {
     let mut out = Vec::with_capacity(WIRE_HEADER_LEN + body_size);
     out.extend_from_slice(&header);
     if body_size > 0 {
-        // The header is already consumed, so a deadline that elapses at the
-        // start of the body is mid-message, not frame-synchronized: report
-        // `Truncated`, not `Timeout` (matches `read_aosp_message_with_fds`,
-        // which carries `total_read` across header+body).
+        // The header is already consumed, so either a deadline that elapses at
+        // the start of the body (`Timeout`) or a clean EOF before the body
+        // (`PeerClosed`, which `read_exact_raw` reports for a 0-byte read) is
+        // mid-message, not frame-synchronized: report `Truncated` in both
+        // cases (matches `read_aosp_message_with_fds`, which carries
+        // `total_read` across header+body). Without the `PeerClosed` arm a peer
+        // that sends only a header and dies would be recorded as a clean close.
         let body = read_exact_raw(r, body_size).map_err(|e| match e {
-            RpcError::Timeout => RpcError::Truncated,
+            RpcError::Timeout | RpcError::PeerClosed => RpcError::Truncated,
             other => other,
         })?;
         out.extend_from_slice(&body);
@@ -1008,6 +1017,17 @@ pub fn client_connect_with_id<S: Read + Write>(
     if requesting_new_session {
         let resp = read_exact_raw(stream, A13_NEW_SESSION_RESP_LEN)?;
         let negotiated = hdr_codec.decode_new_session_response(&resp)?;
+        // AOSP `RpcSession::setProtocolVersionInternal`: a server may
+        // *downgrade* but never *upgrade* past the version the client
+        // advertised (`max_version` is the client's explicit cap). Accepting a
+        // higher version would let a non-compliant server pull, e.g., a
+        // v0-pinned client onto v1+ framing — opening the SCM_RIGHTS fd path
+        // the cap was meant to exclude.
+        if negotiated > max_version {
+            return Err(RpcError::Protocol(
+                "server upgraded the protocol version past the client cap",
+            ));
+        }
         if negotiated == hdr_codec.version() {
             Ok(hdr_codec)
         } else {

--- a/rsbinder/src/rt/tokio_rt.rs
+++ b/rsbinder/src/rt/tokio_rt.rs
@@ -69,30 +69,6 @@ pub async fn get_interface<T: FromIBinder + ?Sized + 'static>(
     }
 }
 
-// /// Retrieve an existing service for a particular interface, or start it if it
-// /// is configured as a dynamic service and isn't yet started.
-// pub async fn wait_for_interface<T: FromIBinder + ?Sized + 'static>(
-//     name: &str,
-// ) -> Result<Strong<T>, StatusCode> {
-//     if rsbinder::is_handling_transaction() {
-//         // See comment in the BinderAsyncPool impl.
-//         return rsbinder::wait_for_interface::<T>(name);
-//     }
-
-//     let name = name.to_string();
-//     let res = tokio::task::spawn_blocking(move || rsbinder::wait_for_interface::<T>(&name)).await;
-
-//     // The `is_panic` branch is not actually reachable in Android as we compile
-//     // with `panic = abort`.
-//     match res {
-//         Ok(Ok(service)) => Ok(service),
-//         Ok(Err(err)) => Err(err),
-//         Err(e) if e.is_panic() => std::panic::resume_unwind(e.into_panic()),
-//         Err(e) if e.is_cancelled() => Err(StatusCode::FailedTransaction),
-//         Err(_) => Err(StatusCode::Unknown),
-//     }
-// }
-
 /// Use the Tokio `spawn_blocking` pool with AIDL.
 pub enum Tokio {}
 

--- a/rsbinder/src/status.rs
+++ b/rsbinder/src/status.rs
@@ -235,7 +235,7 @@ impl Display for Status {
                 "{} / {}: {}",
                 self.exception,
                 self.code,
-                self.message.as_ref().unwrap_or(&"".to_owned())
+                self.message.as_deref().unwrap_or("")
             )
         }
     }
@@ -338,7 +338,7 @@ impl Serialize for Status {
             return Ok(());
         }
 
-        parcel.write::<String>(self.message.as_ref().unwrap_or(&"".to_owned()))?;
+        parcel.write::<str>(self.message.as_deref().unwrap_or(""))?;
         parcel.write::<i32>(&0)?; // Empty remote stack trace header
 
         if self.exception == ExceptionCode::ServiceSpecific {
@@ -408,7 +408,13 @@ impl Deserialize for Status {
         let status = if exception == ExceptionCode::None {
             exception.into()
         } else {
-            let message: String = parcel.read::<String>()?;
+            // AOSP `Status::readFromParcel` reads the message as
+            // `std::optional<String16>` and folds null to empty. A Java peer
+            // that throws an exception with no detail message writes a null
+            // string (`Parcel.writeString(null)` → length -1); reading it as a
+            // non-null `String` would fail the whole exception decode with
+            // `UnexpectedNull`, hiding the real exception code.
+            let message: Option<String> = parcel.read::<Option<String>>()?;
 
             // AOSP `Status::readFromParcel` (frameworks/native/libs/binder/
             // Status.cpp): capture the header start position and the
@@ -467,7 +473,7 @@ impl Deserialize for Status {
                 StatusCode::Ok
             };
 
-            Status::new(exception, code, Some(message))
+            Status::new(exception, code, message)
         };
 
         Ok(status)

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -33,7 +33,7 @@
 //!     (invoked via `deref_native_kernel`), and
 //!     `DeathRecipient::binder_died`.
 //!   - Other functions in this module that take a borrow at some point:
-//!     `transact`, `wait_for_response`, `flush_commands`, `flash_if_needed`,
+//!     `transact`, `wait_for_response`, `flush_commands`, `flush_if_needed`,
 //!     `inc_strong_handle`, `dec_strong_handle`, `inc_weak_handle`,
 //!     `dec_weak_handle`, `free_buffer`, and `process_pending_derefs`.
 //!
@@ -637,8 +637,15 @@ impl ThreadState {
             }
         };
 
+        let start = self.out_parcel.data_size();
         self.out_parcel.write::<u32>(&cmd)?;
-        self.out_parcel.write_aligned(&tr);
+        if let Err(e) = self.out_parcel.write_aligned(&tr) {
+            // Roll back the orphan cmd word: flushing a bare BC_* opcode with
+            // no binder_transaction_data behind it would desync the driver
+            // protocol.
+            let _ = self.out_parcel.set_data_size(start);
+            return Err(e);
+        }
 
         Ok(())
     }
@@ -670,9 +677,17 @@ pub(crate) fn call_restriction() -> CallRestriction {
 /// only when interoperating with Android system_server's strict-mode
 /// chain (disk-I/O / network-on-main-thread / etc. policies).
 ///
+/// No-op in a process where kernel binder is not initialized (pure-RPC
+/// process).
+///
 /// Mirrors AOSP `IPCThreadState::setStrictModePolicy(int32_t)`
 /// (`IPCThreadState.cpp:575`).
 pub fn set_strict_mode_policy(policy: i32) {
+    // In a pure-RPC process the kernel `THREAD_STATE` is not initialized;
+    // touching it would panic (`ThreadState::new` pulls `ProcessState`).
+    if !ProcessState::is_initialized() {
+        return;
+    }
     THREAD_STATE.with(|thread_state| {
         thread_state.borrow_mut().set_strict_mode_policy(policy);
     })
@@ -686,9 +701,15 @@ pub fn set_strict_mode_policy(policy: i32) {
 /// On a client thread, returns whatever was last set by
 /// [`set_strict_mode_policy`] (default `0`).
 ///
+/// Returns `0` in a process where kernel binder is not initialized
+/// (pure-RPC process).
+///
 /// Mirrors AOSP `IPCThreadState::getStrictModePolicy() const`
 /// (`IPCThreadState.cpp:580`).
 pub fn get_strict_mode_policy() -> i32 {
+    if !ProcessState::is_initialized() {
+        return 0;
+    }
     THREAD_STATE.with(|thread_state| thread_state.borrow().strict_mode_policy)
 }
 
@@ -806,6 +827,9 @@ fn wait_for_response(until: UntilResponse) -> Result<Option<Parcel>> {
                         .borrow_mut()
                         .in_parcel
                         .read::<binder::binder_transaction_data>()?;
+                    // SAFETY: for a kernel-delivered BR_REPLY the driver populates
+                    // the `data.ptr` arm of the union (buffer/offsets pointers into
+                    // the mmap region), so reading that arm is valid.
                     let (buffer, offsets) = unsafe { (tr.data.ptr.buffer, tr.data.ptr.offsets) };
                     if let UntilResponse::Reply = until {
                         if (tr.flags & transaction_flags_TF_STATUS_CODE) == 0 {
@@ -1086,12 +1110,21 @@ fn execute_command(cmd: i32) -> Result<()> {
                             Some(arc) => {
                                 let strong = SIBinder::from_arc(arc);
                                 if strong.attempt_increase() {
-                                    let result = dispatch_transact_caught(
-                                        strong.as_transactable().expect("Transactable is None."),
-                                        tr_secctx.transaction_data.code,
-                                        &mut reader,
-                                        &mut reply,
-                                    );
+                                    // `as_transactable()` is a public-trait method that
+                                    // may return `None` for a caller-supplied `IBinder`;
+                                    // reject rather than `expect`-panic on the worker loop.
+                                    let result = match strong.as_transactable() {
+                                        Some(t) => dispatch_transact_caught(
+                                            t,
+                                            tr_secctx.transaction_data.code,
+                                            &mut reader,
+                                            &mut reply,
+                                        ),
+                                        None => {
+                                            log::error!("native id {id} is not Transactable");
+                                            Err(StatusCode::UnknownTransaction)
+                                        }
+                                    };
                                     strong.decrease()?;
                                     result
                                 } else {
@@ -1105,15 +1138,26 @@ fn execute_command(cmd: i32) -> Result<()> {
                             }
                         }
                     } else {
-                        let context = ProcessState::as_self()
-                            .context_manager()
-                            .expect("Transactable is None.");
-                        dispatch_transact_caught(
-                            context.as_transactable().expect("Transactable is None."),
-                            tr_secctx.transaction_data.code,
-                            &mut reader,
-                            &mut reply,
-                        )
+                        match ProcessState::as_self().context_manager() {
+                            Some(context) => match context.as_transactable() {
+                                Some(t) => dispatch_transact_caught(
+                                    t,
+                                    tr_secctx.transaction_data.code,
+                                    &mut reader,
+                                    &mut reply,
+                                ),
+                                None => {
+                                    log::error!("context manager is not Transactable");
+                                    Err(StatusCode::UnknownTransaction)
+                                }
+                            },
+                            None => {
+                                log::error!(
+                                    "BR_TRANSACTION to handle 0 but no context manager set"
+                                );
+                                Err(StatusCode::DeadObject)
+                            }
+                        }
                     }
                 };
                 let flags = tr_secctx.transaction_data.flags;
@@ -1462,7 +1506,7 @@ pub(crate) fn flush_commands() -> Result<()> {
         }
 
         if thread_state.borrow().out_parcel.data_size() > 0 {
-            log::warn!("self.out_parcel.len() > 0 after flash_commands()");
+            log::warn!("self.out_parcel.len() > 0 after flush_commands()");
         }
 
         Ok(())
@@ -1479,7 +1523,7 @@ pub(crate) fn inc_strong_handle(handle: u32) -> Result<()> {
             state.out_parcel.write::<u32>(&(handle))?;
         }
 
-        flash_if_needed()?;
+        flush_if_needed()?;
 
         Ok(())
     })
@@ -1495,7 +1539,7 @@ pub(crate) fn dec_strong_handle(handle: u32) -> Result<()> {
             state.out_parcel.write::<u32>(&(handle))?;
         }
 
-        flash_if_needed()?;
+        flush_if_needed()?;
 
         Ok(())
     })
@@ -1511,7 +1555,7 @@ pub(crate) fn inc_weak_handle(handle: u32) -> Result<()> {
             state.out_parcel.write::<u32>(&(handle))?;
         }
 
-        flash_if_needed()?;
+        flush_if_needed()?;
 
         Ok(())
     })
@@ -1527,13 +1571,13 @@ pub(crate) fn dec_weak_handle(handle: u32) -> Result<()> {
             state.out_parcel.write::<u32>(&(handle))?;
         }
 
-        flash_if_needed()?;
+        flush_if_needed()?;
 
         Ok(())
     })
 }
 
-pub(crate) fn flash_if_needed() -> Result<bool> {
+pub(crate) fn flush_if_needed() -> Result<bool> {
     THREAD_STATE.with(|thread_state| -> Result<bool> {
         {
             let thread_state = thread_state.borrow();
@@ -1617,21 +1661,17 @@ pub(crate) fn transact(
 
     flags |= transaction_flags_TF_ACCEPT_FDS;
 
-    let call_restriction = THREAD_STATE.with(|thread_state| -> Result<CallRestriction> {
-        let mut thread_state = thread_state.borrow_mut();
-        thread_state.write_transaction_data(
-            binder::BC_TRANSACTION,
-            flags,
-            handle,
-            code,
-            data,
-            &0,
-        )?;
-        Ok(thread_state.call_restriction)
-    })?;
-
+    // Enforce the call restriction BEFORE queuing BC_TRANSACTION into
+    // out_parcel. `write_transaction_data` records raw pointers into `data`'s
+    // buffer/offsets; if the FatalIfNotOneway `panic!` unwinds instead of
+    // aborting (it is reachable under `dispatch_transact_caught`'s
+    // `catch_unwind` for a nested sync call, and under tokio's spawn_blocking
+    // panic capture), a completed BC_TRANSACTION with now-dangling pointers
+    // would remain in out_parcel and be flushed to the kernel later —
+    // cross-process use-after-free. AOSP checks *after* queuing, but its
+    // LOG_ALWAYS_FATAL aborts, so the queued command is never flushed.
     if (flags & transaction_flags_TF_ONE_WAY) == 0 {
-        match call_restriction {
+        match call_restriction() {
             CallRestriction::ErrorIfNotOneway => {
                 error!("Process making non-oneway call (code: {code}) but is restricted.")
             }
@@ -1640,7 +1680,14 @@ pub(crate) fn transact(
             }
             _ => (),
         }
+    }
 
+    THREAD_STATE.with(|thread_state| -> Result<()> {
+        let mut thread_state = thread_state.borrow_mut();
+        thread_state.write_transaction_data(binder::BC_TRANSACTION, flags, handle, code, data, &0)
+    })?;
+
+    if (flags & transaction_flags_TF_ONE_WAY) == 0 {
         reply = wait_for_response(UntilResponse::Reply)?;
     } else {
         wait_for_response(UntilResponse::TransactionComplete)?;
@@ -1669,7 +1716,7 @@ fn free_buffer(
         Ok(())
     })?;
 
-    flash_if_needed()?;
+    flush_if_needed()?;
 
     Ok(())
 }
@@ -1706,6 +1753,19 @@ pub(crate) fn join_thread_pool(is_main: bool) -> Result<()> {
         ProcessState::as_self()
             .current_threads
             .fetch_add(1, Ordering::SeqCst);
+
+        // Decrement on every exit — including the `?` early-returns below.
+        // A write/ioctl failure that skipped the decrement would permanently
+        // inflate `current_threads` and stall the pool's spawn heuristic.
+        struct ThreadCountGuard;
+        impl Drop for ThreadCountGuard {
+            fn drop(&mut self) {
+                ProcessState::as_self()
+                    .current_threads
+                    .fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+        let _thread_count_guard = ThreadCountGuard;
 
         let looper = if is_main {
             binder::BC_ENTER_LOOPER
@@ -1769,9 +1829,7 @@ pub(crate) fn join_thread_pool(is_main: bool) -> Result<()> {
         }
 
         talk_with_driver(false)?;
-        ProcessState::as_self()
-            .current_threads
-            .fetch_sub(1, Ordering::SeqCst);
+        // `_thread_count_guard` decrements `current_threads` on drop.
         Ok(())
     })
 }
@@ -2091,6 +2149,11 @@ pub fn get_calling_uid_or_self() -> binder::uid_t {
 /// AOSP user-facing semantics (clear before downstream call, restore
 /// after) match.
 pub fn clear_calling_identity() -> i64 {
+    // Pure-RPC process: no kernel `THREAD_STATE` (touching it would panic),
+    // and no kernel-delivered identity to clear — the documented no-op.
+    if !ProcessState::is_initialized() {
+        return 0;
+    }
     THREAD_STATE.with(|thread_state| {
         let mut thread_state = thread_state.borrow_mut();
         let Some(ref mut tr) = thread_state.transaction else {
@@ -2132,6 +2195,9 @@ pub fn clear_calling_identity() -> i64 {
 /// (caller wraps `clear`/`restore` in a `Drop` impl) is recommended; see
 /// AOSP `IPCThreadState::CallingIdentityScope` for the C++ analogue.
 pub fn restore_calling_identity(token: i64) {
+    if !ProcessState::is_initialized() {
+        return;
+    }
     THREAD_STATE.with(|thread_state| {
         let mut thread_state = thread_state.borrow_mut();
         let Some(ref mut tr) = thread_state.transaction else {
@@ -2267,6 +2333,9 @@ pub fn get_extended_error() -> Result<ExtendedError> {
 ///
 /// Returns `false` when not currently dispatching a transaction.
 pub fn has_explicit_identity() -> bool {
+    if !ProcessState::is_initialized() {
+        return false;
+    }
     THREAD_STATE.with(|thread_state| {
         thread_state
             .borrow()

--- a/rsbinder/tests/rpc_tls.rs
+++ b/rsbinder/tests/rpc_tls.rs
@@ -302,6 +302,35 @@ fn tls_concurrent_bidirectional_duplex() {
     cli_send.join().unwrap();
 }
 
+/// A frame larger than rustls's ~64 KiB plaintext sendable buffer must still
+/// round-trip: `send_raw` chunks the plaintext and interleaves encrypt-drain
+/// (a single unchunked `writer().write_all` of such a payload fails with
+/// `WriteZero`).
+#[test]
+fn tls_large_frame_over_64kib_roundtrips() {
+    let srv_cfg = server_config(SRV_CRT, SRV_KEY);
+    let (s_srv, s_cli) = UnixStream::pair().expect("unix socketpair");
+    let h = thread::spawn(move || {
+        TlsTransport::accept_stream(Box::new(s_srv), srv_cfg).expect("server handshake")
+    });
+    let cli =
+        TlsTransport::connect_stream(Box::new(s_cli), "localhost", client_config_trusting(CA))
+            .expect("client handshake");
+    let srv = Arc::new(h.join().unwrap());
+    let cli = Arc::new(cli);
+
+    // 1 MiB payload — well past the 64 KiB rustls sendable-buffer limit.
+    let payload: Vec<u8> = (0..(1usize << 20)).map(|i| (i % 251) as u8).collect();
+    let srv_s = Arc::clone(&srv);
+    let sent = payload.clone();
+    let sender = thread::spawn(move || {
+        srv_s.send_frame(&sent).expect("srv send large frame");
+    });
+    let got = cli.recv_frame().expect("cli recv large frame");
+    sender.join().unwrap();
+    assert_eq!(got, payload, "1 MiB frame must round-trip over TLS");
+}
+
 /// TLS rejects out-of-band file descriptors *by type*
 /// — `SCM_RIGHTS` cannot ride an encrypted byte stream, so `TlsTransport`
 /// keeps the trait's rejecting default for `send_*_with_fds` (no

--- a/rsbinder/tests/source_invariants.rs
+++ b/rsbinder/tests/source_invariants.rs
@@ -39,25 +39,34 @@ fn visit<F: FnMut(&Path, &str)>(dir: &Path, f: &mut F) {
     }
 }
 
-/// `RpcSessionInner::remove_slot` is `pub(crate)`; callers other than
-/// the slot's own `serve_blocking_on` exit break the "structurally
-/// unreachable" expect at `find_conn_pinned` ([session.rs:780]) and turn
-/// a documented design invariant into a reachable panic on the hot
-/// transact path.
+/// `RpcSessionInner::remove_slot` is `pub(crate)` and safe to call from more
+/// than one site now that `find_conn` / `find_conn_pinned` return
+/// `Err(StatusCode::DeadObject)` (not `expect`-panic) when their reentrant
+/// slot lookup misses. The two sanctioned callers are the slot's own
+/// `serve_blocking_on` exit and `client_transact`'s stale-reply poison (retire
+/// a slot whose reply read failed so the desynced stream is never reused).
+/// A NEW caller MUST re-audit that every slot-lookup path tolerates a missing
+/// slot before being added — this bound guards against accidentally
+/// reintroducing a lookup that assumes the slot is always present.
 #[test]
-fn remove_slot_has_exactly_one_caller() {
+fn remove_slot_has_at_most_two_callers() {
     let src_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     let hits = count_call_sites(&src_root, ".remove_slot(");
-    assert_eq!(
-        hits.len(),
-        1,
-        "RpcSessionInner::remove_slot must have exactly one caller. \
+    // Pin the location too: a count-only bound would still pass if a
+    // sanctioned caller were deleted and an unaudited one added elsewhere.
+    assert!(
+        hits.iter().all(|(p, _)| p.ends_with("rpc/session.rs")),
+        "remove_slot callers must live in rpc/session.rs: {hits:#?}"
+    );
+    assert!(
+        hits.len() <= 2,
+        "RpcSessionInner::remove_slot must have at most two callers. \
          Found {} call sites: {:#?}\n\
-         INVARIANT: only RpcSession::serve_blocking_on's own exit path \
-         may call remove_slot — find_conn / find_conn_pinned rely on it \
-         to keep their slot-lookup `expect` panics structurally \
-         unreachable. A new caller MUST audit both call sites before \
-         being added.",
+         INVARIANT: only serve_blocking_on's exit path and \
+         client_transact's stale-reply poison may call remove_slot — \
+         find_conn / find_conn_pinned must return DeadObject (not panic) \
+         on a missing slot. A new caller MUST audit every slot-lookup \
+         path before being added.",
         hits.len(),
         hits,
     );


### PR DESCRIPTION
## Summary

A full 6-agent source review of the worktree surfaced 28 findings (Critical 0 / Major 4 / Minor 14 / Nit 7 + 3 refactor notes). This PR fixes all of them. The changes are correctness/soundness hardening and AOSP wire-format alignment across the kernel-binder and RPC paths — no new features.

## Correctness & AOSP alignment

- **android-12 stability wire format** — encode the real `Category` repr `((level << 24) | version)` instead of a malformed `level | 0x0c000000` that put the level in the version byte and hard-coded SYSTEM.
- **`check_interface` mismatch** — return `BAD_TYPE` as the transaction *status* (dispatcher emits a `TF_STATUS_CODE` reply), matching AOSP NDK `ABBinder::onTransact`, instead of writing it into the reply payload where clients parse it as success.
- **reliable-PFD comm fd** — consume the second fd object so the parcel cursor stays aligned.
- **`FLAG_PRIVATE_VENDOR`** — `0x10000000` per AOSP `IBinder.h` (was `0`); documented in the changelog as a semver-relevant change. `FLAG_PRIVATE_LOCAL` stays `0`.
- **malformed parcelable presence flag** — keeps returning `UNEXPECTED_NULL`, matching AOSP C++ `Parcel::readData` and the `DeserializeOption` default path (a mid-review divergence to `BadValue` is reverted).

## Error-path hardening

- Roll back the queued `BC_*` opcode when writing `binder_transaction_data` fails, so a truncated command is never flushed to the driver (protocol desync).
- Bound every parcel write funnel's end position to `i32::MAX` before reserving (closes the last capacity-overflow panic path).
- Retire an RPC connection slot after a stale-reply desync instead of reusing the stream; `try_find_conn` claims only genuinely free slots.
- Roll back `GET_ROOT`'s `timesSent` bump on reply write/send failure (symmetric with the twoway reply path).
- Unmap the binder mapping even when the mmap lock is poisoned.
- Deny `check_permission` outside a live transaction before PMS ever sees uid 0.
- Strict-mode policy accessors no-op in pure-RPC processes.
- `try_unregister` on an empty `LazyServiceRegistrar` returns `false`.
- Chunk TLS `send_raw` so frames larger than rustls's ~64 KiB plaintext buffer stream instead of failing with `WriteZero`.

## Also

- Explicit `rt` re-exports so a newly-`pub` item can't leak to the crate root without semver review.
- Transient accept-loop errors (`ECONNRESET`/`EPROTO`/…) no longer take the whole server down.
- Comment hygiene per the project comment policy (drop "previous code did X" narration; keep the enduring invariant).
- Location pin added to the `remove_slot` source-invariant test to close a false-green mode.

## Verification

All green across three platforms:

- **macOS hermetic** — workspace `453/0`, clippy (default + `rpc,rpc-tcp-debug,rpc-tls`) + rustfmt clean.
- **Linux (kernel Rust binder driver)** — rpc-feature lib `305/0`, default lib `203/0`, kernel-binder 3-process e2e sync `139/0`, async `139/0`, death_recipient `2/0`.
- **Android 16 emulator** — unit `197/0`, e2e sync `139/0`, async `139/0`, death_recipient `2/0`.