### PR TITLE
fix(rsbinder): second-pass source review + 0.11.0 API tightening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ This changelog starts at 0.9.0. For earlier releases, see the
   RPC surface stays `RpcServer`, `RpcSession`, `RpcProxy`, the transport traits
   (`RpcTransport`/`PeerIdentity`/`CertId`), and the address/identity types. This
   lets the wire protocol evolve without further semver-breaking releases.
+- **rsbinder (breaking):** additional helpers that were `pub` but never part of
+  the intended API are now `pub(crate)`: the `Parcel` RPC-ops plumbing
+  (`RpcParcelOps`, `Parcel::attach_rpc_ops`, `FnFreeBuffer`), `rpc::RpcSessionInner`,
+  `RpcProxy::stamp_descriptor`, and the `thread_state` functions `check_interface`,
+  `is_handling_transaction`, and `get_calling_uid_or_self`. The public
+  `rsbinder::is_handling_transaction` (re-exported from `native`) is unchanged.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,32 @@ This changelog starts at 0.9.0. For earlier releases, see the
 - **rsbinder (AOSP alignment):** `FLAG_PRIVATE_VENDOR` is now `0x10000000`
   (AOSP `IBinder.h`) instead of `0`. Code passing this flag to `transact`
   now sets bit 28 on the wire. `FLAG_PRIVATE_LOCAL` is unchanged (`0`).
+- **rsbinder (`rpc` feature, breaking):** `WireMessage::DecStrong` now carries
+  the decrement amount (`DecStrong(RpcAddress, u32)`), and
+  `RpcState::dec_strong_local` takes an `amount` argument. A batched
+  `RpcDecStrong` from a libbinder peer (AOSP `sendDecStrongToTarget` sends
+  `timesRecd - target`) is now honored instead of applying a single decrement,
+  which under-counted and leaked local nodes.
+
+### Fixed
+
+- **rsbinder:** a remote binder handle is serialized through the full 8-byte
+  object union, so no uninitialized stack bytes are copied onto the wire; the
+  proxy path previously wrote only the 32-bit handle and leaked 4 bytes to the
+  peer.
+- **rsbinder (`rpc`):** a discarded RPC reply's reference-count bumps are rolled
+  back on the handler-error and oneway dispatch paths, preventing local-node
+  leaks.
+- **rsbinder:** `Parcel::append_from` bounds the source range against the
+  backing buffer length instead of the logical size, avoiding a panic when the
+  source cursor sits past its data end.
+- **rsbinder (`rpc`):** the Unix transport retries `EINTR` on a raw read and
+  rejects file descriptors attached to an empty frame instead of dropping them.
+- **rsbinder:** `get_extended_error` and `query_interface` return a recoverable
+  error instead of panicking in a pure-RPC or malformed-reply path.
+- **rsbinder (`rpc`):** `StatusCode::RpcError` no longer shares AOSP
+  `FROZEN_OBJECT`'s `status_t` value, so an incoming frozen-object status is not
+  mis-decoded.
 
 ## [0.10.0] - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ This changelog starts at 0.9.0. For earlier releases, see the
   `RpcDecStrong` from a libbinder peer (AOSP `sendDecStrongToTarget` sends
   `timesRecd - target`) is now honored instead of applying a single decrement,
   which under-counted and leaked local nodes.
+- **rsbinder (`rpc` feature, breaking):** the RPC wire-codec types
+  (`WireMessage`, `WireCodec`, `R34Codec`, `Android13PlusCodec`, `WireReply`,
+  `WireTransaction`) and `RpcState` are no longer part of the public API. They
+  were internal implementation detail — the codec is selected internally with no
+  user injection point, and `RpcState` is per-session bookkeeping. The public
+  RPC surface stays `RpcServer`, `RpcSession`, `RpcProxy`, the transport traits
+  (`RpcTransport`/`PeerIdentity`/`CertId`), and the address/identity types. This
+  lets the wire protocol evolve without further semver-breaking releases.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ This changelog starts at 0.9.0. For earlier releases, see the
   `RpcProxy::stamp_descriptor`, and the `thread_state` functions `check_interface`,
   `is_handling_transaction`, and `get_calling_uid_or_self`. The public
   `rsbinder::is_handling_transaction` (re-exported from `native`) is unchanged.
+- **rsbinder (breaking):** the low-level `Parcel` buffer accessors `as_ptr`,
+  `as_mut_ptr`, `capacity`, `set_data_size`, `close_file_descriptors`, `is_empty`,
+  and `from_vec` are now `pub(crate)` (internal kernel-buffer plumbing).
+  `Parcel::from_ipc_parts` (the documented `unsafe` raw-buffer primitive) and
+  `Parcel::set_for_rpc` remain public.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "example-hello"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "env_logger",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "rsbinder"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "env_logger",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "rsbinder-aidl"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "convert_case",
  "miette",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "rsbinder-tools"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anstyle",
  "clap",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Jeff Kim <hiking90@gmail.com>"]
@@ -26,13 +26,13 @@ rust-version = "1.85"
 keywords = ["android", "binder", "aidl", "linux"]
 
 [workspace.dependencies]
-rsbinder = { version = "0.10.0", path = "rsbinder" }
+rsbinder = { version = "0.11.0", path = "rsbinder" }
 log = "0.4"
 env_logger = "0.11"
 anstyle = "1.0"
 tokio = { version = "1.52", default-features = false }
 async-trait = "0.1"
-rsbinder-aidl = { version = "0.10.0", path = "rsbinder-aidl" }
+rsbinder-aidl = { version = "0.11.0", path = "rsbinder-aidl" }
 pest = "2.8"
 pest_derive = "2.8"
 convert_case = "0.11"

--- a/rsbinder/src/binder_object.rs
+++ b/rsbinder/src/binder_object.rs
@@ -60,6 +60,25 @@ impl flat_binder_object {
         }
     }
 
