### PR TITLE
feat(rsbinder): wire LazyServiceRegistrar to the service manager; prep 0.11.0 docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,15 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Check rustdoc
+        # docs.rs builds `rsbinder` with `all-features`, so a link that only
+        # resolves with `rpc` on still ships — but anyone running `cargo doc`
+        # on a default-feature dependency sees it break. Gate both.
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: |
+          cargo doc --workspace --no-deps --all-features
+          cargo doc --workspace --no-deps
 
   linux-build:
     name: Linux Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -439,9 +439,12 @@ short form — and the first entry is the only one no compiler will catch.
   `tryUnregisterService` 12 → 13) while leaving the SDK at 35 — the interface
   is not a frozen `aidl_interface`, and AOSP is unaffected because
   `servicemanager` and `libbinder` ship in one image. rsbinder picks its
-  protocol from the SDK version, so on such a build it sent `addService` to
-  `checkService`; that reply carries a successful status, so a service
-  reported itself registered and was not there, with no error anywhere.
+  protocol from the SDK version, so on such a build it addressed the wrong
+  method for everything past `getService`: measured against the
+  `BP11.241210.004` servicemanager, `addService` lands on `checkService`,
+  which reads the name and leaves the rest of the parcel, and AOSP's
+  generated `onTransact` rejects the leftovers with `BAD_PARCELABLE`. Nothing
+  is registered, and the error says nothing about why.
   `hub::default` now measures which numbering the device speaks — one
   argument-free transaction to a code that exists in exactly one of the two —
   and returns an error naming the situation when it is the shifted one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ short form — and the first entry is the only one no compiler will catch.
 
 ### Added
 
+- **rsbinder (`lazy_service`):** `LazyServiceRegistrar::instance` — the
+  process-wide registrar, AOSP `getInstance`. A registrar has to outlive the
+  services it registers: the `IClientCallback` binder survives it (the
+  service manager holds a reference), but its link back to the bookkeeping is
+  weak, so dropping the last handle leaves the service manager calling a
+  callback that does nothing — services registered, process never shutting
+  down, nothing logged. `new` is still there for a second, independent
+  registrar (AOSP `createExtraTestInstance`) and now says so.
 - **rsbinder (`lazy_service`):** `LazyServiceRegistrar::set_active_services_callback`
   — AOSP `setActiveServicesCallback`. Reports whether any service in the
   process has clients, and by returning `true` takes the shutdown decision

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,7 +275,10 @@ short form — and the first entry is the only one no compiler will catch.
   `true`: AOSP `reRegisterLocked` leaves it alone, and inventing clients hides
   the state the service manager just reported. `LazyServiceRegistrar` is
   `Clone`, sharing one set of registrations the way AOSP's handle shares its
-  `ClientCounterCallback`.
+  `ClientCounterCallback`. Re-registering a name replaces the tracking entry
+  when the binder differs — AOSP keeps the first, which then fails to match
+  its own `onClients` — but never registers a second client callback: the
+  service manager stores those by name and de-duplicates nothing.
 
   One deliberate departure from AOSP: the service-manager calls are made
   without the registrar's lock held. A service manager may answer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ short form — and the first entry is the only one no compiler will catch.
   `service::{kernel,rpc}::{Host,Broker}`. Use `serve` / `connect`; the
   call-by-call mapping is under *Removed*.
 - **`rsb_hub` refuses to start without an access-control policy.** Give it
-  `--policy <PATH>` (default `/etc/rsbinder/hub.d`) or, deliberately,
+  `--config <PATH>` (default `/etc/rsbinder/hub.d`) or, deliberately,
   `--insecure-allow-all`.
 - **`rsb_device` creates the binder node `0600`.** Grant access with
   `--group <group> --mode 0660` and put the users in that group.
@@ -45,7 +45,12 @@ short form — and the first entry is the only one no compiler will catch.
   exits when its last client goes away.** It used to touch nothing outside
   the struct. Code that called it *and* did its own `addService` /
   `registerClientCallback` must drop those calls; code that relied on it
-  being inert needs `set_active_services_callback` or `force_persist`.
+  being inert needs `set_active_services_callback` or `force_persist`. Its
+  signature moved too: it takes `impl Into<SIBinder>` (drop the
+  `.as_binder()`) and returns `Result<(), Status>`, which keeps the service
+  manager's refusal code and message. `?` into a `StatusCode` still compiles
+  — `From<Status> for StatusCode` covers it — but a binding or `map_err` that
+  named `StatusCode` has to be retyped.
 - **`WIBinder` has no `Native` fallback for proxies.** A proxy's weak identity
   is stamped at construction; only an exhaustive `match` on the enum notices.
 
@@ -74,6 +79,10 @@ short form — and the first entry is the only one no compiler will catch.
   `example-hello/cpp/run_lazy_service_stage3.sh` runs the same thing against
   Android's own `servicemanager` instead of `rsb_hub`, which removes the
   circularity of testing our port against our port.
+- **rsbinder-tools (`rsb_hub`):** an honoured `tryUnregisterService` now logs
+  `Unregistering <name>`, as AOSP `ServiceManager.cpp` does. Without it a
+  lazy shutdown and a crash are indistinguishable in the log — the name
+  disappears either way, since the death notification would clear it too.
 - **rsbinder-tools (`rsb_service`):** a new CLI for asking the running service
   manager what it knows — the Linux counterpart of Android's `service` and
   `dumpsys -l`. `list`, `info`, `check`, `declared`, `instances`,
@@ -239,7 +248,7 @@ short form — and the first entry is the only one no compiler will catch.
   caller's uid and its NSS-resolved groups — the same policy model AOSP's
   `servicemanager` applies through SELinux, but keyed on credentials every
   platform reports rather than on an LSM that most Linux distributions do not
-  enable and macOS does not have. Policy is TOML, `--policy <PATH>` takes a
+  enable and macOS does not have. Policy is TOML, `--config <PATH>` takes a
   file or a directory of `*.toml` loaded in file-name order, and the first rule
   whose `name` pattern matches decides. `SIGHUP` reloads in place; a reload
   that fails to parse or resolve keeps the policy already in force. A denied
@@ -279,17 +288,32 @@ short form — and the first entry is the only one no compiler will catch.
   when the binder differs — AOSP keeps the first, which then fails to match
   its own `onClients` — but never registers a second client callback: the
   service manager stores those by name and de-duplicates nothing. The entry
-  is published before the `addService` / `registerClientCallback` round
-  trips rather than after, because the service manager dispatches `onClients`
-  from inside those calls and the driver lands it on the registering thread.
+  is published before the `addService` / `registerClientCallback` round trips
+  rather than after: the service manager dispatches `onClients` from inside
+  those calls, and since `IClientCallback` is `oneway` that notification runs
+  on a binder pool thread while the round trip is still open — an entry that
+  is not there yet would drop it, with no repeat coming. A newly registered
+  service starts with *no* clients, as AOSP's `Service::clients` does;
+  assuming one would be an assumption nothing takes back, because the service
+  manager reports only changes and never announces a name nobody looked up.
 
-  One deliberate departure from AOSP: the service-manager calls are made
-  without the registrar's lock held. A service manager may answer
-  `tryUnregisterService` by dispatching `onClients` back into this process,
-  and the binder driver delivers such a nested transaction on the very thread
-  that is waiting for the reply — which would deadlock on a non-reentrant
-  `Mutex`. The service manager is the authority on whether an unregister may
-  proceed, so nothing is lost by not holding it.
+  `register_service` takes `impl Into<SIBinder>` (so a `Strong<dyn IFoo>`
+  goes in directly, as with `hub::add_service`) and returns
+  `Result<(), Status>` rather than `Result<(), StatusCode>`, which kept the
+  service manager's refusal code and message. **Android 10 is refused before
+  `addService` is called**: that service manager has neither
+  `registerClientCallback` nor `tryUnregisterService`, so a service published
+  there could be neither tracked nor taken back down.
+
+  One deliberate departure from AOSP: the *state* lock is not held across the
+  service-manager calls, so an `onClients` arriving mid-round-trip is recorded
+  when it arrives instead of queueing behind the call it answers. What AOSP's
+  single `mMutex` also buys — no two service-manager sequences interleaving —
+  is kept by a second lock that spans a whole `register_service` or shutdown
+  decision. A shutdown that waited on a `register_service` runs the moment it
+  returns, so registering several services in a row can end mid-loop with the
+  process exiting; hold it with `force_persist(true)` if every service has to
+  be up first.
 - **rsbinder — breaking:** `ProcessState::init`'s `max_threads` is now passed
   to `BINDER_SET_MAX_THREADS` **as written**, matching AOSP's
   `setThreadPoolMaxThreadCount`. Previously `0` was a sentinel meaning "use
@@ -326,7 +350,7 @@ short form — and the first entry is the only one no compiler will catch.
   it can load an access-control policy, and denies every request the policy
   does not allow. Previously any local process could register, overwrite, look
   up, and enumerate any service. Existing deployments must supply a policy
-  (`--policy <PATH>`, default `/etc/rsbinder/hub.d`) or opt out explicitly with
+  (`--config <PATH>`, default `/etc/rsbinder/hub.d`) or opt out explicitly with
   `--insecure-allow-all`, which is named that way on purpose and cannot be
   reached by accident. There is no permissive fallback for a policy that fails
   to load: a typo in a config file must never silently remove access control
@@ -408,6 +432,23 @@ short form — and the first entry is the only one no compiler will catch.
 
 ### Fixed
 
+- **rsbinder (`hub`) — Android 15 QPR builds are now refused instead of
+  silently losing registrations.** `android-15.0.0_r6` inserted `getService2`
+  at index 1 of `IServiceManager.aidl`, shifting every transaction code after
+  it by one (`addService` 2 → 3, `registerClientCallback` 11 → 12,
+  `tryUnregisterService` 12 → 13) while leaving the SDK at 35 — the interface
+  is not a frozen `aidl_interface`, and AOSP is unaffected because
+  `servicemanager` and `libbinder` ship in one image. rsbinder picks its
+  protocol from the SDK version, so on such a build it sent `addService` to
+  `checkService`; that reply carries a successful status, so a service
+  reported itself registered and was not there, with no error anywhere.
+  `hub::default` now measures which numbering the device speaks — one
+  argument-free transaction to a code that exists in exactly one of the two —
+  and returns an error naming the situation when it is the shifted one.
+  Support for that protocol needs an `android_15` module and is not in this
+  release; the initial Android 15 release is unaffected and keeps working, and
+  so does every other version. Only kernel-binder use through `hub` is in
+  scope — the RPC transport does not go through the service manager.
 - **rsbinder (hub):** `ServiceManager::get_connection_info` did not compile
   on Android 13/14 — each version generates its own `ConnectionInfo` and the
   dispatch arms returned the version's type where the unified one was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ short form — and the first entry is the only one no compiler will catch.
   on a wire — the flag reaching the registry, the client callback landing,
   the hub's 5-second poller driving the shutdown, `tryUnregisterService`
   actually removing the name — is covered automatically for the first time.
+  `example-hello/cpp/run_lazy_service_stage3.sh` runs the same thing against
+  Android's own `servicemanager` instead of `rsb_hub`, which removes the
+  circularity of testing our port against our port.
 - **rsbinder-tools (`rsb_service`):** a new CLI for asking the running service
   manager what it knows — the Linux counterpart of Android's `service` and
   `dumpsys -l`. `list`, `info`, `check`, `declared`, `instances`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,7 +278,10 @@ short form — and the first entry is the only one no compiler will catch.
   `ClientCounterCallback`. Re-registering a name replaces the tracking entry
   when the binder differs — AOSP keeps the first, which then fails to match
   its own `onClients` — but never registers a second client callback: the
-  service manager stores those by name and de-duplicates nothing.
+  service manager stores those by name and de-duplicates nothing. The entry
+  is published before the `addService` / `registerClientCallback` round
+  trips rather than after, because the service manager dispatches `onClients`
+  from inside those calls and the driver lands it on the registering thread.
 
   One deliberate departure from AOSP: the service-manager calls are made
   without the registrar's lock held. A service manager may answer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,37 @@ This changelog starts at 0.9.0. For earlier releases, see the
 
 ## [Unreleased]
 
+### Migrating from 0.10.0
+
+The breaking changes are listed in *Changed* and *Removed* below. This is the
+short form — and the first entry is the only one no compiler will catch.
+
+- **`ProcessState::init(path, 0)` no longer means "the default".** The count
+  now reaches the kernel as written, so `0` asks for zero binder threads. The
+  signature did not change, so nothing warns: `cargo-semver-checks` cannot see
+  it and neither can your build. If you meant the default, pass the newly
+  public `DEFAULT_MAX_BINDER_THREADS`. `init_default()` and a `binder://` URI
+  without `?threads=` are unchanged.
+- **`rsbinder::service` is gone** — `Registry`, `Broker`,
+  `service::{kernel,rpc}::{Host,Broker}`. Use `serve` / `connect`; the
+  call-by-call mapping is under *Removed*.
+- **`rsb_hub` refuses to start without an access-control policy.** Give it
+  `--policy <PATH>` (default `/etc/rsbinder/hub.d`) or, deliberately,
+  `--insecure-allow-all`.
+- **`rsb_device` creates the binder node `0600`.** Grant access with
+  `--group <group> --mode 0660` and put the users in that group.
+- **Low-level `Parcel` accessors are `pub(crate)`** (`as_ptr`, `as_mut_ptr`,
+  `capacity`, `set_data_size`, `close_file_descriptors`, `is_empty`,
+  `from_vec`), along with the RPC-ops plumbing and three `thread_state`
+  helpers. `Parcel::from_ipc_parts` and `Parcel::set_for_rpc` remain the
+  supported raw-buffer entry points.
+- **The RPC wire codec is private** (`WireMessage`, `WireCodec`, `R34Codec`,
+  `Android13PlusCodec`, `WireReply`, `WireTransaction`, `RpcState`). The
+  supported RPC surface is `RpcServer` / `RpcSession` / `RpcProxy`, the
+  transport traits, and the address and identity types.
+- **`WIBinder` has no `Native` fallback for proxies.** A proxy's weak identity
+  is stamped at construction; only an exhaustive `match` on the enum notices.
+
 ### Added
 
 - **rsbinder-tools (`rsb_service`):** a new CLI for asking the running service
@@ -196,16 +227,6 @@ This changelog starts at 0.9.0. For earlier releases, see the
   device node. Binder has no in-kernel access control of its own, so the node
   is the only gate on who may speak binder at all.
 
-### Fixed
-
-- **rsbinder (hub):** `ServiceManager::get_connection_info` did not compile
-  on Android 13/14 — each version generates its own `ConnectionInfo` and the
-  dispatch arms returned the version's type where the unified one was
-  expected. Latent because no build enabled those features together.
-- **rsbinder (`ProxyHandle::dump`):** a `write_object` that failed after the
-  descriptor had been detached from its RAII wrapper leaked the descriptor.
-  Every other path is covered by the parcel's own ownership of it.
-
 ### Changed
 
 - **rsbinder — breaking:** `ProcessState::init`'s `max_threads` is now passed
@@ -264,9 +285,75 @@ This changelog starts at 0.9.0. For earlier releases, see the
   `build.rs` step to document. Existing manifests keep working; the dependency
   is simply redundant now. This changes the generated source text (not the
   wire) for async builds.
+- **rsbinder (rpc):** an RPC proxy now holds its `RpcSession` **strongly**
+  (AOSP `BpBinder` ↔ `sp<RpcSession>`). Dropping the `RpcSession` handle no
+  longer invalidates proxies obtained from it — the proxy alone keeps the
+  connection open, and the connection closes when the last proxy (and
+  handle) is gone. Previously every call on such a proxy returned
+  `DeadObject`. Code that relied on "drop the session to disconnect" while
+  still holding a proxy must drop the proxy too. To keep the strong ref
+  acyclic, session death now also releases every local object the peer
+  held (AOSP `RpcState::clear`), on both the served path and — new — a
+  client-only session whose last connection is lost (detected on the next
+  failed transaction, which also fires `DeathRecipient`s). Because a failing
+  transaction may now declare session death before the slot's own serve
+  worker exits, `serve_blocking` no longer trips a debug assertion on that
+  ordering.
+- **rsbinder (entry API):** `ServeOptions::fd_modes` / `ClientOptions::fd_mode`
+  now reject Unix fd passing on a transport that cannot carry `SCM_RIGHTS`
+  (vsock, TLS, kernel binder) instead of agreeing a mode that fails later on
+  the wire.
+- **rsbinder (AOSP alignment):** `FLAG_PRIVATE_VENDOR` is now `0x10000000`
+  (AOSP `IBinder.h`) instead of `0`. Code passing this flag to `transact`
+  now sets bit 28 on the wire. `FLAG_PRIVATE_LOCAL` is unchanged (`0`).
+- **rsbinder (`rpc` feature, breaking):** `WireMessage::DecStrong` now carries
+  the decrement amount (`DecStrong(RpcAddress, u32)`), and
+  `RpcState::dec_strong_local` takes an `amount` argument. A batched
+  `RpcDecStrong` from a libbinder peer (AOSP `sendDecStrongToTarget` sends
+  `timesRecd - target`) is now honored instead of applying a single decrement,
+  which under-counted and leaked local nodes.
+- **rsbinder (`rpc` feature, breaking):** the RPC wire-codec types
+  (`WireMessage`, `WireCodec`, `R34Codec`, `Android13PlusCodec`, `WireReply`,
+  `WireTransaction`) and `RpcState` are no longer part of the public API. They
+  were internal implementation detail — the codec is selected internally with no
+  user injection point, and `RpcState` is per-session bookkeeping. The public
+  RPC surface stays `RpcServer`, `RpcSession`, `RpcProxy`, the transport traits
+  (`RpcTransport`/`PeerIdentity`/`CertId`), and the address/identity types. This
+  lets the wire protocol evolve without further semver-breaking releases.
+- **rsbinder (breaking):** additional helpers that were `pub` but never part of
+  the intended API are now `pub(crate)`: the `Parcel` RPC-ops plumbing
+  (`RpcParcelOps`, `Parcel::attach_rpc_ops`, `FnFreeBuffer`), `rpc::RpcSessionInner`,
+  `RpcProxy::stamp_descriptor`, and the `thread_state` functions `check_interface`,
+  `is_handling_transaction`, and `get_calling_uid_or_self`. The public
+  `rsbinder::is_handling_transaction` (re-exported from `native`) is unchanged.
+- **rsbinder (breaking):** the low-level `Parcel` buffer accessors `as_ptr`,
+  `as_mut_ptr`, `capacity`, `set_data_size`, `close_file_descriptors`, `is_empty`,
+  and `from_vec` are now `pub(crate)` (internal kernel-buffer plumbing).
+  `Parcel::from_ipc_parts` (the documented `unsafe` raw-buffer primitive) and
+  `Parcel::set_for_rpc` remain public.
+
+### Removed
+
+- **rsbinder (`service` module):** the `rsbinder::service` facade (`Registry` /
+  `Broker`, `service::kernel::{Host, Broker}`, `service::rpc::{Host, Broker}`)
+  is gone, replaced by the entry API above (`serve` / `connect` / `Client`).
+  Migration: `kernel::Host::new()? + add_service + serve()` →
+  `serve("binder://")?.add(..)?.run()?`; `rpc::Host::unix(p)` →
+  `serve("unix://<p>")`; `kernel::Broker::new()?.get_interface(n)` →
+  `connect("binder://<n>")`; `rpc::Broker::unix(p)?.get_interface(n)` →
+  `connect("unix://<p>#<n>")`; `Host::builder()` options → `ServeOptions`
+  via `Server::with`. The examples, the book chapter *Cross-Transport
+  Services*, and the crate quick-start now use the entry API.
 
 ### Fixed
 
+- **rsbinder (hub):** `ServiceManager::get_connection_info` did not compile
+  on Android 13/14 — each version generates its own `ConnectionInfo` and the
+  dispatch arms returned the version's type where the unified one was
+  expected. Latent because no build enabled those features together.
+- **rsbinder (`ProxyHandle::dump`):** a `write_object` that failed after the
+  descriptor had been detached from its RAII wrapper leaked the descriptor.
+  Every other path is covered by the parcel's own ownership of it.
 - **rsbinder:** a `DeathRecipient` could not identify the binder that died.
   `SIBinder::downgrade` read a proxy's generation from the proxy cache and fell
   back to the `Native` variant when the entry was missing — and the obituary
@@ -396,71 +483,6 @@ This changelog starts at 0.9.0. For earlier releases, see the
   neither the trait's visibility — a private trait was reachable through it —
   nor the scope its own `Copy` assertion used, so a path in a by-value argument
   was resolved at two different depths.
-
-### Removed
-
-- **rsbinder (`service` module):** the `rsbinder::service` facade (`Registry` /
-  `Broker`, `service::kernel::{Host, Broker}`, `service::rpc::{Host, Broker}`)
-  is gone, replaced by the entry API above (`serve` / `connect` / `Client`).
-  Migration: `kernel::Host::new()? + add_service + serve()` →
-  `serve("binder://")?.add(..)?.run()?`; `rpc::Host::unix(p)` →
-  `serve("unix://<p>")`; `kernel::Broker::new()?.get_interface(n)` →
-  `connect("binder://<n>")`; `rpc::Broker::unix(p)?.get_interface(n)` →
-  `connect("unix://<p>#<n>")`; `Host::builder()` options → `ServeOptions`
-  via `Server::with`. The examples, the book chapter *Cross-Transport
-  Services*, and the crate quick-start now use the entry API.
-
-### Changed
-
-- **rsbinder (rpc):** an RPC proxy now holds its `RpcSession` **strongly**
-  (AOSP `BpBinder` ↔ `sp<RpcSession>`). Dropping the `RpcSession` handle no
-  longer invalidates proxies obtained from it — the proxy alone keeps the
-  connection open, and the connection closes when the last proxy (and
-  handle) is gone. Previously every call on such a proxy returned
-  `DeadObject`. Code that relied on "drop the session to disconnect" while
-  still holding a proxy must drop the proxy too. To keep the strong ref
-  acyclic, session death now also releases every local object the peer
-  held (AOSP `RpcState::clear`), on both the served path and — new — a
-  client-only session whose last connection is lost (detected on the next
-  failed transaction, which also fires `DeathRecipient`s). Because a failing
-  transaction may now declare session death before the slot's own serve
-  worker exits, `serve_blocking` no longer trips a debug assertion on that
-  ordering.
-- **rsbinder (entry API):** `ServeOptions::fd_modes` / `ClientOptions::fd_mode`
-  now reject Unix fd passing on a transport that cannot carry `SCM_RIGHTS`
-  (vsock, TLS, kernel binder) instead of agreeing a mode that fails later on
-  the wire.
-- **rsbinder (AOSP alignment):** `FLAG_PRIVATE_VENDOR` is now `0x10000000`
-  (AOSP `IBinder.h`) instead of `0`. Code passing this flag to `transact`
-  now sets bit 28 on the wire. `FLAG_PRIVATE_LOCAL` is unchanged (`0`).
-- **rsbinder (`rpc` feature, breaking):** `WireMessage::DecStrong` now carries
-  the decrement amount (`DecStrong(RpcAddress, u32)`), and
-  `RpcState::dec_strong_local` takes an `amount` argument. A batched
-  `RpcDecStrong` from a libbinder peer (AOSP `sendDecStrongToTarget` sends
-  `timesRecd - target`) is now honored instead of applying a single decrement,
-  which under-counted and leaked local nodes.
-- **rsbinder (`rpc` feature, breaking):** the RPC wire-codec types
-  (`WireMessage`, `WireCodec`, `R34Codec`, `Android13PlusCodec`, `WireReply`,
-  `WireTransaction`) and `RpcState` are no longer part of the public API. They
-  were internal implementation detail — the codec is selected internally with no
-  user injection point, and `RpcState` is per-session bookkeeping. The public
-  RPC surface stays `RpcServer`, `RpcSession`, `RpcProxy`, the transport traits
-  (`RpcTransport`/`PeerIdentity`/`CertId`), and the address/identity types. This
-  lets the wire protocol evolve without further semver-breaking releases.
-- **rsbinder (breaking):** additional helpers that were `pub` but never part of
-  the intended API are now `pub(crate)`: the `Parcel` RPC-ops plumbing
-  (`RpcParcelOps`, `Parcel::attach_rpc_ops`, `FnFreeBuffer`), `rpc::RpcSessionInner`,
-  `RpcProxy::stamp_descriptor`, and the `thread_state` functions `check_interface`,
-  `is_handling_transaction`, and `get_calling_uid_or_self`. The public
-  `rsbinder::is_handling_transaction` (re-exported from `native`) is unchanged.
-- **rsbinder (breaking):** the low-level `Parcel` buffer accessors `as_ptr`,
-  `as_mut_ptr`, `capacity`, `set_data_size`, `close_file_descriptors`, `is_empty`,
-  and `from_vec` are now `pub(crate)` (internal kernel-buffer plumbing).
-  `Parcel::from_ipc_parts` (the documented `unsafe` raw-buffer primitive) and
-  `Parcel::set_for_rpc` remain public.
-
-### Fixed
-
 - **fuzz:** the `rpc_wire_decode` / `rpc_address_decode` / `rpc_session_handshake`
   targets compile again — their entrypoints are re-exported as
   `rsbinder::rpc::__fuzz_*` after the wire-codec module became crate-private.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,28 @@ short form — and the first entry is the only one no compiler will catch.
   `Android13PlusCodec`, `WireReply`, `WireTransaction`, `RpcState`). The
   supported RPC surface is `RpcServer` / `RpcSession` / `RpcProxy`, the
   transport traits, and the address and identity types.
