### PR TITLE
chore(deps): move to syn 3, take rsproperties 0.6, hold serial_test at 3.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "similar",
- "syn 2.0.119",
+ "syn 3.0.3",
  "tempfile",
  "tera",
  "thiserror",
@@ -924,7 +924,7 @@ dependencies = [
  "quote",
  "rsbinder",
  "rsbinder-aidl",
- "syn 2.0.119",
+ "syn 3.0.3",
  "trybuild",
 ]
 
@@ -941,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "rsproperties"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "878032a02f0dd5ec0fdd772e0141c50ef05d406c5a9f2ea79826285270fea168"
+checksum = "e92cdbbe82223006ba7f16e6178dd9b24fbb967d000a096e8dc4129560d7ab41"
 dependencies = [
  "log",
  "pretty-hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,14 @@ pretty_hex = { version = "0.4", package = "pretty-hex" }
 rustix = "1.1"
 libc = "0.2"
 clap = "4.6"
-rsproperties = "0.5"
+rsproperties = "0.6"
 miette = { version = "7.6", features = ["fancy"] }
 thiserror = "2"
 # dev-only: serializes the handful of rsbinder unit tests that share the
 # process-wide `ProcessState` singleton + single binder fd (group key
 # `binder`). default-features = false drops the `logging`/`async` features
 # (and the `futures` dep) — every gated test is a sync `#[test]`.
+#
+# Held at 3.x: 4.0 declares `rust-version = 1.93.1`, above this workspace's
+# 1.85, and the `rust_min` CI job builds dev-dependencies.
 serial_test = { version = "3", default-features = false }

--- a/rsbinder-aidl/Cargo.toml
+++ b/rsbinder-aidl/Cargo.toml
@@ -31,4 +31,4 @@ thiserror = { workspace = true }
 similar = { workspace = true }
 miette = { workspace = true }
 tempfile = "3.27.0"
-syn = { version = "2", features = ["full"] }
+syn = { version = "3", features = ["full"] }

--- a/rsbinder-macros/Cargo.toml
+++ b/rsbinder-macros/Cargo.toml
@@ -25,7 +25,7 @@ async = []
 
 [dependencies]
 rsbinder-aidl = { workspace = true }
-syn = { version = "2", features = ["full", "parsing", "printing"] }
+syn = { version = "3", features = ["full", "parsing", "printing"] }
 proc-macro2 = "1"
 quote = "1"
 

--- a/rsbinder-macros/src/lib.rs
+++ b/rsbinder-macros/src/lib.rs
@@ -332,7 +332,7 @@ fn render_source_with(args: &Args, item: &ItemTrait, enabled_async: bool) -> syn
              so the obligation would be silently dropped",
         ));
     }