+    /// Creates a new flat_binder_object for a remote handle
+    /// (`BINDER_TYPE_HANDLE`).
+    pub(crate) fn new_handle(handle: u32, flags: u32) -> Self {
+        flat_binder_object {
+            hdr: binder_object_header {
+                type_: BINDER_TYPE_HANDLE,
+            },
+            flags,
+            // Init via the 8-byte `binder` field (not the u32 `handle`) so the
+            // upper bytes are zeroed: mirrors AOSP `obj.binder = 0; obj.handle =
+            // handle;` and avoids leaking uninit stack to the remote (the whole
+            // 24-byte struct is copied onto the wire by `write_object`).
+            __bindgen_anon_1: flat_binder_object__bindgen_ty_1 {
+                binder: handle as u64,
+            },
+            cookie: 0,
+        }
+    }
+
     pub(crate) fn header_type(&self) -> u32 {
         self.hdr.type_
     }
@@ -204,19 +223,10 @@ impl From<&SIBinder> for flat_binder_object {
         };
 
         if let Some(proxy) = binder.as_proxy() {
-            flat_binder_object {
-                hdr: binder_object_header {
-                    type_: BINDER_TYPE_HANDLE,
-                },
-                // AOSP-correct: `flattenBinder`'s HANDLE arm sets `obj.flags = 0`,
-                // then applies `obj.flags |= schedBits` after both arms, so the
-                // final value is `0 | schedBits` == `sched_bits`. Do not "fix" to 0.
-                flags: sched_bits,
-                __bindgen_anon_1: flat_binder_object__bindgen_ty_1 {
-                    handle: proxy.handle(),
-                },
-                cookie: 0,
-            }
+            // AOSP-correct: `flattenBinder`'s HANDLE arm sets `obj.flags = 0`,
+            // then applies `obj.flags |= schedBits` after both arms, so the
+            // final value is `0 | schedBits` == `sched_bits`. Do not "fix" to 0.
+            flat_binder_object::new_handle(proxy.handle(), sched_bits)
         } else {
             // Native binder. Acquire (or dedup-resolve) an id via the
             // sidecar table on `ProcessState`; the table holds an
@@ -350,6 +360,38 @@ mod tests {
             obj.handle(),
             fd as u32,
             "handle variant must round-trip the fd"
+        );
+    }
+
+    /// Regression guard for the `From<&SIBinder>` proxy arm, which builds its
+    /// HANDLE object via [`flat_binder_object::new_handle`].
+    ///
+    /// The 8-byte `binder` union field must be written (not the u32 `handle`
+    /// variant) so the upper 4 bytes are zero — AOSP `flattenBinder` does
+    /// `obj.binder = 0; obj.handle = handle`. Writing only the `handle` variant
+    /// leaves the upper half uninitialized, and `write_object` copies the whole
+    /// struct onto the wire (uninitialized-read UB + a 4-byte stack info leak to
+    /// the peer). An rsbinder<->rsbinder round trip cannot catch this because
+    /// both sides ignore the upper bytes, so assert the union directly.
+    #[test]
+    fn new_handle_full_width_init() {
+        let handle: u32 = 0xDEAD_BEEF;
+        let obj = flat_binder_object::new_handle(handle, 0);
+
+        assert_eq!(
+            obj.header_type(),
+            BINDER_TYPE_HANDLE,
+            "must be a HANDLE object"
+        );
+        assert_eq!(
+            obj.pointer(),
+            handle as u64,
+            "upper 32 bits of the union must be zero (uninit-leak UB regression)"
+        );
+        assert_eq!(
+            obj.handle(),
+            handle,
+            "handle variant must round-trip the handle"
         );
     }
 