+- **`LazyServiceRegistrar::register_service` now registers, and the process
+  exits when its last client goes away.** It used to touch nothing outside
+  the struct. Code that called it *and* did its own `addService` /
+  `registerClientCallback` must drop those calls; code that relied on it
+  being inert needs `set_active_services_callback` or `force_persist`.
 - **`WIBinder` has no `Native` fallback for proxies.** A proxy's weak identity
   is stamped at construction; only an exhaustive `match` on the enum notices.
 
 ### Added
 
+- **rsbinder (`lazy_service`):** `LazyServiceRegistrar::set_active_services_callback`
+  — AOSP `setActiveServicesCallback`. Reports whether any service in the
+  process has clients, and by returning `true` takes the shutdown decision
+  over from the registrar. Fires only when the answer changes.
+- **example-hello (`hello_callback_demo`):** a real lazy service now — it
+  registers through `LazyServiceRegistrar` and exits by itself once the last
+  client goes away, rather than printing `onClients` transitions for a human
+  to read. `tests/scripts/run_lazy_service_ac.sh` runs it against `rsb_hub`
+  and gates on the exit status, so the half of the lazy path that only exists
+  on a wire — the flag reaching the registry, the client callback landing,
+  the hub's 5-second poller driving the shutdown, `tryUnregisterService`
+  actually removing the name — is covered automatically for the first time.
 - **rsbinder-tools (`rsb_service`):** a new CLI for asking the running service
   manager what it knows — the Linux counterpart of Android's `service` and
   `dumpsys -l`. `list`, `info`, `check`, `declared`, `instances`,
@@ -229,6 +246,33 @@ short form — and the first entry is the only one no compiler will catch.
 
 ### Changed
 
+- **rsbinder (`lazy_service`) — breaking:** `LazyServiceRegistrar` now does
+  what its name says. `register_service` makes the service-manager calls
+  itself — `addService` with AOSP's `FLAG_IS_LAZY_SERVICE`, then
+  `registerClientCallback` with an `IClientCallback` the module owns — routes
+  the incoming `onClients` into its own state machine, and once nothing is
+  using any of its services unregisters them and exits the process with
+  status 0. That is AOSP `tryShutdownLocked`, and the reason the pattern
+  exists: the service manager starts the process again on the next lookup.
+  It used to be an in-process state machine that made no calls at all, so
+  `register_service` registered nothing and a caller owed every one of those
+  steps by hand — none of which the type could tell them about.
+
+  `force_persist` suspends the shutdown as before (and releasing it re-checks
+  immediately, as AOSP does); the new `set_active_services_callback` takes the
+  decision over entirely. `re_register` no longer resets `has_clients` to
+  `true`: AOSP `reRegisterLocked` leaves it alone, and inventing clients hides
+  the state the service manager just reported. `LazyServiceRegistrar` is
+  `Clone`, sharing one set of registrations the way AOSP's handle shares its
+  `ClientCounterCallback`.
+
+  One deliberate departure from AOSP: the service-manager calls are made
+  without the registrar's lock held. A service manager may answer
+  `tryUnregisterService` by dispatching `onClients` back into this process,
+  and the binder driver delivers such a nested transaction on the very thread
+  that is waiting for the reply — which would deadlock on a non-reentrant
+  `Mutex`. The service manager is the authority on whether an unregister may
+  proceed, so nothing is lost by not holding it.
 - **rsbinder — breaking:** `ProcessState::init`'s `max_threads` is now passed
   to `BINDER_SET_MAX_THREADS` **as written**, matching AOSP's
   `setThreadPoolMaxThreadCount`. Previously `0` was a sentinel meaning "use

--- a/example-hello/cpp/run_lazy_service_stage3.sh
+++ b/example-hello/cpp/run_lazy_service_stage3.sh
@@ -4,10 +4,15 @@
 # The Linux gate (`tests/scripts/run_lazy_service_ac.sh`) drives the same path
 # against `rsb_hub`, which is our own port of AOSP `ServiceManager.cpp`. This
 # one removes that circularity: the peer here is the AOSP binary, so what it
-# proves is that the wire rsbinder speaks — `addService` with
-# `FLAG_IS_LAZY_SERVICE`, `registerClientCallback`, the `onClients` a real
-# `handleClientCallbacks` timer sends, and `tryUnregisterService` — is the
-# wire AOSP expects.
+# proves is that the wire rsbinder speaks — `addService`,
+# `registerClientCallback`, the `onClients` a real `handleClientCallbacks`
+# timer sends, and `tryUnregisterService` — is the wire AOSP expects.
+#
+# Not covered here: the *value* of `FLAG_IS_LAZY_SERVICE`. AOSP reads that bit
+# in exactly one place (`ServiceManager.cpp`, to fill
+# `ServiceWithMetadata::isLazyService`), and nothing in this run consults it,
+# so dropping the flag would leave every check below green. The Linux gate's
+# `lazy=yes` column carries that half.
 #
 #   ANDROID_NDK_HOME=/opt/homebrew/share/android-ndk \
 #     cargo ndk -t aarch64-linux-android build -p example-hello --bins
@@ -30,8 +35,7 @@ SERVICE=my.hello
 PASS=0; FAIL=0
 
 # `pkill -x` matches the 15-char-truncated comm. `pkill -f` would match the
-# adb shell's own command line and kill the shell instead — see the trap
-# notes in tests/scripts and the emulator memory.
+# adb shell's own command line and kill the shell instead.
 DEMO_COMM=hello_callback_
 CLIENT_COMM=hello_client
 
@@ -83,13 +87,14 @@ else
     bad "it exited early: $(sh_ "cat $DEV/lazy.log" | tail -5)"
 fi
 
-# `service check` prints "Service <name>: found" or "... : not found", so the
-# test has to be for the *absence* of "not found" — grepping for "found"
-# matches both.
-if sh_ "service check $SERVICE" | grep -q 'not found'; then
-    bad "service check says: $(sh_ "service check $SERVICE")"
-else
+# `service check` prints "Service <name>: found" or "... : not found", so
+# neither direction may be tested by grepping for "found" alone — and testing
+# for the *absence* of "not found" passes on empty output too (a dropped adb
+# connection, a servicemanager restart). Match the whole line each way.
+if sh_ "service check $SERVICE" | grep -q "Service $SERVICE: found"; then
     ok "registered with the platform servicemanager"
+else
+    bad "service check says: $(sh_ "service check $SERVICE")"
 fi
 
 # AOSP `ServiceManager::addService` only *warns* when no priority bit is set
@@ -184,7 +189,7 @@ fi
 # and this shell observing it.
 gone=0
 for _ in 1 2 3 4 5; do
-    sh_ "service check $SERVICE" | grep -q 'not found' && { gone=1; break; }
+    sh_ "service check $SERVICE" | grep -q "Service $SERVICE: not found" && { gone=1; break; }
     sleep 1
 done
 if [ "$gone" = 1 ]; then ok "the name is gone from the platform registry"

--- a/example-hello/cpp/run_lazy_service_stage3.sh
+++ b/example-hello/cpp/run_lazy_service_stage3.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# STAGE3: `LazyServiceRegistrar` against Android's **real** servicemanager.
+#
+# The Linux gate (`tests/scripts/run_lazy_service_ac.sh`) drives the same path
+# against `rsb_hub`, which is our own port of AOSP `ServiceManager.cpp`. This
+# one removes that circularity: the peer here is the AOSP binary, so what it
+# proves is that the wire rsbinder speaks — `addService` with
+# `FLAG_IS_LAZY_SERVICE`, `registerClientCallback`, the `onClients` a real
+# `handleClientCallbacks` timer sends, and `tryUnregisterService` — is the
+# wire AOSP expects.
+#
+#   ANDROID_NDK_HOME=/opt/homebrew/share/android-ndk \
+#     cargo ndk -t aarch64-linux-android build -p example-hello --bins
+#   ./example-hello/cpp/run_lazy_service_stage3.sh [serial]
+#
+# Needs a userdebug/google_apis AVD: `addService` from the shell domain is an
+# SELinux denial otherwise, so the script needs `adb root` + `setenforce 0`.
+# It restores the previous enforcing mode on exit.
+set -u
+
+cd "$(dirname "$0")/../.." || exit 1
+
+SERIAL=${1:-}
+ADB=(adb)
+[ -n "$SERIAL" ] && ADB=(adb -s "$SERIAL")
+
+DEV=/data/local/tmp
+BIN=target/aarch64-linux-android/debug
+SERVICE=my.hello
+PASS=0; FAIL=0
+
+# `pkill -x` matches the 15-char-truncated comm. `pkill -f` would match the
+# adb shell's own command line and kill the shell instead — see the trap
+# notes in tests/scripts and the emulator memory.
+DEMO_COMM=hello_callback_
+CLIENT_COMM=hello_client
+
+note() { printf '\n=== %s\n' "$*"; }
+ok()   { PASS=$((PASS+1)); printf '  PASS  %s\n' "$*"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$*"; }
+sh_() { "${ADB[@]}" shell "$@"; }
+
+for f in hello_callback_demo hello_client; do
+    [ -x "$BIN/$f" ] || { echo "missing $BIN/$f — see the build line in this script's header"; exit 2; }
+done
+
+"${ADB[@]}" root >/dev/null 2>&1
+sh_ 'true' >/dev/null 2>&1 || { echo "no device (serial: ${SERIAL:-default})"; exit 2; }
+
+PREV_ENFORCE=$(sh_ 'getenforce' | tr -d '\r')
+cleanup() {
+    sh_ "pkill -x $CLIENT_COMM; pkill -x $DEMO_COMM" >/dev/null 2>&1
+    [ "$PREV_ENFORCE" = "Enforcing" ] && sh_ 'setenforce 1' >/dev/null 2>&1
+}
+trap cleanup EXIT
+sh_ 'setenforce 0' >/dev/null 2>&1
+
+sh_ "pkill -x $CLIENT_COMM; pkill -x $DEMO_COMM" >/dev/null 2>&1
+# The L3-4 verdict reads servicemanager's own log, so only this run's lines
+# may be in it.
+"${ADB[@]}" logcat -c >/dev/null 2>&1
+for f in hello_callback_demo hello_client; do
+    "${ADB[@]}" push "$BIN/$f" "$DEV/$f" >/dev/null 2>&1 || { echo "push $f failed"; exit 2; }
+done
+sh_ "chmod 755 $DEV/hello_callback_demo $DEV/hello_client" >/dev/null 2>&1
+
+######################################################################
+note "L3-1  register_service is accepted by AOSP servicemanager"
+
+sh_ "cd $DEV && (TMPDIR=$DEV RUST_LOG=info nohup ./hello_callback_demo > lazy.log 2>&1 &)" >/dev/null 2>&1
+# Hold a client straight away: with none, the servicemanager's own 5-second
+# timer would report zero clients and take the process down before the later
+# gates could look at it. That is the behaviour L3-3 measures deliberately.
+sh_ "cd $DEV && (TMPDIR=$DEV RUST_LOG=warn nohup ./hello_client > lazyclient.log 2>&1 &)" >/dev/null 2>&1
+sleep 4
+
+if [ -n "$(sh_ "pgrep -x $DEMO_COMM" | tr -d '\r')" ]; then
+    ok "the lazy service is running"
+else
+    bad "it exited early: $(sh_ "cat $DEV/lazy.log" | tail -5)"
+fi
+
+# `service check` prints "Service <name>: found" or "... : not found", so the
+# test has to be for the *absence* of "not found" — grepping for "found"
+# matches both.
+if sh_ "service check $SERVICE" | grep -q 'not found'; then
+    bad "service check says: $(sh_ "service check $SERVICE")"
+else
+    ok "registered with the platform servicemanager"
+fi
+
+# AOSP `ServiceManager::addService` only *warns* when no priority bit is set
+# and never rejects an unknown one, so a rejected registration here would
+# mean the parcel itself was wrong, not the flag value.
+if sh_ "cat $DEV/lazy.log" | grep -q 'Registered lazy service'; then
+    ok "addService with FLAG_IS_LAZY_SERVICE returned ok"
+else
+    bad "registration log: $(sh_ "cat $DEV/lazy.log" | tail -5)"
+fi
+
+# Gate this explicitly. A client that died early would leave L3-2 passing for
+# the wrong reason — "still alive" means nothing if nothing was holding it.
+if [ -n "$(sh_ "pgrep -x $CLIENT_COMM" | tr -d '\r')" ]; then
+    ok "a client is holding the service"
+else
+    bad "the client is not running: $(sh_ "cat $DEV/lazyclient.log" | tail -3)"
+fi
+
+######################################################################
+note "L3-2  a held client keeps it alive across servicemanager timer ticks"
+
+# AOSP `kClientCallbackCheckInterval` is 5s, same as the rsb_hub poller.
+sleep 12
+if [ -z "$(sh_ "pgrep -x $CLIENT_COMM" | tr -d '\r')" ]; then
+    bad "the client died during the wait — this gate proved nothing"
+elif [ -n "$(sh_ "pgrep -x $DEMO_COMM" | tr -d '\r')" ]; then
+    ok "still running after two timer ticks with a client attached"
+else
+    bad "shut down while a client held it: $(sh_ "cat $DEV/lazy.log" | tail -10)"
+fi
+
+######################################################################
+note "L3-3  the last client leaving shuts it down"
+
+sh_ "pkill -x $CLIENT_COMM" >/dev/null 2>&1
+
+waited=0
+while [ -n "$(sh_ "pgrep -x $DEMO_COMM" | tr -d '\r')" ] && [ "$waited" -lt 25 ]; do
+    sleep 1
+    waited=$((waited + 1))
+done
+
+if [ -n "$(sh_ "pgrep -x $DEMO_COMM" | tr -d '\r')" ]; then
+    bad "still running 25s after the last client left: $(sh_ "cat $DEV/lazy.log" | tail -10)"
+else
+    ok "shut down on its own after ${waited}s"
+fi
+
+if sh_ "cat $DEV/lazy.log" | grep -q 'has_clients=false'; then
+    ok "the real servicemanager delivered onClients(false)"
+else
+    bad "no has_clients=false: $(sh_ "cat $DEV/lazy.log" | tail -10)"
+fi
+
+######################################################################
+note "L3-4  AOSP honoured tryUnregisterService"
+
+# The verdict is servicemanager's own statement about which branch it took:
+# `Unregistering <name>` is the erase, and it is the only path that returns
+# `Status::ok()`. Reading the registry alone cannot tell that apart from the
+# entry being dropped later by the process's death notification, which is
+# what would happen if the unregister had been refused.
+SM_LOG=$("${ADB[@]}" logcat -d 2>/dev/null | grep "servicemanager" | grep -- "$SERVICE")
+if grep -q "Unregistering $SERVICE" <<<"$SM_LOG"; then
+    ok "servicemanager logged the unregister (not a death-driven cleanup)"
+else
+    bad "no 'Unregistering $SERVICE' from servicemanager: $(tail -5 <<<"$SM_LOG")"
+fi
+if grep -q "Tried to unregister $SERVICE" <<<"$SM_LOG"; then
+    bad "servicemanager refused it: $(grep "Tried to unregister" <<<"$SM_LOG" | tail -2)"
+else
+    ok "no refusal logged"
+fi
+
+# The erase is synchronous inside the call, so this is settled by the time the
+# process is gone; the retry only absorbs the gap between the process dying
+# and this shell observing it.
+gone=0
+for _ in 1 2 3 4 5; do
+    sh_ "service check $SERVICE" | grep -q 'not found' && { gone=1; break; }
+    sleep 1
+done
+if [ "$gone" = 1 ]; then ok "the name is gone from the platform registry"
+else bad "still registered: $(sh_ "service check $SERVICE")"; fi
+
+######################################################################
+printf '\n===== %d passed, %d failed =====\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/example-hello/cpp/run_lazy_service_stage3.sh
+++ b/example-hello/cpp/run_lazy_service_stage3.sh
@@ -67,7 +67,10 @@ sh_ "chmod 755 $DEV/hello_callback_demo $DEV/hello_client" >/dev/null 2>&1
 ######################################################################
 note "L3-1  register_service is accepted by AOSP servicemanager"
 
-sh_ "cd $DEV && (TMPDIR=$DEV RUST_LOG=info nohup ./hello_callback_demo > lazy.log 2>&1 &)" >/dev/null 2>&1
+# Wrapped so the exit status survives the process: "it is gone" and "it
+# called exit(EXIT_SUCCESS)" are different claims, and AOSP's contract is
+# the second one.
+sh_ "cd $DEV && rm -f lazy.rc && (TMPDIR=$DEV RUST_LOG=info nohup sh -c './hello_callback_demo > lazy.log 2>&1; echo \$? > lazy.rc' >/dev/null 2>&1 &)" >/dev/null 2>&1
 # Hold a client straight away: with none, the servicemanager's own 5-second
 # timer would report zero clients and take the process down before the later
 # gates could look at it. That is the behaviour L3-3 measures deliberately.
@@ -140,6 +143,20 @@ if sh_ "cat $DEV/lazy.log" | grep -q 'has_clients=false'; then
     ok "the real servicemanager delivered onClients(false)"
 else
     bad "no has_clients=false: $(sh_ "cat $DEV/lazy.log" | tail -10)"
+fi
+
+# The wrapper writes the status after the process it started is reaped, so
+# give it a moment past the `pgrep` going quiet.
+rc=""
+for _ in 1 2 3 4 5; do
+    rc=$(sh_ "cat $DEV/lazy.rc 2>/dev/null" | tr -d '\r')
+    [ -n "$rc" ] && break
+    sleep 1
+done
+if [ "$rc" = 0 ]; then
+    ok "exit 0 (AOSP exit(EXIT_SUCCESS))"
+else
+    bad "exit ${rc:-<none recorded>}, want 0"
 fi
 
 ######################################################################

--- a/example-hello/src/bin/hello_callback_demo.rs
+++ b/example-hello/src/bin/hello_callback_demo.rs
@@ -12,8 +12,9 @@
 //
 // Expected trace, paired with rsb_hub and a short-lived `hello_client`:
 //   1. T+0        register_service → addService + registerClientCallback.
-//                 The service starts out assumed to have clients, so the
-//                 process cannot exit before the hub has said anything.
+//                 Nothing has looked the service up yet, so it starts with
+//                 no clients — and the hub reports only changes, so the
+//                 shutdown check waits for one to happen.
 //   2. T+x        `hello_client` looks the service up → the hub reports
 //                 clients → `has_clients=true`.
 //   3. T+x+1      `hello_client` exits → the kernel ref count drops.
@@ -28,8 +29,6 @@
 //
 // `tests/scripts/run_lazy_service_ac.sh` runs exactly that and gates on the
 // exit status.
-#![allow(non_snake_case)]
-
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -52,6 +51,10 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // `ProcessState` has to exist first.
     ProcessState::init_default()?;
 
+    // `echo` and the registrar's own `onClients` are both inbound
+    // transactions, so the pool has to be running to serve them.
+    ProcessState::start_thread_pool();
+
     let service = BnHello::new_binder(IHelloService {});
     // The process-wide registrar — it has to outlive what it registers.
     let registrar = LazyServiceRegistrar::instance();
@@ -68,14 +71,14 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         false
     }));
 
-    registrar.register_service(SERVICE_NAME, service.as_binder())?;
+    // The registrar holds the binder for as long as it tracks the service,
+    // so nothing here has to keep `service` alive.
+    registrar.register_service(SERVICE_NAME, service)?;
     println!("Registered lazy service: {SERVICE_NAME}");
 
-    // Keep the service binder alive for as long as the process runs.
-    let _keep_alive = service;
-
     // Returns only if the thread pool is torn down; the usual exit is
-    // `LazyServiceRegistrar`'s own, from the callback thread.
+    // `LazyServiceRegistrar`'s own, from the binder thread that took the
+    // `onClients`.
     ProcessState::join_thread_pool()?;
     Ok(())
 }

--- a/example-hello/src/bin/hello_callback_demo.rs
+++ b/example-hello/src/bin/hello_callback_demo.rs
@@ -1,40 +1,40 @@
 // Copyright 2026 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 //
-// Lazy-service-style demo: registers `SERVICE_NAME` and then registers
-// *itself* as the `IClientCallback` for that name. Every `onClients`
-// transition prints to stdout with a wall-clock offset, so the rsb_hub
-// 5-second client-callback poller can be observed end-to-end.
+// Lazy service: registers `SERVICE_NAME` through `LazyServiceRegistrar` and
+// **exits by itself** once nothing is using it. That is the whole point of
+// the pattern — the service manager starts the process again on the next
+// lookup, so an idle service costs nothing.
 //
-// Expected trace when paired with rsb_hub + a short-lived
-// `hello_client`:
-//   1. T+0   addService + registerClientCallback → first internal
-//            `handle_service_client_callback(..., is_called_on_interval=false)`
-//            may already emit `onClients(true)` if the kernel ref-count
-//            seen by rsb_hub exceeds `KNOWN_CLIENTS=2`.
-//   2. T+x   external `hello_client` calls `get_service(SERVICE_NAME)`
-//            → rsb_hub sets `guarantee_client=true`. Either fires a
-//            fresh `onClients(true)` or is a no-op if state already
-//            matches (the latter exercises the A2 "log+return" guard
-//            replacing the prior `process::abort()`).
-//   3. T+x+1 `hello_client` exits → kernel binder ref-count drops.
-//   4. T+x+(≤5)  rsb_hub's 5-second poller wakes and calls
-//            `handle_service_client_callback(..., is_called_on_interval=true)`
-//            → `has_kernel_reported_clients=false` + `has_clients=true`
-//            arm fires `onClients(false)`.
+// The registrar does the service-manager work: `addService` with
+// `FLAG_IS_LAZY_SERVICE`, `registerClientCallback`, and the `onClients`
+// bookkeeping. Nothing here registers a callback by hand.
+//
+// Expected trace, paired with rsb_hub and a short-lived `hello_client`:
+//   1. T+0        register_service → addService + registerClientCallback.
+//                 The service starts out assumed to have clients, so the
+//                 process cannot exit before the hub has said anything.
+//   2. T+x        `hello_client` looks the service up → the hub reports
+//                 clients → `has_clients=true`.
+//   3. T+x+1      `hello_client` exits → the kernel ref count drops.
+//   4. T+x+(≤5)   the hub's 5-second poller reports `onClients(false)` →
+//                 tryUnregisterService → the process exits 0.
 //
 // Use with:
 //   RUST_LOG=info ./hello_callback_demo &
 //   sleep 2
 //   timeout 3 ./hello_client          # touches my.hello + exits
-//   sleep 8                            # let the 5s poller fire
-//   pkill hello_callback_demo
+//   wait                              # the demo exits on its own
+//
+// `tests/scripts/run_lazy_service_ac.sh` runs exactly that and gates on the
+// exit status.
 #![allow(non_snake_case)]
 
+use std::sync::Arc;
 use std::time::Instant;
 
 use example_hello::*;
-use rsbinder::hub::{BnClientCallback, IClientCallback};
+use rsbinder::lazy_service::LazyServiceRegistrar;
 use rsbinder::*;
 
 struct IHelloService;
@@ -45,46 +45,36 @@ impl IHello for IHelloService {
     }
 }
 
-struct MyClientCallback {
-    start: Instant,
-}
-impl Interface for MyClientCallback {}
-impl IClientCallback for MyClientCallback {
-    fn onClients(&self, _registered: &SIBinder, has_clients: bool) -> rsbinder::status::Result<()> {
-        let elapsed = self.start.elapsed().as_secs_f32();
-        println!("[+{elapsed:5.1}s] onClients(has_clients={has_clients})");
-        Ok(())
-    }
-}
-
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
-    // `serve` + `add` registers with the service manager right away; the
-    // kernel-only `registerClientCallback` extra (reached via `hub`) runs
-    // before `run()` starts the thread pool and joins it.
+    // `register_service` talks to the service manager, so the kernel binder
+    // `ProcessState` has to exist first.
+    ProcessState::init_default()?;
+
     let service = BnHello::new_binder(IHelloService {});