-    if let Some(auto_token) = &item.auto_token {
+    if let Some(auto_token) = &item.modifiers.auto_token {
         return Err(syn::Error::new_spanned(
             auto_token,
             "an `auto` trait carries no methods and cannot be a binder interface",
@@ -410,9 +410,11 @@ fn make_fn_member(f: &TraitItemFn, index: u32) -> syn::Result<FnMembers> {
              alongside it",
         ));
     }
-    if let Some(tok) = &f.sig.unsafety {
+    // `Safety::Safe` parses only inside an `extern` block, so a trait method
+    // reaches here as either `Default` or `Unsafe`.
+    if !matches!(f.sig.safety, syn::Safety::Default) {
         return Err(syn::Error::new_spanned(
-            tok,
+            &f.sig.safety,
             "an `unsafe` binder method is not supported",
         ));
     }
@@ -442,7 +444,7 @@ fn make_fn_member(f: &TraitItemFn, index: u32) -> syn::Result<FnMembers> {
 
     let mut inputs = f.sig.inputs.iter();
     match inputs.next() {
-        Some(FnArg::Receiver(r)) if r.reference.is_some() && r.mutability.is_none() => {}
+        Some(FnArg::Receiver(r)) if matches!(r.kind, syn::ReceiverKind::Reference(_, _, None)) => {}
         _ => {
             return Err(syn::Error::new_spanned(
                 &f.sig,
@@ -1275,6 +1277,25 @@ parcelable GoldenConfig {
             }
         });
         assert!(err.contains("unsafe"), "{err}");
+    }
+
+    /// `syn` keeps the `mut` of `&mut self` inside the receiver kind, not
+    /// beside it, so a shape-only check has to name the kind.
+    #[test]
+    fn rejects_non_shared_receivers() {
+        for recv in [
+            quote!(self),
+            quote!(mut self),
+            quote!(&mut self),
+            quote!(self: Box<Self>),
+        ] {
+            let err = reject(quote! {
+                pub trait IBad {
+                    fn go(#recv) -> BinderResult<()>;
+                }
+            });
+            assert!(err.contains("`&self`"), "{recv}: {err}");
+        }
     }
 
     /// `check_supported` lets `Option<&str>` through for nullable *arguments*;

--- a/rsbinder-macros/src/parcelable.rs
+++ b/rsbinder-macros/src/parcelable.rs
@@ -45,7 +45,7 @@ pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream> {
 fn is_codec_item(item: &syn::Item) -> bool {
     match item {
         syn::Item::Impl(i) => !matches!(
-            i.trait_.as_ref().and_then(|(_, p, _)| p.segments.last()),
+            i.trait_.as_ref().and_then(|(p, _)| p.segments.last()),
             Some(seg) if seg.ident == "Default"
         ),
         syn::Item::Macro(_) => true,


### PR DESCRIPTION
Replaces #176, which failed CI. That PR raised three crates in one group; two of them land here, the third cannot.

## `syn 2 -> 3` — needs source changes

`rsbinder-macros` reads the AST directly, and syn 3 reshaped four of the nodes it touches:

| what | syn 2 | syn 3 |
| --- | --- | --- |
| `ItemImpl::trait_` | `(Option<Not>, Path, For)` | `(Path, For)` — polarity slot dropped |
| trait `auto` token | `ItemTrait::auto_token` | `ItemTrait::modifiers.auto_token` |
| fn safety | `Signature::unsafety: Option<..>` | `Signature::safety: Safety` enum |
| receiver | `Receiver::reference` / `::mutability` | `Receiver::kind: ReceiverKind` |

The receiver change is a trap. For a reference receiver, syn 3 moves the `mut` **into** `ReceiverKind::Reference(_, _, Option<mut>)`, so a check that still reads `Receiver::mutability` beside it silently accepts `&mut self` — exactly the shape the macro exists to refuse, since a binder object is shared. Nothing in the suite covered it, so `rejects_non_shared_receivers` now pins all four receiver shapes (`self`, `mut self`, `&mut self`, `self: Box<Self>`).

For safety, a trait method can only parse as `Default` or `Unsafe` (`safe fn` is accepted only inside an `extern` block), but the check rejects anything that is not `Default` rather than let a qualifier be dropped from the rendered trait.

syn is a normal dependency of `rsbinder-macros` and a dev-dependency of `rsbinder-aidl`; it appears in neither crate's public API, so there is no semver impact. MSRV 1.71, well under this workspace's 1.85.

## `rsproperties 0.5 -> 0.6` — drop-in

No source changes. MSRV 1.77.

## `serial_test 3 -> 4` — held back

4.0 declares `rust-version = 1.93.1`, above this workspace's 1.85, and the `Linux Build` job runs `cargo test --workspace --no-run`, which builds dev-dependencies. This would have failed the `rust_min` jobs even after the clippy job was fixed. Same class as the `trybuild = "=1.0.119"` pin directly above it, and the `ignore` / `globset` ceilings from #181.

Note that dependabot will keep proposing `serial_test 4` weekly. An `ignore` entry for its major updates in `.github/dependabot.yml` would stop the churn — left out of this PR as a separate call.

## Verification (macOS)

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo +1.85 check --workspace --all-features`, `cargo +1.85 test --workspace --no-run`
- rpc build matrix (default / `rpc` / `rpc-tcp-debug` / `rpc-tls` / `rpc-vsock`)
- `rsbinder` 217/0 (default) and 322/0 (`rpc`); `rsbinder-aidl` all suites 0 failed; `rsbinder-macros` 43/0 plus 14/14 trybuild UI cases and the golden macro-vs-`.aidl` equivalence tests
- the `rpc-suite` job's test set: rpc unit + e2e, tls, accessor, generated-stub, `macro_interface`, `macro_cross`

Kernel-binder e2e on Linux and the Android emulator matrix were not run: the change is proc-macro source plus dev-dependency ceilings, with no wire-format surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)