--- a/rsbinder/src/error.rs
+++ b/rsbinder/src/error.rs
@@ -131,8 +131,13 @@ impl From<StatusCode> for i32 {
             StatusCode::BadIndex => -(rustix::io::Errno::OVERFLOW.raw_os_error()),
             StatusCode::FdsNotAllowed => UNKNOWN_ERROR + 7,
             StatusCode::UnexpectedNull => UNKNOWN_ERROR + 8,
+            // `UNKNOWN_ERROR + 9` is AOSP `FROZEN_OBJECT` (Errors.h); keep
+            // `RpcError` off that slot so an incoming kernel `FROZEN_OBJECT`
+            // status is not mis-decoded as an RPC transport error (and so a
+            // stray `RpcError` on a `status_t` wire is not read as "frozen" by a
+            // C++ peer). `+ 10` is unused by AOSP's status_t table.
             #[cfg(feature = "rpc")]
-            StatusCode::RpcError => UNKNOWN_ERROR + 9,
+            StatusCode::RpcError => UNKNOWN_ERROR + 10,
             StatusCode::NotEnoughData => -(rustix::io::Errno::NODATA.raw_os_error()),
             StatusCode::WouldBlock => -(rustix::io::Errno::WOULDBLOCK.raw_os_error()),
             StatusCode::TimedOut => -(rustix::io::Errno::TIMEDOUT.raw_os_error()),
@@ -168,8 +173,9 @@ impl From<i32> for StatusCode {
         const BAD_INDEX: i32 = -Errno::OVERFLOW.raw_os_error();
         const FDS_NOT_ALLOWED: i32 = UNKNOWN_ERROR + 7;
         const UNEXPECTED_NULL: i32 = UNKNOWN_ERROR + 8;
+        // Off AOSP `FROZEN_OBJECT` (`UNKNOWN_ERROR + 9`); see the forward map.
         #[cfg(feature = "rpc")]
-        const RPC_ERROR: i32 = UNKNOWN_ERROR + 9;
+        const RPC_ERROR: i32 = UNKNOWN_ERROR + 10;
         const NOT_ENOUGH_DATA: i32 = -Errno::NODATA.raw_os_error();
         const WOULD_BLOCK: i32 = -Errno::WOULDBLOCK.raw_os_error();
         const TIMED_OUT: i32 = -Errno::TIMEDOUT.raw_os_error();

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -124,6 +124,8 @@ impl<T: Clone + Default> ParcelData<T> {
         ParcelData::Vec(Vec::with_capacity(capacity))
     }
 
+    // Only the RPC stack adopts a ready-made byte buffer as a parcel.
+    #[cfg(feature = "rpc")]
     fn from_vec(data: Vec<T>) -> Self {
         ParcelData::Vec(data)
     }
@@ -458,7 +460,8 @@ impl Parcel {
         }
     }
 
-    pub fn from_vec(data: Vec<u8>) -> Self {
+    #[cfg(feature = "rpc")]
+    pub(crate) fn from_vec(data: Vec<u8>) -> Self {
         Parcel {
             data: ParcelData::from_vec(data),
             objects: ParcelData::new(),
@@ -476,19 +479,19 @@ impl Parcel {
         }
     }
 
-    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut u8 {
         self.data.as_mut_ptr()
     }
 
-    pub fn as_ptr(&self) -> *const u8 {
+    pub(crate) fn as_ptr(&self) -> *const u8 {
         self.data.as_ptr()
     }
 
-    pub fn capacity(&self) -> usize {
+    pub(crate) fn capacity(&self) -> usize {
         self.data.capacity()
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.pos >= self.data.len()
     }
 
@@ -711,7 +714,7 @@ impl Parcel {
         self.rpc.as_mut().and_then(|r| r.take_in_fd(index))
     }
 
-    pub fn set_data_size(&mut self, new_len: usize) -> Result<()> {
+    pub(crate) fn set_data_size(&mut self, new_len: usize) -> Result<()> {
         if new_len > self.data.capacity() {
             // The backing buffer cannot hold `new_len` bytes — a broken
             // driver/buffer contract. Refuse rather than enter the
@@ -729,7 +732,7 @@ impl Parcel {
         Ok(())
     }
 
-    pub fn close_file_descriptors(&self) {
+    pub(crate) fn close_file_descriptors(&self) {
         // RPC-mode parcels never carry kernel FD objects (FD over RPC
         // is rejected by default / opt-in via Unix mode); nothing to close here.
         #[cfg(feature = "rpc")]

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -231,7 +231,7 @@ impl<T: Clone + Default> ParcelData<T> {
     }
 }
 
-pub type FnFreeBuffer =
+pub(crate) type FnFreeBuffer =
     fn(Option<&Parcel>, binder_uintptr_t, usize, binder_uintptr_t, usize) -> Result<()>;
 
 /// RPC object-marshalling hooks attached to an RPC-mode `Parcel`
@@ -243,7 +243,7 @@ pub type FnFreeBuffer =
 /// kernel `flat_binder_object` path — the kernel path is byte-identical
 /// when `is_for_rpc == false`.
 #[cfg(feature = "rpc")]
-pub trait RpcParcelOps: Send + Sync {
+pub(crate) trait RpcParcelOps: Send + Sync {
     /// Marshal a possibly-null binder leaving this process: append the
     /// r34 RPC object encoding (`i32` present flag + 32B address).
     fn write_binder(
@@ -528,7 +528,7 @@ impl Parcel {
     /// Attach the RPC object-marshalling hooks and enter RPC mode
     /// (android `Parcel::markForRpc`/`mSession` equivalent).
     #[cfg(feature = "rpc")]
-    pub fn attach_rpc_ops(&mut self, ops: std::sync::Arc<dyn RpcParcelOps>) {
+    pub(crate) fn attach_rpc_ops(&mut self, ops: std::sync::Arc<dyn RpcParcelOps>) {
         self.rpc.get_or_insert_with(RpcFields::default).ops = Some(ops);
     }
 

--- a/rsbinder/src/parcel.rs
+++ b/rsbinder/src/parcel.rs
@@ -1451,7 +1451,12 @@ impl Parcel {
             log::error!("Parcel::append_from: the size is too large: {size}");
             return Err(StatusCode::BadValue);
         }
-        let other_len = other.data_size();
+        // Bound against the backing slice length, not `data_size()` (which is
+        // `max(data.len(), pos)`): the copy below indexes `other.data[offset..
+        // offset + size]`, so a source parcel whose cursor was seeked past its
+        // data end (`pos > data.len()`) must be rejected here rather than pass
+        // this check and then panic on the slice index.
+        let other_len = other.data.len();
         if offset > other_len || size > other_len || (offset + size) > other_len {
             log::error!("Parcel::append_from: The given offset({offset}) and size({size}) exceed the data range of the parcel.");
             return Err(StatusCode::BadValue);

--- a/rsbinder/src/proxy_count.rs
+++ b/rsbinder/src/proxy_count.rs
@@ -330,13 +330,16 @@ mod tests {
     use super::*;
     use std::sync::Mutex as StdMutex;
 
-    // proxy_count state is process-global; serialize tests so they
-    // don't trip over each other's mutations.
-    static TEST_LOCK: StdMutex<()> = StdMutex::new(());
+    // `PROXY_COUNT` and the per-uid map are process-global. Every test here is
+    // `#[serial_test::serial(binder)]` so it shares the `binder` serial group
+    // with the proxy-creating `process_state` tests: on a real binder those
+    // create `ProxyHandle`s that bump the global count in parallel, which would
+    // otherwise pollute these exact-count assertions (a local mutex serialized
+    // only the proxy_count tests against each other, not against the creators).
 
     #[test]
+    #[serial_test::serial(binder)]
     fn global_counter_increments_and_decrements() {
-        let _g = TEST_LOCK.lock().unwrap();
         reset_for_test();
         assert_eq!(get_binder_proxy_count(), 0);
         on_proxy_create(1000);
@@ -351,8 +354,8 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(binder)]
     fn per_uid_disabled_by_default_skips_map() {
-        let _g = TEST_LOCK.lock().unwrap();
         reset_for_test();
         on_proxy_create(1000);
         on_proxy_create(2000);
@@ -365,8 +368,8 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(binder)]
     fn per_uid_enabled_tracks_each_uid() {
-        let _g = TEST_LOCK.lock().unwrap();
         reset_for_test();
         enable_count_by_uid(true);
         on_proxy_create(1000);
@@ -386,8 +389,8 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(binder)]
     fn limit_callback_fires_once_until_low_watermark_resets() {
-        let _g = TEST_LOCK.lock().unwrap();
         reset_for_test();
         enable_count_by_uid(true);
         set_binder_proxy_count_watermarks(/*high*/ 5, /*low*/ 2, /*warning*/ 4);
@@ -429,8 +432,8 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(binder)]
     fn callback_runs_outside_state_lock() {
-        let _g = TEST_LOCK.lock().unwrap();
         reset_for_test();
         enable_count_by_uid(true);
         set_binder_proxy_count_watermarks(2, 1, 2);
@@ -448,8 +451,8 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(binder)]
     fn clear_count_by_uid_resets_map_only() {
-        let _g = TEST_LOCK.lock().unwrap();
         reset_for_test();
         enable_count_by_uid(true);
         on_proxy_create(1000);
@@ -465,13 +468,13 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(binder)]
     fn per_uid_count_survives_tracking_toggled_off_while_live() {
         // Regression: `on_proxy_drop` must mirror what the proxy's
         // `on_proxy_create` did (captured per-object), not re-read the live
         // `COUNT_BY_UID_ENABLED`. Toggling tracking off while a counted proxy
         // is alive previously skipped its decrement and permanently inflated
         // the uid's count.
-        let _g = TEST_LOCK.lock().unwrap();
         reset_for_test();
 
         enable_count_by_uid(true);

--- a/rsbinder/src/rpc/mod.rs
+++ b/rsbinder/src/rpc/mod.rs
@@ -88,17 +88,27 @@ pub(crate) mod lifecycle;
 pub mod proxy;
 pub mod server;
 pub mod session;
-pub mod state;
+// Internal RPC machinery: the wire-codec layer and per-session refcount/async
+// state. Not part of the public API — the codec is selected internally (no user
+// injection point) and `RpcState` is private session bookkeeping. Keeping them
+// `pub(crate)` lets the protocol evolve without semver-breaking releases.
+pub(crate) mod state;
 pub mod transport;
-pub mod wire;
-pub mod wire_android13;
+// The wire modules implement the complete AOSP codec surface (both directions
+// of every message, all negotiated versions), fully exercised by their own
+// hermetic `mod tests`. Some encode/decode entry points are validated there but
+// not reached by the current live dispatch path; `dead_code` fired on them only
+// after the demotion from `pub`. Keep the complete, tested surface.
+#[allow(dead_code)]
+pub(crate) mod wire;
+#[allow(dead_code)]
+pub(crate) mod wire_android13;
 
 pub use address::{AddressSpace, RpcAddress, SpecialTransaction, RPC_SESSION_ID_NEW};
 pub use fd_mode::FileDescriptorTransportMode;
 pub use proxy::RpcProxy;
 pub use server::RpcServer;
 pub use session::{RpcSession, RpcUnixClientConfig};
-pub use state::RpcState;
 pub use transport::{CertId, PeerIdentity, RpcTransport};
 
 /// Re-export of the exact `rustls` the `tls` backend links, so callers
@@ -106,11 +116,6 @@ pub use transport::{CertId, PeerIdentity, RpcTransport};
 /// (key/cert management stays caller-side).
 #[cfg(feature = "rpc-tls")]
 pub use rustls;
-pub use wire::{R34Codec, WireCodec, WireMessage, WireReply, WireTransaction};
-/// android-13+ versioned wire codec (additive — version-keyed:
-/// v0 = android-13, v1 = android-14/15. `R34Codec`
-/// stays the default; this never affects the kernel path).
-pub use wire_android13::Android13PlusCodec;
 
 use std::fmt;
 

--- a/rsbinder/src/rpc/proxy.rs
+++ b/rsbinder/src/rpc/proxy.rs
@@ -36,7 +36,7 @@ pub struct RpcProxy {
     /// address (not a descriptor string), so a proxy resolved from
     /// `read_binder`/`get_root` starts empty and is stamped **once,
     /// in place** by the generated typed stub's `from_binder`
-    /// (via [`stamp_descriptor`](Self::stamp_descriptor)).
+    /// (via `stamp_descriptor`).
     /// In-place — never a replacement proxy — keeps the dedup-cache
     /// identity and the single `DEC_STRONG` intact.
     descriptor: OnceLock<String>,
@@ -156,7 +156,7 @@ impl RpcProxy {
     /// without an extra `descriptor()` round-trip; existing callers
     /// (generator `from_binder`) can keep ignoring the result with
     /// `let _ = …`.
-    pub fn stamp_descriptor(&self, descriptor: &str) -> bool {
+    pub(crate) fn stamp_descriptor(&self, descriptor: &str) -> bool {
         self.descriptor.set(descriptor.to_string()).is_ok()
     }
 
@@ -202,7 +202,7 @@ impl RpcProxy {
 /// `ProxyHandle`, so the one generated `Bp*` stub drives either stack
 /// (generator emits `as_remote()`). `prepare_transact` writes
 /// the interface token from the descriptor stamped in place by the
-/// generated `from_binder` ([`stamp_descriptor`](RpcProxy::stamp_descriptor)).
+/// generated `from_binder` (`stamp_descriptor`).
 impl crate::binder::RemoteProxy for RpcProxy {
     fn prepare_transact(&self, write_header: bool) -> Result<Parcel> {
         let inner = self.session.upgrade().ok_or(StatusCode::DeadObject)?;

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -4,7 +4,7 @@
 //! `RpcServer` — bind / listen / accept, one session per connection.
 //!
 //! Model: **one connection ⇒ one [`RpcSession`] ⇒ one worker thread**,
-//! each with its own [`super::state::RpcState`] (no global, so sessions
+//! each with its own `RpcState` (no global, so sessions
 //! are isolated and the suite is parallel-safe). Concurrent clients use
 //! independent connections; nested re-entrant calls run inline on a
 //! connection's worker (the `client_transact` recv loop dispatches

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -1401,13 +1401,20 @@ impl RpcSessionInner {
     /// Client outbound transaction. Returns the reply parcel (or `None`
     /// for oneway). Applies any interleaved `DEC_STRONG` and loops to
     /// the matching `REPLY`.
-    /// Undo the reservations a failed outgoing transaction took before the
-    /// send actually happened: the per-node oneway `async_number` (when
+    /// Undo the reservations an outgoing parcel took while it was serialized but
+    /// which never reached the peer: the per-node oneway `async_number` (when
     /// `oneway_addr` is `Some((addr, consumed))`) and every local-binder
-    /// `timesSent` bump recorded in `data` while it was serialized. Invoked
-    /// only on an encode/send error, so the success path is untouched and the
-    /// wire is byte-unchanged.
+    /// `timesSent` bump recorded in `data`. Called on an encode/send failure and
+    /// whenever a reply parcel is discarded (handler `Err`, oneway). The success
+    /// path is untouched, so the wire is byte-unchanged.
     fn rollback_outgoing(&self, data: &Parcel, oneway_addr: Option<(RpcAddress, u64)>) {
+        // Nothing to cancel ⇒ skip the state lock. The oneway dispatch path
+        // calls this on every transaction, but a reply/args parcel that
+        // flattened no local binder has no bump to roll back — avoid the lock on
+        // that hot path (`rpc_leaving_addrs()` is a lock-free read).
+        if oneway_addr.is_none() && data.rpc_leaving_addrs().is_empty() {
+            return;
+        }
         let mut state = self.shared.state.lock().expect("rpc state poisoned");
         if let Some((addr, consumed)) = oneway_addr {
             state.cancel_send_async_number(addr, consumed);
@@ -1540,12 +1547,12 @@ impl RpcSessionInner {
                     reply.set_data_position(0);
                     return Ok(Some(reply));
                 }
-                WireMessage::DecStrong(a) => {
+                WireMessage::DecStrong(a, amount) => {
                     self.shared
                         .state
                         .lock()
                         .expect("rpc state poisoned")
-                        .dec_strong_local(&a);
+                        .dec_strong_local(&a, amount);
                 }
                 WireMessage::Transact(t) => {
                     // Nested / re-entrant call: the peer is calling
@@ -1905,6 +1912,11 @@ impl RpcSessionInner {
             if let Err(e) = result {
                 log::error!("oneway RPC transaction failed (dropped): {e:?}");
             }
+            // A oneway reply is always discarded (never sent). Roll back any
+            // `timesSent` bumps a handler made by writing a binder into `reply`,
+            // so those local nodes do not leak (the peer never receives them and
+            // so never `DEC_STRONG`s). Empty for AIDL-generated oneway stubs.
+            self.rollback_outgoing(&reply, None);
             return Ok(());
         }
         match result {
@@ -1924,7 +1936,14 @@ impl RpcSessionInner {
                 }
                 sent
             }
-            Err(e) => self.send_reply(e.into(), &[], &[], &[]),
+            Err(e) => {
+                // The error reply carries an empty body (the partially-written
+                // `reply` is discarded), so roll back any `timesSent` bumps from
+                // binders a handler wrote before returning `Err` — symmetric with
+                // the send-failure arm above.
+                self.rollback_outgoing(&reply, None);
+                self.send_reply(e.into(), &[], &[], &[])
+            }
         }
     }
 
@@ -1953,12 +1972,12 @@ impl RpcSessionInner {
                 self.dispatch_transact(t, in_fds, peer)?;
                 Ok(true)
             }
-            WireMessage::DecStrong(a) => {
+            WireMessage::DecStrong(a, amount) => {
                 self.shared
                     .state
                     .lock()
                     .expect("rpc state poisoned")
-                    .dec_strong_local(&a);
+                    .dec_strong_local(&a, amount);
                 Ok(true)
             }
             WireMessage::Reply(_) => {

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -8,7 +8,7 @@
 //! * client outbound transactions ([`RpcSession::get_root`], and
 //!   [`super::proxy::RpcProxy::transact`]),
 //! * a blocking server serve loop ([`RpcSession::serve_blocking`]),
-//! * the [`RpcParcelOps`] bridge that lets the `SIBinder`
+//! * the `RpcParcelOps` bridge that lets the `SIBinder`
 //!   (de)serializers marshal binders as `RpcAddress`.
 //!
 //! All state is owned here (no global).
@@ -648,7 +648,7 @@ impl SharedSession {
 /// (their inbound connection). Default single-connection sessions own
 /// one slot, so `find_conn` is a no-wait single-slot pick and the
 /// `enter_connection` semantics are byte-identical.
-pub struct RpcSessionInner {
+pub(crate) struct RpcSessionInner {
     /// AOSP `RpcSession::mMutex` — the session's *single* connection
     /// pool lock, paired with [`slot_cv`](RpcSessionInner::slot_cv).
     /// Held briefly to pick a slot ([`find_conn`]); released for the
@@ -685,7 +685,7 @@ pub struct RpcSessionInner {
     shared: Arc<SharedSession>,
 }
 
-/// The [`RpcParcelOps`] implementation bound to one session.
+/// The `RpcParcelOps` implementation bound to one session.
 struct SessionParcelOps(Weak<RpcSessionInner>);
 
 impl RpcParcelOps for SessionParcelOps {

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -3,7 +3,7 @@
 
 //! `RpcSession` — single-connection RPC session driver.
 //!
-//! Ties one [`RpcTransport`] + [`R34Codec`] + per-session [`RpcState`]
+//! Ties one [`RpcTransport`] + `R34Codec` + per-session `RpcState`
 //! together and provides:
 //! * client outbound transactions ([`RpcSession::get_root`], and
 //!   [`super::proxy::RpcProxy::transact`]),
@@ -2342,7 +2342,7 @@ impl RpcSession {
     /// (`RpcConnectionHeader → RpcNewSessionResponse → "cci"`,
     /// negotiating `min(max_version, server_max)`), then returns a
     /// session that speaks the negotiated version with AOSP-faithful
-    /// framing — reusing the existing per-session [`RpcState`] and
+    /// framing — reusing the existing per-session `RpcState` and
     /// `client_transact`/dispatch unchanged. `max_version` is the
     /// highest `RPC_WIRE_PROTOCOL_VERSION` to offer (0 = android-13,
     /// 1 = android-14/15).

--- a/rsbinder/src/rpc/state.rs
+++ b/rsbinder/src/rpc/state.rs
@@ -247,12 +247,17 @@ impl RpcState {
         }
     }
 
-    /// Apply an inbound `DEC_STRONG` for `addr`. Drops the node (and
-    /// its strong `SIBinder`) once the count reaches 0 — no leak.
+    /// Apply an inbound `DEC_STRONG` for `addr` by `amount` (AOSP
+    /// `doDecStrong`: `timesSent -= amount`). A compliant peer may batch more
+    /// than one decrement into a single command, so the amount must be honored —
+    /// applying a fixed 1 would leak the node on a batched drop. Drops the node
+    /// (and its strong `SIBinder`) once the count reaches 0 — no leak. A hostile
+    /// over-decrement simply removes the node early (contained: the peer loses
+    /// access), and `strong: i64` cannot underflow for a `u32` amount.
     /// Returns `true` if the node was removed.
-    pub fn dec_strong_local(&mut self, addr: &RpcAddress) -> bool {
+    pub fn dec_strong_local(&mut self, addr: &RpcAddress, amount: u32) -> bool {
         if let Some(node) = self.local_nodes.get_mut(addr) {
-            node.strong -= 1;
+            node.strong -= amount as i64;
             if node.strong <= 0 {
                 self.local_nodes.remove(addr);
                 self.local_by_ptr.retain(|_, a| a != addr);
@@ -575,11 +580,29 @@ mod tests {
         let b = SIBinder::new(Arc::new(Dummy)).unwrap();
         let a = st.on_binder_leaving(&b).unwrap();
         assert_eq!(st.local_node_count(), 1);
-        assert!(st.dec_strong_local(&a), "node removed at strong 0");
+        assert!(st.dec_strong_local(&a, 1), "node removed at strong 0");
         assert_eq!(st.local_node_count(), 0, "no leak");
         assert!(st.lookup_local(&a).is_none());
         // DEC_STRONG on an unknown address is safe (idempotent).
-        assert!(!st.dec_strong_local(&a));
+        assert!(!st.dec_strong_local(&a, 1));
+    }
+
+    /// A batched DEC_STRONG (`amount > 1`, as a compliant libbinder peer sends
+    /// on a deduped drop) must free a node sent multiple times in one command —
+    /// applying a fixed 1 would leak `amount - 1` refs.
+    #[test]
+    fn dec_strong_honors_batched_amount() {
+        let mut st = RpcState::new(AddressSpace::Acceptor);
+        let b = SIBinder::new(Arc::new(Dummy)).unwrap();
+        let a = st.on_binder_leaving(&b).unwrap(); // strong 1
+        st.on_binder_leaving(&b).unwrap(); // strong 2
+        st.on_binder_leaving(&b).unwrap(); // strong 3
+        assert_eq!(st.local_node_count(), 1);
+        assert!(
+            st.dec_strong_local(&a, 3),
+            "one batched DEC of amount 3 frees a node sent 3×"
+        );
+        assert_eq!(st.local_node_count(), 0, "no leak on batched drop");
     }
 
     /// A send failure rolls back exactly one `on_binder_leaving` bump; the
@@ -680,7 +703,7 @@ mod tests {
         assert_eq!(s2.local_node_count(), 0);
 
         // Mutating s1 never affects s2 (no shared storage).
-        s1.dec_strong_local(&a1);
+        s1.dec_strong_local(&a1, 1);
         assert_eq!(s1.local_node_count(), 0);
         assert_eq!(s2.local_node_count(), 0);
     }
@@ -817,9 +840,9 @@ mod tests {
             "1st mints; 2nd/3rd are excess receipts (owe a flush DEC)"
         );
         // 2 excess DECs + 1 proxy-drop DEC = 3 = timesSent ⇒ freed.
-        assert!(!srv.dec_strong_local(&a));
-        assert!(!srv.dec_strong_local(&a));
-        assert!(srv.dec_strong_local(&a), "3rd DEC frees the node");
+        assert!(!srv.dec_strong_local(&a, 1));
+        assert!(!srv.dec_strong_local(&a, 1));
+        assert!(srv.dec_strong_local(&a, 1), "3rd DEC frees the node");
         assert_eq!(srv.local_node_count(), 0, "no leak (AC-2.5)");
 
         // (b) Same object sent once to each of 2 *independent* peer
@@ -832,11 +855,11 @@ mod tests {
         let x = s.on_binder_leaving(&o).unwrap(); // conn #1 send
         let _ = s.on_binder_leaving(&o).unwrap(); // conn #2 send (timesSent ⇒ 2)
         assert!(
-            !s.dec_strong_local(&x),
+            !s.dec_strong_local(&x, 1),
             "conn #1 proxy drop must NOT free a node conn #2 still holds (F7)"
         );
         assert!(s.lookup_local(&x).is_some(), "sibling still reachable");
-        assert!(s.dec_strong_local(&x), "conn #2 proxy drop frees it");
+        assert!(s.dec_strong_local(&x, 1), "conn #2 proxy drop frees it");
         assert_eq!(s.local_node_count(), 0, "no leak");
     }
 

--- a/rsbinder/src/rpc/transport/unix.rs
+++ b/rsbinder/src/rpc/transport/unix.rs
@@ -257,15 +257,21 @@ impl RpcTransport for UnixTransport {
     /// of this (`wire_android13::read_aosp_message`).
     fn recv_raw(&self, buf: &mut [u8]) -> RpcResult<usize> {
         let mut r = &self.stream;
-        match r.read(buf) {
-            Ok(n) => Ok(n),
-            // A read deadline (`SO_RCVTIMEO` via `set_read_timeout`)
-            // elapsed. Surface it as `Timeout` rather than a generic `Io`
-            // so the android-13+ reader (`read_exact_raw`) can honor the
-            // `Timeout`/`Truncated` contract and a caller matching
-            // `Timeout`/`StatusCode::TimedOut` sees it.
-            Err(e) if super::is_timeout(&e) => Err(RpcError::Timeout),
-            Err(e) => Err(RpcError::from(e)),
+        loop {
+            return match r.read(buf) {
+                Ok(n) => Ok(n),
+                // A signal (no `SA_RESTART`) interrupted the blocking read.
+                // Retry, mirroring `recv_raw_with_fds` / the framed readers and
+                // AOSP `interruptableReadFully` — do not fail the message.
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                // A read deadline (`SO_RCVTIMEO` via `set_read_timeout`)
+                // elapsed. Surface it as `Timeout` rather than a generic `Io`
+                // so the android-13+ reader (`read_exact_raw`) can honor the
+                // `Timeout`/`Truncated` contract and a caller matching
+                // `Timeout`/`StatusCode::TimedOut` sees it.
+                Err(e) if super::is_timeout(&e) => Err(RpcError::Timeout),
+                Err(e) => Err(RpcError::from(e)),
+            };
         }
     }
 
@@ -283,6 +289,16 @@ impl RpcTransport for UnixTransport {
 
         if fds.is_empty() {
             return self.send_raw(buf);
+        }
+        if buf.is_empty() {
+            // The fds ride the first `sendmsg`; with no payload bytes the send
+            // loop below never runs, so the fds would be silently dropped while
+            // the method still returned `Ok`. The AOSP RPC wire never attaches
+            // fds to an empty frame (every frame carries a >= 16-byte header), so
+            // treat this as protocol misuse rather than lose the fds.
+            return Err(RpcError::Protocol(
+                "cannot attach fds to an empty RPC frame",
+            ));
         }
         if fds.len() > MAX_FDS_PER_FRAME {
             return Err(RpcError::Protocol("too many fds in one RPC frame"));

--- a/rsbinder/src/rpc/wire.rs
+++ b/rsbinder/src/rpc/wire.rs
@@ -96,8 +96,10 @@ pub enum WireMessage {
     Transact(WireTransaction),
     /// `REPLY`.
     Reply(WireReply),
-    /// `DEC_STRONG` against `RpcAddress`.
-    DecStrong(RpcAddress),
+    /// `DEC_STRONG` against `RpcAddress` by the given `amount` (AOSP
+    /// `RpcDecStrong.amount` — a peer may batch more than one decrement into a
+    /// single command; the R34 wire has no amount field and always means `1`).
+    DecStrong(RpcAddress, u32),
 }
 
 /// Pluggable RPC wire format. The session owns a codec instance (no
@@ -295,7 +297,8 @@ impl WireCodec for R34Codec {
                 if body.len() != RPC_ADDR_LEN {
                     return Err(RpcError::Protocol("DEC_STRONG body != 32 bytes"));
                 }
-                Ok(WireMessage::DecStrong(rd_addr(body, 0)?))
+                // The R34 wire carries no amount field: one decrement per command.
+                Ok(WireMessage::DecStrong(rd_addr(body, 0)?, 1))
             }
             _ => Err(RpcError::Protocol("unknown RpcWireHeader.command")),
         }
@@ -424,7 +427,10 @@ mod tests {
         let addr = RpcAddress::unique(&mut ctr, crate::rpc::AddressSpace::Initiator);
         let enc = c.encode_dec_strong(&addr);
         match c.decode_message(&enc).unwrap() {
-            WireMessage::DecStrong(a) => assert_eq!(a, addr),
+            WireMessage::DecStrong(a, amount) => {
+                assert_eq!(a, addr);
+                assert_eq!(amount, 1);
+            }
             other => panic!("expected DecStrong, got {other:?}"),
         }
 

--- a/rsbinder/src/rpc/wire_android13.rs
+++ b/rsbinder/src/rpc/wire_android13.rs
@@ -688,10 +688,12 @@ impl WireCodec for Android13PlusCodec {
                     return Err(RpcError::Protocol("RpcDecStrong body != 16 bytes"));
                 }
                 let address = Self::decode_addr(body, 0)?;
-                // amount @8 — rsbinder applies one decrement per
-                // DEC_STRONG; honoring amount>1 from a live peer is a
-                // separate refinement.
-                Ok(WireMessage::DecStrong(address))
+                // `RpcDecStrong.amount` @8: a compliant libbinder peer batches
+                // `timesRecd - target` decrements (AOSP `sendDecStrongToTarget`)
+                // into one command, so honor it rather than assuming 1 — else a
+                // batched drop under-decrements our local node and leaks it.
+                let amount = rd_u32(body, A13_ADDR_LEN)?;
+                Ok(WireMessage::DecStrong(address, amount))
             }
             _ => Err(RpcError::Protocol("unknown RpcWireHeader.command")),
         }
@@ -1457,7 +1459,23 @@ mod tests {
             let mut ctr = 9u64;
             let addr = RpcAddress::unique(&mut ctr, AddressSpace::Initiator);
             match c.decode_message(&c.encode_dec_strong(&addr)).unwrap() {
-                WireMessage::DecStrong(a) => assert_eq!(a, addr),
+                WireMessage::DecStrong(a, amount) => {
+                    assert_eq!(a, addr);
+                    assert_eq!(amount, 1, "rsbinder emits amount = 1 per DEC_STRONG");
+                }
+                other => panic!("expected DecStrong, got {other:?}"),
+            }
+            // A compliant peer may batch amount > 1 (AOSP `sendDecStrongToTarget`
+            // sends `timesRecd - target`). The decoder must read the field, not
+            // assume 1 — otherwise a batched drop under-decrements and leaks.
+            let mut framed = c.encode_dec_strong(&addr);
+            let amt_off = WIRE_HEADER_LEN + A13_ADDR_LEN;
+            framed[amt_off..amt_off + 4].copy_from_slice(&3u32.to_le_bytes());
+            match c.decode_message(&framed).unwrap() {
+                WireMessage::DecStrong(a, amount) => {
+                    assert_eq!(a, addr);
+                    assert_eq!(amount, 3, "decoder must honor RpcDecStrong.amount");
+                }
                 other => panic!("expected DecStrong, got {other:?}"),
             }
         }
@@ -1645,7 +1663,7 @@ mod tests {
                 // Read a DEC_STRONG.
                 let raw = read_aosp_message(&mut s).expect("read dec_strong");
                 match codec.decode_message(&raw).expect("decode dec_strong") {
-                    WireMessage::DecStrong(_) => {}
+                    WireMessage::DecStrong(..) => {}
                     other => panic!("expected DecStrong, got {other:?}"),
                 }
                 codec.version()

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -1729,9 +1729,10 @@ pub(crate) fn query_interface(handle: u32) -> Result<String> {
 
     let data = Parcel::new();
     let reply = transact(handle, INTERFACE_TRANSACTION, &data, 0)?;
-    let interface: String = reply
-        .expect("INTERFACE_TRANSACTION should have reply parcel")
-        .read()?;
+    // A two-way transact normally yields a reply, but a `break` path in
+    // `wait_for_response` can surface `Ok(None)`; return a recoverable error
+    // rather than panicking the calling thread.
+    let interface: String = reply.ok_or(StatusCode::UnexpectedNull)?.read()?;
 
     Ok(interface)
 }
@@ -2306,6 +2307,13 @@ pub struct ExtendedError {
 /// **Opt-in**: rsbinder does *not* call this automatically from the
 /// `BR_FAILED_REPLY` arm. A no-op for callers that never invoke it.
 pub fn get_extended_error() -> Result<ExtendedError> {
+    // Consistent with the other public accessors in this module (calling
+    // uid/pid/sid, strict-mode policy, identity): in a pure-RPC process kernel
+    // binder was never initialized, so return an error instead of panicking in
+    // `ProcessState::as_self()`.
+    if !ProcessState::is_initialized() {
+        return Err(StatusCode::InvalidOperation);
+    }
     let mut ee = binder::binder_extended_error::default();
     let driver = ProcessState::as_self().driver();
     crate::sys::binder::get_extended_error(driver.as_ref(), &mut ee).map_err(|errno| {

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -1616,7 +1616,7 @@ pub(crate) fn _handle_commands() -> Result<()> {
     Ok(())
 }
 
-pub fn check_interface(reader: &mut Parcel, descriptor: &str) -> Result<bool> {
+pub(crate) fn check_interface(reader: &mut Parcel, descriptor: &str) -> Result<bool> {
     let mut strict_policy: i32 = reader.read()?;
 
     THREAD_STATE.with(|thread_state| -> Result<()> {
@@ -1938,7 +1938,7 @@ impl std::default::Default for CallingContext {
     }
 }
 
-pub fn is_handling_transaction() -> bool {
+pub(crate) fn is_handling_transaction() -> bool {
     // Plan 2-16 Phase B: an in-flight RPC transaction counts (and is
     // detected without forcing the ProcessState-coupled `THREAD_STATE`,
     // which would panic in a pure-RPC process).
@@ -2094,7 +2094,7 @@ pub fn get_calling_uid() -> binder::uid_t {
 /// applies only outside any (kernel or RPC) transaction, so
 /// [`crate::proxy_count`] attribution over a uid-less RPC transport buckets
 /// under the `u32::MAX` sentinel rather than this process's uid.
-pub fn get_calling_uid_or_self() -> binder::uid_t {
+pub(crate) fn get_calling_uid_or_self() -> binder::uid_t {
     // Plan 2-16 Phase B: prefer the RPC caller uid when dispatching an RPC
     // transaction; otherwise fall back to the process's own uid without
     // forcing `THREAD_STATE` in a pure-RPC process.


### PR DESCRIPTION
A second, independent review pass over `rsbinder/src` (following #172), plus the public-API tightening it motivated. Targets **0.11.0** (contains breaking API changes; a 0.x minor bump).

## 1. Correctness & soundness fixes

- **Uninitialized stack leaked to the wire on every remote-handle send.** The `From<&SIBinder>` proxy arm initialized the 8-byte `flat_binder_object` union through its `u32 handle` variant, so `write_object` copied 4 uninitialized stack bytes onto the wire (UB-adjacent + a peer-visible info leak). Now serialized through the 8-byte `binder` field (AOSP `flattenBinder`) via a new `new_handle` helper + regression test. Same bug class #172 fixed in `new_with_fd`; this was the remaining site.
- **`RpcDecStrong.amount` was ignored.** A libbinder peer batches `timesRecd - target` decrements into one `DEC_STRONG`; the decoder always applied `1`, under-counting and leaking the local node. The amount is now decoded and applied.
- **Discarded reply parcels leaked `timesSent` bumps** on the handler-`Err` and oneway dispatch paths — now rolled back, symmetric with the send-failure path.
- **`Parcel::append_from`** was bounded against `data_size()` while indexing the backing slice; now bounded against `data.len()` so a source cursor past the data end is rejected rather than panicking.
- **`StatusCode::RpcError` collided with AOSP `FROZEN_OBJECT`** (both `UNKNOWN_ERROR + 9`); moved to `+ 10` so an incoming frozen-object status is not mis-decoded (`rpc`-gated; default builds byte-unchanged).

## 2. Robustness

- `get_extended_error` / `query_interface` no longer panic in a pure-RPC or non-conforming-reply path.
- `UnixTransport::recv_raw` retries `EINTR`; fds attached to an empty RPC frame are rejected instead of silently dropped.
- `rollback_outgoing` skips the RPC state lock when there is nothing to cancel (hot oneway path).

## 3. Public-API tightening (0.11.0, breaking)

The wire protocol was leaking internal types into the public API, making every protocol change a semver break. Now `pub(crate)`:

- The RPC **wire-codec layer** (`WireMessage`, `WireCodec`, `R34Codec`, `Android13PlusCodec`, `WireReply`, `WireTransaction`) and **`RpcState`** — internal detail; the codec is selected internally with no user injection point.
- Internal helpers with no consumer and no documented contract: `Parcel`'s RPC-ops plumbing (`RpcParcelOps`, `attach_rpc_ops`, `FnFreeBuffer`), `RpcSessionInner`, `RpcProxy::stamp_descriptor`, `thread_state::{check_interface, is_handling_transaction, get_calling_uid_or_self}`, and the low-level `Parcel` buffer accessors (`as_ptr`, `as_mut_ptr`, `capacity`, `set_data_size`, `close_file_descriptors`, `is_empty`, `from_vec`).

The public RPC surface stays `RpcServer` / `RpcSession` / `RpcProxy` / the transport traits / the address & identity types. The public `rsbinder::is_handling_transaction` (from `native`), `Parcel::from_ipc_parts`, and `Parcel::set_for_rpc` are unchanged. `hub`'s accessor-register surface was audited and **kept public** — it is driven by `rsbinder/tests/rpc_accessor.rs`. Full details in `CHANGELOG.md`.

## 4. Test isolation

`proxy_count` tests are moved into the `#[serial_test::serial(binder)]` group so they no longer race with the proxy-creating `process_state` tests on a real binder (the global `PROXY_COUNT` / per-uid map was polluted under parallel execution).

## Verification

- **macOS hermetic**: workspace green; `rsbinder` default 183/0, `--features rpc` 305/0 + integration suites; clippy (default + all rpc backends) and `rustfmt` clean; `cargo-semver-checks` clean under the 0.11.0 bump.
- **REMOTE_LINUX** (real `/dev/binder`): lib default 212/0, lib rpc 305/0 (parallel, ×3 after the proxy_count fix), e2e sync/async 139/0 each, mesh (RPC + kernel) pass, death/obituary 4/4.
- **Android 16 emulator** (arm64, real binder): lib 198/0, e2e 139/0 (+6 ignored), death/obituary 4/4.