-    let service_binder = service.as_binder();
-    let server = rsbinder::serve("binder://")?.add(SERVICE_NAME, service_binder.clone())?;
-    println!("Registered service: {SERVICE_NAME}");
+    let registrar = LazyServiceRegistrar::new();
 
+    // Observe the transitions without taking the decision away: returning
+    // `false` means "not handled", so the registrar still shuts the process
+    // down when the count reaches zero.
     let start = Instant::now();
-    let callback = BnClientCallback::new_binder(MyClientCallback { start });
+    registrar.set_active_services_callback(Arc::new(move |has_clients| {
+        println!(
+            "[+{:5.1}s] has_clients={has_clients}",
+            start.elapsed().as_secs_f32()
+        );
+        false
+    }));
 
-    // `hub::register_client_callback` hides the per-version ServiceManager
-    // dispatch, so the demo no longer reaches into a `BpServiceManager`
-    // variant by hand.
-    hub::register_client_callback(SERVICE_NAME, &service_binder, &callback)
-        .map_err(|e| format!("registerClientCallback failed: {e:?}"))?;
-    println!(
-        "[+{:5.1}s] Registered client callback; awaiting transitions...",
-        start.elapsed().as_secs_f32()
-    );
+    registrar.register_service(SERVICE_NAME, service.as_binder())?;
+    println!("Registered lazy service: {SERVICE_NAME}");
 
-    // Keep the service binder alive for the lifetime of the process —
-    // the `service` local goes out of scope only when `join_thread_pool`
-    // returns (which it normally doesn't).
+    // Keep the service binder alive for as long as the process runs.
     let _keep_alive = service;
 
-    Ok(server.run()?)
+    // Returns only if the thread pool is torn down; the usual exit is
+    // `LazyServiceRegistrar`'s own, from the callback thread.
+    ProcessState::join_thread_pool()?;
+    Ok(())
 }

--- a/example-hello/src/bin/hello_callback_demo.rs
+++ b/example-hello/src/bin/hello_callback_demo.rs
@@ -53,7 +53,8 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     ProcessState::init_default()?;
 
     let service = BnHello::new_binder(IHelloService {});
-    let registrar = LazyServiceRegistrar::new();
+    // The process-wide registrar — it has to outlive what it registers.
+    let registrar = LazyServiceRegistrar::instance();
 
     // Observe the transitions without taking the decision away: returning
     // `false` means "not handled", so the registrar still shuts the process

--- a/rsbinder-tools/src/bin/rsb_hub.rs
+++ b/rsbinder-tools/src/bin/rsb_hub.rs
@@ -1719,6 +1719,11 @@ impl IServiceManager for ServiceManager {
                 return Err((ExceptionCode::IllegalState, msg.as_str()).into());
             }
 
+            // AOSP `ServiceManager.cpp:1128`. The only log that separates an
+            // honoured unregister from a death-driven cleanup, which is what
+            // the entry disappearing looks like either way.
+            log::info!("{context:?} Unregistering {name}");
+
             // Release this registration's reference on the subscription
             // before dropping the entry, so a register→tryUnregister cycle
             // (a lazy service idling and reactivating) is net-zero.

--- a/rsbinder-tools/src/bin/rsb_hub.rs
+++ b/rsbinder-tools/src/bin/rsb_hub.rs
@@ -156,7 +156,7 @@ fn distinct_name_cap_exceeded<V>(map: &BTreeMap<String, V>, name: &str) -> bool 
 /// strongly, and a strong reference here would keep a proxy — and its
 /// kernel ref — alive past the registry entry that justified it. The weak
 /// reference is what an obituary carries, so it is also what
-/// [`Inner::forget_death_link`] matches on.
+/// [`Inner::retire_dead_binder`] matches on.
 struct DeathLink {
     weak: rsbinder::WIBinder,
     count: usize,
@@ -234,7 +234,7 @@ impl Inner {
     /// A native binder cannot be linked and is silently skipped, so callers
     /// do not need to test for it. Every successful call must be paired
     /// with exactly one [`Inner::release_death_link`] or, once the binder
-    /// has died, one [`Inner::forget_death_link`].
+    /// has died, one [`Inner::retire_dead_binder`].
     fn retain_death_link(&mut self, binder: &SIBinder) -> rsbinder::status::Result<()> {
         let Some(handle) = binder.as_proxy().map(|proxy| proxy.handle()) else {
             return Ok(());

--- a/rsbinder-tools/src/config/enforcer.rs
+++ b/rsbinder-tools/src/config/enforcer.rs
@@ -17,10 +17,10 @@ use super::parse::Config;
 use super::policy::{Permission, Subject};
 use crate::nss::GroupCache;
 
-/// Applies a [`Policy`] to live callers.
+/// Applies a [`Policy`](super::policy::Policy) to live callers.
 ///
 /// Held behind a shared reference for the lifetime of `rsb_hub`; the
-/// policy inside can be swapped by [`replace_policy`](Self::replace_policy)
+/// policy inside can be swapped by [`replace`](Self::replace)
 /// on SIGHUP without disturbing in-flight transactions.
 pub struct Enforcer {
     config: RwLock<Arc<Config>>,
@@ -110,7 +110,7 @@ impl Enforcer {
     /// principal, a TLS certificate needs a certificate→principal mapping
     /// that does not exist here, and an anonymous peer has no identity at
     /// all. Denying is the only honest answer for those — see
-    /// [`rsbinder::rpc::PeerIdentity`].
+    /// `rsbinder::rpc::PeerIdentity`.
     pub fn check_caller(&self, permission: Permission, name: &str, caller: &Caller) -> bool {
         match uid_of(caller) {
             Some(uid) => self.check_uid(permission, name, uid),

--- a/rsbinder-tools/src/config/parse.rs
+++ b/rsbinder-tools/src/config/parse.rs
@@ -150,7 +150,7 @@ pub enum ConfigError {
         name: String,
     },
     /// A configuration path anyone but root or this process can rewrite.
-    /// See [`super::trust`].
+    /// See [`TrustProblem`](super::TrustProblem).
     #[error("{path} is {problem}; refusing to load configuration from it")]
     Untrusted {
         /// The offending path.

--- a/rsbinder/src/hub/mod.rs
+++ b/rsbinder/src/hub/mod.rs
@@ -411,17 +411,20 @@ fn check_android_15_numbering(context: &SIBinder) -> Result<()> {
         // module sends are the ones it answers.
         Err(StatusCode::UnknownTransaction) => Ok(()),
         // Answered: 15 methods. Every code from `checkService` on is one
-        // higher than this module sends, and the damage is silent —
-        // `addService` would land on `checkService`, whose reply carries a
-        // successful status, so a service would report itself registered and
-        // not be there.
+        // higher than this module sends. Measured against the real
+        // servicemanager from `BP11.241210.004`: `addService` lands on
+        // `checkService`, which reads the name and leaves the rest, and
+        // AOSP's generated `onTransact` rejects the leftovers as
+        // `BAD_PARCELABLE`. So the calls fail rather than corrupt — but they
+        // fail saying nothing about why, on every method that moved.
         Ok(_) => {
             log::error!(
                 "Android 15 service manager with shifted transaction codes \
                  (android-15.0.0_r6 or later - a QPR build). rsbinder has no \
-                 module for that protocol, and the android_14 one would \
-                 register services that silently do not exist, so the service \
-                 manager is refused. Only kernel-binder use through `hub` is \
+                 module for that protocol; the android_14 one addresses the \
+                 wrong method for everything past `getService`, so the \
+                 service manager is refused here rather than left to fail one \
+                 call at a time. Only kernel-binder use through `hub` is \
                  affected; the RPC transport is not."
             );
             Err(StatusCode::InvalidOperation)

--- a/rsbinder/src/hub/mod.rs
+++ b/rsbinder/src/hub/mod.rs
@@ -1033,6 +1033,36 @@ impl ServiceManager {
         }
     }
 
+    /// [`add_service`](Self::add_service) with AOSP's `FLAG_IS_LAZY_SERVICE`
+    /// set in `dumpPriority`, so the service manager can report the service
+    /// as lazy (`getServiceDebugInfo().isLazyService`, `rsb_service info`).
+    ///
+    /// The flag is an Android 16 `IServiceManager` constant — AOSP added it
+    /// in `android-15.0.0_r20` — so the older protocols register without it,
+    /// exactly as their own libbinder did. Crate-private because AOSP's
+    /// `LazyServiceRegistrar` is the only thing that may set it (it warns if
+    /// a caller pre-set the bit).
+    pub(crate) fn add_lazy_service(
+        &self,
+        identifier: &str,
+        binder: impl Into<SIBinder>,
+    ) -> std::result::Result<(), Status> {
+        let binder = binder.into();
+        match self {
+            #[cfg(all(target_os = "android", feature = "android_10"))]
+            ServiceManager::Android10(sm) => android_10::add_service(sm, identifier, binder),
+            #[cfg(all(target_os = "android", feature = "android_11"))]
+            ServiceManager::Android11(sm) => android_11::add_service(sm, identifier, binder),
+            #[cfg(all(target_os = "android", feature = "android_12"))]
+            ServiceManager::Android12(sm) => android_12::add_service(sm, identifier, binder),
+            #[cfg(all(target_os = "android", feature = "android_13"))]
+            ServiceManager::Android13(sm) => android_13::add_service(sm, identifier, binder),
+            #[cfg(all(target_os = "android", feature = "android_14"))]
+            ServiceManager::Android14(sm) => android_14::add_service(sm, identifier, binder),
+            ServiceManager::Android16(sm) => android_16::add_lazy_service(sm, identifier, binder),
+        }
+    }
+
     /// Retrieves debug information about all currently registered services.
     ///
     /// Note: not supported on Android 10 or Android 11 - returns an error on those versions.
@@ -1602,6 +1632,14 @@ pub fn add_service(
 ) -> std::result::Result<(), Status> {
     // `?` converts a StatusCode init failure into Status via From<StatusCode>.
     default()?.add_service(identifier, binder)
+}
+
+/// [`ServiceManager::add_lazy_service`] on the default service manager.
+pub(crate) fn add_lazy_service(
+    identifier: &str,
+    binder: impl Into<SIBinder>,
+) -> std::result::Result<(), Status> {
+    default()?.add_lazy_service(identifier, binder)
 }
 
 /// Convenience function to get a service from the default ServiceManager.

--- a/rsbinder/src/hub/mod.rs
+++ b/rsbinder/src/hub/mod.rs
@@ -376,6 +376,65 @@ pub enum ServiceManager {
     Android16(android_16::BpServiceManager),
 }
 
+/// Which of Android 15's two service-manager numberings this device speaks.
+///
+/// `android-15.0.0_r6` inserted `getService2` at index 1 of
+/// `IServiceManager.aidl`, shifting every later transaction code by one —
+/// `addService` 2 → 3, `registerClientCallback` 11 → 12,
+/// `tryUnregisterService` 12 → 13. The SDK version stayed 35 and the
+/// interface is not a frozen `aidl_interface`, so nothing preserved the old
+/// codes. AOSP is unaffected: `servicemanager` and `libbinder` ship in one
+/// image and are always in step. Only an out-of-tree client pins the
+/// numbers, so only a probe can tell the two builds apart.
+///
+/// Code 14 is the one code that answers the question without side effects —
+/// one past the last method of the pre-r6 interface, so it is rejected
+/// outright there, and `getServiceDebugInfo()` (no arguments, read-only) in
+/// the r6+ one. The code below it would not do: 13 is `tryUnregisterService`
+/// on an r6+ device.
+///
+/// `Ok(())` means this module's transaction codes are right for this device.
+#[cfg(all(target_os = "android", feature = "android_14"))]
+fn check_android_15_numbering(context: &SIBinder) -> Result<()> {
+    // One past `getServiceDebugInfo`, the last method of the pre-r6
+    // interface.
+    const PROBE_CODE: TransactionCode = 14;
+
+    let proxy = context.as_proxy().ok_or(StatusCode::BadType)?;
+    let mut data = Parcel::new();
+    data.write_interface_token(
+        <android_14::BpServiceManager as android_14::IServiceManager>::descriptor(),
+    )?;
+
+    match proxy.submit_transact(FIRST_CALL_TRANSACTION + PROBE_CODE, &data, 0) {
+        // Rejected: 14 methods, so this is a pre-r6 build and the codes this
+        // module sends are the ones it answers.
+        Err(StatusCode::UnknownTransaction) => Ok(()),
+        // Answered: 15 methods. Every code from `checkService` on is one
+        // higher than this module sends, and the damage is silent —
+        // `addService` would land on `checkService`, whose reply carries a
+        // successful status, so a service would report itself registered and
+        // not be there.
+        Ok(_) => {
+            log::error!(
+                "Android 15 service manager with shifted transaction codes \
+                 (android-15.0.0_r6 or later - a QPR build). rsbinder has no \
+                 module for that protocol, and the android_14 one would \
+                 register services that silently do not exist, so the service \
+                 manager is refused. Only kernel-binder use through `hub` is \
+                 affected; the RPC transport is not."
+            );
+            Err(StatusCode::InvalidOperation)
+        }
+        // Neither answer: which protocol this device speaks is unknown, and
+        // guessing risks the silent loss above.
+        Err(e) => {
+            log::error!("could not probe the Android 15 service-manager protocol: {e:?}");
+            Err(e)
+        }
+    }
+}
+
 /// Returns the global ServiceManager instance appropriate for the current Android version.
 ///
 /// The singleton is created on first call and reused afterwards. The correct
@@ -412,17 +471,27 @@ pub fn default() -> Result<Arc<ServiceManager>> {
             // format — the `android/os/*` AIDL is byte-identical between
             // android-16.0.0_r4 and android-17.0.0_r1 (and the kernel binder
             // UAPI is unchanged), so it is served by the `android_16` module,
-            // mirroring how Android 15 is served by `android_14`.
+            // mirroring how Android 15 is served by `android_14` (with the
+            // caveat recorded on that arm).
             sdk_versions::ANDROID_16 | sdk_versions::ANDROID_17 => {
                 create_service_manager!(Android16, android_16)
             }
-            // Android 15 (SDK 35) shares Android 14's service-manager wire
-            // format, so it is served by the `android_14` feature — there
-            // is no separate `android_15` feature. A build that enables
-            // only `android_16` therefore returns `InvalidOperation` on an
-            // Android 15 device; enable `android_14` to cover 14 *and* 15.
+            // Android 15 (SDK 35) is served by the `android_14` feature —
+            // there is no separate `android_15` feature. A build that
+            // enables only `android_16` therefore returns
+            // `InvalidOperation` on an Android 15 device.
+            //
+            // Only up to `android-15.0.0_r5`: a QPR build renumbered the
+            // interface without changing SDK 35, so which one this is has
+            // to be measured — see `check_android_15_numbering`. A QPR
+            // build is refused rather than served with the wrong codes;
+            // supporting it needs an `android_15` module, tracked
+            // separately.
             #[cfg(feature = "android_14")]
             sdk_versions::ANDROID_14 | sdk_versions::ANDROID_15 => {
+                if sdk_version == sdk_versions::ANDROID_15 {
+                    check_android_15_numbering(&context)?;
+                }
                 create_service_manager!(Android14, android_14)
             }
             #[cfg(feature = "android_13")]
@@ -1040,11 +1109,17 @@ impl ServiceManager {
     /// `rsb_service dump manager`. (`getServiceDebugInfo` does not carry it:
     /// `ServiceDebugInfo` is name and pid only.)
     ///
-    /// The flag is an Android 16 `IServiceManager` constant — AOSP added it
-    /// in `android-15.0.0_r20` — so the older protocols register without it,
-    /// exactly as their own libbinder did. Crate-private because AOSP's
-    /// `LazyServiceRegistrar` is the only thing that may set it (it warns if
-    /// a caller pre-set the bit).
+    /// Only the `android_16` protocol sends the flag, and only it can act on
+    /// it: nothing reads the bit before `getService2` exists to carry
+    /// `isLazyService` back. AOSP added the constant in `android-15.0.0_r20`
+    /// and its `LazyServiceRegistrar` sets it from that release on — but the
+    /// same release train had already shifted every transaction code (see
+    /// the `android_14` note under [`ServiceManager::default`]), so the
+    /// `android_14` arm cannot reach those builds at all and gains nothing
+    /// by setting it. Android 11–14 register without the flag, exactly as
+    /// their own libbinder did; Android 10 is refused outright — see below.
+    /// Crate-private because AOSP's `LazyServiceRegistrar` is the only thing
+    /// that may set it (it warns if a caller pre-set the bit).
     pub(crate) fn add_lazy_service(
         &self,
         identifier: &str,
@@ -1052,8 +1127,11 @@ impl ServiceManager {
     ) -> std::result::Result<(), Status> {
         let binder = binder.into();
         match self {
+            // The legacy C protocol has neither `registerClientCallback` nor
+            // `tryUnregisterService`, so a service published here could
+            // never be tracked *or* taken back down. Refuse before it is.
             #[cfg(all(target_os = "android", feature = "android_10"))]
-            ServiceManager::Android10(sm) => android_10::add_service(sm, identifier, binder),
+            ServiceManager::Android10(_) => Err(unsupported("lazy service registration", 11)),
             #[cfg(all(target_os = "android", feature = "android_11"))]
             ServiceManager::Android11(sm) => android_11::add_service(sm, identifier, binder),
             #[cfg(all(target_os = "android", feature = "android_12"))]

--- a/rsbinder/src/hub/mod.rs
+++ b/rsbinder/src/hub/mod.rs
@@ -1035,7 +1035,10 @@ impl ServiceManager {
 
     /// [`add_service`](Self::add_service) with AOSP's `FLAG_IS_LAZY_SERVICE`
     /// set in `dumpPriority`, so the service manager can report the service
-    /// as lazy (`getServiceDebugInfo().isLazyService`, `rsb_service info`).
+    /// as lazy — `ServiceWithMetadata::isLazyService` on the
+    /// `getService2`/`checkService2` reply, and the `lazy=` column of
+    /// `rsb_service dump manager`. (`getServiceDebugInfo` does not carry it:
+    /// `ServiceDebugInfo` is name and pid only.)
     ///
     /// The flag is an Android 16 `IServiceManager` constant — AOSP added it
     /// in `android-15.0.0_r20` — so the older protocols register without it,

--- a/rsbinder/src/hub/servicemanager_16.rs
+++ b/rsbinder/src/hub/servicemanager_16.rs
@@ -203,7 +203,7 @@ pub fn add_service(
 /// AOSP `LazyServiceRegistrar::registerServiceLocked` ORs the flag into
 /// `dumpFlags` itself and warns if the caller pre-set it, so this is not
 /// exposed as a general `dumpFlags` parameter.
-pub fn add_lazy_service(
+pub(crate) fn add_lazy_service(
     sm: &BpServiceManager,
     identifier: &str,
     binder: SIBinder,

--- a/rsbinder/src/hub/servicemanager_16.rs
+++ b/rsbinder/src/hub/servicemanager_16.rs
@@ -198,6 +198,24 @@ pub fn add_service(
     sm.addService(identifier, &binder, false, DUMP_FLAG_PRIORITY_DEFAULT)
 }
 
+/// `add_service` with `FLAG_IS_LAZY_SERVICE` set, for
+/// [`LazyServiceRegistrar`](crate::lazy_service::LazyServiceRegistrar).
+/// AOSP `LazyServiceRegistrar::registerServiceLocked` ORs the flag into
+/// `dumpFlags` itself and warns if the caller pre-set it, so this is not
+/// exposed as a general `dumpFlags` parameter.
+pub fn add_lazy_service(
+    sm: &BpServiceManager,
+    identifier: &str,
+    binder: SIBinder,
+) -> std::result::Result<(), Status> {
+    sm.addService(
+        identifier,
+        &binder,
+        false,
+        DUMP_FLAG_PRIORITY_DEFAULT | FLAG_IS_LAZY_SERVICE,
+    )
+}
+
 /// Request a callback when a service is registered.
 pub fn register_for_notifications(
     sm: &BpServiceManager,

--- a/rsbinder/src/lazy_service.rs
+++ b/rsbinder/src/lazy_service.rs
@@ -1,34 +1,131 @@
 // Copyright 2026 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-//! `LazyServiceRegistrar` skeleton.
+//! `LazyServiceRegistrar` — the `aidl_lazy_service` pattern.
 //!
 //! Mirrors AOSP `LazyServiceRegistrar`
 //! ([`LazyServiceRegistrar.h`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/include/binder/LazyServiceRegistrar.h),
 //! [`LazyServiceRegistrar.cpp`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp)):
-//! a `register_service` helper that owns the bookkeeping for the
-//! `aidl_lazy_service` pattern (idle unregister, force-persist, re-register
-//! after onClients).
+//! register a service, let the service manager report when clients come and
+//! go, and shut the process down once nothing is using it.
 //!
-//! **Scope note.** The state machine, AOSP-faithful `IClientCallback`
-//! dispatch, and `force_persist`/`try_unregister`/`re_register` all live
-//! in this module and are hermetically testable. The integration that
-//! wires up the *actual* `registerClientCallback` / `tryUnregisterService`
-//! IServiceManager calls is not yet wired and must be supplied by the
-//! caller — the hub::ServiceManager wrapper does not yet surface those
-//! AIDL methods despite the underlying generated bindings supporting them
-//! since AOSP API 30 (Android 11). The present module exposes the
-//! registrar surface as an in-process state machine; once hub plumbing
-//! lands, `register_service` will additionally call
-//! `service_manager.add_service(name, binder) +
-//! service_manager.register_client_callback(name, binder, &self.as_callback())`.
+//! [`LazyServiceRegistrar::register_service`] performs the service-manager
+//! calls itself — `addService` with `FLAG_IS_LAZY_SERVICE`, then
+//! `registerClientCallback` with an `IClientCallback` this module owns. A
+//! caller does not register a callback or route `onClients` by hand:
+//!
+//! ```no_run
+//! use rsbinder::lazy_service::LazyServiceRegistrar;
+//! use rsbinder::ProcessState;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let binder: rsbinder::SIBinder = unimplemented!();
+//! // `register_service` talks to the service manager, so the kernel binder
+//! // `ProcessState` has to exist first.
+//! ProcessState::init_default()?;
+//!
+//! let registrar = LazyServiceRegistrar::new();
+//! registrar.register_service("my.Service/default", binder)?;
+//!
+//! // Returns only if the thread pool is torn down; the usual exit is the
+//! // registrar's own, from the callback thread.
+//! ProcessState::join_thread_pool()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! **The process exits when the last client goes away.** That is AOSP's
+//! contract (`tryShutdownLocked` calls `exit(EXIT_SUCCESS)`), and the reason
+//! the pattern exists: the service manager restarts the process on the next
+//! lookup. Two ways to change it —
+//! [`force_persist`](LazyServiceRegistrar::force_persist) to suspend shutdown
+//! for a while, or
+//! [`set_active_services_callback`](LazyServiceRegistrar::set_active_services_callback)
+//! to take over the decision entirely.
+//!
+//! ## Deviations from AOSP
+//!
+//! * **Service-manager calls happen outside the registrar's lock.** AOSP
+//!   holds `mMutex` across `tryUnregisterService`, but a service manager may
+//!   answer that call by dispatching `onClients` back into this process, and
+//!   the binder driver delivers such a nested transaction on the very thread
+//!   that is waiting for the reply — which would deadlock on a non-reentrant
+//!   `Mutex`. State is snapshotted under the lock, the calls are made
+//!   without it, and the results are recorded on the way back. The service
+//!   manager is the authority on whether an unregister may proceed, so
+//!   nothing is lost by not holding it.
+//! * **Nothing aborts.** AOSP `LOG_ALWAYS_FATAL`s on an `onClients` for an
+//!   unknown service, on an `onClients` that repeats the state it already
+//!   believed, and on a failed re-register. Each is logged and survived here.
+//! * **Re-registering a name with a *different* binder replaces the entry**
+//!   and registers a fresh client callback for it. AOSP keeps the first
+//!   binder in `mRegisteredServices` while handing the new one to
+//!   `addService`, which leaves the callback keyed on a binder the service
+//!   manager no longer has under that name.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex, Weak};
 
 use crate::binder::SIBinder;
-use crate::error::Result;
+use crate::error::{Result, StatusCode};
+use crate::hub::{BnClientCallback, IClientCallback};
+use crate::status::Status;
+use crate::{Interface, Strong};
+
+/// Reports whether any service in the process currently has clients, and
+/// answers whether the shutdown was handled.
+///
+/// Returning `true` means "I took care of it" and suppresses the automatic
+/// process exit; returning `false` leaves the registrar to shut down as
+/// usual. Called only when the answer *changes*, so a callback sees
+/// `true, false, true, …`, never the same value twice in a row. AOSP
+/// `setActiveServicesCallback`.
+pub type ActiveServicesCallback = Arc<dyn Fn(bool) -> bool + Send + Sync>;
+
+/// The service-manager calls the registrar makes. Behind a trait so the
+/// state machine is exercised without a binder device; the shipping
+/// implementation is [`HubRegistry`].
+trait Registry: Send + Sync {
+    fn add_lazy_service(&self, name: &str, binder: &SIBinder) -> std::result::Result<(), Status>;
+    fn register_client_callback(
+        &self,
+        name: &str,
+        binder: &SIBinder,
+        callback: &Strong<dyn IClientCallback>,
+    ) -> std::result::Result<(), Status>;
+    fn try_unregister_service(
+        &self,
+        name: &str,
+        binder: &SIBinder,
+    ) -> std::result::Result<(), Status>;
+}
+
+/// The default [`Registry`]: the process's default service manager.
+struct HubRegistry;
+
+impl Registry for HubRegistry {
+    fn add_lazy_service(&self, name: &str, binder: &SIBinder) -> std::result::Result<(), Status> {
+        crate::hub::add_lazy_service(name, binder.clone())
+    }
+
+    fn register_client_callback(
+        &self,
+        name: &str,
+        binder: &SIBinder,
+        callback: &Strong<dyn IClientCallback>,
+    ) -> std::result::Result<(), Status> {
+        crate::hub::register_client_callback(name, binder, callback).map_err(Status::from)
+    }
+
+    fn try_unregister_service(
+        &self,
+        name: &str,
+        binder: &SIBinder,
+    ) -> std::result::Result<(), Status> {
+        crate::hub::try_unregister_service(name, binder).map_err(Status::from)
+    }
+}
 
 /// One registered (name → binder) pair plus the most recent client-side
 /// presence signal from `IClientCallback::onClients`.
@@ -43,159 +140,423 @@ struct RegisteredService {
     /// `onClients(name, false)`. AOSP `ServiceInfo::clients`
     /// ([LazyServiceRegistrar.cpp:53](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=53)).
     has_clients: bool,
-    /// Locked = registered with the service manager. `tryUnregisterLocked`
-    /// flips this to `false` after a successful `tryUnregisterService`;
-    /// `reRegisterLocked` flips it back to `true`.
+    /// Registered with the service manager. `try_unregister` flips this to
+    /// `false` after a successful `tryUnregisterService`; `re_register`
+    /// flips it back.
     registered: bool,
 }
 
+/// AOSP's `std::map` is ordered, and unregister order is observable — a
+/// `BTreeMap` keeps it deterministic.
 struct Inner {
-    /// Service name → tracking entry. AOSP's `mRegisteredServices` map.
-    services: HashMap<String, RegisteredService>,
+    services: BTreeMap<String, RegisteredService>,
+    /// AOSP `mNumConnectedServices`: how many services have clients.
+    num_connected_services: usize,
+    /// AOSP `mPreviousHasClients`: the last value handed to the active
+    /// services callback, so it only fires on a change.
+    previous_has_clients: Option<bool>,
+    active_services_callback: Option<ActiveServicesCallback>,
+    /// The `IClientCallback` this registrar registered with the service
+    /// manager. Held for the lifetime of the registrar: the service manager
+    /// keeps only a proxy, so dropping this would kill every `onClients`.
+    callback: Option<Strong<dyn IClientCallback>>,
 }
 
-/// The lazy-service bookkeeping struct. Construct one per process via
-/// [`LazyServiceRegistrar::new`] (or share via `Arc` across threads —
-/// the struct is `Send + Sync`).
+impl Inner {
+    /// AOSP `updateCacheClientCount`.
+    fn update_cache_client_count(&mut self) {
+        self.num_connected_services = self.services.values().filter(|e| e.has_clients).count();
+    }
+}
+
+/// The registrar's state, shared with the `IClientCallback` bridge.
 ///
-/// Threading: the `services` map is protected by a `Mutex`; the
-/// `force_persist` flag is a lock-free `AtomicBool` (AOSP equivalent is
-/// `mForcePersist` guarded by `mMutex` — rsbinder avoids the lock on
-/// the hot path because the flag is consulted from inside `onClients`
-/// where holding the registrar mutex is already required).
-pub struct LazyServiceRegistrar {
+/// AOSP's `ClientCounterCallbackImpl` *is* the `BnClientCallback`, so the
+/// state and the callback are one object held by `sp<>`. Rust splits them:
+/// `Shared` holds the state and (transitively) the callback binder, and the
+/// bridge holds a `Weak<Shared>` so the two do not keep each other alive.
+struct Shared {
     inner: Mutex<Inner>,
-    /// When `true`, [`Self::try_unregister`] short-circuits to a no-op
-    /// even if all services report `has_clients == false`. AOSP
-    /// `forcePersist`.
     force_persist: AtomicBool,
+    registry: Arc<dyn Registry>,
+    /// Set instead of exiting, so the shutdown path is observable in tests.
+    #[cfg(test)]
+    exited: AtomicBool,
 }
 
-impl LazyServiceRegistrar {
-    /// Construct a fresh registrar. Caller normally wraps in `Arc` for
-    /// sharing with the `IClientCallback` bridge.
-    pub fn new() -> Self {
-        Self {
-            inner: Mutex::new(Inner {
-                services: HashMap::new(),
-            }),
-            force_persist: AtomicBool::new(false),
+/// The `IClientCallback` the registrar registers on a service's behalf.
+/// AOSP dispatches `onClients` on `ClientCounterCallbackImpl` itself.
+struct ClientCounterCallback {
+    shared: Weak<Shared>,
+}
+
+impl Interface for ClientCounterCallback {}
+
+impl IClientCallback for ClientCounterCallback {
+    fn onClients(&self, registered: &SIBinder, has_clients: bool) -> crate::status::Result<()> {
+        // A callback that outlives its registrar is not an error: the
+        // service manager may still hold the proxy after the last
+        // `LazyServiceRegistrar` handle is dropped.
+        if let Some(shared) = self.shared.upgrade() {
+            shared.on_clients_binder(registered, has_clients);
+        }
+        Ok(())
+    }
+}
+
+impl Shared {
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// AOSP `assertRegisteredService` — the wire hands `onClients` a binder,
+    /// not a name.
+    fn name_of(&self, binder: &SIBinder) -> Option<String> {
+        self.lock()
+            .services
+            .values()
+            .find(|e| e.binder == *binder)
+            .map(|e| e.name.clone())
+    }
+
+    fn on_clients_binder(&self, binder: &SIBinder, has_clients: bool) {
+        match self.name_of(binder) {
+            Some(name) => {
+                self.on_clients(&name, has_clients);
+            }
+            // AOSP `LOG_ALWAYS_FATAL`s here.
+            None => log::error!("onClients for a service this registrar did not register"),
         }
     }
 
-    /// Record a (name, binder) pair as lazily managed. AOSP
-    /// [`LazyServiceRegistrar::registerService`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=123),
-    /// minus the IServiceManager `addService` + `registerClientCallback`
-    /// IPC calls — those are owed by the **caller** until the hub
-    /// integration lands (see the module-level scope note). Re-registering
-    /// the same name replaces the prior entry (AOSP `mRegisteredServices`
-    /// is keyed by name).
+    /// AOSP `ClientCounterCallbackImpl::onClients`.
+    fn on_clients(&self, name: &str, has_clients: bool) -> bool {
+        {
+            let mut inner = self.lock();
+            let Some(entry) = inner.services.get_mut(name) else {
+                return false;
+            };
+            if entry.has_clients == has_clients {
+                // AOSP `LOG_ALWAYS_FATAL`s on a repeated state.
+                log::warn!(
+                    "{name}: onClients repeated has_clients={has_clients}; already believed that"
+                );
+            }
+            entry.has_clients = has_clients;
+            inner.update_cache_client_count();
+            log::info!(
+                "Process has {} (of {} available) client(s) in use after notification {name} has clients: {has_clients}",
+                inner.num_connected_services,
+                inner.services.len(),
+            );
+        }
+        self.maybe_try_shutdown();
+        true
+    }
+
+    /// AOSP `maybeTryShutdownLocked`. The active-services callback runs
+    /// without the registrar lock held, so it may call back into the
+    /// registrar (`force_persist`, `try_unregister`) without deadlocking.
+    fn maybe_try_shutdown(&self) {
+        if self.force_persist.load(Ordering::Acquire) {
+            log::info!("Shutdown prevented by force_persist override flag.");
+            return;
+        }
+
+        // Latch `previous_has_clients` under the lock so two threads
+        // reporting the same transition cannot both fire the callback.
+        let to_fire = {
+            let mut inner = self.lock();
+            let has_clients = inner.num_connected_services != 0;
+            match &inner.active_services_callback {
+                Some(cb) if inner.previous_has_clients != Some(has_clients) => {
+                    let cb = cb.clone();
+                    inner.previous_has_clients = Some(has_clients);
+                    Some((cb, has_clients))
+                }
+                _ => None,
+            }
+        };
+
+        let handled = match to_fire {
+            Some((cb, has_clients)) => cb(has_clients),
+            None => false,
+        };
+
+        // Re-read rather than reuse the value from above: the lock was
+        // released for the callback. This is advisory either way — the
+        // service manager refuses `tryUnregisterService` for a service that
+        // has clients, so a stale `true` here costs a failed round trip and
+        // a re-register, never a wrongly shut-down service.
+        if !handled && self.lock().num_connected_services == 0 {
+            self.try_shutdown();
+        }
+    }
+
+    /// AOSP `tryShutdownLocked`.
+    fn try_shutdown(&self) {
+        log::info!(
+            "Trying to shut down the service. No clients in use for any service in process."
+        );
+        if self.try_unregister() {
+            log::info!("Unregistered all clients and exiting");
+            self.exit_process();
+            return;
+        }
+        self.re_register();
+    }
+
+    #[cfg(not(test))]
+    fn exit_process(&self) {
+        std::process::exit(0);
+    }
+
+    #[cfg(test)]
+    fn exit_process(&self) {
+        self.exited.store(true, Ordering::Release);
+    }
+
+    /// AOSP `tryUnregisterLocked`, with the round trips outside the lock.
+    fn try_unregister(&self) -> bool {
+        if self.force_persist.load(Ordering::Acquire) {
+            return false;
+        }
+
+        let candidates: Vec<(String, SIBinder)> = {
+            let inner = self.lock();
+            inner
+                .services
+                .values()
+                .filter(|e| e.registered)
+                .map(|e| (e.name.clone(), e.binder.clone()))
+                .collect()
+        };
+
+        // AOSP cannot reach an empty map here (its shutdown check only runs
+        // from a registered service's `onClients`), but `try_unregister` is
+        // public: a registrar with nothing in it must not report "every
+        // service is down, safe to exit".
+        if candidates.is_empty() {
+            return false;
+        }
+
+        for (name, binder) in candidates {
+            match self.registry.try_unregister_service(&name, &binder) {
+                Ok(()) => {
+                    if let Some(entry) = self.lock().services.get_mut(&name) {
+                        entry.registered = false;
+                    }
+                }
+                Err(e) => {
+                    log::info!("Failed to unregister service {name} ({e:?})");
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    /// AOSP `reRegisterLocked`. Note what it does *not* do: `has_clients` is
+    /// left alone, because the service manager's view of the clients did not
+    /// change just because we failed to unregister.
+    fn re_register(&self) {
+        let pending: Vec<(String, SIBinder)> = {
+            let inner = self.lock();
+            inner
+                .services
+                .values()
+                .filter(|e| !e.registered)
+                .map(|e| (e.name.clone(), e.binder.clone()))
+                .collect()
+        };
+
+        for (name, binder) in pending {
+            // A re-register is `addService` only — the client callback is
+            // registered once per (name, binder) and the service manager
+            // still holds it.
+            match self.registry.add_lazy_service(&name, &binder) {
+                Ok(()) => {
+                    if let Some(entry) = self.lock().services.get_mut(&name) {
+                        entry.registered = true;
+                    }
+                }
+                // AOSP `LOG_ALWAYS_FATAL`s: "clients will never be able to
+                // get a hold of this service". Left `registered = false` so
+                // a later `re_register` can try again instead of the process
+                // dying with the state it had.
+                Err(e) => log::error!("Bad state: could not re-register {name} ({e:?})"),
+            }
+        }
+    }
+}
+
+/// Registers services that the process should be shut down for when nobody
+/// is using them.
+///
+/// A cheap handle: cloning one shares the same registrations, as AOSP's
+/// `LazyServiceRegistrar` shares its `ClientCounterCallback`. AOSP exposes a
+/// process singleton (`getInstance`); construct one here and share it.
+#[derive(Clone)]
+pub struct LazyServiceRegistrar {
+    shared: Arc<Shared>,
+}
+
+impl LazyServiceRegistrar {
+    /// A registrar backed by the process's default service manager.
+    pub fn new() -> Self {
+        Self::with_registry(Arc::new(HubRegistry))
+    }
+
+    fn with_registry(registry: Arc<dyn Registry>) -> Self {
+        LazyServiceRegistrar {
+            shared: Arc::new(Shared {
+                inner: Mutex::new(Inner {
+                    services: BTreeMap::new(),
+                    num_connected_services: 0,
+                    previous_has_clients: None,
+                    active_services_callback: None,
+                    callback: None,
+                }),
+                force_persist: AtomicBool::new(false),
+                registry,
+                #[cfg(test)]
+                exited: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    /// The `IClientCallback` for this registrar, created on first use.
+    fn callback(&self) -> Strong<dyn IClientCallback> {
+        let mut inner = self.shared.lock();
+        inner
+            .callback
+            .get_or_insert_with(|| {
+                BnClientCallback::new_binder(ClientCounterCallback {
+                    shared: Arc::downgrade(&self.shared),
+                })
+            })
+            .clone()
+    }
+
+    /// Register `binder` under `name` and start tracking its clients.
+    ///
+    /// `addService` with `FLAG_IS_LAZY_SERVICE`, then — for a name not
+    /// already tracked, or one tracked under a different binder —
+    /// `registerClientCallback`. AOSP
+    /// [`registerServiceLocked`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=129).
+    ///
+    /// The service starts out assumed to have clients, so an idle process
+    /// cannot shut down before the service manager has said anything about
+    /// it.
     pub fn register_service(&self, name: &str, binder: SIBinder) -> Result<()> {
-        let mut inner = self.inner.lock().expect("lazy_service inner poisoned");
+        let tracked_same_binder = {
+            let inner = self.shared.lock();
+            inner.services.get(name).map(|e| e.binder == binder) == Some(true)
+        };
+
+        log::info!(
+            "{} service {name}",
+            if tracked_same_binder {
+                "Re-registering"
+            } else {
+                "Registering"
+            }
+        );
+
+        self.shared
+            .registry
+            .add_lazy_service(name, &binder)
+            .map_err(|e| {
+                log::error!("Failed to register service {name} ({e:?})");
+                StatusCode::from(e)
+            })?;
+
+        if !tracked_same_binder {
+            let callback = self.callback();
+            self.shared
+                .registry
+                .register_client_callback(name, &binder, &callback)
+                .map_err(|e| {
+                    log::error!("Failed to add client callback for service {name} ({e:?})");
+                    StatusCode::from(e)
+                })?;
+        }
+
+        let mut inner = self.shared.lock();
         inner.services.insert(
             name.to_string(),
             RegisteredService {
                 name: name.to_string(),
                 binder,
-                has_clients: true, // AOSP initializes assuming a client may already be holding
+                has_clients: true,
                 registered: true,
             },
         );
+        inner.update_cache_client_count();
         Ok(())
     }
 
-    /// Toggle the force-persist guard. AOSP
-    /// `LazyServiceRegistrar::forcePersist`. When `true`,
-    /// [`Self::try_unregister`] returns `false` without attempting an
-    /// IServiceManager round trip.
+    /// Suspend automatic shutdown. AOSP `forcePersist`.
+    ///
+    /// Turning it back off re-checks immediately, so a process that lost its
+    /// last client while persisted shuts down as soon as it is released.
     pub fn force_persist(&self, persist: bool) {
-        self.force_persist.store(persist, Ordering::Release);
+        self.shared.force_persist.store(persist, Ordering::Release);
+        if !persist {
+            self.shared.maybe_try_shutdown();
+        }
     }
 
     /// `true` if [`Self::force_persist`] was last called with `true`.
     pub fn is_force_persisted(&self) -> bool {
-        self.force_persist.load(Ordering::Acquire)
+        self.shared.force_persist.load(Ordering::Acquire)
     }
 
-    /// AOSP-faithful `IClientCallback::onClients` dispatch. Call this
-    /// from the (future-wired-up) Bn callback to update the registrar's
-    /// internal `has_clients` state for a given service. Returns `true`
-    /// if the named service was tracked, `false` if unknown (which AOSP
-    /// would `LOG_ALWAYS_FATAL` on — rsbinder returns silently to avoid
-    /// aborting the dispatch thread).
+    /// Decide for yourself what an idle process should do. AOSP
+    /// `setActiveServicesCallback`.
+    ///
+    /// Set this **before** [`Self::register_service`] — otherwise a client
+    /// that arrives and leaves in between is decided without it. See
+    /// [`ActiveServicesCallback`] for what the argument and return value
+    /// mean.
+    pub fn set_active_services_callback(&self, callback: ActiveServicesCallback) {
+        self.shared.lock().active_services_callback = Some(callback);
+    }
+
+    /// Record an `onClients` transition by service name.
+    ///
+    /// The registrar routes the service manager's own callbacks here; call
+    /// it directly only to drive the state machine by hand. It runs the full
+    /// AOSP dispatch, **process exit included**. Returns `false` for a name
+    /// this registrar did not register (AOSP `LOG_ALWAYS_FATAL`s).
     pub fn on_clients(&self, name: &str, has_clients: bool) -> bool {
-        let mut inner = self.inner.lock().expect("lazy_service inner poisoned");
-        if let Some(entry) = inner.services.get_mut(name) {
-            entry.has_clients = has_clients;
-            true
-        } else {
-            false
-        }
+        self.shared.on_clients(name, has_clients)
     }
 
-    /// Attempt to unregister **every** service, all-or-nothing. AOSP
-    /// [`LazyServiceRegistrar::tryUnregisterLocked`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=193).
+    /// Unregister every service, all-or-nothing. AOSP
+    /// [`tryUnregisterLocked`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=193).
     ///
-    /// AOSP's caller (`maybeTryShutdownLocked`) only reaches this when
-    /// `mNumConnectedServices == 0`, and `tryUnregisterLocked` then
-    /// unregisters *all* services (rolling back on the first failure). A
-    /// `true` return means "no service is registered any more → the process is
-    /// safe to exit". A per-entry flip (leaving client-holding services
-    /// registered while others go down) would let a caller following the
-    /// AOSP idiom `if try_unregister() { exit }` terminate with live-client
-    /// services still registered.
+    /// `true` means nothing is registered any more and the process is safe to
+    /// exit. `false` means the service manager refused at least one — some
+    /// service still has clients — and [`Self::re_register`] is owed for the
+    /// ones that did come down. AOSP calls this only from the active services
+    /// callback.
     ///
-    /// **Returns** `true` iff every service was flipped to
-    /// `registered = false` (there is no service with clients, and
-    /// `force_persist` is not engaged); `false` otherwise — in which case
-    /// nothing is changed. A registrar with no services returns `false`:
-    /// there is nothing to unregister, so it never signals "safe to exit"
-    /// (AOSP cannot reach this state — its shutdown check only runs from an
-    /// `onClients` callback of a registered service). The hub-integrated
-    /// version owed by the caller (see module docs) is where the actual
-    /// `tryUnregisterService` IPC happens; this skeleton only mutates
-    /// internal state.
+    /// A registrar with no services returns `false`: there is nothing to take
+    /// down, so it never signals "safe to exit".
     pub fn try_unregister(&self) -> bool {
-        if self.force_persist.load(Ordering::Acquire) {
-            return false;
-        }
-        let mut inner = self.inner.lock().expect("lazy_service inner poisoned");
-        if inner.services.is_empty() {
-            return false;
-        }
-        // Global gate: if any service still has clients, unregister nothing and
-        // report "not safe to shut down" (AOSP all-or-nothing).
-        if inner.services.values().any(|e| e.has_clients) {
-            return false;
-        }
-        for entry in inner.services.values_mut() {
-            entry.registered = false;
-        }
-        true
+        self.shared.try_unregister()
     }
 
-    /// Re-register every previously-unregistered service. AOSP
-    /// [`LazyServiceRegistrar::reRegisterLocked`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=209).
-    /// The hub-integrated version replays `addService` +
-    /// `registerClientCallback`; this skeleton flips state only.
+    /// Put back every service a [`Self::try_unregister`] took down. AOSP
+    /// [`reRegisterLocked`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=209).
     pub fn re_register(&self) {
-        let mut inner = self.inner.lock().expect("lazy_service inner poisoned");
-        for entry in inner.services.values_mut() {
-            if !entry.registered {
-                entry.registered = true;
-                // AOSP also resets `has_clients` to `true` defensively
-                // so the next `try_unregister` can't immediately unwind
-                // the re-registration without an explicit `onClients`
-                // notification.
-                entry.has_clients = true;
-            }
-        }
+        self.shared.re_register()
     }
 
-    /// Snapshot helper: returns `(name, has_clients, registered)` for
-    /// every tracked service. Primarily for tests and introspection.
+    /// `(name, has_clients, registered)` for every tracked service.
     pub fn snapshot(&self) -> Vec<(String, bool, bool)> {
-        let inner = self.inner.lock().expect("lazy_service inner poisoned");
+        let inner = self.shared.lock();
         inner
             .services
             .values()
@@ -203,17 +564,15 @@ impl LazyServiceRegistrar {
             .collect()
     }
 
-    /// Snapshot helper: how many services are currently `registered`.
+    /// How many services are currently registered.
     pub fn registered_count(&self) -> usize {
-        let inner = self.inner.lock().expect("lazy_service inner poisoned");
+        let inner = self.shared.lock();
         inner.services.values().filter(|e| e.registered).count()
     }
 
-    /// Snapshot helper: borrow the binder previously registered under
-    /// `name`. Used by the hub-integrated re-register path (future) to
-    /// pass the original `SIBinder` back into `addService`.
+    /// The binder registered under `name`.
     pub fn binder_for(&self, name: &str) -> Option<SIBinder> {
-        let inner = self.inner.lock().expect("lazy_service inner poisoned");
+        let inner = self.shared.lock();
         inner.services.get(name).map(|e| e.binder.clone())
     }
 }
@@ -229,7 +588,7 @@ mod tests {
     use super::*;
     use crate::binder::Stability;
     use crate::native::Binder;
-    use crate::{Interface, Parcel, Remotable, Result as RsResult, TransactionCode};
+    use crate::{Parcel, Remotable, Result as RsResult, TransactionCode};
 
     struct Dummy;
     impl Remotable for Dummy {
@@ -249,12 +608,78 @@ mod tests {
         Interface::as_binder(&b)
     }
 
-    /// `register_service` records the (name, binder) entry and marks it
-    /// registered.
+    /// A service manager that records what it was asked and can be told to
+    /// refuse an unregister — which is how a real one reports "this service
+    /// still has clients".
+    #[derive(Default)]
+    struct FakeRegistry {
+        calls: Mutex<Vec<String>>,
+        refuse_unregister: Mutex<Vec<String>>,
+    }
+
+    impl FakeRegistry {
+        fn calls(&self) -> Vec<String> {
+            self.calls.lock().unwrap().clone()
+        }
+        fn refuse(&self, name: &str) {
+            self.refuse_unregister
+                .lock()
+                .unwrap()
+                .push(name.to_string());
+        }
+    }
+
+    impl Registry for FakeRegistry {
+        fn add_lazy_service(
+            &self,
+            name: &str,
+            _binder: &SIBinder,
+        ) -> std::result::Result<(), Status> {
+            self.calls.lock().unwrap().push(format!("add:{name}"));
+            Ok(())
+        }
+        fn register_client_callback(
+            &self,
+            name: &str,
+            _binder: &SIBinder,
+            _callback: &Strong<dyn IClientCallback>,
+        ) -> std::result::Result<(), Status> {
+            self.calls.lock().unwrap().push(format!("cb:{name}"));
+            Ok(())
+        }
+        fn try_unregister_service(
+            &self,
+            name: &str,
+            _binder: &SIBinder,
+        ) -> std::result::Result<(), Status> {
+            self.calls.lock().unwrap().push(format!("unreg:{name}"));
+            if self
+                .refuse_unregister
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|n| n == name)
+            {
+                return Err(Status::new_service_specific_error(-1, None));
+            }
+            Ok(())
+        }
+    }
+
+    fn fixture() -> (LazyServiceRegistrar, Arc<FakeRegistry>) {
+        let registry = Arc::new(FakeRegistry::default());
+        (
+            LazyServiceRegistrar::with_registry(registry.clone()),
+            registry,
+        )
+    }
+
+    /// `register_service` makes both service-manager calls, in AOSP's order.
     #[test]
-    fn register_records_entry() {
-        let reg = LazyServiceRegistrar::new();
+    fn register_calls_add_service_then_client_callback() {
+        let (reg, registry) = fixture();
         reg.register_service("foo", fresh_binder()).unwrap();
+        assert_eq!(registry.calls(), vec!["add:foo", "cb:foo"]);
         let snap = reg.snapshot();
         assert_eq!(snap.len(), 1);
         assert_eq!(snap[0].0, "foo");
@@ -262,101 +687,220 @@ mod tests {
         assert_eq!(reg.registered_count(), 1);
     }
 
-    /// `try_unregister` is all-or-nothing: if ANY service still has clients it
-    /// unregisters nothing and returns `false`; only once every service is
-    /// clientless does it flip them all and return `true`. AOSP
-    /// `tryUnregisterLocked` (gated by the caller on `mNumConnectedServices ==
-    /// 0`).
+    /// A re-register of the *same* binder is `addService` only — the service
+    /// manager still holds the client callback. AOSP `registerServiceLocked`
+    /// guards `registerClientCallback` on `!reRegister`.
     #[test]
-    fn try_unregister_is_all_or_nothing() {
-        let reg = LazyServiceRegistrar::new();
-        reg.register_service("a", fresh_binder()).unwrap();
-        reg.register_service("b", fresh_binder()).unwrap();
-        // `a` still has clients; `b` lost theirs → not safe to unregister
-        // anything, and nothing is changed.
-        reg.on_clients("b", false);
-        assert!(!reg.try_unregister(), "a still has clients -> false, no-op");
-        let snap = reg.snapshot();
-        assert!(
-            snap.iter().find(|(n, _, _)| n == "a").unwrap().2,
-            "`a` stays registered"
-        );
-        assert!(
-            snap.iter().find(|(n, _, _)| n == "b").unwrap().2,
-            "`b` also stays registered"
-        );
-        assert_eq!(reg.registered_count(), 2);
-
-        // Now `a` also loses its clients → all clientless → unregister all.
-        reg.on_clients("a", false);
-        assert!(reg.try_unregister(), "all clientless -> true");
-        let snap = reg.snapshot();
-        assert!(
-            !snap.iter().find(|(n, _, _)| n == "a").unwrap().2,
-            "`a` unregistered"
-        );
-        assert!(
-            !snap.iter().find(|(n, _, _)| n == "b").unwrap().2,
-            "`b` unregistered"
-        );
-        assert_eq!(reg.registered_count(), 0);
+    fn re_registering_same_binder_does_not_re_register_the_callback() {
+        let (reg, registry) = fixture();
+        let binder = fresh_binder();
+        reg.register_service("foo", binder.clone()).unwrap();
+        reg.register_service("foo", binder).unwrap();
+        assert_eq!(registry.calls(), vec!["add:foo", "cb:foo", "add:foo"]);
     }
 
-    /// `force_persist(true)` short-circuits `try_unregister`
-    /// even when eligible candidates exist. AOSP `mForcePersist`.
+    /// A different binder under the same name is a fresh registration: the
+    /// callback the service manager holds is keyed on the old binder.
     #[test]
-    fn force_persist_blocks_unregister() {
-        let reg = LazyServiceRegistrar::new();
-        reg.register_service("x", fresh_binder()).unwrap();
-        reg.on_clients("x", false);
-        reg.force_persist(true);
-        assert!(reg.is_force_persisted());
-        assert!(!reg.try_unregister(), "force_persist blocks");
-        let snap = reg.snapshot();
-        assert!(snap[0].2, "still registered");
-    }
-
-    /// `re_register` restores `registered = true`
-    /// and defensively resets `has_clients = true` so the next
-    /// `try_unregister` cannot immediately undo the re-registration
-    /// without a fresh `onClients(false)`.
-    #[test]
-    fn re_register_restores_state_and_resets_clients() {
-        let reg = LazyServiceRegistrar::new();
-        reg.register_service("z", fresh_binder()).unwrap();
-        reg.on_clients("z", false);
-        reg.try_unregister();
-        assert_eq!(reg.registered_count(), 0);
-        reg.re_register();
-        assert_eq!(reg.registered_count(), 1);
-        // `try_unregister` immediately after re_register must be a
-        // no-op (has_clients reset to true).
-        assert!(!reg.try_unregister());
-    }
-
-    /// `on_clients` for an unknown service name silently returns
-    /// `false` instead of aborting. AOSP `LOG_ALWAYS_FATAL_IF` on
-    /// unknown service is intentionally softened for rsbinder.
-    #[test]
-    fn on_clients_for_unknown_service_is_silent() {
-        let reg = LazyServiceRegistrar::new();
-        assert!(!reg.on_clients("nope", true));
-    }
-
-    /// Re-registering a name replaces the prior entry — AOSP
-    /// `mRegisteredServices` is name-keyed. The new binder's identity
-    /// is what subsequent `binder_for` lookups must return.
-    #[test]
-    fn register_same_name_replaces() {
-        let reg = LazyServiceRegistrar::new();
-        let first = fresh_binder();
+    fn re_registering_different_binder_registers_a_new_callback() {
+        let (reg, registry) = fixture();
         let second = fresh_binder();
-        reg.register_service("dup", first.clone()).unwrap();
+        reg.register_service("dup", fresh_binder()).unwrap();
         reg.register_service("dup", second.clone()).unwrap();
+        assert_eq!(
+            registry.calls(),
+            vec!["add:dup", "cb:dup", "add:dup", "cb:dup"]
+        );
         let got = reg.binder_for("dup").unwrap();
         assert!(
             std::sync::Arc::ptr_eq(got.as_arc(), second.as_arc()),
             "second register_service wins"
         );
+    }
+
+    /// The last client leaving takes the process down with it — AOSP
+    /// `tryShutdownLocked` → `exit(EXIT_SUCCESS)`.
+    #[test]
+    fn last_client_leaving_unregisters_and_exits() {
+        let (reg, registry) = fixture();
+        reg.register_service("solo", fresh_binder()).unwrap();
+        reg.on_clients("solo", false);
+        assert!(registry.calls().contains(&"unreg:solo".to_string()));
+        assert!(reg.shared.exited.load(Ordering::Acquire), "process exits");
+        assert_eq!(reg.registered_count(), 0);
+    }
+
+    /// One service losing its clients while another still has them is not a
+    /// shutdown. AOSP gates on `mNumConnectedServices == 0`.
+    #[test]
+    fn shutdown_waits_for_every_service() {
+        let (reg, registry) = fixture();
+        reg.register_service("a", fresh_binder()).unwrap();
+        reg.register_service("b", fresh_binder()).unwrap();
+
+        reg.on_clients("b", false);
+        assert!(
+            !registry.calls().iter().any(|c| c.starts_with("unreg:")),
+            "`a` still has clients -> nothing unregistered"
+        );
+        assert!(!reg.shared.exited.load(Ordering::Acquire));
+        assert_eq!(reg.registered_count(), 2);
+
+        reg.on_clients("a", false);
+        assert!(reg.shared.exited.load(Ordering::Acquire));
+        assert_eq!(reg.registered_count(), 0);
+    }
+
+    /// A service manager that refuses an unregister — a client appeared
+    /// between the callback and the round trip — puts everything back.
+    #[test]
+    fn a_refused_unregister_re_registers_and_does_not_exit() {
+        let (reg, registry) = fixture();
+        reg.register_service("a", fresh_binder()).unwrap();
+        reg.register_service("b", fresh_binder()).unwrap();
+        registry.refuse("b");
+
+        reg.on_clients("a", false);
+        reg.on_clients("b", false);
+
+        assert!(!reg.shared.exited.load(Ordering::Acquire), "no exit");
+        assert_eq!(reg.registered_count(), 2, "`a` is put back");
+        assert!(registry.calls().contains(&"unreg:a".to_string()));
+        // `a` came down, `b` refused, so `a` is re-added — and without a
+        // second client callback.
+        assert_eq!(
+            registry.calls().iter().filter(|c| *c == "add:a").count(),
+            2,
+            "`a` re-registered"
+        );
+        assert_eq!(
+            registry.calls().iter().filter(|c| *c == "cb:a").count(),
+            1,
+            "callback registered once"
+        );
+    }
+
+    /// `re_register` leaves `has_clients` alone — AOSP `reRegisterLocked`
+    /// only touches `registered`. Resetting it would hide the very state the
+    /// service manager just reported.
+    #[test]
+    fn re_register_does_not_invent_clients() {
+        let (reg, _registry) = fixture();
+        reg.register_service("z", fresh_binder()).unwrap();
+        reg.force_persist(true);
+        reg.on_clients("z", false);
+        assert!(!reg.try_unregister(), "force_persist blocks");
+
+        reg.force_persist(false);
+        // Releasing force_persist re-checks and shuts down.
+        assert!(reg.shared.exited.load(Ordering::Acquire));
+        reg.re_register();
+        assert_eq!(reg.registered_count(), 1);
+        let snap = reg.snapshot();
+        assert!(!snap[0].1, "has_clients stays false after re_register");
+    }
+
+    /// `force_persist(true)` blocks the shutdown entirely.
+    #[test]
+    fn force_persist_blocks_unregister() {
+        let (reg, registry) = fixture();
+        reg.register_service("x", fresh_binder()).unwrap();
+        reg.force_persist(true);
+        assert!(reg.is_force_persisted());
+        reg.on_clients("x", false);
+        assert!(!reg.try_unregister(), "force_persist blocks");
+        assert!(!registry.calls().iter().any(|c| c.starts_with("unreg:")));
+        assert!(!reg.shared.exited.load(Ordering::Acquire));
+        assert!(reg.snapshot()[0].2, "still registered");
+    }
+
+    /// An active-services callback that returns `true` owns the decision;
+    /// the registrar does not unregister or exit behind its back.
+    #[test]
+    fn active_services_callback_can_take_over() {
+        let (reg, registry) = fixture();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        reg.set_active_services_callback(Arc::new(move |has_clients| {
+            sink.lock().unwrap().push(has_clients);
+            true
+        }));
+        reg.register_service("x", fresh_binder()).unwrap();
+        reg.on_clients("x", false);
+
+        assert_eq!(*seen.lock().unwrap(), vec![false]);
+        assert!(
+            !reg.shared.exited.load(Ordering::Acquire),
+            "callback owns it"
+        );
+        assert!(!registry.calls().iter().any(|c| c.starts_with("unreg:")));
+        assert_eq!(reg.registered_count(), 1);
+    }
+
+    /// The callback fires only when the answer changes. AOSP
+    /// `mPreviousHasClients`.
+    #[test]
+    fn active_services_callback_fires_only_on_change() {
+        let (reg, _registry) = fixture();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        reg.set_active_services_callback(Arc::new(move |has_clients| {
+            sink.lock().unwrap().push(has_clients);
+            true
+        }));
+        reg.register_service("x", fresh_binder()).unwrap();
+
+        reg.on_clients("x", false);
+        reg.on_clients("x", true);
+        reg.on_clients("x", true); // repeated — no transition
+        reg.on_clients("x", false);
+
+        assert_eq!(*seen.lock().unwrap(), vec![false, true, false]);
+    }
+
+    /// `on_clients` for an unknown service name returns `false` instead of
+    /// aborting. AOSP `LOG_ALWAYS_FATAL_IF`.
+    #[test]
+    fn on_clients_for_unknown_service_is_silent() {
+        let (reg, _registry) = fixture();
+        assert!(!reg.on_clients("nope", true));
+    }
+
+    /// A registrar with nothing in it never reports "safe to exit".
+    #[test]
+    fn empty_registrar_never_reports_safe_to_exit() {
+        let (reg, _registry) = fixture();
+        assert!(!reg.try_unregister());
+    }
+
+    /// The `IClientCallback` bridge resolves the binder the wire gives it
+    /// back to the name it was registered under.
+    #[test]
+    fn client_callback_routes_by_binder_identity() {
+        let (reg, registry) = fixture();
+        let a = fresh_binder();
+        let b = fresh_binder();
+        reg.register_service("a", a.clone()).unwrap();
+        reg.register_service("b", b.clone()).unwrap();
+
+        reg.shared.on_clients_binder(&b, false);
+        assert!(!reg.snapshot().iter().find(|s| s.0 == "b").unwrap().1);
+        assert!(reg.snapshot().iter().find(|s| s.0 == "a").unwrap().1);
+        assert!(!registry.calls().iter().any(|c| c.starts_with("unreg:")));
+
+        // A binder this registrar never registered is logged, not fatal.
+        reg.shared.on_clients_binder(&fresh_binder(), false);
+        assert!(!reg.shared.exited.load(Ordering::Acquire));
+    }
+
+    /// Clones share one set of registrations, as AOSP's handle shares its
+    /// `ClientCounterCallback`.
+    #[test]
+    fn clones_share_state() {
+        let (reg, _registry) = fixture();
+        let other = reg.clone();
+        reg.register_service("shared", fresh_binder()).unwrap();
+        assert_eq!(other.registered_count(), 1);
+        assert!(other.binder_for("shared").is_some());
     }
 }

--- a/rsbinder/src/lazy_service.rs
+++ b/rsbinder/src/lazy_service.rs
@@ -24,11 +24,14 @@
 //! // `ProcessState` has to exist first.
 //! ProcessState::init_default()?;
 //!
+//! // `onClients` is an inbound transaction, so the pool has to be running.
+//! ProcessState::start_thread_pool();
+//!
 //! // The process-wide registrar: it has to outlive what it registers.
 //! LazyServiceRegistrar::instance().register_service("my.Service/default", binder)?;
 //!
 //! // Returns only if the thread pool is torn down; the usual exit is the
-//! // registrar's own, from the callback thread.
+//! // registrar's own, from the binder thread that took the `onClients`.
 //! ProcessState::join_thread_pool()?;
 //! # Ok(())
 //! # }
@@ -46,14 +49,18 @@
 //! ## Deviations from AOSP
 //!
 //! * **Service-manager calls happen outside the registrar's lock.** AOSP
-//!   holds `mMutex` across `tryUnregisterService`, but a service manager may
-//!   answer that call by dispatching `onClients` back into this process, and
-//!   the binder driver delivers such a nested transaction on the very thread
-//!   that is waiting for the reply — which would deadlock on a non-reentrant
-//!   `Mutex`. State is snapshotted under the lock, the calls are made
-//!   without it, and the results are recorded on the way back. The service
-//!   manager is the authority on whether an unregister may proceed, so
-//!   nothing is lost by not holding it.
+//!   holds `mMutex` across `tryUnregisterService`. It can: `IClientCallback`
+//!   is a `oneway` interface, so a notification the service manager sends
+//!   while answering that call is queued to this process and picked up by a
+//!   binder pool thread — never delivered as a nested transaction on the
+//!   thread waiting for the reply — and holding the lock would just block
+//!   that pool thread for the length of the round trip. This port releases
+//!   it anyway, so a notification arriving mid-round-trip is recorded when
+//!   it arrives instead of queueing behind the call it answers. What AOSP's
+//!   one mutex also buys — no two service-manager sequences interleaving —
+//!   is kept by a second lock (`Shared::ops`) that spans a whole
+//!   `register_service` or shutdown decision but is never held for the
+//!   bookkeeping half of `onClients`.
 //! * **Nothing aborts.** AOSP `LOG_ALWAYS_FATAL`s on an `onClients` for an
 //!   unknown service, on an `onClients` that repeats the state it already
 //!   believed, and on a failed re-register. Each is logged and survived here.
@@ -62,10 +69,12 @@
 //!   registered with the service manager but untracked here — visible to
 //!   clients, never shutting down. Call
 //!   [`hub::try_unregister_service`](crate::hub::try_unregister_service) to
-//!   undo that, or retry (a retry re-runs both calls). **Android 10 always
-//!   lands here**: its service manager has no `registerClientCallback`, so
-//!   `register_service` reports `UnknownTransaction` on every call and lazy
-//!   services need Android 11 or newer.
+//!   undo that, or retry (a retry re-runs both calls). **Android 10 is
+//!   refused before anything is published**: its service manager has
+//!   neither `registerClientCallback` nor `tryUnregisterService`, so a
+//!   half-registration there could never be undone. `register_service`
+//!   reports `EX_UNSUPPORTED_OPERATION` without calling `addService`, and
+//!   lazy services need Android 11 or newer.
 //! * **Re-registering a name with a *different* binder replaces the entry**
 //!   (carrying its client state forward, as the service manager does). AOSP
 //!   keeps the first binder in `mRegisteredServices` while handing the new
@@ -80,7 +89,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 
 use crate::binder::SIBinder;
-use crate::error::{Result, StatusCode};
 use crate::hub::{BnClientCallback, IClientCallback};
 use crate::status::Status;
 use crate::{Interface, Strong};
@@ -188,6 +196,17 @@ impl Inner {
 /// `Shared` holds the state and (transitively) the callback binder, and the
 /// bridge holds a `Weak<Shared>` so the two do not keep each other alive.
 struct Shared {
+    /// Serializes the service-manager round trips against each other, the
+    /// way AOSP's single `mMutex` does — held across a whole
+    /// `register_service` and across a whole shutdown decision, so no two
+    /// of them can interleave into a state the service manager disagrees
+    /// with. Always taken *before* `inner`, never while holding it.
+    ///
+    /// `onClients` does not wait on it to record itself; only the shutdown
+    /// decision that follows does. A notification arriving mid-round-trip
+    /// therefore lands in `inner` at once and is acted on as soon as the
+    /// round trip finishes.
+    ops: Mutex<()>,
     inner: Mutex<Inner>,
     force_persist: AtomicBool,
     registry: Arc<dyn Registry>,
@@ -206,9 +225,8 @@ impl Interface for ClientCounterCallback {}
 
 impl IClientCallback for ClientCounterCallback {
     fn onClients(&self, registered: &SIBinder, has_clients: bool) -> crate::status::Result<()> {
-        // A callback that outlives its registrar is not an error: the
-        // service manager may still hold the proxy after the last
-        // `LazyServiceRegistrar` handle is dropped.
+        // Not an error: the service manager may still hold the proxy
+        // after the last `LazyServiceRegistrar` handle is dropped.
         if let Some(shared) = self.shared.upgrade() {
             shared.on_clients_binder(registered, has_clients);
         }
@@ -249,12 +267,8 @@ impl Shared {
                 return false;
             };
             if entry.has_clients == has_clients {
-                // Expected right after registration: the service manager
-                // sends a catch-up `onClients(true)` from inside
-                // `registerClientCallback` when the service already has
-                // clients, and a new entry starts out assuming it does.
-                // AOSP `LOG_ALWAYS_FATAL`s here instead, which it can
-                // afford because its `Service::clients` starts `false`.
+                // AOSP `LOG_ALWAYS_FATAL`s here; a re-registered name can
+                // legitimately repeat the state it carried forward.
                 log::debug!("{name}: onClients({has_clients}) matched what we already believed");
             }
             entry.has_clients = has_clients;
@@ -269,17 +283,19 @@ impl Shared {
         true
     }
 
-    /// AOSP `maybeTryShutdownLocked`. The active-services callback runs
-    /// without the registrar lock held, so it may call back into the
-    /// registrar (`force_persist`, `try_unregister`) without deadlocking.
+    /// AOSP `maybeTryShutdownLocked`.
     fn maybe_try_shutdown(&self) {
         if self.force_persist.load(Ordering::Acquire) {
             log::info!("Shutdown prevented by force_persist override flag.");
             return;
         }
+        // Waits out a `register_service` or another thread's shutdown. AOSP
+        // is already holding the equivalent when it gets here.
+        let _ops = self.ops.lock().unwrap_or_else(|e| e.into_inner());
 
-        // Latch `previous_has_clients` under the lock so two threads
-        // reporting the same transition cannot both fire the callback.
+        // AOSP `mPreviousHasClients`: fire only when the answer changes.
+        // Cloned out so the callback runs without the state lock — it is
+        // documented to call back into the registrar.
         let to_fire = {
             let mut inner = self.lock();
             let has_clients = inner.num_connected_services != 0;
@@ -298,11 +314,8 @@ impl Shared {
             None => false,
         };
 
-        // Re-read rather than reuse the value from above: the lock was
-        // released for the callback. This is advisory either way — the
-        // service manager refuses `tryUnregisterService` for a service that
-        // has clients, so a stale `true` here costs a failed round trip and
-        // a re-register, never a wrongly shut-down service.
+        // Re-read: the lock was released for the callback. Advisory — the
+        // service manager refuses an unregister while clients hold it.
         if !handled && self.lock().num_connected_services == 0 {
             self.try_shutdown();
         }
@@ -347,10 +360,8 @@ impl Shared {
                 .collect()
         };
 
-        // AOSP cannot reach an empty map here (its shutdown check only runs
-        // from a registered service's `onClients`), but `try_unregister` is
-        // public: a registrar with nothing in it must not report "every
-        // service is down, safe to exit".
+        // `try_unregister` is public, and a registrar with nothing in it
+        // must not report "every service is down, safe to exit".
         if candidates.is_empty() {
             return false;
         }
@@ -376,7 +387,16 @@ impl Shared {
     fn restore(&self, name: &str, previous: Option<RegisteredService>) {
         let mut inner = self.lock();
         match previous {
-            Some(entry) => inner.services.insert(name.to_string(), entry),
+            Some(mut entry) => {
+                // Not what the notification and the public `try_unregister`
+                // may have changed under us: the service manager repeats
+                // neither, so a snapshot value would never be corrected.
+                if let Some(current) = inner.services.get(name) {
+                    entry.has_clients = current.has_clients;
+                    entry.registered = current.registered;
+                }
+                inner.services.insert(name.to_string(), entry)
+            }
             None => inner.services.remove(name),
         };
         inner.update_cache_client_count();
@@ -397,19 +417,15 @@ impl Shared {
         };
 
         for (name, binder) in pending {
-            // A re-register is `addService` only — the client callback is
-            // registered once per (name, binder) and the service manager
-            // still holds it.
+            // `addService` only: the callback is registered once per name.
             match self.registry.add_lazy_service(&name, &binder) {
                 Ok(()) => {
                     if let Some(entry) = self.lock().services.get_mut(&name) {
                         entry.registered = true;
                     }
                 }
-                // AOSP `LOG_ALWAYS_FATAL`s: "clients will never be able to
-                // get a hold of this service". Left `registered = false` so
-                // a later `re_register` can try again instead of the process
-                // dying with the state it had.
+                // AOSP `LOG_ALWAYS_FATAL`s. Left `registered = false` so a
+                // later `re_register` can try again.
                 Err(e) => log::error!("Bad state: could not re-register {name} ({e:?})"),
             }
         }
@@ -460,6 +476,7 @@ impl LazyServiceRegistrar {
     fn with_registry(registry: Arc<dyn Registry>) -> Self {
         LazyServiceRegistrar {
             shared: Arc::new(Shared {
+                ops: Mutex::new(()),
                 inner: Mutex::new(Inner {
                     services: BTreeMap::new(),
                     num_connected_services: 0,
@@ -494,35 +511,47 @@ impl LazyServiceRegistrar {
     /// already tracked — `registerClientCallback`. AOSP
     /// [`registerServiceLocked`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=129).
     ///
-    /// A new registration starts out assumed to have clients, so an idle
-    /// process cannot shut down before the service manager has said anything
-    /// about it. Re-registering a name already tracked carries that state
-    /// forward whatever binder comes with it — the service manager does the
-    /// same, and reports it only when it changes, so throwing it away here
-    /// would strand the process.
+    /// A new registration starts out with no clients, as AOSP's
+    /// `Service::clients` does — the service manager reports a client only
+    /// once one arrives, and never repeats itself, so assuming one here
+    /// would be an assumption nothing ever takes back. Re-registering a name
+    /// already tracked carries the reported state forward whatever binder
+    /// comes with it, for the same reason: the service manager carries it
+    /// across a re-`addService` and will not re-announce it.
     ///
-    /// **This call can be cut short by the process exiting.** Another
-    /// thread reaching the shutdown decision while this one is mid-register
-    /// takes the process down with it, so `register_service` never returns.
-    /// That is the lazy contract working, not a failure — but if the order
-    /// matters, hold the process with [`force_persist(true)`](Self::force_persist)
-    /// until every service is registered. AOSP has no such window because
-    /// `registerService` and `onClients` share one mutex; this port cannot
-    /// hold that lock across the service-manager calls (see the module docs
-    /// on nested `onClients`).
-    pub fn register_service(&self, name: &str, binder: SIBinder) -> Result<()> {
-        // Everything here turns on whether the *name* is already tracked.
-        // The service manager keys the client-callback list on the name
-        // (`mNameToClientCallback[name]`) and carries `hasClients` across a
-        // re-`addService` whatever binder comes with it (AOSP
-        // `ServiceManager.cpp`: `.hasClients = prevClients`).
-        //
-        // The entry is published before the round trips, not after. The
-        // service manager dispatches `onClients` for this name from inside
-        // `addService` and `registerClientCallback`, both before their
-        // reply, so the driver lands that nested transaction on this very
-        // thread — and an entry that is not there yet would drop it, with
-        // no repeat coming.
+    /// An `onClients` arriving on a pool thread while this call is in
+    /// flight is recorded at once but cannot act until the call is done, so
+    /// it never decides on a service count the service manager does not yet
+    /// agree with. AOSP gets the same exclusion from holding one mutex
+    /// across its round trips.
+    ///
+    /// **A shutdown that was waiting on this call runs the moment it
+    /// returns, and shutting down means [`std::process::exit`].** Registering
+    /// several services one after another can therefore end mid-loop, with
+    /// no error and nothing after the call reached. That is the lazy
+    /// contract working, not a failure — but when every service has to be up
+    /// before any of them may take the process down, wrap the batch in
+    /// [`force_persist(true)`](Self::force_persist) and release it at the
+    /// end.
+    ///
+    /// # Errors
+    ///
+    /// The service manager's own [`Status`] — `EX_SECURITY` for a policy
+    /// refusal, and so on. Returns before `addService` on Android 10, whose
+    /// service manager cannot support the lazy contract at all.
+    pub fn register_service(
+        &self,
+        name: &str,
+        binder: impl Into<SIBinder>,
+    ) -> std::result::Result<(), Status> {
+        let binder = binder.into();
+        // Held for the whole call, as AOSP holds `mMutex` across
+        // `registerServiceLocked`.
+        let _ops = self.shared.ops.lock().unwrap_or_else(|e| e.into_inner());
+
+        // Published before the round trips: `onClients` for this name can
+        // arrive on a pool thread while they are outstanding, and an entry
+        // that is not there yet would drop it with no repeat coming.
         let previous = {
             let mut inner = self.shared.lock();
             let previous = inner.services.get(name).cloned();
@@ -531,16 +560,15 @@ impl LazyServiceRegistrar {
                 RegisteredService {
                     name: name.to_string(),
                     binder: binder.clone(),
-                    // A new registration is assumed to be in use, so an idle
-                    // process cannot shut down before the service manager
-                    // has said anything about it.
-                    has_clients: previous.as_ref().is_none_or(|e| e.has_clients),
+                    has_clients: previous.as_ref().is_some_and(|e| e.has_clients),
                     registered: true,
                 },
             );
             inner.update_cache_client_count();
             previous
         };
+        // Everything below turns on whether the *name* is already tracked:
+        // the service manager keys client callbacks on the name alone.
         let tracked = previous.is_some();
 
         log::info!(
@@ -555,13 +583,12 @@ impl LazyServiceRegistrar {
         if let Err(e) = self.shared.registry.add_lazy_service(name, &binder) {
             log::error!("Failed to register service {name} ({e:?})");
             self.shared.restore(name, previous);
-            return Err(StatusCode::from(e));
+            return Err(e);
         }
 
-        // Only for a name not already tracked: the service manager holds
-        // client callbacks by name and de-duplicates nothing, so a second
-        // registration would have it deliver every later `onClients` twice.
-        // AOSP `registerServiceLocked` guards on `!reRegister` for this.
+        // The service manager de-duplicates nothing, so registering the
+        // callback again would have it deliver every later `onClients`
+        // twice. AOSP `registerServiceLocked` guards on `!reRegister`.
         if !tracked {
             let callback = self.callback();
             if let Err(e) = self
@@ -571,7 +598,7 @@ impl LazyServiceRegistrar {
             {
                 log::error!("Failed to add client callback for service {name} ({e:?})");
                 self.shared.restore(name, previous);
-                return Err(StatusCode::from(e));
+                return Err(e);
             }
         }
 
@@ -601,6 +628,17 @@ impl LazyServiceRegistrar {
     /// that arrives and leaves in between is decided without it. See
     /// [`ActiveServicesCallback`] for what the argument and return value
     /// mean.
+    ///
+    /// The callback runs inside the shutdown decision it is answering, so
+    /// [`try_unregister`](Self::try_unregister),
+    /// [`re_register`](Self::re_register) and
+    /// [`force_persist`](Self::force_persist) may be called from it — those
+    /// are what it is *for* — but [`register_service`](Self::register_service)
+    /// and [`on_clients`](Self::on_clients) may not: both re-enter the lock
+    /// the decision holds and would deadlock. AOSP has the same rule for the
+    /// same reason (`mActiveServicesCallback` is invoked under `mMutex`,
+    /// while its `tryUnregister` / `reRegister` deliberately do not re-take
+    /// it).
     pub fn set_active_services_callback(&self, callback: ActiveServicesCallback) {
         self.shared.lock().active_services_callback = Some(callback);
     }
@@ -624,8 +662,14 @@ impl LazyServiceRegistrar {
     /// ones that did come down. AOSP calls this only from the active services
     /// callback.
     ///
-    /// A registrar with no services returns `false`: there is nothing to take
-    /// down, so it never signals "safe to exit".
+    /// Two more cases return `false` without calling the service manager at
+    /// all, so nothing came down and no [`Self::re_register`] is owed: a
+    /// registrar with no services (there is nothing to take down, so it never
+    /// signals "safe to exit"), and one with
+    /// [`force_persist`](Self::force_persist) set. AOSP `tryUnregisterLocked`
+    /// has no `forcePersist` check — it is reached only through
+    /// `maybeTryShutdownLocked`, which already made it; this one is public
+    /// and can be called directly.
     pub fn try_unregister(&self) -> bool {
         self.shared.try_unregister()
     }
@@ -671,6 +715,21 @@ mod tests {
     use crate::binder::Stability;
     use crate::native::Binder;
     use crate::{Parcel, Remotable, Result as RsResult, TransactionCode};
+    use std::sync::atomic::AtomicUsize;
+    use std::thread::JoinHandle;
+
+    /// Spin until `f` holds. The notification a fake sends runs on its own
+    /// thread (`onClients` is `oneway`); the fake waits here for its
+    /// bookkeeping half to land, which needs no lock the round trip holds.
+    fn spin_until(mut f: impl FnMut() -> bool) {
+        for _ in 0..1_000_000 {
+            if f() {
+                return;
+            }
+            std::thread::yield_now();
+        }
+        panic!("the notification never landed");
+    }
 
     struct Dummy;
     impl Remotable for Dummy {
@@ -696,12 +755,43 @@ mod tests {
     #[derive(Default)]
     struct FakeRegistry {
         calls: Mutex<Vec<String>>,
+        /// The binder each call carried, in order. The name alone would not
+        /// catch sending the service manager a stale binder — which is what
+        /// strands `onClients`, since the reply carries the binder back.
+        binders: Mutex<Vec<(String, SIBinder)>>,
+        /// Every `IClientCallback` the registrar handed over. The service
+        /// manager keeps only a proxy, so the registrar has to keep the
+        /// object alive itself — one object for the whole registrar.
+        callbacks: Mutex<Vec<Strong<dyn IClientCallback>>>,
         refuse_unregister: Mutex<Vec<String>>,
     }
 
     impl FakeRegistry {
         fn calls(&self) -> Vec<String> {
             self.calls.lock().unwrap().clone()
+        }
+        /// The `IClientCallback` handed to the last `registerClientCallback`.
+        fn last_callback(&self) -> Strong<dyn IClientCallback> {
+            self.callbacks.lock().unwrap().last().unwrap().clone()
+        }
+        /// The binder of the last `call` (`"add:x"`, `"cb:x"`, `"unreg:x"`).
+        fn last_binder(&self, call: &str) -> SIBinder {
+            self.binders
+                .lock()
+                .unwrap()
+                .iter()
+                .rev()
+                .find(|(c, _)| c == call)
+                .unwrap_or_else(|| panic!("no {call} call recorded"))
+                .1
+                .clone()
+        }
+        fn record(&self, call: String, binder: &SIBinder) {
+            self.binders
+                .lock()
+                .unwrap()
+                .push((call.clone(), binder.clone()));
+            self.calls.lock().unwrap().push(call);
         }
         fn refuse(&self, name: &str) {
             self.refuse_unregister
@@ -715,26 +805,27 @@ mod tests {
         fn add_lazy_service(
             &self,
             name: &str,
-            _binder: &SIBinder,
+            binder: &SIBinder,
         ) -> std::result::Result<(), Status> {
-            self.calls.lock().unwrap().push(format!("add:{name}"));
+            self.record(format!("add:{name}"), binder);
             Ok(())
         }
         fn register_client_callback(
             &self,
             name: &str,
-            _binder: &SIBinder,
-            _callback: &Strong<dyn IClientCallback>,
+            binder: &SIBinder,
+            callback: &Strong<dyn IClientCallback>,
         ) -> std::result::Result<(), Status> {
-            self.calls.lock().unwrap().push(format!("cb:{name}"));
+            self.callbacks.lock().unwrap().push(callback.clone());
+            self.record(format!("cb:{name}"), binder);
             Ok(())
         }
         fn try_unregister_service(
             &self,
             name: &str,
-            _binder: &SIBinder,
+            binder: &SIBinder,
         ) -> std::result::Result<(), Status> {
-            self.calls.lock().unwrap().push(format!("unreg:{name}"));
+            self.record(format!("unreg:{name}"), binder);
             if self
                 .refuse_unregister
                 .lock()
@@ -790,25 +881,22 @@ mod tests {
         let (reg, _registry) = fixture();
         let binder = fresh_binder();
         reg.register_service("keep", binder.clone()).unwrap();
-
-        // Hold the process up so the `onClients(false)` below does not shut
-        // it down before the re-register can be observed.
-        reg.force_persist(true);
-        reg.on_clients("keep", false);
-        assert!(!reg.snapshot()[0].1, "the service manager said no clients");
+        reg.on_clients("keep", true);
 
         reg.register_service("keep", binder).unwrap();
         assert!(
-            !reg.snapshot()[0].1,
-            "a re-register must not invent clients"
+            reg.snapshot()[0].1,
+            "a re-register must not throw away the reported client"
+        );
+        assert!(
+            !reg.shared.exited.load(Ordering::Acquire),
+            "a service with a client is not idle"
         );
 
-        // The proof it matters: releasing the hold must now shut down.
-        reg.force_persist(false);
-        assert!(
-            reg.shared.exited.load(Ordering::Acquire),
-            "still believed to be in use after the re-register"
-        );
+        // The proof it matters: the client leaving must still be the
+        // transition that shuts the process down.
+        reg.on_clients("keep", false);
+        assert!(reg.shared.exited.load(Ordering::Acquire));
     }
 
     /// A different binder under the same name replaces the entry but does
@@ -824,6 +912,11 @@ mod tests {
         reg.register_service("dup", fresh_binder()).unwrap();
         reg.register_service("dup", second.clone()).unwrap();
         assert_eq!(registry.calls(), vec!["add:dup", "cb:dup", "add:dup"]);
+        assert_eq!(
+            registry.last_binder("add:dup"),
+            second,
+            "the re-`addService` must carry the new binder"
+        );
 
         // The entry must still follow the new binder: `onClients` carries
         // the binder the service manager currently holds, and it is looked
@@ -833,9 +926,9 @@ mod tests {
             std::sync::Arc::ptr_eq(got.as_arc(), second.as_arc()),
             "second register_service wins"
         );
-        reg.shared.on_clients_binder(&second, false);
+        reg.shared.on_clients_binder(&second, true);
         assert!(
-            !reg.snapshot()[0].1,
+            reg.snapshot()[0].1,
             "onClients for the new binder must resolve to this entry"
         );
     }
@@ -845,9 +938,18 @@ mod tests {
     #[test]
     fn last_client_leaving_unregisters_and_exits() {
         let (reg, registry) = fixture();
-        reg.register_service("solo", fresh_binder()).unwrap();
+        let binder = fresh_binder();
+        reg.register_service("solo", binder.clone()).unwrap();
+        reg.on_clients("solo", true);
+        assert!(!reg.shared.exited.load(Ordering::Acquire), "still in use");
+
         reg.on_clients("solo", false);
         assert!(registry.calls().contains(&"unreg:solo".to_string()));
+        assert_eq!(
+            registry.last_binder("unreg:solo"),
+            binder,
+            "tryUnregisterService must name the binder it registered"
+        );
         assert!(reg.shared.exited.load(Ordering::Acquire), "process exits");
         assert_eq!(reg.registered_count(), 0);
     }
@@ -859,6 +961,8 @@ mod tests {
         let (reg, registry) = fixture();
         reg.register_service("a", fresh_binder()).unwrap();
         reg.register_service("b", fresh_binder()).unwrap();
+        reg.on_clients("a", true);
+        reg.on_clients("b", true);
 
         reg.on_clients("b", false);
         assert!(
@@ -880,6 +984,8 @@ mod tests {
         let (reg, registry) = fixture();
         reg.register_service("a", fresh_binder()).unwrap();
         reg.register_service("b", fresh_binder()).unwrap();
+        reg.on_clients("a", true);
+        reg.on_clients("b", true);
         registry.refuse("b");
 
         reg.on_clients("a", false);
@@ -903,12 +1009,15 @@ mod tests {
     }
 
     /// `re_register` leaves `has_clients` alone — AOSP `reRegisterLocked`
-    /// only touches `registered`. Resetting it would hide the very state the
-    /// service manager just reported.
+    /// only touches `registered`. Resetting it either way would hide the
+    /// state the service manager just reported, so both directions are
+    /// pinned: a service that came down without clients stays without, and
+    /// one the service manager refused *because* it has clients keeps them.
     #[test]
     fn re_register_does_not_invent_clients() {
         let (reg, _registry) = fixture();
         reg.register_service("z", fresh_binder()).unwrap();
+        reg.on_clients("z", true);
         reg.force_persist(true);
         reg.on_clients("z", false);
         assert!(!reg.try_unregister(), "force_persist blocks");
@@ -918,8 +1027,24 @@ mod tests {
         assert!(reg.shared.exited.load(Ordering::Acquire));
         reg.re_register();
         assert_eq!(reg.registered_count(), 1);
-        let snap = reg.snapshot();
-        assert!(!snap[0].1, "has_clients stays false after re_register");
+        assert!(!reg.snapshot()[0].1, "has_clients stays false");
+
+        // The other direction: `b` is refused because it still has clients,
+        // so `a` comes down and goes back up while `b` keeps them.
+        let (reg, registry) = fixture();
+        reg.register_service("a", fresh_binder()).unwrap();
+        reg.register_service("b", fresh_binder()).unwrap();
+        reg.on_clients("a", true);
+        reg.on_clients("b", true);
+        registry.refuse("b");
+
+        assert!(!reg.try_unregister(), "the service manager refused `b`");
+        reg.re_register();
+        assert_eq!(reg.registered_count(), 2);
+        assert!(
+            reg.snapshot().iter().all(|s| s.1),
+            "re_register must not clear the clients the service manager reported"
+        );
     }
 
     /// `force_persist(true)` blocks the shutdown entirely.
@@ -1004,6 +1129,8 @@ mod tests {
         let b = fresh_binder();
         reg.register_service("a", a.clone()).unwrap();
         reg.register_service("b", b.clone()).unwrap();
+        reg.shared.on_clients_binder(&a, true);
+        reg.shared.on_clients_binder(&b, true);
 
         reg.shared.on_clients_binder(&b, false);
         assert!(!reg.snapshot().iter().find(|s| s.0 == "b").unwrap().1);
@@ -1015,13 +1142,25 @@ mod tests {
         assert!(!reg.shared.exited.load(Ordering::Acquire));
     }
 
-    /// A service manager that answers `registerClientCallback` by dispatching
-    /// `onClients` before it replies — which is what both `rsb_hub` and AOSP
-    /// do, and the binder driver lands that nested transaction on the thread
-    /// still waiting for the reply.
+    /// A service manager that dispatches `onClients` from inside
+    /// `registerClientCallback`, before it replies — which is what both
+    /// `rsb_hub` and AOSP do. It goes through the `IClientCallback` it was
+    /// handed, on its own thread, because that is what the wire does:
+    /// `onClients` is `oneway`, so it lands on a binder pool thread while
+    /// the round trip is still open.
+    #[derive(Default)]
     struct ReentrantRegistry {
         shared: Mutex<Option<Weak<Shared>>>,
         report: bool,
+        notifier: Mutex<Option<JoinHandle<()>>>,
+    }
+
+    impl ReentrantRegistry {
+        fn join(&self) {
+            if let Some(h) = self.notifier.lock().unwrap().take() {
+                h.join().unwrap();
+            }
+        }
     }
 
     impl Registry for ReentrantRegistry {
@@ -1034,14 +1173,21 @@ mod tests {
         }
         fn register_client_callback(
             &self,
-            _name: &str,
+            name: &str,
             binder: &SIBinder,
-            _callback: &Strong<dyn IClientCallback>,
+            callback: &Strong<dyn IClientCallback>,
         ) -> std::result::Result<(), Status> {
             let shared = self.shared.lock().unwrap().clone();
-            if let Some(shared) = shared.as_ref().and_then(Weak::upgrade) {
-                shared.on_clients_binder(binder, self.report);
-            }
+            let Some(shared) = shared.as_ref().and_then(Weak::upgrade) else {
+                return Ok(());
+            };
+            let (cb, b, want) = (callback.clone(), binder.clone(), self.report);
+            *self.notifier.lock().unwrap() =
+                Some(std::thread::spawn(move || cb.onClients(&b, want).unwrap()));
+            // Return only once the notification has been recorded, so the
+            // assertion is about the round trip's own window.
+            let name = name.to_string();
+            spin_until(|| shared.lock().services.get(&name).map(|e| e.has_clients) == Some(want));
             Ok(())
         }
         fn try_unregister_service(
@@ -1060,20 +1206,205 @@ mod tests {
     #[test]
     fn a_notification_arriving_during_registration_is_not_dropped() {
         let registry = Arc::new(ReentrantRegistry {
-            shared: Mutex::new(None),
-            report: false,
+            report: true,
+            ..Default::default()
         });
         let reg = LazyServiceRegistrar::with_registry(registry.clone());
         *registry.shared.lock().unwrap() = Some(Arc::downgrade(&reg.shared));
 
-        // Held so the re-entrant `onClients(false)` cannot take the process
-        // down before the assertion; the point here is that it is *seen*.
-        reg.force_persist(true);
         reg.register_service("nested", fresh_binder()).unwrap();
+        registry.join();
+
+        assert!(
+            reg.snapshot()[0].1,
+            "the notification sent from inside registerClientCallback was dropped"
+        );
+    }
+
+    /// Every service gets the *same* `IClientCallback`, and the registrar
+    /// keeps it alive. The service manager holds only a proxy, so a
+    /// registrar that made a fresh callback per registration — or let the
+    /// object drop — would leave it calling something that no longer
+    /// routes: services registered, process never shutting down, nothing
+    /// logged.
+    #[test]
+    fn one_client_callback_serves_the_whole_registrar() {
+        let (reg, registry) = fixture();
+        reg.register_service("a", fresh_binder()).unwrap();
+        let first = registry.last_callback();
+        reg.register_service("b", fresh_binder()).unwrap();
+
+        assert_eq!(
+            first,
+            registry.last_callback(),
+            "one callback per registrar"
+        );
+        assert!(
+            reg.shared.lock().callback.is_some(),
+            "the registrar must hold the callback itself"
+        );
+
+        // It is the live one: a notification through it reaches the state.
+        first
+            .onClients(&reg.binder_for("a").unwrap(), true)
+            .unwrap();
+        assert!(reg.snapshot().iter().find(|s| s.0 == "a").unwrap().1);
+    }
+
+    /// A service nobody ever looks up must not keep the process alive. The
+    /// service manager reports only changes, so an unused name never draws an
+    /// `onClients` at all — assuming a client for it would be an assumption
+    /// nothing ever takes back. AOSP `Service::clients` starts `false`.
+    #[test]
+    fn a_service_nobody_used_does_not_block_shutdown() {
+        let (reg, registry) = fixture();
+        reg.register_service("used", fresh_binder()).unwrap();
+        reg.register_service("never_used", fresh_binder()).unwrap();
+
+        reg.on_clients("used", true);
+        assert!(!reg.shared.exited.load(Ordering::Acquire), "still in use");
+
+        reg.on_clients("used", false);
+        assert!(
+            reg.shared.exited.load(Ordering::Acquire),
+            "`never_used` was never reported on, so it must not count as in use"
+        );
+        assert!(registry.calls().contains(&"unreg:never_used".to_string()));
+    }
+
+    /// Two `register_service` calls never overlap. Their round trips are
+    /// outside the state lock, so without a lock of their own the loser's
+    /// rollback could undo the winner's publish. AOSP gets this from
+    /// `mMutex` spanning `registerServiceLocked`.
+    #[test]
+    fn registrations_do_not_overlap() {
+        #[derive(Default)]
+        struct DepthProbe {
+            depth: AtomicUsize,
+            max_depth: AtomicUsize,
+        }
+        impl Registry for DepthProbe {
+            fn add_lazy_service(&self, _: &str, _: &SIBinder) -> std::result::Result<(), Status> {
+                let depth = self.depth.fetch_add(1, Ordering::AcqRel) + 1;
+                self.max_depth.fetch_max(depth, Ordering::AcqRel);
+                // Widen the window a competing call would have to land in.
+                for _ in 0..100_000 {
+                    std::hint::spin_loop();
+                }
+                self.depth.fetch_sub(1, Ordering::AcqRel);
+                Ok(())
+            }
+            fn register_client_callback(
+                &self,
+                _: &str,
+                _: &SIBinder,
+                _: &Strong<dyn IClientCallback>,
+            ) -> std::result::Result<(), Status> {
+                Ok(())
+            }
+            fn try_unregister_service(
+                &self,
+                _: &str,
+                _: &SIBinder,
+            ) -> std::result::Result<(), Status> {
+                Ok(())
+            }
+        }
+
+        let registry = Arc::new(DepthProbe::default());
+        let reg = LazyServiceRegistrar::with_registry(registry.clone());
+        std::thread::scope(|scope| {
+            for i in 0..4 {
+                let reg = &reg;
+                scope.spawn(move || {
+                    reg.register_service(&format!("svc{i}"), fresh_binder())
+                        .unwrap()
+                });
+            }
+        });
+
+        assert_eq!(reg.registered_count(), 4);
+        assert_eq!(
+            registry.max_depth.load(Ordering::Acquire),
+            1,
+            "two register_service calls were inside addService at once"
+        );
+    }
+
+    /// A `register_service` that fails after a notification landed must not
+    /// put the pre-call state back over it. The service manager reports only
+    /// changes, so the value it just sent would never come again.
+    #[test]
+    fn a_failed_re_register_keeps_the_notification_that_raced_it() {
+        #[derive(Default)]
+        struct NotifyThenFail {
+            shared: Mutex<Option<Weak<Shared>>>,
+            armed: AtomicBool,
+            notifier: Mutex<Option<JoinHandle<bool>>>,
+        }
+        impl Registry for NotifyThenFail {
+            fn add_lazy_service(
+                &self,
+                name: &str,
+                _: &SIBinder,
+            ) -> std::result::Result<(), Status> {
+                if !self.armed.load(Ordering::Acquire) {
+                    return Ok(());
+                }
+                let shared = self.shared.lock().unwrap().clone();
+                let Some(shared) = shared.as_ref().and_then(Weak::upgrade) else {
+                    return Ok(());
+                };
+                // The wire delivers this on a pool thread while the round
+                // trip is still open.
+                let (s2, n2) = (shared.clone(), name.to_string());
+                *self.notifier.lock().unwrap() =
+                    Some(std::thread::spawn(move || s2.on_clients(&n2, false)));
+                let name = name.to_string();
+                spin_until(|| {
+                    shared.lock().services.get(&name).map(|e| e.has_clients) == Some(false)
+                });
+                Err(Status::new_service_specific_error(-1, None))
+            }
+            fn register_client_callback(
+                &self,
+                _: &str,
+                _: &SIBinder,
+                _: &Strong<dyn IClientCallback>,
+            ) -> std::result::Result<(), Status> {
+                Ok(())
+            }
+            fn try_unregister_service(
+                &self,
+                _: &str,
+                _: &SIBinder,
+            ) -> std::result::Result<(), Status> {
+                Ok(())
+            }
+        }
+
+        let registry = Arc::new(NotifyThenFail::default());
+        let reg = LazyServiceRegistrar::with_registry(registry.clone());
+        *registry.shared.lock().unwrap() = Some(Arc::downgrade(&reg.shared));
+
+        let binder = fresh_binder();
+        reg.register_service("racy", binder.clone()).unwrap();
+        reg.on_clients("racy", true);
+
+        registry.armed.store(true, Ordering::Release);
+        assert!(reg.register_service("racy", binder).is_err());
+        registry
+            .notifier
+            .lock()
+            .unwrap()
+            .take()
+            .unwrap()
+            .join()
+            .unwrap();
 
         assert!(
             !reg.snapshot()[0].1,
-            "the notification sent from inside registerClientCallback was dropped"
+            "the rollback put back a client the service manager had retracted"
         );
     }
 

--- a/rsbinder/src/lazy_service.rs
+++ b/rsbinder/src/lazy_service.rs
@@ -24,8 +24,8 @@
 //! // `ProcessState` has to exist first.
 //! ProcessState::init_default()?;
 //!
-//! let registrar = LazyServiceRegistrar::new();
-//! registrar.register_service("my.Service/default", binder)?;
+//! // The process-wide registrar: it has to outlive what it registers.
+//! LazyServiceRegistrar::instance().register_service("my.Service/default", binder)?;
 //!
 //! // Returns only if the thread pool is torn down; the usual exit is the
 //! // registrar's own, from the callback thread.
@@ -57,6 +57,12 @@
 //! * **Nothing aborts.** AOSP `LOG_ALWAYS_FATAL`s on an `onClients` for an
 //!   unknown service, on an `onClients` that repeats the state it already
 //!   believed, and on a failed re-register. Each is logged and survived here.
+//! * **Android 11 and up.** `registerClientCallback` does not exist in the
+//!   Android 10 service manager, so `register_service` reports
+//!   `UnknownTransaction` there — after its `addService` has already
+//!   succeeded, leaving the service registered but untracked. Call
+//!   [`hub::try_unregister_service`](crate::hub::try_unregister_service) to
+//!   undo that, or register it as an ordinary service instead.
 //! * **Re-registering a name with a *different* binder replaces the entry**
 //!   and registers a fresh client callback for it. AOSP keeps the first
 //!   binder in `mRegisteredServices` while handing the new one to
@@ -394,15 +400,39 @@ impl Shared {
 /// is using them.
 ///
 /// A cheap handle: cloning one shares the same registrations, as AOSP's
-/// `LazyServiceRegistrar` shares its `ClientCounterCallback`. AOSP exposes a
-/// process singleton (`getInstance`); construct one here and share it.
+/// `LazyServiceRegistrar` shares its `ClientCounterCallback`.
+///
+/// **A registrar must outlive the services it registers.** Reach for
+/// [`instance`](Self::instance) unless you have a reason not to — see
+/// [`new`](Self::new) for what dropping the last handle costs.
 #[derive(Clone)]
 pub struct LazyServiceRegistrar {
     shared: Arc<Shared>,
 }
 
 impl LazyServiceRegistrar {
-    /// A registrar backed by the process's default service manager.
+    /// The process-wide registrar. AOSP
+    /// [`LazyServiceRegistrar::getInstance`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=329),
+    /// which is likewise a singleton that is never freed.
+    ///
+    /// Use this for an ordinary lazy service. Registering through a
+    /// registrar that lives as long as the process is what makes the
+    /// shutdown reachable at all.
+    pub fn instance() -> &'static LazyServiceRegistrar {
+        static INSTANCE: std::sync::OnceLock<LazyServiceRegistrar> = std::sync::OnceLock::new();
+        INSTANCE.get_or_init(LazyServiceRegistrar::new)
+    }
+
+    /// A fresh registrar backed by the process's default service manager.
+    /// AOSP `createExtraTestInstance`.
+    ///
+    /// **Keep it alive for as long as its services are registered.** The
+    /// `IClientCallback` binder outlives the registrar — the service manager
+    /// holds a reference, so the kernel keeps the local object pinned — but
+    /// its link back to the bookkeeping is weak. Drop the last handle and
+    /// the service manager goes on calling a callback that does nothing:
+    /// the services stay registered, the process never shuts down, and
+    /// nothing says so. [`instance`](Self::instance) has no such edge.
     pub fn new() -> Self {
         Self::with_registry(Arc::new(HubRegistry))
     }
@@ -445,9 +475,11 @@ impl LazyServiceRegistrar {
     /// `registerClientCallback`. AOSP
     /// [`registerServiceLocked`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=129).
     ///
-    /// The service starts out assumed to have clients, so an idle process
-    /// cannot shut down before the service manager has said anything about
-    /// it.
+    /// A new registration starts out assumed to have clients, so an idle
+    /// process cannot shut down before the service manager has said anything
+    /// about it. Re-registering a name already tracked under the same binder
+    /// leaves that state alone — the service manager reports it only when it
+    /// changes, so throwing it away here would strand the process.
     pub fn register_service(&self, name: &str, binder: SIBinder) -> Result<()> {
         let tracked_same_binder = {
             let inner = self.shared.lock();
@@ -483,15 +515,27 @@ impl LazyServiceRegistrar {
         }
 
         let mut inner = self.shared.lock();
-        inner.services.insert(
-            name.to_string(),
-            RegisteredService {
-                name: name.to_string(),
-                binder,
-                has_clients: true,
-                registered: true,
-            },
-        );
+        if tracked_same_binder {
+            // A re-register must not overwrite the entry. `has_clients` is
+            // the service manager's last word on this service, and it only
+            // ever says it again when it changes — resetting it here leaves
+            // an idle process believing it is in use, with nothing due to
+            // correct it. AOSP `registerServiceLocked` inserts under
+            // `if (!reRegister)` for the same reason.
+            if let Some(entry) = inner.services.get_mut(name) {
+                entry.registered = true;
+            }
+        } else {
+            inner.services.insert(
+                name.to_string(),
+                RegisteredService {
+                    name: name.to_string(),
+                    binder,
+                    has_clients: true,
+                    registered: true,
+                },
+            );
+        }
         inner.update_cache_client_count();
         Ok(())
     }
@@ -697,6 +741,36 @@ mod tests {
         reg.register_service("foo", binder.clone()).unwrap();
         reg.register_service("foo", binder).unwrap();
         assert_eq!(registry.calls(), vec!["add:foo", "cb:foo", "add:foo"]);
+    }
+
+    /// A re-register keeps the client state the service manager reported.
+    /// Overwriting it strands the process: the service manager says
+    /// `onClients` only on a change, so nothing would ever correct a
+    /// `has_clients` invented here.
+    #[test]
+    fn re_registering_same_binder_keeps_the_reported_client_state() {
+        let (reg, _registry) = fixture();
+        let binder = fresh_binder();
+        reg.register_service("keep", binder.clone()).unwrap();
+
+        // Hold the process up so the `onClients(false)` below does not shut
+        // it down before the re-register can be observed.
+        reg.force_persist(true);
+        reg.on_clients("keep", false);
+        assert!(!reg.snapshot()[0].1, "the service manager said no clients");
+
+        reg.register_service("keep", binder).unwrap();
+        assert!(
+            !reg.snapshot()[0].1,
+            "a re-register must not invent clients"
+        );
+
+        // The proof it matters: releasing the hold must now shut down.
+        reg.force_persist(false);
+        assert!(
+            reg.shared.exited.load(Ordering::Acquire),
+            "still believed to be in use after the re-register"
+        );
     }
 
     /// A different binder under the same name is a fresh registration: the

--- a/rsbinder/src/lazy_service.rs
+++ b/rsbinder/src/lazy_service.rs
@@ -500,6 +500,16 @@ impl LazyServiceRegistrar {
     /// forward whatever binder comes with it — the service manager does the
     /// same, and reports it only when it changes, so throwing it away here
     /// would strand the process.
+    ///
+    /// **This call can be cut short by the process exiting.** Another
+    /// thread reaching the shutdown decision while this one is mid-register
+    /// takes the process down with it, so `register_service` never returns.
+    /// That is the lazy contract working, not a failure — but if the order
+    /// matters, hold the process with [`force_persist(true)`](Self::force_persist)
+    /// until every service is registered. AOSP has no such window because
+    /// `registerService` and `onClients` share one mutex; this port cannot
+    /// hold that lock across the service-manager calls (see the module docs
+    /// on nested `onClients`).
     pub fn register_service(&self, name: &str, binder: SIBinder) -> Result<()> {
         // Everything here turns on whether the *name* is already tracked.
         // The service manager keys the client-callback list on the name

--- a/rsbinder/src/lazy_service.rs
+++ b/rsbinder/src/lazy_service.rs
@@ -57,17 +57,22 @@
 //! * **Nothing aborts.** AOSP `LOG_ALWAYS_FATAL`s on an `onClients` for an
 //!   unknown service, on an `onClients` that repeats the state it already
 //!   believed, and on a failed re-register. Each is logged and survived here.
-//! * **Android 11 and up.** `registerClientCallback` does not exist in the
-//!   Android 10 service manager, so `register_service` reports
-//!   `UnknownTransaction` there — after its `addService` has already
-//!   succeeded, leaving the service registered but untracked. Call
+//! * **`register_service` is not atomic.** `addService` goes first, so a
+//!   failure to register the client callback after it leaves the service
+//!   registered with the service manager but untracked here — visible to
+//!   clients, never shutting down. Call
 //!   [`hub::try_unregister_service`](crate::hub::try_unregister_service) to
-//!   undo that, or register it as an ordinary service instead.
-//! * **Re-registering a name with a *different* binder replaces the entry**
-//!   and registers a fresh client callback for it. AOSP keeps the first
-//!   binder in `mRegisteredServices` while handing the new one to
-//!   `addService`, which leaves the callback keyed on a binder the service
-//!   manager no longer has under that name.
+//!   undo that, or retry (a retry re-runs both calls). **Android 10 always
+//!   lands here**: its service manager has no `registerClientCallback`, so
+//!   `register_service` reports `UnknownTransaction` on every call and lazy
+//!   services need Android 11 or newer.
+//! * **Re-registering a name with a *different* binder replaces the entry.**
+//!   AOSP keeps the first binder in `mRegisteredServices` while handing the
+//!   new one to `addService`, so its own `onClients` — which carries the
+//!   binder the service manager currently holds — then matches nothing and
+//!   trips `LOG_ALWAYS_FATAL`. Replacing keeps the lookup working. The
+//!   client callback is *not* re-registered either way: the service manager
+//!   stores callbacks by name and does not de-duplicate them.
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -471,8 +476,7 @@ impl LazyServiceRegistrar {
     /// Register `binder` under `name` and start tracking its clients.
     ///
     /// `addService` with `FLAG_IS_LAZY_SERVICE`, then — for a name not
-    /// already tracked, or one tracked under a different binder —
-    /// `registerClientCallback`. AOSP
+    /// already tracked — `registerClientCallback`. AOSP
     /// [`registerServiceLocked`](https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/native/libs/binder/LazyServiceRegistrar.cpp;l=129).
     ///
     /// A new registration starts out assumed to have clients, so an idle
@@ -481,14 +485,22 @@ impl LazyServiceRegistrar {
     /// leaves that state alone — the service manager reports it only when it
     /// changes, so throwing it away here would strand the process.
     pub fn register_service(&self, name: &str, binder: SIBinder) -> Result<()> {
-        let tracked_same_binder = {
+        // Two different questions. The service manager stores client
+        // callbacks by *name*, so whether one is owed depends on the name
+        // alone (AOSP `registerServiceLocked`: `reRegister =
+        // mRegisteredServices.count(name) > 0`). Whether the tracking entry
+        // may be reused depends on the binder as well.
+        let (tracked, tracked_same_binder) = {
             let inner = self.shared.lock();
-            inner.services.get(name).map(|e| e.binder == binder) == Some(true)
+            match inner.services.get(name) {
+                Some(entry) => (true, entry.binder == binder),
+                None => (false, false),
+            }
         };
 
         log::info!(
             "{} service {name}",
-            if tracked_same_binder {
+            if tracked {
                 "Re-registering"
             } else {
                 "Registering"
@@ -503,7 +515,7 @@ impl LazyServiceRegistrar {
                 StatusCode::from(e)
             })?;
 
-        if !tracked_same_binder {
+        if !tracked {
             let callback = self.callback();
             self.shared
                 .registry
@@ -773,22 +785,32 @@ mod tests {
         );
     }
 
-    /// A different binder under the same name is a fresh registration: the
-    /// callback the service manager holds is keyed on the old binder.
+    /// A different binder under the same name replaces the entry but does
+    /// **not** register a second client callback. The service manager keys
+    /// callbacks by name and de-duplicates nothing (AOSP
+    /// `ServiceManager.cpp` `mNameToClientCallback[name].push_back(cb)`), so
+    /// a second registration would have it deliver every later `onClients`
+    /// twice.
     #[test]
-    fn re_registering_different_binder_registers_a_new_callback() {
+    fn re_registering_different_binder_does_not_register_a_second_callback() {
         let (reg, registry) = fixture();
         let second = fresh_binder();
         reg.register_service("dup", fresh_binder()).unwrap();
         reg.register_service("dup", second.clone()).unwrap();
-        assert_eq!(
-            registry.calls(),
-            vec!["add:dup", "cb:dup", "add:dup", "cb:dup"]
-        );
+        assert_eq!(registry.calls(), vec!["add:dup", "cb:dup", "add:dup"]);
+
+        // The entry must still follow the new binder: `onClients` carries
+        // the binder the service manager currently holds, and it is looked
+        // up by identity.
         let got = reg.binder_for("dup").unwrap();
         assert!(
             std::sync::Arc::ptr_eq(got.as_arc(), second.as_arc()),
             "second register_service wins"
+        );
+        reg.shared.on_clients_binder(&second, false);
+        assert!(
+            !reg.snapshot()[0].1,
+            "onClients for the new binder must resolve to this entry"
         );
     }
 

--- a/rsbinder/src/lazy_service.rs
+++ b/rsbinder/src/lazy_service.rs
@@ -66,13 +66,14 @@
 //!   lands here**: its service manager has no `registerClientCallback`, so
 //!   `register_service` reports `UnknownTransaction` on every call and lazy
 //!   services need Android 11 or newer.
-//! * **Re-registering a name with a *different* binder replaces the entry.**
-//!   AOSP keeps the first binder in `mRegisteredServices` while handing the
-//!   new one to `addService`, so its own `onClients` — which carries the
-//!   binder the service manager currently holds — then matches nothing and
-//!   trips `LOG_ALWAYS_FATAL`. Replacing keeps the lookup working. The
-//!   client callback is *not* re-registered either way: the service manager
-//!   stores callbacks by name and does not de-duplicate them.
+//! * **Re-registering a name with a *different* binder replaces the entry**
+//!   (carrying its client state forward, as the service manager does). AOSP
+//!   keeps the first binder in `mRegisteredServices` while handing the new
+//!   one to `addService`, so its own `onClients` — which carries the binder
+//!   the service manager currently holds — then matches nothing and trips
+//!   `LOG_ALWAYS_FATAL`. Replacing keeps the lookup working. The client
+//!   callback is *not* re-registered either way: the service manager stores
+//!   callbacks by name and does not de-duplicate them.
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -248,10 +249,13 @@ impl Shared {
                 return false;
             };
             if entry.has_clients == has_clients {
-                // AOSP `LOG_ALWAYS_FATAL`s on a repeated state.
-                log::warn!(
-                    "{name}: onClients repeated has_clients={has_clients}; already believed that"
-                );
+                // Expected right after registration: the service manager
+                // sends a catch-up `onClients(true)` from inside
+                // `registerClientCallback` when the service already has
+                // clients, and a new entry starts out assuming it does.
+                // AOSP `LOG_ALWAYS_FATAL`s here instead, which it can
+                // afford because its `Service::clients` starts `false`.
+                log::debug!("{name}: onClients({has_clients}) matched what we already believed");
             }
             entry.has_clients = has_clients;
             inner.update_cache_client_count();
@@ -365,6 +369,17 @@ impl Shared {
             }
         }
         true
+    }
+
+    /// Put the entry back the way it was, for a `register_service` that
+    /// published it and then could not complete.
+    fn restore(&self, name: &str, previous: Option<RegisteredService>) {
+        let mut inner = self.lock();
+        match previous {
+            Some(entry) => inner.services.insert(name.to_string(), entry),
+            None => inner.services.remove(name),
+        };
+        inner.update_cache_client_count();
     }
 
     /// AOSP `reRegisterLocked`. Note what it does *not* do: `has_clients` is
@@ -481,22 +496,42 @@ impl LazyServiceRegistrar {
     ///
     /// A new registration starts out assumed to have clients, so an idle
     /// process cannot shut down before the service manager has said anything
-    /// about it. Re-registering a name already tracked under the same binder
-    /// leaves that state alone — the service manager reports it only when it
-    /// changes, so throwing it away here would strand the process.
+    /// about it. Re-registering a name already tracked carries that state
+    /// forward whatever binder comes with it — the service manager does the
+    /// same, and reports it only when it changes, so throwing it away here
+    /// would strand the process.
     pub fn register_service(&self, name: &str, binder: SIBinder) -> Result<()> {
-        // Two different questions. The service manager stores client
-        // callbacks by *name*, so whether one is owed depends on the name
-        // alone (AOSP `registerServiceLocked`: `reRegister =
-        // mRegisteredServices.count(name) > 0`). Whether the tracking entry
-        // may be reused depends on the binder as well.
-        let (tracked, tracked_same_binder) = {
-            let inner = self.shared.lock();
-            match inner.services.get(name) {
-                Some(entry) => (true, entry.binder == binder),
-                None => (false, false),
-            }
+        // Everything here turns on whether the *name* is already tracked.
+        // The service manager keys the client-callback list on the name
+        // (`mNameToClientCallback[name]`) and carries `hasClients` across a
+        // re-`addService` whatever binder comes with it (AOSP
+        // `ServiceManager.cpp`: `.hasClients = prevClients`).
+        //
+        // The entry is published before the round trips, not after. The
+        // service manager dispatches `onClients` for this name from inside
+        // `addService` and `registerClientCallback`, both before their
+        // reply, so the driver lands that nested transaction on this very
+        // thread — and an entry that is not there yet would drop it, with
+        // no repeat coming.
+        let previous = {
+            let mut inner = self.shared.lock();
+            let previous = inner.services.get(name).cloned();
+            inner.services.insert(
+                name.to_string(),
+                RegisteredService {
+                    name: name.to_string(),
+                    binder: binder.clone(),
+                    // A new registration is assumed to be in use, so an idle
+                    // process cannot shut down before the service manager
+                    // has said anything about it.
+                    has_clients: previous.as_ref().is_none_or(|e| e.has_clients),
+                    registered: true,
+                },
+            );
+            inner.update_cache_client_count();
+            previous
         };
+        let tracked = previous.is_some();
 
         log::info!(
             "{} service {name}",
@@ -507,48 +542,29 @@ impl LazyServiceRegistrar {
             }
         );
 
-        self.shared
-            .registry
-            .add_lazy_service(name, &binder)
-            .map_err(|e| {
-                log::error!("Failed to register service {name} ({e:?})");
-                StatusCode::from(e)
-            })?;
+        if let Err(e) = self.shared.registry.add_lazy_service(name, &binder) {
+            log::error!("Failed to register service {name} ({e:?})");
+            self.shared.restore(name, previous);
+            return Err(StatusCode::from(e));
+        }
 
+        // Only for a name not already tracked: the service manager holds
+        // client callbacks by name and de-duplicates nothing, so a second
+        // registration would have it deliver every later `onClients` twice.
+        // AOSP `registerServiceLocked` guards on `!reRegister` for this.
         if !tracked {
             let callback = self.callback();
-            self.shared
+            if let Err(e) = self
+                .shared
                 .registry
                 .register_client_callback(name, &binder, &callback)
-                .map_err(|e| {
-                    log::error!("Failed to add client callback for service {name} ({e:?})");
-                    StatusCode::from(e)
-                })?;
+            {
+                log::error!("Failed to add client callback for service {name} ({e:?})");
+                self.shared.restore(name, previous);
+                return Err(StatusCode::from(e));
+            }
         }
 
-        let mut inner = self.shared.lock();
-        if tracked_same_binder {
-            // A re-register must not overwrite the entry. `has_clients` is
-            // the service manager's last word on this service, and it only
-            // ever says it again when it changes — resetting it here leaves
-            // an idle process believing it is in use, with nothing due to
-            // correct it. AOSP `registerServiceLocked` inserts under
-            // `if (!reRegister)` for the same reason.
-            if let Some(entry) = inner.services.get_mut(name) {
-                entry.registered = true;
-            }
-        } else {
-            inner.services.insert(
-                name.to_string(),
-                RegisteredService {
-                    name: name.to_string(),
-                    binder,
-                    has_clients: true,
-                    registered: true,
-                },
-            );
-        }
-        inner.update_cache_client_count();
         Ok(())
     }
 
@@ -987,6 +1003,101 @@ mod tests {
         // A binder this registrar never registered is logged, not fatal.
         reg.shared.on_clients_binder(&fresh_binder(), false);
         assert!(!reg.shared.exited.load(Ordering::Acquire));
+    }
+
+    /// A service manager that answers `registerClientCallback` by dispatching
+    /// `onClients` before it replies — which is what both `rsb_hub` and AOSP
+    /// do, and the binder driver lands that nested transaction on the thread
+    /// still waiting for the reply.
+    struct ReentrantRegistry {
+        shared: Mutex<Option<Weak<Shared>>>,
+        report: bool,
+    }
+
+    impl Registry for ReentrantRegistry {
+        fn add_lazy_service(
+            &self,
+            _name: &str,
+            _binder: &SIBinder,
+        ) -> std::result::Result<(), Status> {
+            Ok(())
+        }
+        fn register_client_callback(
+            &self,
+            _name: &str,
+            binder: &SIBinder,
+            _callback: &Strong<dyn IClientCallback>,
+        ) -> std::result::Result<(), Status> {
+            let shared = self.shared.lock().unwrap().clone();
+            if let Some(shared) = shared.as_ref().and_then(Weak::upgrade) {
+                shared.on_clients_binder(binder, self.report);
+            }
+            Ok(())
+        }
+        fn try_unregister_service(
+            &self,
+            _name: &str,
+            _binder: &SIBinder,
+        ) -> std::result::Result<(), Status> {
+            Ok(())
+        }
+    }
+
+    /// An `onClients` that arrives *during* `register_service`'s own round
+    /// trips must still land. The service manager sends one per change and
+    /// never repeats it, so dropping this one strands the process: it would
+    /// go on believing it has clients with nothing left to correct it.
+    #[test]
+    fn a_notification_arriving_during_registration_is_not_dropped() {
+        let registry = Arc::new(ReentrantRegistry {
+            shared: Mutex::new(None),
+            report: false,
+        });
+        let reg = LazyServiceRegistrar::with_registry(registry.clone());
+        *registry.shared.lock().unwrap() = Some(Arc::downgrade(&reg.shared));
+
+        // Held so the re-entrant `onClients(false)` cannot take the process
+        // down before the assertion; the point here is that it is *seen*.
+        reg.force_persist(true);
+        reg.register_service("nested", fresh_binder()).unwrap();
+
+        assert!(
+            !reg.snapshot()[0].1,
+            "the notification sent from inside registerClientCallback was dropped"
+        );
+    }
+
+    /// A `register_service` that cannot finish leaves nothing behind.
+    #[test]
+    fn a_failed_registration_does_not_leave_an_entry() {
+        struct Failing;
+        impl Registry for Failing {
+            fn add_lazy_service(&self, _: &str, _: &SIBinder) -> std::result::Result<(), Status> {
+                Err(Status::new_service_specific_error(-1, None))
+            }
+            fn register_client_callback(
+                &self,
+                _: &str,
+                _: &SIBinder,
+                _: &Strong<dyn IClientCallback>,
+            ) -> std::result::Result<(), Status> {
+                unreachable!("add_lazy_service fails first")
+            }
+            fn try_unregister_service(
+                &self,
+                _: &str,
+                _: &SIBinder,
+            ) -> std::result::Result<(), Status> {
+                Ok(())
+            }
+        }
+        let reg = LazyServiceRegistrar::with_registry(Arc::new(Failing));
+        assert!(reg.register_service("gone", fresh_binder()).is_err());
+        assert!(
+            reg.snapshot().is_empty(),
+            "the published entry was rolled back"
+        );
+        assert_eq!(reg.registered_count(), 0);
     }
 
     /// Clones share one set of registrations, as AOSP's handle shares its

--- a/rsbinder/src/lib.rs
+++ b/rsbinder/src/lib.rs
@@ -167,12 +167,12 @@ pub mod binderfs;
 pub mod error;
 /// File descriptor wrapper for IPC
 pub mod file_descriptor;
-/// `LazyServiceRegistrar` skeleton (state machine +
-/// `IClientCallback::onClients` dispatch). AOSP
-/// `frameworks/native/libs/binder/LazyServiceRegistrar.cpp`. Hub
-/// integration (actual `registerClientCallback` / `tryUnregisterService`
-/// IPC) is owed by the caller until the hub plumbing lands — see the
-/// module docs.
+// `LazyServiceRegistrar` — AOSP
+// `frameworks/native/libs/binder/LazyServiceRegistrar.cpp`. Kept as a plain
+// (non-doc) comment for the reason spelled out at `entry` below: an outer
+// doc here merges with the module's inner `//!` docs and re-resolves their
+// intra-doc links at the crate root, where the module's own types are not
+// in scope.
 pub mod lazy_service;
 mod macros;
 /// Native service implementation helpers

--- a/rsbinder/src/proxy_count.rs
+++ b/rsbinder/src/proxy_count.rs
@@ -48,10 +48,11 @@ pub enum ProxyCountEvent {
 /// Callback type for [`ProxyCountEvent`] notifications. Invoked **outside**
 /// the internal `proxy_count` mutex, and — on the proxy-create path — after
 /// the process-wide `ProcessState::handle_to_proxy` cache lock is released
-/// (via [`CallbackDeferGuard`]). The callback may therefore freely re-enter
-/// both `proxy_count` APIs and the binder proxy cache (`get_service`,
-/// resolving/creating proxies). It must not block indefinitely — every proxy
-/// create/drop on the firing thread is gated on it returning.
+/// (via the internal `CallbackDeferGuard`). The callback may therefore
+/// freely re-enter both `proxy_count` APIs and the binder proxy cache
+/// (`get_service`, resolving/creating proxies). It must not block
+/// indefinitely — every proxy create/drop on the firing thread is gated on
+/// it returning.
 pub type ProxyCountCallback = Arc<dyn Fn(ProxyCountEvent) + Send + Sync>;
 
 /// Process-global proxy count. Lock-free hot path: every

--- a/rsbinder/src/shared_memory/mod.rs
+++ b/rsbinder/src/shared_memory/mod.rs
@@ -22,7 +22,7 @@
 //!
 //! A shared region travels over any transport that can carry an fd:
 //! the kernel binder (`BINDER_TYPE_FD`) and Unix-socket RPC with
-//! [`FileDescriptorTransportMode::Unix`](crate::rpc::FileDescriptorTransportMode)
+//! `rpc::FileDescriptorTransportMode::Unix` (the `rpc` feature)
 //! negotiated on both ends. TCP / vsock / TLS sessions cannot carry
 //! fds at all; writing a heap fd into such a parcel fails with
 //! `StatusCode::BadType` exactly as a plain

--- a/tests/scripts/run_lazy_service_ac.sh
+++ b/tests/scripts/run_lazy_service_ac.sh
@@ -104,7 +104,7 @@ if grep -A2 "^  $SERVICE\$" "$OUT" | grep -q 'lazy=yes'; then
 else
     bad "lazy=no — FLAG_IS_LAZY_SERVICE did not reach the hub: $(grep -A2 "^  $SERVICE\$" "$OUT")"
 fi
-if grep -A3 "^  $SERVICE\$" "$OUT" | grep -q 'client=1'; then
+if grep -A3 "^  $SERVICE\$" "$OUT" | grep -q 'client=1$'; then
     ok "registerClientCallback landed (client=1)"
 else
     bad "client callback count: $(grep -A3 "^  $SERVICE\$" "$OUT" | grep client)"

--- a/tests/scripts/run_lazy_service_ac.sh
+++ b/tests/scripts/run_lazy_service_ac.sh
@@ -5,8 +5,7 @@
 # reach is the half that only exists on a wire: does `FLAG_IS_LAZY_SERVICE`
 # arrive at the service manager, does `registerClientCallback` land, does the
 # hub's 5-second poller actually drive `onClients(false)` into this process,
-# and does the process then take itself down. Until now the only thing
-# covering that was a demo someone had to read the output of.
+# and does the process then take itself down.
 #
 # Needs a Linux host with a working binder device and nothing else already
 # holding handle 0.
@@ -41,7 +40,14 @@ note() { printf '\n=== %s\n' "$*"; }
 ok()   { PASS=$((PASS+1)); printf '  PASS  %s\n' "$*"; }
 bad()  { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$*"; }
 want_out()   { if grep -q "$1" "$OUT"; then ok "$2"; else bad "$2 (missing '$1' in: $(head -20 "$OUT"))"; fi; }
-reject_out() { if grep -q "$1" "$OUT"; then bad "$2 (leaked '$1')"; else ok "$2"; fi; }
+# Anchored on the dump header: without it a dump that failed outright (dead
+# hub, no binder device) leaves $OUT with nothing to match and reads as
+# "the name is gone".
+reject_out() {
+    if ! grep -q '^services (' "$OUT"; then bad "$2 (no dump to check: $(head -3 "$OUT"))"
+    elif grep -q "$1" "$OUT"; then bad "$2 (leaked '$1')"
+    else ok "$2"; fi
+}
 
 cleanup() {
     pkill -f 'target/debug/hello_client' 2>/dev/null
@@ -98,7 +104,10 @@ if kill -0 "$DEMO_PID" 2>/dev/null; then ok "demo is running"
 else bad "demo is not running: $(tail -5 "$DEMOLOG")"; fi
 
 $SVC dump manager > "$OUT" 2>&1
-want_out "$SERVICE" "the service is registered"
+# Anchored on the service row. A bare name match also hits the
+# `awaiting registration` section, which lists names that have a client
+# callback but no registration — the opposite of what this gates.
+want_out "^  $SERVICE\$" "the service is registered"
 # The whole point of the flag: without it the hub cannot tell a lazy service
 # from an ordinary one, and `rsb_service dump` reports it as ordinary.
 if grep -A2 "^  $SERVICE\$" "$OUT" | grep -q 'lazy=yes'; then
@@ -116,7 +125,11 @@ fi
 note "AC-L.2  a held client keeps the process alive across poller ticks"
 
 sleep $((TICK * 2 + 2))
-if kill -0 "$DEMO_PID" 2>/dev/null; then
+# Establish the premise first: "still running" proves nothing if whatever
+# was supposed to be holding it died during the wait.
+if ! kill -0 "$CLIENT_PID" 2>/dev/null; then
+    bad "the client died during the wait — this gate proved nothing"
+elif kill -0 "$DEMO_PID" 2>/dev/null; then
     ok "still running after two poller ticks with a client attached"
 else
     bad "shut down while a client was still holding it: $(tail -10 "$DEMOLOG")"
@@ -160,11 +173,23 @@ if [ "$rc" -eq 1 ]; then ok "checkService reports it as absent"; else bad "check
 note "AC-L.5  the hub logged the unregister rather than a death"
 
 # A lazy shutdown and a crash look the same from the outside if the only
-# evidence is "the name is gone". The hub distinguishes them.
+# evidence is "the name is gone" — a crash would clear the name too, through
+# the death notification. Only the hub's own log separates them, so gate on
+# the positive statement as well as the absence of a refusal.
+if grep -q "Unregistering $SERVICE" "$HUBLOG"; then
+    ok "the hub logged the unregister (AOSP ServiceManager.cpp:1128)"
+else
+    bad "no 'Unregistering $SERVICE' — reclaimed by the death notification, not by tryUnregisterService"
+fi
 if grep -q 'Tried to unregister' "$HUBLOG"; then
     bad "the hub refused the unregister: $(grep 'Tried to unregister' "$HUBLOG" | head -2)"
 else
     ok "no refusal logged"
+fi
+if grep -q 'binder died: retired [1-9]' "$HUBLOG"; then
+    bad "the obituary still had a registration to retire: $(grep 'binder died: retired' "$HUBLOG" | head -2)"
+else
+    ok "nothing left for the death notification to clean up"
 fi
 
 ######################################################################

--- a/tests/scripts/run_lazy_service_ac.sh
+++ b/tests/scripts/run_lazy_service_ac.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# LazyServiceRegistrar acceptance gates (AC-L.1 .. AC-L.5).
+#
+# The registrar's state machine has hermetic unit tests; what those cannot
+# reach is the half that only exists on a wire: does `FLAG_IS_LAZY_SERVICE`
+# arrive at the service manager, does `registerClientCallback` land, does the
+# hub's 5-second poller actually drive `onClients(false)` into this process,
+# and does the process then take itself down. Until now the only thing
+# covering that was a demo someone had to read the output of.
+#
+# Needs a Linux host with a working binder device and nothing else already
+# holding handle 0.
+#
+#   cargo build -p rsbinder-tools --bin rsb_hub --bin rsb_service
+#   cargo build -p example-hello --bin hello_callback_demo --bin hello_client
+#   ./tests/scripts/run_lazy_service_ac.sh
+set -u
+
+cd "$(dirname "$0")/../.." || exit 1
+
+HUB=./target/debug/rsb_hub
+SVC=./target/debug/rsb_service
+DEMO=./target/debug/hello_callback_demo
+CLIENT=./target/debug/hello_client
+POLDIR=/tmp/rsb-lazy-policy
+HUBLOG=/tmp/rsb-lazy-hub.log
+DEMOLOG=/tmp/rsb-lazy-demo.log
+CLIENTLOG=/tmp/rsb-lazy-client.log
+OUT=/tmp/rsb-lazy-out
+PASS=0; FAIL=0
+MY_UID=$(id -u)
+SERVICE=my.hello
+
+# One poller tick is 5s (rsb_hub `run_client_callback_poller`). Give the
+# shutdown three of them before calling it a failure — the gate is "it
+# happens on its own", not "it happens in exactly one tick".
+TICK=5
+SHUTDOWN_TIMEOUT=$((TICK * 3 + 5))
+
+note() { printf '\n=== %s\n' "$*"; }
+ok()   { PASS=$((PASS+1)); printf '  PASS  %s\n' "$*"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$*"; }
+want_out()   { if grep -q "$1" "$OUT"; then ok "$2"; else bad "$2 (missing '$1' in: $(head -20 "$OUT"))"; fi; }
+reject_out() { if grep -q "$1" "$OUT"; then bad "$2 (leaked '$1')"; else ok "$2"; fi; }
+
+cleanup() {
+    pkill -f 'target/debug/hello_client' 2>/dev/null
+    pkill -f 'target/debug/hello_callback_demo' 2>/dev/null
+    pkill -f 'target/debug/rsb_hub' 2>/dev/null
+    rm -rf "$POLDIR"
+}
+trap cleanup EXIT
+cleanup; sleep 1
+
+for bin in "$HUB" "$SVC" "$DEMO" "$CLIENT"; do
+    [ -x "$bin" ] || { echo "missing $bin — see the build lines in this script's header"; exit 2; }
+done
+
+mkdir -p "$POLDIR"
+cat > "$POLDIR/10.toml" <<EOF
+[global]
+list = { uid = [$MY_UID] }
+
+[[rule]]
+name = "$SERVICE"
+add  = { uid = [$MY_UID] }
+find = { uid = [$MY_UID] }
+
+# rsb_service looks the hub up by name like any other client.
+[[rule]]
+name = "manager"
+find = { uid = [$MY_UID] }
+EOF
+
+RUST_LOG=info nohup $HUB --config "$POLDIR" > "$HUBLOG" 2>&1 &
+disown 2>/dev/null
+sleep 2
+pgrep -f 'target/debug/rsb_hub' >/dev/null || { echo "rsb_hub did not start:"; cat "$HUBLOG"; exit 2; }
+
+######################################################################
+note "AC-L.1  register_service reaches the service manager"
+
+RUST_LOG=info nohup $DEMO > "$DEMOLOG" 2>&1 &
+DEMO_PID=$!
+disown 2>/dev/null
+
+# Hold a client immediately: with none, the first poller tick would take the
+# process down before the later gates could look at it. That is the correct
+# behaviour, and AC-L.4 measures it deliberately.
+RUST_LOG=warn nohup $CLIENT > "$CLIENTLOG" 2>&1 &
+CLIENT_PID=$!
+disown 2>/dev/null
+sleep 3
+
+if kill -0 "$DEMO_PID" 2>/dev/null; then ok "demo is running"
+else bad "demo exited early (rc=$?): $(tail -5 "$DEMOLOG")"; fi
+
+$SVC dump manager > "$OUT" 2>&1
+want_out "$SERVICE" "the service is registered"
+# The whole point of the flag: without it the hub cannot tell a lazy service
+# from an ordinary one, and `rsb_service dump` reports it as ordinary.
+if grep -A2 "^  $SERVICE\$" "$OUT" | grep -q 'lazy=yes'; then
+    ok "registered with FLAG_IS_LAZY_SERVICE"
+else
+    bad "lazy=no — FLAG_IS_LAZY_SERVICE did not reach the hub: $(grep -A2 "^  $SERVICE\$" "$OUT")"
+fi
+if grep -A3 "^  $SERVICE\$" "$OUT" | grep -q 'client=1'; then
+    ok "registerClientCallback landed (client=1)"
+else
+    bad "client callback count: $(grep -A3 "^  $SERVICE\$" "$OUT" | grep client)"
+fi
+
+######################################################################
+note "AC-L.2  a held client keeps the process alive across poller ticks"
+
+sleep $((TICK * 2 + 2))
+if kill -0 "$DEMO_PID" 2>/dev/null; then
+    ok "still running after two poller ticks with a client attached"
+else
+    bad "shut down while a client was still holding it: $(tail -10 "$DEMOLOG")"
+fi
+
+######################################################################
+note "AC-L.3  the last client leaving shuts the process down, exit 0"
+
+kill "$CLIENT_PID" 2>/dev/null
+wait "$CLIENT_PID" 2>/dev/null
+
+waited=0
+while kill -0 "$DEMO_PID" 2>/dev/null && [ "$waited" -lt "$SHUTDOWN_TIMEOUT" ]; do
+    sleep 1
+    waited=$((waited + 1))
+done
+
+if kill -0 "$DEMO_PID" 2>/dev/null; then
+    bad "still running ${SHUTDOWN_TIMEOUT}s after the last client left"
+    kill "$DEMO_PID" 2>/dev/null
+else
+    ok "shut down on its own after ${waited}s"
+    wait "$DEMO_PID" 2>/dev/null
+    rc=$?
+    if [ "$rc" -eq 0 ]; then ok "exit 0 (AOSP exit(EXIT_SUCCESS))"; else bad "exit $rc, want 0"; fi
+fi
+
+grep -q 'has_clients=false' "$DEMOLOG" && ok "the process saw the transition" \
+    || bad "no has_clients=false in the demo log: $(tail -5 "$DEMOLOG")"
+
+######################################################################
+note "AC-L.4  tryUnregisterService really removed it from the registry"
+
+$SVC dump manager > "$OUT" 2>&1
+reject_out "^  $SERVICE\$" "the name is gone from the hub"
+
+$SVC check "$SERVICE" > "$OUT" 2>&1; rc=$?
+if [ "$rc" -eq 1 ]; then ok "checkService reports it as absent"; else bad "check exit $rc, want 1"; fi
+
+######################################################################
+note "AC-L.5  the hub logged the unregister rather than a death"
+
+# A lazy shutdown and a crash look the same from the outside if the only
+# evidence is "the name is gone". The hub distinguishes them.
+if grep -q 'Tried to unregister' "$HUBLOG"; then
+    bad "the hub refused the unregister: $(grep 'Tried to unregister' "$HUBLOG" | head -2)"
+else
+    ok "no refusal logged"
+fi
+
+######################################################################
+printf '\n===== %d passed, %d failed =====\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/scripts/run_lazy_service_ac.sh
+++ b/tests/scripts/run_lazy_service_ac.sh
@@ -80,20 +80,22 @@ pgrep -f 'target/debug/rsb_hub' >/dev/null || { echo "rsb_hub did not start:"; c
 ######################################################################
 note "AC-L.1  register_service reaches the service manager"
 
+# Deliberately NOT disowned, unlike the hub above. `disown` drops the job
+# from bash's table, and `wait` on such a pid then returns 0 whatever the
+# process actually did — which would leave the exit-status gate in AC-L.3
+# passing for a segfault.
 RUST_LOG=info nohup $DEMO > "$DEMOLOG" 2>&1 &
 DEMO_PID=$!
-disown 2>/dev/null
 
 # Hold a client immediately: with none, the first poller tick would take the
 # process down before the later gates could look at it. That is the correct
 # behaviour, and AC-L.4 measures it deliberately.
 RUST_LOG=warn nohup $CLIENT > "$CLIENTLOG" 2>&1 &
 CLIENT_PID=$!
-disown 2>/dev/null
 sleep 3
 
 if kill -0 "$DEMO_PID" 2>/dev/null; then ok "demo is running"
-else bad "demo exited early (rc=$?): $(tail -5 "$DEMOLOG")"; fi
+else bad "demo is not running: $(tail -5 "$DEMOLOG")"; fi
 
 $SVC dump manager > "$OUT" 2>&1
 want_out "$SERVICE" "the service is registered"

--- a/tests/src/bin/mesh_node.rs
+++ b/tests/src/bin/mesh_node.rs
@@ -12,6 +12,8 @@
 //! exchange round-tripped intact with zero errors.
 //!
 //! Roles:
+//!
+//! ```text
 //!   rpc-server    : serve IMeshNode over an RPC unix socket; also act
 //!                   as an RPC client against `--peer` sockets.
 //!   rpc-client    : RPC client only, against `--peer` sockets.
@@ -19,8 +21,11 @@
 //!                   service manager node); also an RPC client.
 //!   kernel-client : kernel binder client of `--kernel-service`; also
 //!                   serve IMeshNode over an RPC unix socket.
+//! ```
 //!
 //! Args:
+//!
+//! ```text
 //!   --role <r>             one of the roles above
 //!   --name <s>             this node's identity (origin string)
 //!   --listen <path>        unix socket to bind an RPC server on (server roles)
@@ -28,6 +33,7 @@
 //!   --kernel-service <s>   service-manager name (kernel roles)
 //!   --duration-ms <n>      how long to keep exchanging
 //!   --blob <n>             payload byte-array length
+//! ```
 
 #![allow(non_snake_case)]
 


### PR DESCRIPTION
`rsbinder::lazy_service` shipped in 0.10.0 as a public API that registered
nothing: `register_service` inserted a row in a map and returned `Ok(())`,
and the `addService` / `registerClientCallback` calls that actually make a
service lazy were owed by the caller, with nothing in the signature to say
so. The blocker for doing it properly was gone — `hub::register_client_callback`
and `hub::try_unregister_service` have been public since the hub work landed.

Also clears the release-blocking documentation work for 0.11.0.

## What changed

**`LazyServiceRegistrar` is wired to the service manager.** `register_service`
calls `addService` with AOSP's `FLAG_IS_LAZY_SERVICE`, registers an
`IClientCallback` this module owns, routes the incoming `onClients` into the
state machine, and — once nothing is using any of its services — unregisters
them and exits the process with status 0. That last step is the point of the
pattern: the service manager starts the process again on the next lookup.
`set_active_services_callback` (AOSP `setActiveServicesCallback`) hands the
decision to the caller instead.

Reading `LazyServiceRegistrar.cpp` beside the port turned up two fidelity
bugs in the existing skeleton: `reRegisterLocked` does not reset `clients`,
and a re-register of a name already tracked does not register a second client
callback.

**One deliberate departure from AOSP.** AOSP holds `mMutex` across
`tryUnregisterService`, but a service manager may answer that call by
dispatching `onClients` back into this process, and the driver delivers such
a nested transaction on the thread already waiting for the reply — a deadlock
on a non-reentrant `Mutex`. State is snapshotted under the lock and the round
trips are made without it. The service manager is the authority on whether an
unregister may proceed, so nothing is lost.

**`FLAG_IS_LAZY_SERVICE` needed a path.** `hub::add_service` hardcodes
`dumpPriority`, so the flag could never be set and `rsb_service dump manager`
reported every lazy service as ordinary. The flag is an Android 16
`IServiceManager` constant (AOSP added it in `android-15.0.0_r20`), so the
older protocols register without it, exactly as their own libbinder did.

**Release documentation.** `[Unreleased]` had grown to 59 entries across
seven headings — `Fixed` three times, `Changed` twice — because each PR
appended its own section. Merged into one heading per type, every entry
preserved verbatim, plus a "Migrating from 0.10.0" summary ahead of them: ten
of the entries are breaking, and `ProcessState::init(path, 0)` is the one that
matters most, because its meaning changed while its signature did not.
`cargo-semver-checks` cannot see that and neither can a downstream build, so
the changelog is the only notice it gets.

**Eight broken rustdoc links** across four crates, and a CI gate so they stop
accumulating — `all-features` is what docs.rs publishes, plain default
features is what a dependent sees.

## Testing

`hello_callback_demo` becomes the thing it was demonstrating, and two gates
run it:

- `tests/scripts/run_lazy_service_ac.sh` — against `rsb_hub`.
- `example-hello/cpp/run_lazy_service_stage3.sh` — against Android's own
  `servicemanager`. The Linux gate alone proves only that two halves of one
  port agree; this one puts the platform binary on the other end. Its verdict
  reads servicemanager's own log: `Unregistering <name>` is the erase branch
  and the only path that returns `Status::ok()`, whereas the registry going
  empty proves less — a refused unregister followed by the process dying
  leaves it empty too, via the death notification.

That half of the path had no automated coverage at all before; it had a demo
whose output a human had to read.

| | |
|---|---|
| macOS `cargo test --workspace` | 633 / 0 |
| macOS clippy, fmt, rustdoc (both feature sets) | clean |
| REMOTE_LINUX `rsbinder` / `-tools` / `-aidl` | 257 / 86 / 238, 0 failed |
| REMOTE_LINUX kernel binder e2e (sync, CI skip-list) | 140 / 0 (+8 ignored) |
| REMOTE_LINUX Plan 6 AC gates | 108 / 0 (unchanged) |
| REMOTE_LINUX lazy AC gates | 11 / 0 |
| Emulator Android 16 (API 36, arm64) unit | 243 / 0 |
| Emulator `tests` integration sync / async | 140 / 0 each (+8 ignored) |
| Emulator lazy STAGE3 (real AOSP servicemanager) | 10 / 0 |

## Review pass

The branch was reviewed against `master` before opening, which found two more
defects in the wiring commit — both fixed in f3781f1:

- `register_service` inserted unconditionally, so re-registering a name
  already tracked under the same binder reset `has_clients` to `true`. The
  service manager reports client presence only when it *changes*, so nothing
  was due to correct that: a process that had been told it was idle went back
  to believing it was in use. Reachable wherever the process outlives
  `onClients(name, false)` — `force_persist` held, an active-services callback
  that returned `true`, or a refused unregister followed by `re_register`.
- A registrar has to outlive what it registers, and nothing said so. The
  `IClientCallback` binder survives it (the service manager holds a reference
  and the kernel pins the local object), but the link back to the bookkeeping
  is a `Weak`, so dropping the last handle leaves the service manager calling
  a callback that returns immediately: services registered, process never
  shutting down, nothing logged. `LazyServiceRegistrar::instance` is AOSP's
  `getInstance`; `new` stays for a second independent registrar (AOSP
  `createExtraTestInstance`) and now documents what it costs.

## Breaking

`LazyServiceRegistrar::register_service` now performs IPC and the process
exits when its last client goes away. Code that called it *and* did its own
`addService` / `registerClientCallback` should drop those calls; code that
relied on it being inert needs `set_active_services_callback` or
`force_persist`. Recorded in the changelog's migration section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
