### PR TITLE
feat(rpc): client incoming connections for callbacks outside a handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,6 @@ example-hello/cpp/rpc_accessor_interop_launcher
 example-hello/cpp/rpc_accessor_register_interop_launcher
 example-hello/cpp/rpc_multiconn_interop_launcher
 example-hello/cpp/rpc_fd_interop_launcher
+example-hello/cpp/rpc_incoming_interop_launcher
 example-hello/cpp/phasec_vintf_client
 example-hello/cpp/codegen_shapes_interop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,19 @@ short form — and the first entry is the only one no compiler will catch.
 
 ### Added
 
+- **rsbinder (RPC):** client-side **incoming (callback) connections** —
+  `RpcUnixClientConfig::incoming_connections(n)`,
+  `RpcSession::add_incoming_connection_android13plus_with_config`, and
+  `ClientOptions::incoming_connections` (AOSP `setMaxIncomingThreads`).
+  Until now a server could reach a client's callback only from inside a
+  handler answering that client; a call from any other server thread
+  blocked forever. With `n ≥ 1` the client attaches `n` connections the
+  server sends on, each served by a thread the session owns, so callbacks
+  work from timers, workers, and oneway notifications. Such a session also
+  observes the server's death as soon as the connection drops. The threads
+  keep the session alive until `RpcSession::shutdown()` (which now shuts
+  every connection down and joins them) or the server closes the session.
+  Android-13+ profile, Unix sockets.
 - **rsbinder (`binder`):** `Strong::try_into_async` — the fallible form of
   `into_async`. A local service published sync-only (`Bn*::new_binder`)
   cannot back the async view; the generated cast reports `BadType`, which
@@ -331,6 +344,24 @@ short form — and the first entry is the only one no compiler will catch.
 
 ### Changed
 
+- **rsbinder (RPC):** a non-nested call on a session with no connection to
+  send on — a server calling a client callback outside any handler, the
+  client having opened no incoming connection — now fails immediately with
+  `FailedTransaction` (AOSP `WOULD_BLOCK`) and a log line naming the
+  remedy, instead of waiting forever (or until `set_timeout`). Connection
+  slots are now tagged with the direction they are used in (AOSP
+  `mOutgoing`/`mIncoming`), so a serve-driven connection is never claimed
+  by another thread's transaction between two of its messages.
+- **rsbinder (RPC):** the server's callback-slot budget (`2 × set_max_threads`
+  per session) now counts callback connections only; a client's outgoing
+  fan-out no longer eats into it (before, a default server admitted a single
+  callback connection). The server also no longer arms `set_idle_timeout` on
+  callback slots (it would have cut short a server's own reply wait there),
+  and confirms a callback attach only after admitting it, so a refused
+  attach is an error on the client instead of a silently dead connection.
+- **rsbinder (RPC):** on session death every connection slot's transport is
+  shut down and the pool is emptied, releasing callback-slot descriptors at
+  once rather than when the session object is finally dropped.
 - **rsbinder (`shared_memory`) — breaking:** `IMemoryHeap::base` now returns
   `Option<SharedBytes<'_>>`, a read-only view. A `&[u8]` over a `MAP_SHARED`
   region promises the compiler an immutability the peer process does not

--- a/book/src/rpc-transport.md
+++ b/book/src/rpc-transport.md
@@ -427,7 +427,10 @@ kernel binder for, with a few extras specific to socket transport:
   interfaces, enums, unions, oneway methods.
 - **Callbacks (nested binders)** — a callback object created on the
   client crosses the socket like any other Binder and the server
-  invokes it back through the same session.
+  invokes it back through the same session. From inside a handler
+  this always works; to call a callback from *any other* server
+  thread the client must open an incoming connection — see
+  [Callbacks outside a handler](#callbacks-outside-a-handler).
 - **`ParcelFileDescriptor`** — opt in with
   `RpcSession::negotiate_fd_transport` and
   `RpcServer::set_supported_fd_modes`. File descriptors ride
@@ -457,6 +460,49 @@ worker-thread fan-out regardless of how many sessions a single client
 opens — use
 [`RpcServer::set_max_connections(N)`](https://docs.rs/rsbinder/latest/rsbinder/rpc/struct.RpcServer.html#method.set_max_connections)
 (default: unlimited). Both knobs are independent and additive.
+
+### Callbacks outside a handler
+
+A server can always call a client's callback *while it is answering
+that client* — the nested call rides the connection the request came
+in on. Calling it from anywhere else (a timer, a worker thread, a
+oneway notification fired later) needs a connection the server can
+*send* on, and by default a session has none: the server fails such a
+call at once with `FailedTransaction` (AOSP `WOULD_BLOCK`) rather than
+waiting for a slot that will never free up.
+
+The client provides that connection, exactly as libbinder's
+`ARpcSession_setMaxIncomingThreads(n)` does:
+
+```rust
+use rsbinder::rpc::{RpcSession, RpcUnixClientConfig};
+
+let session = RpcSession::setup_unix_client_android13plus_with_config(
+    RpcUnixClientConfig::path(std::path::Path::new(RPC_SOCKET), 2)
+        .incoming_connections(1),
+)?;
+```
+
+or, through the unified entry, `Client::open_with(uri, |o, _| {
+o.incoming_connections = Some(1) })` on an `?profile=android13plus`
+URI. Each incoming connection is attached to the same session and
+served by a thread the session owns; `n` of them let `n` server
+threads call back in parallel. The server budgets them at
+`2 × set_max_threads` per session (two on a default server) and
+refuses the rest, which the client sees as a setup error.
+
+Two consequences worth knowing:
+
+- **Death is observed at once.** The serving thread sees the server's
+  connection drop and fires the linked death recipients immediately —
+  the session no longer waits for its next failed call to notice.
+- **Stop the session explicitly.** The serving threads keep the session
+  alive; dropping the `RpcSession` handle and every proxy does not end
+  them. Call `RpcSession::shutdown()` when you are done — it shuts the
+  connections down and joins the threads.
+
+This needs the android-13+ profile (the attach echoes the session id)
+and is currently offered for Unix-domain sockets.
 
 ## Bridging RPC and the service manager: the Accessor pattern
 

--- a/example-hello/Cargo.toml
+++ b/example-hello/Cargo.toml
@@ -91,6 +91,13 @@ required-features = ["rpc", "android_16"]
 name = "rpc_multiconn_interop_server"
 required-features = ["rpc"]
 
+# Plan 2-20 STAGE3 gate (e) — rsbinder client with one incoming (callback)
+# connection against a real-libbinder RpcServer that calls back from a
+# plain thread. Run via cpp/run_rpc_incoming_interop.sh.
+[[bin]]
+name = "rpc_incoming_interop_client"
+required-features = ["rpc"]
+
 # Plan 2-11 AC-11.3 STAGE3 — rsbinder side of the FD-over-RPC
 # real-libbinder gate. Pairs with cpp/rpc_fd_interop_launcher (a real
 # libbinder `ARpcSession` client with the `Unix` fd transport mode);

--- a/example-hello/cpp/rpc_incoming_interop_launcher.cpp
+++ b/example-hello/cpp/rpc_incoming_interop_launcher.cpp
@@ -1,0 +1,292 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+//
+// Plan 2-20 STAGE3 gate (e) — the **reverse** direction of gate (d) in
+// `rpc_multiconn_interop_launcher.cpp`: a real-libbinder **RPC server**
+// (this launcher) and an rsbinder **client** that opened one incoming
+// connection (`RpcUnixClientConfig::incoming_connections(1)`).
+//
+// The client hands us a callback and asks (`TX_SCHEDULE_CALLBACK`) for it
+// to be driven later. We do that from a plain `std::thread` — no handler
+// on the stack — which in libbinder means `ExclusiveConnection::find`
+// must pick a connection from the session's `mOutgoing` pool. That pool
+// holds exactly the connection the rsbinder client attached with the
+// INCOMING header bit; without it libbinder fails with WOULD_BLOCK.
+// The rsbinder client serves that connection on its own thread and
+// answers the twoway echo, then receives a oneway notify.
+//
+// Wire: android-13+ v2 (whatever the on-device libbinder speaks; the
+// rsbinder client asks for max_version=2). Interface token: bare
+// `writeString16(descriptor)` (the STAGE3 RPC convention).
+
+#include <android/binder_ibinder.h>
+#include <android/binder_parcel.h>
+#include <android/binder_status.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <thread>
+
+extern "C" {
+void ABinderProcess_setThreadPoolMaxThreadCount(uint32_t numThreads);
+void ABinderProcess_startThreadPool();
+
+// --- libbinder_rpc_unstable.so ---
+struct ARpcServer;
+ARpcServer* ARpcServer_newBoundSocket(AIBinder* service, int socketFd);
+void ARpcServer_setMaxThreads(ARpcServer* server, size_t threads);
+void ARpcServer_join(ARpcServer* server);
+}
+
+namespace {
+
+constexpr const char* kRootDescriptor = "rsbinder.test.IIncomingInterop";
+constexpr const char* kCallbackDescriptor = "rsbinder.test.IIncomingInteropCallback";
+
+// Must match the rsbinder client's TX_* constants.
+constexpr transaction_code_t TX_ECHO = FIRST_CALL_TRANSACTION + 0;
+constexpr transaction_code_t TX_SCHEDULE_CALLBACK = FIRST_CALL_TRANSACTION + 5;
+constexpr transaction_code_t TX_GET_SCHED = FIRST_CALL_TRANSACTION + 6;
+constexpr transaction_code_t TX_CALLBACK_ECHO = FIRST_CALL_TRANSACTION + 0;
+constexpr transaction_code_t TX_CALLBACK_NOTIFY = FIRST_CALL_TRANSACTION + 1; // oneway
+
+struct AStatusOwned {
+    AStatus* s = nullptr;
+    ~AStatusOwned() {
+        if (s) AStatus_delete(s);
+    }
+};
+struct InParcel {
+    AParcel* p = nullptr;
+    ~InParcel() {
+        if (p) AParcel_delete(p);
+    }
+};
+struct OutParcel {
+    AParcel* p = nullptr;
+    ~OutParcel() {
+        if (p) AParcel_delete(p);
+    }
+};
+
+bool read_string_into(void* opaque, int32_t length, char** outBuf) {
+    auto* dst = static_cast<std::string*>(opaque);
+    if (length < 0) {
+        *outBuf = nullptr;
+        return true;
+    }
+    dst->resize(length);
+    *outBuf = dst->data();
+    return true;
+}
+
+// Outcome of the scheduled callback, read back via TX_GET_SCHED.
+std::mutex g_sched_mu;
+std::string g_sched = "pending";
+
+void set_sched(std::string s) {
+    std::lock_guard<std::mutex> l(g_sched_mu);
+    g_sched = std::move(s);
+}
+
+AIBinder_Class* g_cb_clazz = nullptr;
+
+binder_status_t cb_stub_on_transact(AIBinder*, transaction_code_t, const AParcel*, AParcel*) {
+    // Never called: the class only gives the *proxy* its descriptor.
+    return STATUS_UNKNOWN_TRANSACTION;
+}
+void* on_create(void* args) { return args; }
+void on_destroy(void* /*userData*/) {}
+
+// The out-of-handler driver: runs on a plain thread ~150 ms after the
+// request that parked `cb` has been answered.
+void drive_callback_later(AIBinder* cb, std::string arg) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+    std::string outcome;
+    do {
+        InParcel in;
+        binder_status_t rc = AIBinder_prepareTransaction(cb, &in.p);
+        if (rc != STATUS_OK) {
+            outcome = "err:prepare:" + std::to_string(rc);
+            break;
+        }
+        rc = AParcel_writeString(in.p, arg.c_str(), (int32_t)arg.size());
+        if (rc != STATUS_OK) {
+            outcome = "err:writeString:" + std::to_string(rc);
+            break;
+        }
+        OutParcel out;
+        rc = AIBinder_transact(cb, TX_CALLBACK_ECHO, &in.p, &out.p, 0);
+        in.p = nullptr;
+        if (rc != STATUS_OK) {
+            outcome = "err:transact:" + std::to_string(rc);
+            break;
+        }
+        AStatusOwned st;
+        rc = AParcel_readStatusHeader(out.p, &st.s);
+        if (rc != STATUS_OK || !AStatus_isOk(st.s)) {
+            outcome = "err:status";
+            break;
+        }
+        std::string echoed;
+        rc = AParcel_readString(out.p, &echoed, read_string_into);
+        if (rc != STATUS_OK) {
+            outcome = "err:readString:" + std::to_string(rc);
+            break;
+        }
+        if (!echoed.empty() && echoed.back() == '\0') echoed.pop_back();
+
+        InParcel in2;
+        rc = AIBinder_prepareTransaction(cb, &in2.p);
+        if (rc != STATUS_OK) {
+            outcome = "err:prepare2:" + std::to_string(rc);
+            break;
+        }
+        OutParcel out2;
+        rc = AIBinder_transact(cb, TX_CALLBACK_NOTIFY, &in2.p, &out2.p, FLAG_ONEWAY);
+        in2.p = nullptr;
+        if (rc != STATUS_OK) {
+            outcome = "err:oneway:" + std::to_string(rc);
+            break;
+        }
+        outcome = "ok:" + echoed;
+    } while (false);
+    fprintf(stderr, "[cpp-server] scheduled callback outside a handler: %s\n", outcome.c_str());
+    set_sched(outcome);
+    AIBinder_decStrong(cb);
+}
+
+binder_status_t root_on_transact(AIBinder* /*binder*/, transaction_code_t code,
+                                 const AParcel* in, AParcel* out) {
+    switch (code) {
+        case TX_ECHO: {
+            std::string s;
+            binder_status_t rc = AParcel_readString(in, &s, read_string_into);
+            if (rc != STATUS_OK) return rc;
+            if (!s.empty() && s.back() == '\0') s.pop_back();
+            fprintf(stderr, "[cpp-server] TX_ECHO arg=%.*s\n", (int)s.size(), s.data());
+            binder_status_t st0 = AParcel_writeInt32(out, 0);
+            if (st0 != STATUS_OK) return st0;
+            return AParcel_writeString(out, s.data(), (int32_t)s.size());
+        }
+        case TX_SCHEDULE_CALLBACK: {
+            AIBinder* cb = nullptr;
+            binder_status_t rc = AParcel_readStrongBinder(in, &cb);
+            if (rc != STATUS_OK || !cb) {
+                fprintf(stderr, "[cpp-server] readStrongBinder: %d\n", rc);
+                return rc != STATUS_OK ? rc : STATUS_BAD_VALUE;
+            }
+            if (!AIBinder_associateClass(cb, g_cb_clazz)) {
+                fprintf(stderr, "[cpp-server] associateClass(cb) failed\n");
+                AIBinder_decStrong(cb);
+                return STATUS_BAD_TYPE;
+            }
+            std::string s;
+            rc = AParcel_readString(in, &s, read_string_into);
+            if (rc != STATUS_OK) {
+                AIBinder_decStrong(cb);
+                return rc;
+            }
+            if (!s.empty() && s.back() == '\0') s.pop_back();
+            set_sched("pending");
+            // `cb` (already +1 strong from readStrongBinder) is released
+            // by the thread when done.
+            std::thread(drive_callback_later, cb, s).detach();
+            fprintf(stderr, "[cpp-server] TX_SCHEDULE_CALLBACK parked; driving in 150 ms\n");
+            return AParcel_writeInt32(out, 0);
+        }
+        case TX_GET_SCHED: {
+            std::string s;
+            {
+                std::lock_guard<std::mutex> l(g_sched_mu);
+                s = g_sched;
+            }
+            binder_status_t st0 = AParcel_writeInt32(out, 0);
+            if (st0 != STATUS_OK) return st0;
+            return AParcel_writeString(out, s.data(), (int32_t)s.size());
+        }
+        default:
+            return STATUS_UNKNOWN_TRANSACTION;
+    }
+}
+
+int bind_uds_listen(const std::string& path) {
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        perror("[cpp-server] socket");
+        return -1;
+    }
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    if (path.size() >= sizeof(addr.sun_path)) {
+        fprintf(stderr, "[cpp-server] socket path too long\n");
+        close(fd);
+        return -1;
+    }
+    strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+    unlink(path.c_str());
+    socklen_t len = (socklen_t)(offsetof(sockaddr_un, sun_path) + path.size() + 1);
+    if (bind(fd, reinterpret_cast<sockaddr*>(&addr), len) < 0) {
+        perror("[cpp-server] bind");
+        close(fd);
+        return -1;
+    }
+    if (listen(fd, 5) < 0) {
+        perror("[cpp-server] listen");
+        close(fd);
+        return -1;
+    }
+    chmod(path.c_str(), 0666);
+    return fd;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    const char* sock_path = (argc > 1) ? argv[1] : "/data/local/tmp/rsinc.sock";
+    fprintf(stderr, "[cpp-server] plan 2-20 gate (e): libbinder RpcServer on %s\n", sock_path);
+
+    ABinderProcess_setThreadPoolMaxThreadCount(2);
+    ABinderProcess_startThreadPool();
+
+    int sockfd = bind_uds_listen(sock_path);
+    if (sockfd < 0) return 1;
+
+    g_cb_clazz = AIBinder_Class_define(kCallbackDescriptor, on_create, on_destroy,
+                                       cb_stub_on_transact);
+    AIBinder_Class* root_clazz =
+            AIBinder_Class_define(kRootDescriptor, on_create, on_destroy, root_on_transact);
+    if (!g_cb_clazz || !root_clazz) {
+        fprintf(stderr, "[cpp-server] AIBinder_Class_define failed\n");
+        return 2;
+    }
+    AIBinder* root_binder = AIBinder_new(root_clazz, nullptr);
+    if (!root_binder) {
+        fprintf(stderr, "[cpp-server] AIBinder_new failed\n");
+        return 3;
+    }
+    ARpcServer* server = ARpcServer_newBoundSocket(root_binder, sockfd);
+    if (!server) {
+        fprintf(stderr, "[cpp-server] ARpcServer_newBoundSocket failed\n");
+        return 4;
+    }
+    ARpcServer_setMaxThreads(server, 2);
+    fprintf(stderr, "[cpp-server] READY (joining)\n");
+    printf("[cpp-server] READY\n");
+    fflush(stdout);
+    ARpcServer_join(server);
+    AIBinder_decStrong(root_binder);
+    return 0;
+}

--- a/example-hello/cpp/rpc_multiconn_interop_launcher.cpp
+++ b/example-hello/cpp/rpc_multiconn_interop_launcher.cpp
@@ -108,7 +108,15 @@ constexpr transaction_code_t TX_SLOW_ECHO = FIRST_CALL_TRANSACTION + 1;
 constexpr transaction_code_t TX_ONEWAY = FIRST_CALL_TRANSACTION + 2;
 constexpr transaction_code_t TX_GET_LOG = FIRST_CALL_TRANSACTION + 3;
 constexpr transaction_code_t TX_INVOKE_CALLBACK = FIRST_CALL_TRANSACTION + 4;
+constexpr transaction_code_t TX_SCHEDULE_CALLBACK = FIRST_CALL_TRANSACTION + 5;
+constexpr transaction_code_t TX_GET_SCHED = FIRST_CALL_TRANSACTION + 6;
 constexpr transaction_code_t TX_CALLBACK_ECHO = FIRST_CALL_TRANSACTION + 0;
+constexpr transaction_code_t TX_CALLBACK_NOTIFY = FIRST_CALL_TRANSACTION + 1; // oneway
+
+// Gate (d) observers: what the server's out-of-handler thread delivered
+// to our callback (dispatched on the libbinder incoming thread).
+std::atomic<int> g_cb_echo_seen{0};
+std::atomic<int> g_cb_notify_seen{0};
 
 // --- AParcel string allocator (std::string sink) -----------------
 bool read_string_into(void* opaque, int32_t length, char** outBuf) {
@@ -190,9 +198,16 @@ struct AStatusOwned {
 // convention). The NDK dispatches that to our `on_transact` here.
 binder_status_t callback_on_transact(AIBinder* /*binder*/, transaction_code_t code,
                                      const AParcel* in, AParcel* out) {
+    if (code == TX_CALLBACK_NOTIFY) {
+        // oneway from the server's out-of-handler thread (gate (d)).
+        g_cb_notify_seen.fetch_add(1);
+        fprintf(stderr, "[cpp-cb] notify (oneway) received\n");
+        return STATUS_OK;
+    }
     if (code != TX_CALLBACK_ECHO) {
         return STATUS_UNKNOWN_TRANSACTION;
     }
+    g_cb_echo_seen.fetch_add(1);
     std::string s;
     binder_status_t rc = AParcel_readString(in, &s, read_string_into);
     if (rc != STATUS_OK) {
@@ -338,6 +353,45 @@ bool do_invoke_callback(AIBinder* root, AIBinder* cb, const char* arg,
     rc = AParcel_readString(out.p, out_reply, read_string_into);
     if (rc != STATUS_OK) return false;
     if (!out_reply->empty() && out_reply->back() == '\0') out_reply->pop_back();
+    return true;
+}
+
+// Gate (d): `TX_SCHEDULE_CALLBACK(cb, arg)` returns at once; the server
+// drives `cb` later from a thread inside no handler.
+bool do_schedule_callback(AIBinder* root, AIBinder* cb, const char* arg) {
+    InParcel in;
+    binder_status_t rc = AIBinder_prepareTransaction(root, &in.p);
+    if (rc != STATUS_OK) return false;
+    rc = AParcel_writeStrongBinder(in.p, cb);
+    if (rc != STATUS_OK) return false;
+    rc = AParcel_writeString(in.p, arg, (int32_t)strlen(arg));
+    if (rc != STATUS_OK) return false;
+    OutParcel out;
+    rc = AIBinder_transact(root, TX_SCHEDULE_CALLBACK, &in.p, &out.p, 0);
+    in.p = nullptr;
+    if (rc != STATUS_OK) {
+        fprintf(stderr, "[cpp-client] transact(schedule_callback): %d\n", rc);
+        return false;
+    }
+    AStatusOwned st;
+    rc = AParcel_readStatusHeader(out.p, &st.s);
+    return rc == STATUS_OK && AStatus_isOk(st.s);
+}
+
+bool do_get_sched(AIBinder* root, std::string* out_text) {
+    InParcel in;
+    binder_status_t rc = AIBinder_prepareTransaction(root, &in.p);
+    if (rc != STATUS_OK) return false;
+    OutParcel out;
+    rc = AIBinder_transact(root, TX_GET_SCHED, &in.p, &out.p, 0);
+    in.p = nullptr;
+    if (rc != STATUS_OK) return false;
+    AStatusOwned st;
+    rc = AParcel_readStatusHeader(out.p, &st.s);
+    if (rc != STATUS_OK || !AStatus_isOk(st.s)) return false;
+    rc = AParcel_readString(out.p, out_text, read_string_into);
+    if (rc != STATUS_OK) return false;
+    if (!out_text->empty() && out_text->back() == '\0') out_text->pop_back();
     return true;
 }
 
@@ -570,6 +624,53 @@ int main(int argc, char** argv) {
             }
         }
         fprintf(stderr, "[cpp-client] (c) PASS — %d parallel nested callbacks round-tripped\n", kN);
+
+        // ---- (d) Callback from OUTSIDE a handler (plan 2-20) --------
+        // The server parks `cb` and, ~150 ms later, calls it from a plain
+        // thread: twoway `echo("later")` then oneway `notify()`. Those
+        // sends need a connection the server may claim on its own — the
+        // incoming connection this client opened via
+        // `setMaxIncomingThreads(1)`, which the rsbinder server admitted
+        // as a callback slot. libbinder dispatches both on that
+        // connection's thread. We then read the server's own view of the
+        // outcome (`ok:cb-echo:later`).
+        fprintf(stderr, "[cpp-client] (d) callback outside a handler: TX_SCHEDULE_CALLBACK\n");
+        g_cb_echo_seen.store(0);
+        g_cb_notify_seen.store(0);
+        if (!do_schedule_callback(root, cb, "later")) {
+            fprintf(stderr, "[cpp-client] (d) FAIL: schedule_callback\n");
+            return 40;
+        }
+        int waited_ms = 0;
+        while ((g_cb_echo_seen.load() < 1 || g_cb_notify_seen.load() < 1) && waited_ms < 3000) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            waited_ms += 20;
+        }
+        if (g_cb_echo_seen.load() < 1 || g_cb_notify_seen.load() < 1) {
+            fprintf(stderr,
+                    "[cpp-client] (d) FAIL: after %d ms echo_seen=%d notify_seen=%d\n",
+                    waited_ms, g_cb_echo_seen.load(), g_cb_notify_seen.load());
+            return 41;
+        }
+        std::string sched;
+        int polls = 0;
+        do {
+            if (!do_get_sched(root, &sched)) {
+                fprintf(stderr, "[cpp-client] (d) FAIL: get_sched\n");
+                return 42;
+            }
+            if (sched != "pending") break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        } while (++polls < 100);
+        if (sched != "ok:cb-echo:later") {
+            fprintf(stderr, "[cpp-client] (d) FAIL: server outcome \"%.*s\"\n",
+                    (int)sched.size(), sched.data());
+            return 43;
+        }
+        fprintf(stderr,
+                "[cpp-client] (d) PASS — twoway+oneway from a server thread outside any handler "
+                "(after %d ms)\n",
+                waited_ms);
     }
 
     printf("AC-12.6 PASS — multi-conn real-libbinder ↔ rsbinder full transact\n");

--- a/example-hello/cpp/run_rpc_incoming_interop.sh
+++ b/example-hello/cpp/run_rpc_incoming_interop.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Plan 2-20 STAGE3 gate (e) — the reverse of `run_rpc_multiconn_interop.sh`
+# gate (d): a real-libbinder **RPC server** (`rpc_incoming_interop_launcher.cpp`)
+# drives an rsbinder **client**'s callback from a plain `std::thread`; the
+# client opened one incoming connection (`incoming_connections(1)`).
+#
+# STATUS: see the bottom of this file / the plan (plans/2-20-*.md).
+#
+# Prereqs: as run_rpc_multiconn_interop.sh (Android 16 AVD, NDK, cargo ndk,
+# aarch64-linux-android target).
+#
+# Usage: ./run_rpc_incoming_interop.sh [-s emulator-5554]
+# Exits 0 on PASS; non-zero otherwise.
+
+set -euo pipefail
+
+DEVICE=emulator-5554
+SOCK=/data/local/tmp/rsinc.sock
+CPP_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$CPP_DIR/../.." && pwd)"
+NDK_BIN="${ANDROID_NDK_HOME:-/opt/homebrew/share/android-ndk}/toolchains/llvm/prebuilt/darwin-x86_64/bin"
+
+if [[ ${1:-} == "-s" ]]; then
+    DEVICE="$2"
+    shift 2
+fi
+
+echo "==> verifying device $DEVICE is Android 16"
+sdk=$(adb -s "$DEVICE" shell getprop ro.build.version.sdk | tr -d '\r')
+[[ "$sdk" == "36" ]] || { echo "device $DEVICE is SDK $sdk, expected 36"; exit 1; }
+
+echo "==> pulling libbinder_*.so so we can link against them"
+adb -s "$DEVICE" pull /system/lib64/libbinder_ndk.so /tmp/libbinder_ndk.so >/dev/null
+adb -s "$DEVICE" pull /system/lib64/libbinder_rpc_unstable.so /tmp/libbinder_rpc_unstable.so >/dev/null
+
+echo "==> building C++ server launcher (NDK)"
+"$NDK_BIN/aarch64-linux-android35-clang++" \
+    -O2 -Wall -std=c++17 -static-libstdc++ \
+    -L /tmp \
+    -lbinder_ndk -lbinder_rpc_unstable -llog \
+    "$CPP_DIR/rpc_incoming_interop_launcher.cpp" \
+    -o "$CPP_DIR/rpc_incoming_interop_launcher"
+
+echo "==> cross-compiling rsbinder client"
+( cd "$REPO_ROOT" && \
+    ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-/opt/homebrew/share/android-ndk}" \
+    cargo ndk -t arm64-v8a -p 35 build --release -p example-hello \
+        --features rpc \
+        --bin rpc_incoming_interop_client )
+
+echo "==> pushing binaries"
+adb -s "$DEVICE" push "$CPP_DIR/rpc_incoming_interop_launcher" /data/local/tmp/ >/dev/null
+adb -s "$DEVICE" push "$REPO_ROOT/target/aarch64-linux-android/release/rpc_incoming_interop_client" \
+    /data/local/tmp/ >/dev/null
+
+echo "==> killing any old launcher + cleaning state"
+adb -s "$DEVICE" shell "pkill -9 -f rpc_incoming_interop 2>/dev/null; rm -f $SOCK /data/local/tmp/rsinc.stdout /data/local/tmp/rsinc.stderr; sleep 1" || true
+
+echo "==> starting libbinder server launcher (background)"
+adb -s "$DEVICE" shell "nohup /data/local/tmp/rpc_incoming_interop_launcher $SOCK > /data/local/tmp/rsinc.stdout 2> /data/local/tmp/rsinc.stderr &" &
+sleep 3
+adb -s "$DEVICE" shell "cat /data/local/tmp/rsinc.stderr"
+
+echo "==> running rsbinder client"
+client_out=$(adb -s "$DEVICE" shell "/data/local/tmp/rpc_incoming_interop_client $SOCK 2>&1; echo client-exit=\$?" | tr -d '\r')
+printf '%s\n' "$client_out"
+
+echo "==> server log"
+adb -s "$DEVICE" shell "cat /data/local/tmp/rsinc.stderr"
+
+echo "==> stopping launcher"
+adb -s "$DEVICE" shell "pkill -9 -f rpc_incoming_interop_launcher 2>/dev/null; rm -f $SOCK" || true
+
+if ! grep -q '^client-exit=0$' <<<"$client_out"; then
+    echo "FAIL: rsbinder client exited non-zero"
+    exit 1
+fi
+if ! grep -q '^PASS' <<<"$client_out"; then
+    echo "FAIL: no PASS marker"
+    exit 1
+fi
+echo "PASS: plan 2-20 (e) rsbinder incoming connection ↔ real libbinder RpcServer"

--- a/example-hello/cpp/run_rpc_multiconn_interop.sh
+++ b/example-hello/cpp/run_rpc_multiconn_interop.sh
@@ -22,6 +22,12 @@
 #     out-of-order arrivals and the priority replay drains them when
 #     the matching expected `async_number` arrives — eventual per-
 #     node monotonic order, bounded poll window in the launcher.
+#   * (d) PASS (2026-08-30, plan 2-20): TX_SCHEDULE_CALLBACK parks the
+#     callback and the rsbinder server drives it ~150 ms later from a
+#     thread inside no handler (twoway echo + oneway notify). The send
+#     rides the client's `setMaxIncomingThreads(1)` connection, admitted
+#     by the server as a callback (`Outgoing`) slot; libbinder dispatches
+#     both on that connection's thread.
 #   * (c) PASS: 2 parallel TX_INVOKE_CALLBACK from 2 client threads
 #     each land on their own server incoming-slot worker; the nested
 #     server→client `cb.transact` rides the **same** slot via the
@@ -98,7 +104,20 @@ sleep 3
 adb -s "$DEVICE" shell "cat /data/local/tmp/rsmc.stderr"
 
 echo "==> running C++ launcher (libbinder client)"
-adb -s "$DEVICE" shell "/data/local/tmp/rpc_multiconn_interop_launcher $SOCK; echo client-exit=\$?"
+launcher_out=$(adb -s "$DEVICE" shell "/data/local/tmp/rpc_multiconn_interop_launcher $SOCK 2>&1; echo client-exit=\$?" | tr -d '\r')
+printf '%s\n' "$launcher_out"
 
 echo "==> stopping server"
 adb -s "$DEVICE" shell "pkill -9 -f rpc_multiconn_interop_server 2>/dev/null; rm -f $SOCK" || true
+
+# Gate: the launcher's exit status (0 only after (a)–(d) all passed) and
+# the (d) marker — the plan 2-20 out-of-handler callback gate.
+if ! grep -q '^client-exit=0$' <<<"$launcher_out"; then
+    echo "FAIL: launcher exited non-zero"
+    exit 1
+fi
+if ! grep -q '(d) PASS' <<<"$launcher_out"; then
+    echo "FAIL: gate (d) (callback outside a handler) did not pass"
+    exit 1
+fi
+echo "PASS: AC-12.6 (a)(b)(c) + plan 2-20 (d)"

--- a/example-hello/src/bin/rpc_incoming_interop_client.rs
+++ b/example-hello/src/bin/rpc_incoming_interop_client.rs
@@ -1,0 +1,188 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Plan 2-20 STAGE3 gate (e) — rsbinder **client** with one incoming
+//! (callback) connection against a real-libbinder **RPC server**
+//! (`cpp/rpc_incoming_interop_launcher.cpp`) that drives the callback
+//! from a plain `std::thread`, i.e. outside any handler.
+//!
+//! What the gate proves, on the real wire:
+//!
+//! 1. the INCOMING-bit attach + `"cci"` read that
+//!    `RpcUnixClientConfig::incoming_connections(1)` performs is what
+//!    libbinder's `RpcServer::establishConnection` expects
+//!    (`addOutgoingConnection(init=true)`);
+//! 2. libbinder's `ExclusiveConnection::find` from a non-handler thread
+//!    picks that connection and the rsbinder incoming thread answers the
+//!    twoway echo and receives the oneway notify;
+//! 3. `RpcSession::shutdown` ends the incoming thread cleanly.
+//!
+//! Exit code 0 = PASS; non-zero = the failing step.
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use rsbinder::rpc::{RpcProxy, RpcSession, RpcUnixClientConfig};
+use rsbinder::*;
+
+const ROOT_DESC: &str = "rsbinder.test.IIncomingInterop";
+const CB_DESC: &str = "rsbinder.test.IIncomingInteropCallback";
+
+const TX_ECHO: TransactionCode = FIRST_CALL_TRANSACTION;
+const TX_SCHEDULE_CALLBACK: TransactionCode = FIRST_CALL_TRANSACTION + 5;
+const TX_GET_SCHED: TransactionCode = FIRST_CALL_TRANSACTION + 6;
+const TX_CALLBACK_ECHO: TransactionCode = FIRST_CALL_TRANSACTION;
+const TX_CALLBACK_NOTIFY: TransactionCode = FIRST_CALL_TRANSACTION + 1;
+
+struct Cb {
+    echo_seen: Arc<AtomicI32>,
+    notify_seen: Arc<AtomicI32>,
+}
+impl Interface for Cb {}
+impl Remotable for Cb {
+    fn descriptor() -> &'static str {
+        CB_DESC
+    }
+    fn on_transact(
+        &self,
+        code: TransactionCode,
+        reader: &mut Parcel,
+        reply: &mut Parcel,
+    ) -> Result<()> {
+        match code {
+            TX_CALLBACK_ECHO => {
+                let s: String = reader.read()?;
+                eprintln!(
+                    "[rsbinder-cb] echo({s}) on {:?}",
+                    std::thread::current().name()
+                );
+                self.echo_seen.fetch_add(1, Ordering::SeqCst);
+                reply.write(&Status::from(StatusCode::Ok))?;
+                reply.write(&format!("cb-echo:{s}"))
+            }
+            TX_CALLBACK_NOTIFY => {
+                eprintln!("[rsbinder-cb] notify (oneway)");
+                self.notify_seen.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+            _ => Err(StatusCode::UnknownTransaction),
+        }
+    }
+    fn on_dump(&self, _w: &mut dyn std::io::Write, _a: &[String]) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn read_status(reply: &mut Parcel) -> Result<()> {
+    let st: Status = reply.read()?;
+    if st.is_ok() {
+        Ok(())
+    } else {
+        Err(StatusCode::from(st))
+    }
+}
+
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or("rsbinder::rpc=info"),
+    )
+    .init();
+    let sock = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/data/local/tmp/rsinc.sock".to_string());
+    eprintln!("[rsbinder-client] plan 2-20 gate (e): sock={sock}");
+
+    let session = RpcSession::setup_unix_client_android13plus_with_config(
+        RpcUnixClientConfig::path(std::path::Path::new(&sock), 2).incoming_connections(1),
+    )?;
+    eprintln!(
+        "[rsbinder-client] session up: wire v{:?}, slots={}, incoming threads={}",
+        session.wire_protocol_version(),
+        session.__slot_count(),
+        session.__incoming_thread_count()
+    );
+    let root = session.get_root()?;
+    let rp = (*root)
+        .as_any()
+        .downcast_ref::<RpcProxy>()
+        .ok_or("root is not an RpcProxy")?;
+
+    // Sanity.
+    {
+        let mut d = rp.build_request(ROOT_DESC)?;
+        d.write(&"sanity")?;
+        let mut r = rp.transact(TX_ECHO, &d, 0)?.ok_or("echo: no reply")?;
+        read_status(&mut r)?;
+        let got: String = r.read()?;
+        if got != "sanity" {
+            eprintln!("[rsbinder-client] sanity echo mismatch: {got:?}");
+            std::process::exit(10);
+        }
+    }
+    eprintln!("[rsbinder-client] sanity OK");
+
+    // Schedule.
+    let echo_seen = Arc::new(AtomicI32::new(0));
+    let notify_seen = Arc::new(AtomicI32::new(0));
+    let cb: SIBinder = Interface::as_binder(&Binder::new(Cb {
+        echo_seen: Arc::clone(&echo_seen),
+        notify_seen: Arc::clone(&notify_seen),
+    }));
+    {
+        let mut d = rp.build_request(ROOT_DESC)?;
+        d.write(&cb)?;
+        d.write(&"later")?;
+        let mut r = rp
+            .transact(TX_SCHEDULE_CALLBACK, &d, 0)?
+            .ok_or("schedule: no reply")?;
+        read_status(&mut r)?;
+    }
+    eprintln!("[rsbinder-client] scheduled; waiting for the server's out-of-handler callback");
+    let t0 = Instant::now();
+    while (echo_seen.load(Ordering::SeqCst) < 1 || notify_seen.load(Ordering::SeqCst) < 1)
+        && t0.elapsed() < Duration::from_secs(3)
+    {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    if echo_seen.load(Ordering::SeqCst) < 1 || notify_seen.load(Ordering::SeqCst) < 1 {
+        eprintln!(
+            "[rsbinder-client] FAIL: after {:?} echo_seen={} notify_seen={}",
+            t0.elapsed(),
+            echo_seen.load(Ordering::SeqCst),
+            notify_seen.load(Ordering::SeqCst)
+        );
+        std::process::exit(11);
+    }
+    // The server's own view of the outcome.
+    let mut outcome = String::from("pending");
+    for _ in 0..100 {
+        let d = rp.build_request(ROOT_DESC)?;
+        let mut r = rp
+            .transact(TX_GET_SCHED, &d, 0)?
+            .ok_or("get_sched: no reply")?;
+        read_status(&mut r)?;
+        outcome = r.read()?;
+        if outcome != "pending" {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    if outcome != "ok:cb-echo:later" {
+        eprintln!("[rsbinder-client] FAIL: server outcome {outcome:?}");
+        std::process::exit(12);
+    }
+    eprintln!(
+        "[rsbinder-client] (e) callback outside a handler round-tripped after {:?}",
+        t0.elapsed()
+    );
+
+    // Teardown: the incoming thread is joined here.
+    drop(root);
+    session.shutdown();
+    if session.__incoming_thread_count() != 0 {
+        eprintln!("[rsbinder-client] FAIL: incoming thread not joined");
+        std::process::exit(13);
+    }
+    println!("PASS — plan 2-20 (e): rsbinder incoming connection ↔ real libbinder RpcServer");
+    Ok(())
+}

--- a/example-hello/src/bin/rpc_multiconn_interop_server.rs
+++ b/example-hello/src/bin/rpc_multiconn_interop_server.rs
@@ -45,7 +45,7 @@
 //! just exposes the transactions and lets the genuine peer drive them.
 
 use std::sync::atomic::{AtomicI32, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use rsbinder::rpc::{RpcProxy, RpcServer};
@@ -64,8 +64,16 @@ const TX_SLOW_ECHO: TransactionCode = FIRST_CALL_TRANSACTION + 1;
 const TX_ONEWAY: TransactionCode = FIRST_CALL_TRANSACTION + 2;
 const TX_GET_LOG: TransactionCode = FIRST_CALL_TRANSACTION + 3;
 const TX_INVOKE_CALLBACK: TransactionCode = FIRST_CALL_TRANSACTION + 4;
-/// The callback's `on_transact` code on the C launcher side.
+/// `(cb: IBinder, s: String)` — park `cb` and, from a thread that is
+/// inside no handler, call `cb.echo(s)` (twoway) then `cb.notify()`
+/// (oneway) ~150 ms later (plan 2-20 gate (d)).
+const TX_SCHEDULE_CALLBACK: TransactionCode = FIRST_CALL_TRANSACTION + 5;
+/// `() -> String` — outcome of the scheduled callback: `pending`,
+/// `ok:<reply>` or `err:<StatusCode>`.
+const TX_GET_SCHED: TransactionCode = FIRST_CALL_TRANSACTION + 6;
+/// The callback's `on_transact` codes on the C launcher side.
 const TX_CALLBACK_ECHO: TransactionCode = FIRST_CALL_TRANSACTION;
+const TX_CALLBACK_NOTIFY: TransactionCode = FIRST_CALL_TRANSACTION + 1; // oneway
 
 struct MultiConn {
     /// Oneway log — every `TX_ONEWAY(i)` appends `i` here, in receipt
@@ -79,6 +87,9 @@ struct MultiConn {
     /// observable via `TX_GET_LOG`'s negative-index probe shouldn't be
     /// needed — overlap is decided by wall-clock at the launcher).
     in_flight: AtomicI32,
+    /// Outcome of the `TX_SCHEDULE_CALLBACK` thread (gate (d)); shared
+    /// with that thread.
+    sched: Arc<Mutex<Option<String>>>,
 }
 
 impl Interface for MultiConn {}
@@ -151,6 +162,56 @@ impl Remotable for MultiConn {
                 reply.write(&Status::from(StatusCode::Ok))?;
                 reply.write(&cb_reply)
             }
+            TX_SCHEDULE_CALLBACK => {
+                // Gate (d): the callback is driven **outside** this
+                // handler, from a plain thread. That send needs a slot the
+                // server may claim on its own — the client's incoming
+                // connection (`setMaxIncomingThreads(1)`), admitted as a
+                // callback slot. Without one it fails at once.
+                let cb: SIBinder = reader.read()?;
+                let s: String = reader.read()?;
+                *self.sched.lock().expect("sched poisoned") = None;
+                let sched = Arc::clone(&self.sched);
+                std::thread::spawn(move || {
+                    std::thread::sleep(Duration::from_millis(150));
+                    let outcome = (|| -> Result<String> {
+                        let rp = (*cb)
+                            .as_any()
+                            .downcast_ref::<RpcProxy>()
+                            .ok_or(StatusCode::BadType)?;
+                        let mut d = rp.build_request(CALLBACK_DESC)?;
+                        d.write(&s)?;
+                        let mut r = rp
+                            .transact(TX_CALLBACK_ECHO, &d, 0)?
+                            .ok_or(StatusCode::UnexpectedNull)?;
+                        let st: Status = r.read()?;
+                        if !st.is_ok() {
+                            return Err(StatusCode::from(st));
+                        }
+                        let echoed: String = r.read()?;
+                        let d2 = rp.build_request(CALLBACK_DESC)?;
+                        rp.transact(TX_CALLBACK_NOTIFY, &d2, rsbinder::FLAG_ONEWAY)?;
+                        Ok(echoed)
+                    })();
+                    let text = match outcome {
+                        Ok(s) => format!("ok:{s}"),
+                        Err(e) => format!("err:{e:?}"),
+                    };
+                    eprintln!("[rsbinder-server] scheduled callback outside a handler: {text}");
+                    *sched.lock().expect("sched poisoned") = Some(text);
+                });
+                reply.write(&Status::from(StatusCode::Ok))
+            }
+            TX_GET_SCHED => {
+                let text = self
+                    .sched
+                    .lock()
+                    .expect("sched poisoned")
+                    .clone()
+                    .unwrap_or_else(|| "pending".to_string());
+                reply.write(&Status::from(StatusCode::Ok))?;
+                reply.write(&text)
+            }
             _ => Err(StatusCode::UnknownTransaction),
         }
     }
@@ -191,6 +252,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     server.set_root(Interface::as_binder(&Binder::new(MultiConn {
         oneway_log: Mutex::new(Vec::new()),
         in_flight: AtomicI32::new(0),
+        sched: Arc::new(Mutex::new(None)),
     })));
 
     println!("[rsbinder-server] READY v2 max_threads={max_threads} on {sock}");

--- a/rsbinder/src/binderfs.rs
+++ b/rsbinder/src/binderfs.rs
@@ -73,7 +73,8 @@ mod tests {
         _fd: Fd,
         device: &mut binder::binderfs_device,
     ) -> std::result::Result<(), rustix::io::Errno> {
-        let bytes: Vec<u8> = device.name.to_vec();
+        #[allow(clippy::unnecessary_cast)]
+        let bytes: Vec<u8> = device.name.iter().map(|&c| c as u8).collect();
         let nul = bytes
             .iter()
             .position(|&b| b == 0)

--- a/rsbinder/src/binderfs.rs
+++ b/rsbinder/src/binderfs.rs
@@ -73,7 +73,7 @@ mod tests {
         _fd: Fd,
         device: &mut binder::binderfs_device,
     ) -> std::result::Result<(), rustix::io::Errno> {
-        let bytes: Vec<u8> = device.name.iter().map(|&c| c as u8).collect();
+        let bytes: Vec<u8> = device.name.to_vec();
         let nul = bytes
             .iter()
             .position(|&b| b == 0)

--- a/rsbinder/src/entry/client.rs
+++ b/rsbinder/src/entry/client.rs
@@ -25,6 +25,12 @@ pub struct ClientOptions {
     /// RPC (android13plus profile, `unix`/`unix-abstract`): number of
     /// outgoing connections to open (AOSP `setupClient` fan-out).
     pub outgoing_connections: Option<u32>,
+    /// RPC, android-13+ profile, Unix sockets only: number of incoming
+    /// (callback) connections to open — AOSP `setMaxIncomingThreads`.
+    /// Needed for the server to call this client's callbacks from
+    /// outside a handler; see
+    /// [`RpcUnixClientConfig::incoming_connections`](crate::rpc::RpcUnixClientConfig::incoming_connections).
+    pub incoming_connections: Option<u32>,
     /// RPC: FD transport mode to negotiate. Requesting
     /// [`FileDescriptorTransportMode::Unix`](crate::rpc::FileDescriptorTransportMode)
     /// is rejected on a transport that cannot carry fds — see
@@ -69,7 +75,8 @@ impl std::fmt::Debug for ClientOptions {
         d.field("tls", &self.tls.is_some())
             .field("tls_server_name", &self.tls_server_name);
         d.field("session_id", &self.session_id.as_ref().map(|v| v.len()))
-            .field("outgoing_connections", &self.outgoing_connections);
+            .field("outgoing_connections", &self.outgoing_connections)
+            .field("incoming_connections", &self.incoming_connections);
         #[cfg(feature = "rpc")]
         d.field("fd_mode", &self.fd_mode);
         d.field("timeout", &self.timeout)
@@ -100,8 +107,14 @@ pub(super) fn new_client(uri: Uri, o: ClientOptions) -> Result<Client> {
     };
     match &uri.endpoint {
         Endpoint::Kernel { driver, threads } => {
-            if o.session_id.is_some() || o.outgoing_connections.is_some() || o.timeout.is_some() {
-                return Err(reject("session_id/outgoing_connections/timeout"));
+            if o.session_id.is_some()
+                || o.outgoing_connections.is_some()
+                || o.incoming_connections.is_some()
+                || o.timeout.is_some()
+            {
+                return Err(reject(
+                    "session_id/outgoing_connections/incoming_connections/timeout",
+                ));
             }
             #[cfg(feature = "rpc")]
             if o.fd_mode.is_some() {
@@ -166,17 +179,19 @@ fn rpc_connect(uri: &Uri, o: &ClientOptions) -> Result<crate::rpc::RpcSession> {
 
     let versioned = uri.wire_max_version;
     let fan_out = o.outgoing_connections.unwrap_or(1);
-    if versioned.is_none() && (o.session_id.is_some() || fan_out > 1) {
+    let incoming = o.incoming_connections.unwrap_or(0);
+    if versioned.is_none() && (o.session_id.is_some() || fan_out > 1 || incoming > 0) {
         log::error!(
-            "rsbinder::Client::open: session_id/outgoing_connections need \
-             `?profile=android13plus` ({:?})",
+            "rsbinder::Client::open: session_id/outgoing_connections/incoming_connections \
+             need `?profile=android13plus` ({:?})",
             uri.endpoint
         );
         return Err(StatusCode::BadValue);
     }
 
-    // The unix fan-out path has its own multi-connection setup.
-    if let (Some(v), true) = (versioned, fan_out > 1) {
+    // The unix fan-out / incoming-connection path has its own
+    // multi-connection setup.
+    if let (Some(v), true) = (versioned, fan_out > 1 || incoming > 0) {
         let mut cfg = match &uri.endpoint {
             Endpoint::Unix(path) => crate::rpc::RpcUnixClientConfig::path(path, v),
             #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -184,11 +199,15 @@ fn rpc_connect(uri: &Uri, o: &ClientOptions) -> Result<crate::rpc::RpcSession> {
                 crate::rpc::RpcUnixClientConfig::abstract_name(name.as_slice(), v)
             }
             _ => {
-                log::error!("rsbinder::Client::open: outgoing_connections > 1 is unix-only");
+                log::error!(
+                    "rsbinder::Client::open: outgoing_connections > 1 / incoming_connections \
+                     are unix-only"
+                );
                 return Err(StatusCode::BadValue);
             }
         }
-        .outgoing_connections(fan_out);
+        .outgoing_connections(fan_out)
+        .incoming_connections(incoming);
         if let Some(m) = o.fd_mode {
             cfg = cfg.fd_mode(m);
         }

--- a/rsbinder/src/entry/client.rs
+++ b/rsbinder/src/entry/client.rs
@@ -29,7 +29,15 @@ pub struct ClientOptions {
     /// (callback) connections to open — AOSP `setMaxIncomingThreads`.
     /// Needed for the server to call this client's callbacks from
     /// outside a handler; see
-    /// [`RpcUnixClientConfig::incoming_connections`](crate::rpc::RpcUnixClientConfig::incoming_connections).
+    // The target only exists with `rpc`, so only link it then.
+    #[cfg_attr(
+        feature = "rpc",
+        doc = "[`RpcUnixClientConfig::incoming_connections`](crate::rpc::RpcUnixClientConfig::incoming_connections)."
+    )]
+    #[cfg_attr(
+        not(feature = "rpc"),
+        doc = "`RpcUnixClientConfig::incoming_connections` (`rpc` feature)."
+    )]
     pub incoming_connections: Option<u32>,
     /// RPC: FD transport mode to negotiate. Requesting
     /// [`FileDescriptorTransportMode::Unix`](crate::rpc::FileDescriptorTransportMode)

--- a/rsbinder/src/rpc/proxy.rs
+++ b/rsbinder/src/rpc/proxy.rs
@@ -282,6 +282,12 @@ impl IBinder for RpcProxy {
     /// connection runs the same death sequence (obituaries + local
     /// object release) — a documented rsbinder model property, faithful
     /// to AOSP's incoming-thread requirement.
+    ///
+    /// A client built with
+    /// [`RpcUnixClientConfig::incoming_connections`](super::session::RpcUnixClientConfig::incoming_connections)
+    /// `≥ 1` *is* served — by the threads on its incoming (callback)
+    /// connections — so it observes the drop at once (AOSP
+    /// `onSessionAllIncomingThreadsEnded`) with no serve loop of its own.
     fn link_to_death(&self, recipient: sync::Weak<dyn DeathRecipient>) -> Result<()> {
         // Lock first, then check `obituary_sent` — kernel/AOSP ordering
         // (`BpBinder::linkToDeath` checks `mObitsSent` under `mLock`).

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -672,6 +672,11 @@ impl RpcServer {
     ///    attach attempts past `n` with `rejected_unknown_id` —
     ///    AOSP-faithful `setMaxIncomingThreads` (`RpcServer.cpp`
     ///    `session->setMaxIncomingThreads(server->mMaxThreads)`).
+    ///    Callback connections — the ones a client opens with
+    ///    `ARpcSession_setMaxIncomingThreads` / rsbinder's client-side
+    ///    incoming connections, on which this server *sends* — are
+    ///    budgeted separately at `2 * n` per session; served slots do
+    ///    not count against that budget.
     ///
     /// Distinct from [`set_max_connections`](RpcServer::set_max_connections),
     /// which caps *concurrent connection-worker threads*
@@ -765,6 +770,12 @@ impl RpcServer {
     /// legitimately reads a large reply slower than `d` is also dropped
     /// mid-send (the connection is torn down, not desynced). Size `d`
     /// against the slowest acceptable consumer, not just the idle gap.
+    ///
+    /// Callback connections (a client's incoming attaches, which this
+    /// server only ever *sends* on) are exempt: they have no serve loop,
+    /// and a sticky deadline there would cut short the server's own
+    /// reply wait on a callback issued outside a handler. Only the
+    /// session reply deadline bounds those sends.
     pub fn set_idle_timeout(&self, timeout: Option<std::time::Duration>) {
         *self.idle_timeout.lock().expect("idle_timeout poisoned") = timeout;
     }
@@ -1229,11 +1240,24 @@ impl RpcServer {
                 // serve-phase deadline — `None` (default, unbounded idle) or
                 // the configured `set_idle_timeout` so a post-handshake
                 // silent peer is evicted instead of pinning its slot.
-                server.arm_serve_timeouts(transport.as_ref());
                 if incoming {
                     // Attach + incoming (`server_accept` already
                     // rejected new + incoming): resolve the session,
                     // register a callback slot, and exit the worker.
+                    //
+                    // A callback slot is never served, so the serve-phase
+                    // idle deadline must NOT be armed on it: `SO_RCVTIMEO`
+                    // is sticky, and the server's own reply wait on this
+                    // slot (a callback issued outside any handler) would
+                    // otherwise be cut short by `set_idle_timeout`. Lift
+                    // the handshake deadline instead — only the session
+                    // reply deadline bounds sends on this slot.
+                    if let Err(e) = transport.set_read_timeout(None) {
+                        log::debug!("RPC: failed to clear callback-slot read timeout: {e:?}");
+                    }
+                    if let Err(e) = transport.set_write_timeout(None) {
+                        log::debug!("RPC: failed to clear callback-slot write timeout: {e:?}");
+                    }
                     // The slot lives in the pool for server→client
                     // sends; there is no read loop because
                     // client→server traffic only uses outgoing
@@ -1273,9 +1297,10 @@ impl RpcServer {
                             // pool (and its held fds) without bound. AOSP opens
                             // symmetric incoming+outgoing connections (each
                             // bounded by the negotiated max-threads), so cap the
-                            // shared pool at `2 * max_threads` — tight enough to
-                            // bound the DoS, loose enough never to refuse a
-                            // well-behaved client's callback connections.
+                            // callback slots at `2 * max_threads` (served slots
+                            // are not counted) — tight enough to bound the DoS,
+                            // loose enough never to refuse a well-behaved
+                            // client's callback connections.
                             //
                             // The cap is enforced atomically inside
                             // `add_callback_slot` (check-and-push under the
@@ -1285,7 +1310,9 @@ impl RpcServer {
                             let incoming_cap =
                                 (inner.max_threads_value() as usize).saturating_mul(2);
                             let session = RpcSession::wrap_inner(inner);
-                            if let Err(e) = session.add_callback_slot(transport, incoming_cap) {
+                            if let Err(e) =
+                                session.add_callback_slot_and_init(transport, incoming_cap, &codec)
+                            {
                                 server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
                                 log::warn!(
                                     "android-13+ RPC: incoming callback attach refused \
@@ -1305,6 +1332,7 @@ impl RpcServer {
                     }
                     return;
                 }
+                server.arm_serve_timeouts(transport.as_ref());
                 if client_id.is_empty() {
                     // New session: mint, register, serve. Registry
                     // entry is `Weak`; reclaimed by the next

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -33,9 +33,10 @@ use super::state::RpcState;
 use super::transport::{PeerIdentity, RpcTransport};
 use super::wire::{R34Codec, WireCodec, WireMessage, WireReply, WireTransaction};
 use super::wire_android13::{
-    client_connect_with_id, read_aosp_message, read_aosp_message_with_fds, server_accept,
-    write_aosp_message, write_aosp_message_with_fds, Android13PlusCodec, RawTransportIo,
-    A13_ADDR_LEN, FD_MODE_NONE, FD_MODE_UNIX, PROTOCOL_V1, PROTOCOL_V2,
+    client_connect_with_id, read_aosp_message, read_aosp_message_with_fds,
+    server_accept_deferred_init, write_aosp_message, write_aosp_message_with_fds,
+    Android13PlusCodec, RawTransportIo, A13_ADDR_LEN, FD_MODE_NONE, FD_MODE_UNIX, PROTOCOL_V1,
+    PROTOCOL_V2,
 };
 use super::{RpcError, RpcResult};
 
@@ -73,6 +74,7 @@ pub struct RpcUnixClientConfig<'a> {
     max_version: u32,
     session_id: &'a [u8],
     outgoing_connections: u32,
+    incoming_connections: u32,
     fd_mode: Option<FileDescriptorTransportMode>,
 }
 
@@ -83,6 +85,7 @@ impl<'a> RpcUnixClientConfig<'a> {
             max_version,
             session_id: &[],
             outgoing_connections: 1,
+            incoming_connections: 0,
             fd_mode: None,
         }
     }
@@ -114,6 +117,32 @@ impl<'a> RpcUnixClientConfig<'a> {
     /// only, skipping negotiation entirely.
     pub fn outgoing_connections(mut self, n: u32) -> Self {
         self.outgoing_connections = n;
+        self
+    }
+
+    /// Open `n` **incoming (callback) connections** in addition to the
+    /// outgoing pool — AOSP `RpcSession::setMaxIncomingThreads(n)`.
+    /// Each one is attached with the `INCOMING` header bit, added to
+    /// the server's session as a slot the server *sends* on, and served
+    /// here by a dedicated thread. Without at least one, the server can
+    /// reach this client's callbacks only from inside a handler that is
+    /// answering one of this client's calls (a nested call); a call
+    /// from any other server thread — a timer, a worker, a oneway
+    /// notification — fails with `FailedTransaction` on the server.
+    ///
+    /// Side effect: a session with an incoming connection detects the
+    /// server's death as soon as the connection drops (obituaries fire
+    /// from the serving thread), instead of on the next failed call.
+    ///
+    /// Requires the android-13+ profile (a session id), so it cannot be
+    /// combined with [`session_id`](Self::session_id) (attaching to a
+    /// session you do not own). Bounded on the server by twice its
+    /// `RpcServer::set_max_threads` value. Default 0. The threads end
+    /// when the server closes the session or on
+    /// [`RpcSession::shutdown`]; dropping the `RpcSession` handle alone
+    /// does not stop them.
+    pub fn incoming_connections(mut self, n: u32) -> Self {
+        self.incoming_connections = n;
         self
     }
 
@@ -429,6 +458,30 @@ thread_local! {
     static DRIVING: RefCell<Vec<(usize, u64)>> = const { RefCell::new(Vec::new()) };
 }
 
+/// Which direction this endpoint uses a connection slot in — AOSP's
+/// `RpcSession::mConnections.{mOutgoing, mIncoming}` split, kept as a
+/// per-slot tag on the single pool (plan 2-20).
+///
+/// A non-nested outbound call (`client_transact` from a thread that is
+/// not already driving a slot of this session) may only claim an
+/// `Outgoing` slot: an `Incoming` slot is driven by a serve loop, and
+/// its peer reads it only inside its own reply wait, so a transaction
+/// written there from outside a dispatch would sit unread — and the
+/// worker would be locked out of its own slot for the duration. A
+/// nested call (the `DRIVING` reentrant pin) re-enters whichever slot
+/// the thread already drives, whatever its role.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum SlotRole {
+    /// This endpoint serves the connection (AOSP `mIncoming`): the
+    /// server's founding slot and its id-echoing attaches, and a
+    /// client's incoming (callback) connections.
+    Incoming,
+    /// This endpoint sends on the connection (AOSP `mOutgoing`): the
+    /// client's founding slot and its fan-out, and the callback slots
+    /// a server accepted from a client's incoming attaches.
+    Outgoing,
+}
+
 /// AOSP `RpcConnection::exclusiveTid` equivalent — `std::thread::
 /// ThreadId` (`Copy + Eq`, opaque: NO process global, NO extra
 /// thread_local needed beyond `std`'s own thread bookkeeping).
@@ -461,10 +514,10 @@ struct ConnSlot {
     /// [`remove_slot`](RpcSessionInner::remove_slot) drops the slot
     /// only on its own worker's exit, never re-using an id.
     id: u64,
-    /// Serve-driven (the founding slot and id-echoing attached
-    /// connections — AOSP `mIncoming`) vs. outgoing / callback slots
-    /// (AOSP `mOutgoing`). `setMaxIncomingThreads` caps only the former.
-    incoming: bool,
+    /// Direction this endpoint uses the slot in — see [`SlotRole`].
+    /// `setMaxIncomingThreads` caps only `Incoming` slots; the
+    /// callback-slot cap counts only `Outgoing` ones.
+    role: SlotRole,
     /// Replies still owed to this slot by nested client calls that gave up
     /// waiting (`set_timeout`); the next that many `REPLY`s are skipped
     /// instead of being taken for unsolicited ones (see
@@ -612,6 +665,10 @@ pub(crate) struct SharedSession {
     /// `obituary_sent.load()` (which only flipped after the callback
     /// returned).
     lifecycle: SessionLifecycle,
+    /// Which side of the connection this session is: decides the
+    /// founding slot's [`SlotRole`] and the client-vs-server teardown
+    /// rules for serve-driven slots.
+    space: AddressSpace,
 }
 
 impl SharedSession {
@@ -643,6 +700,10 @@ impl SharedSession {
     /// "still Live" state from any other observer.
     pub(crate) fn try_bump_live_conns(&self) -> bool {
         self.lifecycle.try_bump_live()
+    }
+
+    pub(crate) fn space(&self) -> AddressSpace {
+        self.space
     }
 }
 
@@ -692,6 +753,9 @@ pub(crate) struct RpcSessionInner {
     /// `SharedSession` so the leak/teardown invariants are anchored in
     /// one place.
     shared: Arc<SharedSession>,
+    /// Threads serving this client's incoming (callback) connections,
+    /// keyed by slot id. Joined by [`RpcSession::shutdown`].
+    incoming_threads: Mutex<Vec<(u64, std::thread::JoinHandle<()>)>>,
 }
 
 /// The `RpcParcelOps` implementation bound to one session.
@@ -724,10 +788,22 @@ impl RpcSessionInner {
     ///     slot.
     ///  2. **Exclusive** — a slot whose `exclusive_tid == this tid`
     ///     (defensive: should be covered by 1).
-    ///  3. **First available** — the first slot with `exclusive_tid ==
-    ///     None`. Claim it (`exclusive_tid = this tid`), push the
-    ///     `DRIVING` marker so any same-thread nested call re-enters
-    ///     here, return the guard.
+    ///  3. **First available `Outgoing` slot** — the first slot with
+    ///     `exclusive_tid == None` **and** [`SlotRole::Outgoing`] (AOSP
+    ///     scans only `mOutgoing` here). Claim it (`exclusive_tid = this
+    ///     tid`), push the `DRIVING` marker so any same-thread nested
+    ///     call re-enters here, return the guard. An `Incoming` slot is
+    ///     never claimed by a non-nested call: it is a serve loop's
+    ///     socket, read by the peer only inside its own reply wait.
+    /// - **No `Outgoing` slot at all** — fail **immediately** with
+    ///   `Err(StatusCode::FailedTransaction)` (AOSP `WOULD_BLOCK`:
+    ///   "Session has no outgoing connections"). This is a server
+    ///   calling a client proxy outside any handler while the client
+    ///   opened no incoming connection; waiting would never end,
+    ///   since only a peer attach can add an `Outgoing` slot.
+    ///   `send_dec_strong` uses the lenient variant instead (AOSP
+    ///   `CLIENT_REFCOUNT` — a `DEC_STRONG` carries no reply, so it
+    ///   may ride a momentarily free serve-driven slot).
     ///  4. **Pool exhausted** — `wait` on `slot_cv` (released on slot
     ///     drop OR `add_*_slot`). **Block-and-wait, never busy
     ///     try-loop**. Each wakeup (and the first park) rechecks the
@@ -749,6 +825,19 @@ impl RpcSessionInner {
     /// receive-side priority replay (see [`super::state`]), not by
     /// pinning oneway sends to a fixed slot.
     fn find_conn(&self) -> Result<ConnGuard<'_>> {
+        self.find_conn_impl(true)
+    }
+
+    /// [`find_conn`] for reply-less `DEC_STRONG` sends: any free slot
+    /// qualifies (`Outgoing` preferred) and there is no step 3b. Without
+    /// this a server dropping a client proxy outside a handler, on a
+    /// session with no callback slot, could never release the peer's
+    /// node before session end.
+    fn find_conn_lenient(&self) -> Result<ConnGuard<'_>> {
+        self.find_conn_impl(false)
+    }
+
+    fn find_conn_impl(&self, outgoing_only: bool) -> Result<ConnGuard<'_>> {
         let mut wait_until: Option<Instant> = None;
         let tid = current_tid();
         let sess_ptr = self as *const RpcSessionInner as usize;
@@ -788,12 +877,22 @@ impl RpcSessionInner {
                 return Err(StatusCode::DeadObject);
             }
             // (2) Defensive exclusive match (shouldn't fire if (1) is correct).
-            // (3) First available.
-            if let Some(s) = st
+            // (3) First available — `Outgoing` first; any free slot only
+            //     on the lenient (`DEC_STRONG`) path.
+            let free = |s: &ConnSlot| s.exclusive_tid == Some(tid) || s.exclusive_tid.is_none();
+            let pick = st
                 .slots
-                .iter_mut()
-                .find(|s| s.exclusive_tid == Some(tid) || s.exclusive_tid.is_none())
-            {
+                .iter()
+                .position(|s| free(s) && s.role == SlotRole::Outgoing)
+                .or_else(|| {
+                    if outgoing_only {
+                        None
+                    } else {
+                        st.slots.iter().position(free)
+                    }
+                });
+            if let Some(idx) = pick {
+                let s = &mut st.slots[idx];
                 s.exclusive_tid = Some(tid);
                 let slot_id = s.id;
                 let transport = Arc::clone(&s.transport);
@@ -804,6 +903,17 @@ impl RpcSessionInner {
                     transport,
                     reentrant: false,
                 });
+            }
+            // (3b) Nothing to wait for: no `Outgoing` slot exists, and only a
+            //      peer attach can create one. AOSP `WOULD_BLOCK`.
+            if outgoing_only && !st.slots.iter().any(|s| s.role == SlotRole::Outgoing) {
+                log::error!(
+                    "RPC: session has no outgoing connection — a non-nested call (from \
+                     another thread, or a oneway outside a handler) needs the peer to open \
+                     incoming connections (RpcUnixClientConfig::incoming_connections / \
+                     ARpcSession_setMaxIncomingThreads); refusing instead of waiting forever"
+                );
+                return Err(StatusCode::FailedTransaction);
             }
             // (4) Pool exhausted — wait, bounded by the session deadline: a serve-pinned slot is released only by the peer.
             let deadline = *self.shared.timeout.lock().expect("timeout poisoned");
@@ -868,9 +978,15 @@ impl RpcSessionInner {
                 reentrant: true,
             });
         }
-        // (3) First available — only a truly free slot.
+        // (3) First available — only a truly free slot, `Outgoing` first
+        //     (a `DEC_STRONG` may ride a free serve-driven slot: no reply).
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
-        let s = st.slots.iter_mut().find(|s| s.exclusive_tid.is_none())?;
+        let idx = st
+            .slots
+            .iter()
+            .position(|s| s.exclusive_tid.is_none() && s.role == SlotRole::Outgoing)
+            .or_else(|| st.slots.iter().position(|s| s.exclusive_tid.is_none()))?;
+        let s = &mut st.slots[idx];
         s.exclusive_tid = Some(tid);
         let slot_id = s.id;
         let transport = Arc::clone(&s.transport);
@@ -906,11 +1022,14 @@ impl RpcSessionInner {
             if self.shared.lifecycle.is_torn_down() || st.slots.is_empty() {
                 return None;
             }
-            if let Some(s) = st
+            let free = |s: &ConnSlot| s.exclusive_tid == Some(tid) || s.exclusive_tid.is_none();
+            let pick = st
                 .slots
-                .iter_mut()
-                .find(|s| s.exclusive_tid == Some(tid) || s.exclusive_tid.is_none())
-            {
+                .iter()
+                .position(|s| free(s) && s.role == SlotRole::Outgoing)
+                .or_else(|| st.slots.iter().position(free));
+            if let Some(idx) = pick {
+                let s = &mut st.slots[idx];
                 s.exclusive_tid = Some(tid);
                 let slot_id = s.id;
                 let transport = Arc::clone(&s.transport);
@@ -1047,7 +1166,7 @@ impl RpcSessionInner {
     /// actually for. The thundering-herd cost is bounded by waiter
     /// count and is zero on the default single-slot path (no waiters
     /// at all), so the trade favors mixed-waiter correctness.
-    fn add_slot_inner(&self, transport: Box<dyn RpcTransport>, incoming: bool) -> u64 {
+    fn add_slot_inner(&self, transport: Box<dyn RpcTransport>, role: SlotRole) -> u64 {
         // `Arc::from(Box<dyn T>)` is the stable std conversion that
         // re-takes the heap allocation under an `Arc` without copying
         // (impl<T: ?Sized> From<Box<T>> for Arc<T>). The slot holds
@@ -1060,7 +1179,7 @@ impl RpcSessionInner {
             transport,
             exclusive_tid: None,
             id,
-            incoming,
+            role,
             stale_replies: 0,
         });
         drop(st);
@@ -1081,7 +1200,13 @@ impl RpcSessionInner {
         cap: usize,
     ) -> Result<u64> {
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
-        if st.slots.iter().filter(|s| s.incoming).count() >= cap {
+        if st
+            .slots
+            .iter()
+            .filter(|s| s.role == SlotRole::Incoming)
+            .count()
+            >= cap
+        {
             return Err(StatusCode::FailedTransaction);
         }
         if !self.shared.try_bump_live_conns() {
@@ -1094,7 +1219,7 @@ impl RpcSessionInner {
             transport,
             exclusive_tid: None,
             id,
-            incoming: true,
+            role: SlotRole::Incoming,
             stale_replies: 0,
         });
         drop(st);
@@ -1107,21 +1232,38 @@ impl RpcSessionInner {
     /// are not serve-driven). See
     /// [`RpcSession::add_outgoing_connection_android13plus`].
     fn add_outgoing_slot(&self, transport: Box<dyn RpcTransport>) -> u64 {
-        self.add_slot_inner(transport, false)
+        self.add_slot_inner(transport, SlotRole::Outgoing)
     }
 
     /// Like [`add_slot_inner`](Self::add_slot_inner) but enforces a
-    /// maximum pool size **atomically** under the `conn_state` lock:
-    /// returns `None` (adding nothing, closing `transport`) when the pool
-    /// already holds `cap` slots. Used for the server callback-slot
+    /// maximum number of callback (`Outgoing`) slots **atomically** under
+    /// the `conn_state` lock: returns `None` (adding nothing, closing
+    /// `transport`) when the pool already holds `cap` of them. Serve-driven
+    /// slots do not count — a client's outgoing fan-out must never eat
+    /// into its callback budget. Used for the server callback-slot
     /// admission cap — callback slots have no serve loop and are only
     /// reclaimed at session teardown, so a separate pre-check + add would
     /// let concurrent attach workers each pass the check and overshoot the
     /// cap, letting an untrusted peer grow the pool (and its held fds)
     /// unbounded. Folding the check into the push closes that TOCTOU.
-    fn add_slot_inner_capped(&self, transport: Box<dyn RpcTransport>, cap: usize) -> Option<u64> {
+    ///
+    /// `claimed`: push the slot already driven by the calling thread
+    /// (`exclusive_tid = current`), so the caller can finish a wire
+    /// exchange on it before anyone else may pick it.
+    fn add_slot_inner_capped(
+        &self,
+        transport: Box<dyn RpcTransport>,
+        cap: usize,
+        claimed: bool,
+    ) -> Option<u64> {
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
-        if st.slots.len() >= cap {
+        if st
+            .slots
+            .iter()
+            .filter(|s| s.role == SlotRole::Outgoing)
+            .count()
+            >= cap
+        {
             return None;
         }
         let transport: Arc<dyn RpcTransport> = Arc::from(transport);
@@ -1129,9 +1271,9 @@ impl RpcSessionInner {
         st.next_slot_id += 1;
         st.slots.push(ConnSlot {
             transport,
-            exclusive_tid: None,
+            exclusive_tid: if claimed { Some(current_tid()) } else { None },
             id,
-            incoming: false,
+            role: SlotRole::Outgoing,
             stale_replies: 0,
         });
         drop(st);
@@ -1209,6 +1351,16 @@ impl RpcSessionInner {
             .clear_local();
         drop(locals);
         drop(root);
+        // Last: wake anything still blocked in `recv` on this session (a
+        // client's incoming-connection threads, a user `serve_blocking`)
+        // and drop every slot — callback slots have no serve loop to
+        // retire them, and a dead session's pool is only ever consulted
+        // by paths that already answer `DeadObject` on `is_torn_down`.
+        self.shutdown_all_transports();
+        let mut st = self.conn_state.lock().expect("conn_state poisoned");
+        st.slots.clear();
+        drop(st);
+        self.slot_cv.notify_all();
     }
 
     pub(crate) fn fd_mode(&self) -> FileDescriptorTransportMode {
@@ -1335,6 +1487,58 @@ impl RpcSessionInner {
     /// id-echoing connection when adding it would push
     /// `slot_count() > max_threads_value()`. Default 1 ⇒ founding-only
     /// (multi-conn callers must explicitly `set_max_threads(N >= 2)`).
+    /// A client's incoming (callback) slot: served by a thread this
+    /// session owns and not counted in `live_conns`.
+    fn is_client_incoming_slot(&self, slot_id: u64) -> bool {
+        self.shared.space() == AddressSpace::Initiator
+            && self
+                .conn_state
+                .lock()
+                .expect("conn_state poisoned")
+                .slots
+                .iter()
+                .any(|s| s.id == slot_id && s.role == SlotRole::Incoming)
+    }
+
+    fn incoming_slot_count(&self) -> usize {
+        self.conn_state
+            .lock()
+            .expect("conn_state poisoned")
+            .slots
+            .iter()
+            .filter(|s| s.role == SlotRole::Incoming)
+            .count()
+    }
+
+    /// Shut every slot's transport down (best-effort) so a thread blocked
+    /// in `recv` on this session — a client's incoming-connection thread,
+    /// a user `serve_blocking` — returns with `PeerClosed`. Transports are
+    /// cloned out first: the lock is never held across the syscalls.
+    fn shutdown_all_transports(&self) {
+        let transports: Vec<Arc<dyn RpcTransport>> = self
+            .conn_state
+            .lock()
+            .expect("conn_state poisoned")
+            .slots
+            .iter()
+            .map(|s| Arc::clone(&s.transport))
+            .collect();
+        for t in transports {
+            if let Err(e) = t.shutdown() {
+                log::debug!("RPC: transport shutdown failed (already closed?): {e:?}");
+            }
+        }
+    }
+
+    fn take_incoming_threads(&self) -> Vec<(u64, std::thread::JoinHandle<()>)> {
+        std::mem::take(
+            &mut *self
+                .incoming_threads
+                .lock()
+                .expect("incoming_threads poisoned"),
+        )
+    }
+
     pub(crate) fn max_threads_value(&self) -> u32 {
         // `Relaxed` is sufficient: this atomic is a single-cell config
         // value (set by `RpcSession::set_max_threads` before any
@@ -1795,10 +1999,10 @@ impl RpcSessionInner {
         if self.shared.lifecycle.is_torn_down() {
             return Ok(());
         }
-        // `find_conn` picks an available slot (or — if this thread is
-        // already driving one of the session's slots — reuses it via
-        // `DRIVING`, the documented "interleaved DEC_STRONG" path).
-        let conn = self.find_conn()?;
+        // Lenient pick: an available slot of any role (or — if this
+        // thread is already driving one of the session's slots — reuse
+        // it via `DRIVING`, the documented "interleaved DEC_STRONG" path).
+        let conn = self.find_conn_lenient()?;
         let frame = self.profile.codec().encode_dec_strong(&addr);
         self.send_msg(conn.transport(), &frame, &[])?;
         Ok(())
@@ -2294,6 +2498,13 @@ impl RpcSessionInner {
 /// to the peer may itself hold a proxy back into this session, and if the
 /// session neither serves nor transacts again, nothing runs the release.
 /// [`RpcSession::shutdown`] is the explicit break for it.
+///
+/// A client session with incoming (callback) connections
+/// ([`RpcUnixClientConfig::incoming_connections`]) owns the threads that
+/// serve them, and those threads keep the session alive: dropping every
+/// handle and proxy does not stop them. They end when the server closes
+/// the session or on [`RpcSession::shutdown`] — call it when you are done
+/// with such a session.
 #[derive(Clone)]
 pub struct RpcSession {
     inner: Arc<RpcSessionInner>,
@@ -2345,6 +2556,7 @@ impl RpcSession {
             fd_unix_supported: AtomicBool::new(false),
             rpc_session_id: gen_rpc_session_id()?,
             lifecycle: SessionLifecycle::new(),
+            space,
         }))
     }
 
@@ -2369,11 +2581,18 @@ impl RpcSession {
         // pick ⇒ `enter_connection` byte-identical. The slot
         // owns its transport via `Arc<dyn RpcTransport>` — see
         // [`ConnSlot::transport`] for why.
+        // The founding connection is the one this endpoint sends on
+        // (client) or serves (server) — AOSP `setupClient` vs
+        // `RpcServer::establishConnection`.
+        let founding_role = match shared.space() {
+            AddressSpace::Initiator => SlotRole::Outgoing,
+            AddressSpace::Acceptor => SlotRole::Incoming,
+        };
         let founding = ConnSlot {
             transport: Arc::from(transport),
             exclusive_tid: None,
             id: 1,
-            incoming: true,
+            role: founding_role,
             stale_replies: 0,
         };
         let (dec_strong_tx, dec_strong_rx) = mpsc::channel();
@@ -2387,6 +2606,7 @@ impl RpcSession {
             self_weak: Mutex::new(Weak::new()),
             shared,
             dec_strong_tx,
+            incoming_threads: Mutex::new(Vec::new()),
         });
         *inner.self_weak.lock().expect("self_weak") = Arc::downgrade(&inner);
         // Reaper thread for non-blocking `DEC_STRONG` from
@@ -2452,6 +2672,60 @@ impl RpcSession {
     /// (`RpcSessionInner`) so concurrent attach workers cannot each clear
     /// an advisory pre-check and overshoot it — callback slots are never
     /// serve-reclaimed, so an unbounded pool is a peer-driven DoS.
+    /// [`add_callback_slot`](Self::add_callback_slot) followed by the
+    /// server's `"cci"` on the new connection — the admission-then-init
+    /// order that lets a refused client see an error (the accept
+    /// handshake defers that write; see
+    /// `wire_android13::server_write_connection_init`). The slot is
+    /// held exclusive by this thread while the init goes out, so no
+    /// callback transaction can overtake it on the wire.
+    pub(crate) fn add_callback_slot_and_init(
+        &self,
+        transport: Box<dyn RpcTransport>,
+        cap: usize,
+        codec: &Android13PlusCodec,
+    ) -> Result<u64> {
+        if self.inner.shared.lifecycle.is_torn_down() {
+            return Err(StatusCode::DeadObject);
+        }
+        let slot_id = self
+            .inner
+            .add_slot_inner_capped(transport, cap, true)
+            .ok_or(StatusCode::FailedTransaction)?;
+        let transport = {
+            let st = self.inner.conn_state.lock().expect("conn_state poisoned");
+            st.slots
+                .iter()
+                .find(|s| s.id == slot_id)
+                .map(|s| Arc::clone(&s.transport))
+                .ok_or(StatusCode::DeadObject)?
+        };
+        let sent = {
+            let mut io = RawTransportIo(&*transport);
+            super::wire_android13::server_write_connection_init(&mut io, codec)
+        };
+        {
+            let mut st = self.inner.conn_state.lock().expect("conn_state poisoned");
+            if let Some(s) = st.slots.iter_mut().find(|s| s.id == slot_id) {
+                s.exclusive_tid = None;
+            }
+        }
+        self.inner.slot_cv.notify_all();
+        match sent {
+            Ok(()) => Ok(slot_id),
+            Err(e) => {
+                // The client never got its init and will drop the socket;
+                // shut ours so the first send on this slot fails fast and
+                // the send-failure poison retires it.
+                let _ = transport.shutdown();
+                Err(StatusCode::from(e))
+            }
+        }
+    }
+
+    /// Test form of [`add_callback_slot_and_init`](Self::add_callback_slot_and_init)
+    /// without the wire init (no peer on the other end).
+    #[cfg(test)]
     pub(crate) fn add_callback_slot(
         &self,
         transport: Box<dyn RpcTransport>,
@@ -2464,7 +2738,7 @@ impl RpcSession {
             return Err(StatusCode::DeadObject);
         }
         self.inner
-            .add_slot_inner_capped(transport, cap)
+            .add_slot_inner_capped(transport, cap, false)
             .ok_or(StatusCode::FailedTransaction)
     }
 
@@ -2500,7 +2774,7 @@ impl RpcSession {
     ) -> Result<Android13PlusAccept> {
         let (codec, client_fd_mode, client_id, incoming) = {
             let mut io = RawTransportIo(transport.as_ref());
-            server_accept(&mut io, server_max_version).map_err(StatusCode::from)?
+            server_accept_deferred_init(&mut io, server_max_version).map_err(StatusCode::from)?
         };
         Ok((transport, codec, client_fd_mode, client_id, incoming))
     }
@@ -2882,7 +3156,15 @@ impl RpcSession {
         // workers still drive the session. After firing, transition
         // Dying → Dead via `mark_dead` so subsequent attach attempts
         // and best-effort `dec_strong` calls see a settled state.
-        if self.inner.shared.lifecycle.drop_connection() {
+        //
+        // A client's incoming (callback) slot never bumped `live_conns`,
+        // so its exit must not decrement either; instead the session dies
+        // once the **last** such slot is gone (AOSP
+        // `onSessionAllIncomingThreadsEnded`): the founding connection's
+        // `Live(1)` is what the CAS consumes. Its role is read before the
+        // slot is retired.
+        let client_incoming = self.inner.is_client_incoming_slot(slot_id);
+        if !client_incoming && self.inner.shared.lifecycle.drop_connection() {
             self.inner.on_session_dead();
         }
         // Drop this worker's slot from the pool **after**
@@ -2897,6 +3179,12 @@ impl RpcSession {
         // `slot_cv` (no add_slot can race the obituary thanks to
         // `try_bump_live_conns`).
         self.inner.remove_slot(slot_id);
+        if client_incoming
+            && self.inner.incoming_slot_count() == 0
+            && self.inner.shared.lifecycle.try_drop_sole_connection()
+        {
+            self.inner.on_session_dead();
+        }
         result
     }
 
@@ -2932,9 +3220,15 @@ impl RpcSession {
     /// the type-level `# Lifetime` note). Call it when abandoning such a
     /// session.
     ///
-    /// Unlike AOSP `RpcSession::shutdownAndWait` this does **not** join
-    /// worker threads or interrupt a blocked `serve_blocking`; those exit
-    /// on their own when the transport closes.
+    /// The threads serving this client's incoming (callback) connections
+    /// (`RpcUnixClientConfig::incoming_connections`) are stopped and
+    /// joined here — every slot's transport is shut down, which ends
+    /// their serve loops — except a thread that calls `shutdown` from
+    /// inside its own callback handler, which is left to finish on its
+    /// own (joining it would deadlock). Unlike AOSP
+    /// `RpcSession::shutdownAndWait`, a user-driven `serve_blocking` on
+    /// the founding slot is not joined; it exits on its own once the
+    /// transport is shut down.
     pub fn shutdown(&self) {
         let lifecycle = &self.inner.shared.lifecycle;
         if lifecycle.try_drop_sole_connection() {
@@ -2944,6 +3238,21 @@ impl RpcSession {
                 "RpcSession::shutdown: {} connections still live; nothing torn down",
                 lifecycle.live_count()
             );
+        }
+        let me = std::thread::current().id();
+        for (slot_id, handle) in self.inner.take_incoming_threads() {
+            if handle.thread().id() == me {
+                // `shutdown` from inside this connection's own dispatch:
+                // the loop ends when the handler returns; dropping the
+                // handle detaches it.
+                log::debug!(
+                    "RPC: shutdown from incoming connection {slot_id}'s own thread; not joined"
+                );
+                continue;
+            }
+            if handle.join().is_err() {
+                log::warn!("RPC: incoming connection {slot_id} thread panicked");
+            }
         }
     }
 
@@ -3100,7 +3409,10 @@ impl RpcSession {
         config: RpcUnixClientConfig,
     ) -> Result<RpcSession> {
         let local = config.outgoing_connections.max(1);
-        if local > 1 && !config.session_id.is_empty() {
+        let incoming = config.incoming_connections;
+        // Fan-out and incoming connections are a session *owner*'s
+        // business: an attach (echoed id) gets neither.
+        if (local > 1 || incoming > 0) && !config.session_id.is_empty() {
             return Err(StatusCode::BadValue);
         }
 
@@ -3110,23 +3422,46 @@ impl RpcSession {
             config.fd_mode.unwrap_or(FileDescriptorTransportMode::None),
             config.session_id,
         )?;
-        if local == 1 {
+        if local == 1 && incoming == 0 {
+            // Single-connection path: byte-identical to
+            // `setup_unix_client_android13plus`.
             return Ok(session);
         }
 
-        let negotiated = session.negotiate(local)?;
-        if negotiated <= 1 {
-            return Ok(session);
-        }
-        let session_id = session.get_session_id()?;
-        let fd_mode = session.fd_transport_mode();
-        for _ in 1..negotiated {
-            session.add_outgoing_connection_android13plus_transport(
-                || config.connect(),
-                config.max_version,
-                &session_id,
-                fd_mode,
-            )?;
+        // AOSP `setupClient` order: outgoing fan-out first, then the
+        // incoming connections.
+        let build = || -> Result<()> {
+            let negotiated = if local > 1 {
+                session.negotiate(local)?
+            } else {
+                1
+            };
+            let session_id = session.get_session_id()?;
+            let fd_mode = session.fd_transport_mode();
+            for _ in 1..negotiated {
+                session.add_outgoing_connection_android13plus_transport(
+                    || config.connect(),
+                    config.max_version,
+                    &session_id,
+                    fd_mode,
+                )?;
+            }
+            for _ in 0..incoming {
+                session.add_incoming_connection_android13plus_transport(
+                    || config.connect(),
+                    config.max_version,
+                    &session_id,
+                    fd_mode,
+                )?;
+            }
+            Ok(())
+        };
+        if let Err(e) = build() {
+            // No degradation: the partial session is torn down here —
+            // including any incoming threads already serving — since the
+            // caller never gets a handle to do it.
+            session.shutdown();
+            return Err(e);
         }
         Ok(session)
     }
@@ -3162,7 +3497,10 @@ impl RpcSession {
         &self,
         config: RpcUnixClientConfig,
     ) -> Result<u64> {
-        if config.outgoing_connections.max(1) != 1 || config.session_id.len() != 32 {
+        if config.outgoing_connections.max(1) != 1
+            || config.incoming_connections != 0
+            || config.session_id.len() != 32
+        {
             return Err(StatusCode::BadValue);
         }
         let fd_mode = self.fd_transport_mode();
@@ -3223,6 +3561,110 @@ impl RpcSession {
             return Err(StatusCode::BadType);
         }
         Ok(self.inner.add_outgoing_slot(Box::new(t)))
+    }
+
+    /// Open one *additional* **incoming (callback) connection** to the
+    /// android-13+ server session this client founded and serve it on a
+    /// thread owned by this session — the manual, one-at-a-time form of
+    /// [`RpcUnixClientConfig::incoming_connections`] (AOSP
+    /// `RpcSession::addIncomingConnection`). `config` must carry this
+    /// session's id (`get_session_id()`), no fan-out and no incoming
+    /// count of its own; the server adds the connection as a slot it
+    /// sends on. Returns the new slot id.
+    ///
+    /// Profile uniformity is enforced as for the outgoing attach
+    /// (R34 ⇒ `BadType`; a server that negotiates the attach below the
+    /// founding version ⇒ `BadType`). The server refusing the attach
+    /// (its callback-slot budget, `2 * set_max_threads`, is spent)
+    /// surfaces as a handshake error.
+    pub fn add_incoming_connection_android13plus_with_config(
+        &self,
+        config: RpcUnixClientConfig,
+    ) -> Result<u64> {
+        if config.outgoing_connections.max(1) != 1
+            || config.incoming_connections != 0
+            || config.session_id.len() != 32
+        {
+            return Err(StatusCode::BadValue);
+        }
+        let fd_mode = self.fd_transport_mode();
+        if config.fd_mode.is_some_and(|mode| mode != fd_mode) {
+            return Err(StatusCode::BadValue);
+        }
+        self.add_incoming_connection_android13plus_transport(
+            || config.connect(),
+            config.max_version,
+            config.session_id,
+            fd_mode,
+        )
+    }
+
+    fn add_incoming_connection_android13plus_transport(
+        &self,
+        connect: impl FnOnce() -> Result<super::transport::UnixTransport>,
+        max_version: u32,
+        session_id: &[u8],
+        fd_mode: FileDescriptorTransportMode,
+    ) -> Result<u64> {
+        // Only the side that connected owns incoming threads (a server
+        // session's callback slots come from the peer's attaches).
+        if self.inner.shared.space() != AddressSpace::Initiator {
+            return Err(StatusCode::InvalidOperation);
+        }
+        if session_id.len() != 32 {
+            return Err(StatusCode::BadValue);
+        }
+        let session_version = match &self.inner.profile {
+            WireProfile::Android13Plus(c) => c.version(),
+            WireProfile::R34(_) => return Err(StatusCode::BadType),
+        };
+        if self.inner.shared.lifecycle.is_torn_down() {
+            return Err(StatusCode::DeadObject);
+        }
+        let effective_max = max_version.min(session_version);
+        let hdr_fd_mode = if fd_mode == FileDescriptorTransportMode::Unix {
+            FD_MODE_UNIX
+        } else {
+            FD_MODE_NONE
+        };
+        let t = connect()?;
+        let codec = {
+            let mut io = RawTransportIo(&t);
+            // `incoming = true`: the header carries the INCOMING bit and
+            // this side *reads* the server's `"cci"`.
+            client_connect_with_id(&mut io, effective_max, true, hdr_fd_mode, session_id)
+                .map_err(StatusCode::from)?
+        };
+        if codec.version() != session_version {
+            return Err(StatusCode::BadType);
+        }
+        let slot_id = self.inner.add_slot_inner(Box::new(t), SlotRole::Incoming);
+        let inner = Arc::clone(&self.inner);
+        let spawned = std::thread::Builder::new()
+            .name(format!("rsbinder-rpc-in-{slot_id}"))
+            .spawn(move || {
+                let session = RpcSession::wrap_inner(inner);
+                if let Err(e) = session.serve_blocking_on(slot_id) {
+                    log::debug!("RPC: incoming connection {slot_id} ended: {e:?}");
+                }
+            });
+        match spawned {
+            Ok(handle) => {
+                self.inner
+                    .incoming_threads
+                    .lock()
+                    .expect("incoming_threads poisoned")
+                    .push((slot_id, handle));
+                Ok(slot_id)
+            }
+            Err(e) => {
+                // A slot nobody reads would make every server send on it
+                // hang: retire it before reporting.
+                log::error!("RPC: incoming connection thread spawn failed: {e}");
+                self.inner.remove_slot(slot_id);
+                Err(StatusCode::from(e))
+            }
+        }
     }
 
     /// Automatic outgoing-pool fan-out.
@@ -3396,6 +3838,24 @@ impl RpcSession {
         )?;
         session.inner.clear_handshake_timeouts();
         Ok(session)
+    }
+
+    /// Test/diagnostic: number of connection slots in this session's pool
+    /// (founding + fan-out + incoming, or founding + attaches + callback
+    /// slots on a server session). Not a stable API.
+    #[doc(hidden)]
+    pub fn __slot_count(&self) -> usize {
+        self.inner.slot_count()
+    }
+
+    /// Test/diagnostic: incoming-connection threads not yet joined.
+    #[doc(hidden)]
+    pub fn __incoming_thread_count(&self) -> usize {
+        self.inner
+            .incoming_threads
+            .lock()
+            .expect("incoming_threads poisoned")
+            .len()
     }
 
     /// Test/diagnostic: live local-node count (leak check).
@@ -3611,8 +4071,10 @@ mod tests {
         )
         .expect("build session");
 
+        // The cap counts callback (`Outgoing`) slots only — the served
+        // founding slot is not part of the budget.
         let base = session.inner.slot_count();
-        let cap = base + 2;
+        let cap = 2;
         let mut peers = Vec::new();
         let mut admitted = 0usize;
         let mut refused = 0usize;
@@ -3626,10 +4088,10 @@ mod tests {
         }
         assert_eq!(
             session.inner.slot_count(),
-            cap,
-            "pool never exceeds the cap"
+            base + cap,
+            "pool never exceeds founding + cap"
         );
-        assert_eq!(admitted, cap - base, "exactly cap-base slots admitted");
+        assert_eq!(admitted, cap, "exactly cap callback slots admitted");
         assert!(refused >= 1, "attaches past the cap are refused");
     }
 

--- a/rsbinder/src/rpc/transport/mem.rs
+++ b/rsbinder/src/rpc/transport/mem.rs
@@ -29,6 +29,12 @@ pub struct MemTransport {
     peer: PeerIdentity,
     desc: &'static str,
     timeout: Mutex<Option<std::time::Duration>>,
+    /// Set by [`shutdown`](RpcTransport::shutdown); `recv_frame` then
+    /// reports `PeerClosed` even if frames are queued. A blocked
+    /// `recv_frame` notices within one poll tick — a sender into our own
+    /// `rx` would have been a cleaner wake-up, but it would also keep the
+    /// channel alive past the peer's drop and hide `PeerClosed`.
+    closed: std::sync::atomic::AtomicBool,
 }
 
 impl MemTransport {
@@ -46,6 +52,7 @@ impl MemTransport {
                 peer: peer.clone(),
                 desc: "mem",
                 timeout: Mutex::new(None),
+                closed: std::sync::atomic::AtomicBool::new(false),
             },
             MemTransport {
                 tx: b_tx,
@@ -53,6 +60,7 @@ impl MemTransport {
                 peer,
                 desc: "mem",
                 timeout: Mutex::new(None),
+                closed: std::sync::atomic::AtomicBool::new(false),
             },
         )
     }
@@ -85,17 +93,44 @@ impl RpcTransport for MemTransport {
     }
 
     fn recv_frame(&self) -> RpcResult<Vec<u8>> {
+        use std::sync::atomic::Ordering;
+        if self.closed.load(Ordering::SeqCst) {
+            return Err(RpcError::PeerClosed);
+        }
         let timeout = *self.timeout.lock().expect("mem timeout poisoned");
         let rx = self.rx.lock().expect("mem rx poisoned");
-        match timeout {
-            // `recv`/`recv_timeout` block until a frame arrives, the
-            // deadline elapses, or every sender drops (peer closed) —
-            // never spin, never panic.
-            None => rx.recv().map_err(|_| RpcError::PeerClosed),
-            Some(d) => rx.recv_timeout(d).map_err(|e| match e {
-                std::sync::mpsc::RecvTimeoutError::Timeout => RpcError::Timeout,
-                std::sync::mpsc::RecvTimeoutError::Disconnected => RpcError::PeerClosed,
-            }),
+        // Block in short `recv_timeout` ticks so a local `shutdown` is
+        // noticed; a frame or the peer's drop (every sender gone) returns
+        // at once, never spinning.
+        const TICK: std::time::Duration = std::time::Duration::from_millis(20);
+        let deadline = timeout.map(|d| std::time::Instant::now() + d);
+        loop {
+            let wait = match deadline {
+                Some(at) => {
+                    let left = at.saturating_duration_since(std::time::Instant::now());
+                    if left.is_zero() {
+                        return Err(RpcError::Timeout);
+                    }
+                    left.min(TICK)
+                }
+                None => TICK,
+            };
+            match rx.recv_timeout(wait) {
+                Ok(frame) => {
+                    if self.closed.load(Ordering::SeqCst) {
+                        return Err(RpcError::PeerClosed);
+                    }
+                    return Ok(frame);
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    return Err(RpcError::PeerClosed);
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    if self.closed.load(Ordering::SeqCst) {
+                        return Err(RpcError::PeerClosed);
+                    }
+                }
+            }
         }
     }
 
@@ -105,6 +140,11 @@ impl RpcTransport for MemTransport {
 
     fn describe(&self) -> &str {
         self.desc
+    }
+
+    fn shutdown(&self) -> RpcResult<()> {
+        self.closed.store(true, std::sync::atomic::Ordering::SeqCst);
+        Ok(())
     }
 
     fn set_read_timeout(&self, timeout: Option<std::time::Duration>) -> RpcResult<()> {

--- a/rsbinder/src/rpc/transport/mod.rs
+++ b/rsbinder/src/rpc/transport/mod.rs
@@ -108,6 +108,15 @@ pub trait RpcTransport: Send + Sync {
         Ok(())
     }
 
+    /// Shut the connection down in both directions so a thread blocked in
+    /// [`recv_frame`](Self::recv_frame) returns (`PeerClosed`) and later
+    /// sends fail. Used to end a client's incoming-connection threads on
+    /// session death / `RpcSession::shutdown`. Best-effort; the default
+    /// does nothing, for a transport that cannot be interrupted.
+    fn shutdown(&self) -> RpcResult<()> {
+        Ok(())
+    }
+
     /// Send one frame plus passed file descriptors out-of-band (opt-in
     /// `FileDescriptorTransportMode::Unix`).
     ///

--- a/rsbinder/src/rpc/transport/tcp_debug.rs
+++ b/rsbinder/src/rpc/transport/tcp_debug.rs
@@ -150,6 +150,11 @@ impl RpcTransport for TcpDebugTransport {
         self.stream.set_write_timeout(timeout)?;
         Ok(())
     }
+
+    fn shutdown(&self) -> RpcResult<()> {
+        self.stream.shutdown(std::net::Shutdown::Both)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/rsbinder/src/rpc/transport/tls.rs
+++ b/rsbinder/src/rpc/transport/tls.rs
@@ -77,6 +77,9 @@ pub trait TlsStream: Send + Sync {
     fn set_read_timeout(&self, t: Option<Duration>) -> std::io::Result<()>;
     /// Set the write deadline for subsequent `write`s (`None` = blocking).
     fn set_write_timeout(&self, t: Option<Duration>) -> std::io::Result<()>;
+    /// Shut the underlying stream down in both directions (wakes a
+    /// blocked `read`).
+    fn shutdown(&self) -> std::io::Result<()>;
 }
 
 // All std stream types implement `Read`/`Write` for `&Stream`, so the
@@ -97,6 +100,9 @@ impl TlsStream for TcpStream {
     fn set_write_timeout(&self, t: Option<Duration>) -> std::io::Result<()> {
         TcpStream::set_write_timeout(self, t)
     }
+    fn shutdown(&self) -> std::io::Result<()> {
+        TcpStream::shutdown(self, std::net::Shutdown::Both)
+    }
 }
 
 impl TlsStream for UnixStream {
@@ -114,6 +120,9 @@ impl TlsStream for UnixStream {
     }
     fn set_write_timeout(&self, t: Option<Duration>) -> std::io::Result<()> {
         UnixStream::set_write_timeout(self, t)
+    }
+    fn shutdown(&self) -> std::io::Result<()> {
+        UnixStream::shutdown(self, std::net::Shutdown::Both)
     }
 }
 
@@ -133,6 +142,9 @@ impl TlsStream for vsock::VsockStream {
     }
     fn set_write_timeout(&self, t: Option<Duration>) -> std::io::Result<()> {
         vsock::VsockStream::set_write_timeout(self, t)
+    }
+    fn shutdown(&self) -> std::io::Result<()> {
+        vsock::VsockStream::shutdown(self, std::net::Shutdown::Both)
     }
 }
 
@@ -461,6 +473,13 @@ impl RpcTransport for TlsTransport {
 
     fn set_write_timeout(&self, timeout: Option<std::time::Duration>) -> RpcResult<()> {
         self.stream.set_write_timeout(timeout)?;
+        Ok(())
+    }
+
+    fn shutdown(&self) -> RpcResult<()> {
+        // TCP-level shutdown, not a TLS close_notify: the goal is to wake
+        // the reader, and the peer sees a truncated stream either way.
+        self.stream.shutdown()?;
         Ok(())
     }
 }

--- a/rsbinder/src/rpc/transport/unix.rs
+++ b/rsbinder/src/rpc/transport/unix.rs
@@ -470,6 +470,11 @@ impl RpcTransport for UnixTransport {
         Ok(())
     }
 
+    fn shutdown(&self) -> RpcResult<()> {
+        self.stream.shutdown(std::net::Shutdown::Both)?;
+        Ok(())
+    }
+
     /// Send `buf` as a length-prefixed frame, passing `fds` out-of-band
     /// via `SCM_RIGHTS` (`Unix` fd-mode). The ancillary
     /// fds ride the **first** `sendmsg`; remaining bytes (rare — fd

--- a/rsbinder/src/rpc/transport/vsock.rs
+++ b/rsbinder/src/rpc/transport/vsock.rs
@@ -131,4 +131,9 @@ impl RpcTransport for VsockTransport {
         self.stream.set_write_timeout(timeout)?;
         Ok(())
     }
+
+    fn shutdown(&self) -> RpcResult<()> {
+        self.stream.shutdown(std::net::Shutdown::Both)?;
+        Ok(())
+    }
 }

--- a/rsbinder/src/rpc/wire_android13.rs
+++ b/rsbinder/src/rpc/wire_android13.rs
@@ -1102,6 +1102,34 @@ pub fn server_accept<S: Read + Write>(
     stream: &mut S,
     server_max_version: u32,
 ) -> RpcResult<(Android13PlusCodec, u8, Vec<u8>, bool)> {
+    let accepted = server_accept_deferred_init(stream, server_max_version)?;
+    if accepted.3 {
+        server_write_connection_init(stream, &accepted.0)?;
+    }
+    Ok(accepted)
+}
+
+/// The server's `"cci"` for an **incoming** (callback) attach —
+/// `addOutgoingConnection(init=true)` → `sendConnectionInit`. Split out
+/// of [`server_accept`] so the server can admit the connection (its
+/// callback-slot budget) *before* telling the client the attach is
+/// good: a client whose attach is refused then reads EOF instead of
+/// `"cci"` and gets an error, rather than a connection that is silently
+/// dead. On the wire the success path is byte-identical.
+pub fn server_write_connection_init<S: Write>(
+    stream: &mut S,
+    codec: &Android13PlusCodec,
+) -> RpcResult<()> {
+    write_all_raw(stream, &codec.encode_connection_init())
+}
+
+/// [`server_accept`] minus the incoming-direction `"cci"` write, which
+/// the caller owes via [`server_write_connection_init`] once it has
+/// admitted the connection.
+pub fn server_accept_deferred_init<S: Read + Write>(
+    stream: &mut S,
+    server_max_version: u32,
+) -> RpcResult<(Android13PlusCodec, u8, Vec<u8>, bool)> {
     // Fixed 16-byte header first, then the variable session id.
     let head = read_exact_raw(stream, A13_CONN_HEADER_LEN)?;
     let client_version = u32::from_le_bytes([head[0], head[1], head[2], head[3]]);
@@ -1143,16 +1171,15 @@ pub fn server_accept<S: Read + Write>(
             "new-session request set RPC_CONNECTION_OPTION_INCOMING",
         ));
     }
-    if incoming {
-        // attach + incoming: server-driven send of the init okay
-        // (`addOutgoingConnection(init=true)`).
-        write_all_raw(stream, &codec.encode_connection_init())?;
-    } else {
+    if !incoming {
         // outgoing-from-client (both new and attach): server reads the
         // client's init (`preJoinSetup` → `readConnectionInit`).
         let init = read_exact_raw(stream, A13_CONN_INIT_LEN)?;
         codec.decode_connection_init(&init)?;
     }
+    // attach + incoming: the server-driven init okay
+    // (`addOutgoingConnection(init=true)`) is the caller's, after
+    // admission — see `server_write_connection_init`.
     Ok((codec, fd_mode, session_id, incoming))
 }
 

--- a/rsbinder/src/shared_memory/shared.rs
+++ b/rsbinder/src/shared_memory/shared.rs
@@ -199,7 +199,7 @@ pub(crate) fn is_ashmem_fd(fd: std::os::fd::BorrowedFd<'_>) -> bool {
     let Ok(st) = rustix::fs::fstat(fd) else {
         return false;
     };
-    if st.st_mode & libc::S_IFMT as u32 != libc::S_IFCHR as u32 {
+    if st.st_mode & libc::S_IFMT != libc::S_IFCHR {
         return false;
     }
     match rustix::fs::stat("/dev/ashmem") {

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -11,8 +11,8 @@
 #![cfg(feature = "rpc")]
 
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use rsbinder::rpc::{RpcProxy, RpcServer, RpcSession, RpcUnixClientConfig};
 use rsbinder::{
@@ -26,6 +26,7 @@ const TX_BUMP: TransactionCode = FIRST_CALL_TRANSACTION + 1; // oneway
 const TX_COUNT: TransactionCode = FIRST_CALL_TRANSACTION + 2;
 const TX_SLOW: TransactionCode = FIRST_CALL_TRANSACTION + 3;
 const TX_ROUNDTRIP: TransactionCode = FIRST_CALL_TRANSACTION + 4; // nested
+const TX_HOLD_CB: TransactionCode = FIRST_CALL_TRANSACTION + 5; // store a callback for later
 
 trait IEcho2: Interface {
     fn echo(&self, s: &str) -> Result<String>;
@@ -35,6 +36,9 @@ trait IEcho2: Interface {
     /// Server calls `cb.echo("ping")` and returns its result
     /// (exercises a server→client nested callback).
     fn roundtrip(&self, cb: &SIBinder) -> Result<String>;
+    /// Server stores `cb`; a test then drives it from **outside** any
+    /// handler (plan 2-20).
+    fn hold(&self, cb: &SIBinder) -> Result<()>;
 }
 
 struct EchoSvc {
@@ -48,6 +52,8 @@ struct EchoSvc {
     /// fresh `AtomicBool` and ignore it. Set is one-way (no reset) —
     /// "at least one slow call entered" is the only signal needed.
     slow_entered: Arc<AtomicBool>,
+    /// Callback parked by `hold()` for out-of-handler use.
+    held: Arc<Mutex<Option<SIBinder>>>,
 }
 impl Interface for EchoSvc {}
 impl IEcho2 for EchoSvc {
@@ -81,6 +87,10 @@ impl IEcho2 for EchoSvc {
         let got: String = r.read()?;
         let _ = self.deeper;
         Ok(format!("rt:{got}"))
+    }
+    fn hold(&self, cb: &SIBinder) -> Result<()> {
+        *self.held.lock().unwrap() = Some(cb.clone());
+        Ok(())
     }
 }
 
@@ -117,6 +127,13 @@ fn echo_on_transact(
         TX_ROUNDTRIP => {
             let cb: SIBinder = reader.read()?;
             ok_str(reply, s.roundtrip(&cb))
+        }
+        TX_HOLD_CB => {
+            let cb: SIBinder = reader.read()?;
+            match s.hold(&cb) {
+                Ok(()) => reply.write(&Status::from(StatusCode::Ok)),
+                Err(e) => reply.write(&Status::from(e)),
+            }
         }
         _ => Err(StatusCode::UnknownTransaction),
     }
@@ -175,6 +192,17 @@ fn make_service_with_slow_signal(
         counter,
         deeper: false,
         slow_entered,
+        held: Arc::new(Mutex::new(None)),
+    }))))
+}
+/// Build an `EchoSvc` whose `hold()` parks the callback in `held`, so a
+/// test can drive that proxy from a thread that is inside no handler.
+fn make_service_with_hold(counter: Arc<AtomicI64>, held: Arc<Mutex<Option<SIBinder>>>) -> SIBinder {
+    Interface::as_binder(&Binder::new(BnEcho2(Box::new(EchoSvc {
+        counter,
+        deeper: false,
+        slow_entered: Arc::new(AtomicBool::new(false)),
+        held,
     }))))
 }
 
@@ -231,6 +259,15 @@ impl EchoProxy {
             .ok_or(StatusCode::UnexpectedNull)?;
         read_status(&mut r)?;
         r.read::<String>()
+    }
+    fn hold(&self, cb: &SIBinder) -> Result<()> {
+        let mut d = self.rp().build_request(DESC)?;
+        d.write(cb)?;
+        let mut r = self
+            .rp()
+            .transact(TX_HOLD_CB, &d, 0)?
+            .ok_or(StatusCode::UnexpectedNull)?;
+        read_status(&mut r)
     }
 }
 
@@ -2541,5 +2578,682 @@ fn authorizer_gate_rejects_before_any_rpc_byte() {
         let root = EchoProxy(client.get_root().expect("get_root (authorized)"));
         assert_eq!(root.echo("authorized").unwrap(), "authorized");
         // _cu (scope-end) handles teardown.
+    }
+}
+
+// ---- plan 2-20 Phase A: slot roles + fast-fail --------------------------
+
+/// Boot a server whose `hold()` parks the client callback in `held`, connect
+/// one r34 client, and hand the parked proxy back — the server side of a
+/// callback the server may later drive from outside any handler.
+struct HeldSetup {
+    client: RpcSession,
+    root: EchoProxy,
+    /// The client's local callback object (an `EchoSvc` by default, so
+    /// `TX_ECHO` / `TX_BUMP` / `TX_SLOW` answer on it).
+    cb: SIBinder,
+    /// `cb`'s `bump()` counter (oneway delivery check).
+    cb_counter: Arc<AtomicI64>,
+    /// The server's proxy to `cb`, taken out of `held` (`Option` so a test
+    /// can `take()` it — a `Drop` type cannot be moved out of).
+    server_cb: Option<SIBinder>,
+    held: Arc<Mutex<Option<SIBinder>>>,
+    /// The server's root as a *local* binder (for handing back to the
+    /// client inside a callback).
+    root_local: SIBinder,
+    server: Arc<RpcServer>,
+    /// Last field on purpose: fields drop in declaration order, and
+    /// `ServeCleanup::drop` joins the worker serving `client`'s connection —
+    /// it can only return once `client` and the proxies are gone.
+    _cu: ServeCleanup,
+}
+/// `HeldSetup::drop` runs before its fields drop: stop the client's
+/// incoming-connection threads first, or `ServeCleanup::join_workers`
+/// would wait on a founding connection those threads keep open.
+impl Drop for HeldSetup {
+    fn drop(&mut self) {
+        self.client.shutdown();
+    }
+}
+/// Everything `boot_held_cfg` can vary.
+struct HeldCfg {
+    /// android-13+ profile (needed for any multi-connection option).
+    a13: bool,
+    incoming: u32,
+    fan_out: u32,
+    max_threads: u32,
+    /// Custom callback object; default an `EchoSvc`.
+    cb: Option<SIBinder>,
+}
+impl Default for HeldCfg {
+    fn default() -> Self {
+        Self {
+            a13: false,
+            incoming: 0,
+            fan_out: 1,
+            max_threads: 1,
+            cb: None,
+        }
+    }
+}
+fn boot_held(tag: &str) -> HeldSetup {
+    boot_held_cfg(tag, HeldCfg::default())
+}
+fn boot_held_cfg(tag: &str, cfg: HeldCfg) -> HeldSetup {
+    let path = tmp_sock(tag);
+    let held = Arc::new(Mutex::new(None));
+    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    if cfg.a13 {
+        server.set_android13plus(2);
+    }
+    server.set_max_threads(cfg.max_threads);
+    let root_local = make_service_with_hold(Arc::new(AtomicI64::new(0)), Arc::clone(&held));
+    server.set_root(root_local.clone());
+    let bg = server.run_background();
+    let cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
+    wait_for_sock(&path);
+    let client = if cfg.a13 {
+        RpcSession::setup_unix_client_android13plus_with_config(
+            RpcUnixClientConfig::path(&path, 2)
+                .outgoing_connections(cfg.fan_out)
+                .incoming_connections(cfg.incoming),
+        )
+        .expect("connect android13plus")
+    } else {
+        RpcSession::setup_unix_client(&path).expect("connect")
+    };
+    let root = EchoProxy(client.get_root().expect("get_root"));
+    let cb_counter = Arc::new(AtomicI64::new(0));
+    let cb = cfg
+        .cb
+        .unwrap_or_else(|| make_service(Arc::clone(&cb_counter)));
+    root.hold(&cb).expect("hold");
+    let server_cb = held
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("server parked the callback");
+    HeldSetup {
+        client,
+        root,
+        cb,
+        cb_counter,
+        server_cb: Some(server_cb),
+        held,
+        root_local,
+        server,
+        _cu: cu,
+    }
+}
+impl HeldSetup {
+    fn cb_proxy(&self) -> SIBinder {
+        self.server_cb.clone().expect("server callback proxy")
+    }
+}
+fn rpc_of(b: &SIBinder) -> &RpcProxy {
+    (**b).as_any().downcast_ref::<RpcProxy>().expect("RpcProxy")
+}
+/// `TX_SLOW` on a proxy.
+fn drive_slow(cb: &SIBinder, ms: i32) -> Result<()> {
+    let rp = rpc_of(cb);
+    let mut d = rp.build_request(DESC)?;
+    d.write(&ms)?;
+    let mut r = rp
+        .transact(TX_SLOW, &d, 0)?
+        .ok_or(StatusCode::UnexpectedNull)?;
+    read_status(&mut r)
+}
+/// `TX_ROUNDTRIP` on a proxy, handing it `target`: the callee calls
+/// `target.echo("ping")` back (a nested call from inside the callback).
+fn drive_roundtrip(cb: &SIBinder, target: &SIBinder) -> Result<String> {
+    let rp = rpc_of(cb);
+    let mut d = rp.build_request(DESC)?;
+    d.write(target)?;
+    let mut r = rp
+        .transact(TX_ROUNDTRIP, &d, 0)?
+        .ok_or(StatusCode::UnexpectedNull)?;
+    read_status(&mut r)?;
+    r.read::<String>()
+}
+/// Drive `cb` (a proxy) with `TX_ECHO` (twoway) or `TX_BUMP` (oneway).
+fn drive(cb: &SIBinder, oneway: bool) -> Result<()> {
+    let rp = (**cb)
+        .as_any()
+        .downcast_ref::<RpcProxy>()
+        .expect("RpcProxy");
+    let mut d = rp.build_request(DESC)?;
+    if oneway {
+        rp.transact(TX_BUMP, &d, rsbinder::FLAG_ONEWAY).map(|_| ())
+    } else {
+        d.write(&"x")?;
+        let mut r = rp
+            .transact(TX_ECHO, &d, 0)?
+            .ok_or(StatusCode::UnexpectedNull)?;
+        read_status(&mut r)?;
+        let got: String = r.read()?;
+        assert_eq!(got, "x");
+        Ok(())
+    }
+}
+
+/// AC-20.1 — the client opened no incoming connection, so the server has no
+/// `Outgoing` slot: a call on the parked proxy from a thread inside no handler
+/// must fail **at once** (AOSP `WOULD_BLOCK`), not block until a deadline that
+/// was never set. The served slot is untouched: the client's next calls and a
+/// nested callback (`roundtrip`) still work.
+#[test]
+fn a_outside_handler_call_without_outgoing_slot_fails_fast() {
+    let h = boot_held("a_fastfail");
+    for oneway in [false, true] {
+        let t0 = Instant::now();
+        let r = drive(&h.cb_proxy(), oneway);
+        assert!(
+            matches!(r, Err(StatusCode::FailedTransaction)),
+            "oneway={oneway}: expected FailedTransaction, got {r:?}"
+        );
+        assert!(
+            t0.elapsed() < Duration::from_millis(500),
+            "oneway={oneway}: must fail immediately, took {:?}",
+            t0.elapsed()
+        );
+    }
+    assert_eq!(h.root.echo("still in sync").unwrap(), "still in sync");
+    assert_eq!(h.root.roundtrip(&h.cb).unwrap(), "rt:ping");
+}
+
+/// AC-20.9 — the served slot is momentarily free between two messages of the
+/// worker's loop. Before the role split a non-nested call could claim it in
+/// that window and write a transaction the idle client would never read. Now
+/// every out-of-handler attempt is refused while the client hammers the same
+/// connection, and the wire stays in sync.
+#[test]
+fn a_served_slot_never_taken_by_outside_transact() {
+    let h = boot_held("a_theft");
+    let stop = Arc::new(AtomicBool::new(false));
+    let hammer = {
+        let root = EchoProxy(h.client.get_root().expect("root"));
+        let stop = Arc::clone(&stop);
+        std::thread::spawn(move || {
+            let mut n = 0u32;
+            while !stop.load(Ordering::SeqCst) {
+                let s = format!("m{n}");
+                assert_eq!(root.echo(&s).expect("echo under contention"), s);
+                n += 1;
+            }
+            n
+        })
+    };
+    let mut refused = 0;
+    for i in 0..200 {
+        match drive(&h.cb_proxy(), i % 2 == 1) {
+            Err(StatusCode::FailedTransaction) => refused += 1,
+            other => panic!("attempt {i}: expected FailedTransaction, got {other:?}"),
+        }
+    }
+    stop.store(true, Ordering::SeqCst);
+    let echoed = hammer.join().expect("hammer thread");
+    assert_eq!(refused, 200);
+    assert!(echoed > 0, "the client thread must have made progress");
+    assert_eq!(h.root.echo("after").unwrap(), "after");
+}
+
+/// AC-20.10 — dropping the parked proxy from a thread inside no handler
+/// must neither block that thread nor desync the wire. The `DEC_STRONG` it
+/// queues has no reply, so it is allowed to ride the served slot (AOSP would
+/// refuse with `WOULD_BLOCK`); but that slot is only free between two of the
+/// worker's messages, so *when* it goes out is best-effort — the node is
+/// released at the latest at session end, and promptly once the client has
+/// an incoming connection (plan 2-20 Phase B). What this gate pins is the
+/// safety property, not the timing.
+#[test]
+fn a_dec_strong_outside_handler_does_not_block_or_desync() {
+    let h = boot_held("a_dec");
+    assert_eq!(
+        h.client.local_node_count(),
+        1,
+        "the parked callback is the one local node"
+    );
+    let held = Arc::clone(&h.held);
+    let mut h = h;
+    drop(h.server_cb.take());
+    let t0 = Instant::now();
+    std::thread::spawn(move || {
+        *held.lock().unwrap() = None;
+    })
+    .join()
+    .expect("drop thread");
+    assert!(
+        t0.elapsed() < Duration::from_millis(500),
+        "dropping a proxy outside a handler must not block: {:?}",
+        t0.elapsed()
+    );
+    // The wire on the served slot is intact whether or not the deferred DEC
+    // has gone out yet.
+    for i in 0..20 {
+        let s = format!("tick{i}");
+        assert_eq!(h.root.echo(&s).unwrap(), s);
+    }
+    assert_eq!(h.root.roundtrip(&h.cb).unwrap(), "rt:ping");
+}
+
+// ---- plan 2-20 Phase B/C: client incoming connections ------------------
+
+/// AC-20.2 — with one incoming connection the server reaches the client's
+/// callback from a thread inside no handler: twoway returns, oneway lands.
+/// Also with an outgoing fan-out alongside (AOSP `setupClient` order).
+#[test]
+fn b_outside_handler_callback_completes() {
+    for (fan_out, max_threads) in [(1, 1), (2, 2)] {
+        let h = boot_held_cfg(
+            &format!("b_complete{fan_out}"),
+            HeldCfg {
+                a13: true,
+                incoming: 1,
+                fan_out,
+                max_threads,
+                ..Default::default()
+            },
+        );
+        assert_eq!(h.client.__incoming_thread_count(), 1);
+        let cb = h.cb_proxy();
+        let worker = std::thread::spawn(move || (drive(&cb, false), drive(&cb, true)));
+        let (twoway, oneway) = worker.join().expect("worker");
+        assert_eq!(
+            twoway,
+            Ok(()),
+            "fan_out={fan_out}: twoway outside a handler"
+        );
+        assert_eq!(
+            oneway,
+            Ok(()),
+            "fan_out={fan_out}: oneway outside a handler"
+        );
+        let counter = Arc::clone(&h.cb_counter);
+        assert!(
+            poll_until(|| counter.load(Ordering::SeqCst) == 1),
+            "fan_out={fan_out}: the oneway never reached the callback"
+        );
+        // The served connection is untouched by all of that.
+        assert_eq!(h.root.echo("still").unwrap(), "still");
+        assert_eq!(h.root.roundtrip(&h.cb).unwrap(), "rt:ping");
+    }
+}
+
+/// AC-20.3 — many server threads at once: one incoming connection
+/// serialises them (all succeed); two run them in parallel.
+#[test]
+fn b_outside_handler_parallel_callbacks() {
+    let h = boot_held_cfg(
+        "b_par1",
+        HeldCfg {
+            a13: true,
+            incoming: 1,
+            ..Default::default()
+        },
+    );
+    let workers: Vec<_> = (0..8)
+        .map(|_| {
+            let cb = h.cb_proxy();
+            std::thread::spawn(move || (0..3).map(|_| drive(&cb, false)).collect::<Vec<_>>())
+        })
+        .collect();
+    for w in workers {
+        for r in w.join().expect("worker") {
+            assert_eq!(r, Ok(()));
+        }
+    }
+    // Serial on one slot: two 300 ms calls take ≥ 600 ms …
+    let t0 = Instant::now();
+    let a = {
+        let cb = h.cb_proxy();
+        std::thread::spawn(move || drive_slow(&cb, 300))
+    };
+    let b = {
+        let cb = h.cb_proxy();
+        std::thread::spawn(move || drive_slow(&cb, 300))
+    };
+    assert_eq!(a.join().unwrap(), Ok(()));
+    assert_eq!(b.join().unwrap(), Ok(()));
+    assert!(
+        t0.elapsed() >= Duration::from_millis(600),
+        "one incoming connection must serialise: {:?}",
+        t0.elapsed()
+    );
+    drop(h);
+    // … and in parallel on two (the default server budget is 2 × max_threads).
+    let h = boot_held_cfg(
+        "b_par2",
+        HeldCfg {
+            a13: true,
+            incoming: 2,
+            ..Default::default()
+        },
+    );
+    assert_eq!(h.client.__slot_count(), 3);
+    let t0 = Instant::now();
+    let a = {
+        let cb = h.cb_proxy();
+        std::thread::spawn(move || drive_slow(&cb, 300))
+    };
+    let b = {
+        let cb = h.cb_proxy();
+        std::thread::spawn(move || drive_slow(&cb, 300))
+    };
+    assert_eq!(a.join().unwrap(), Ok(()));
+    assert_eq!(b.join().unwrap(), Ok(()));
+    assert!(
+        t0.elapsed() < Duration::from_millis(550),
+        "two incoming connections must run in parallel: {:?}",
+        t0.elapsed()
+    );
+}
+
+/// AC-20.4 — the callback's handler (on the client's incoming thread) calls
+/// the server back; that nested call re-enters the incoming slot and the
+/// server answers it from its own reply wait.
+#[test]
+fn b_nested_call_from_callback_handler() {
+    let h = boot_held_cfg(
+        "b_nested",
+        HeldCfg {
+            a13: true,
+            incoming: 1,
+            ..Default::default()
+        },
+    );
+    let cb = h.cb_proxy();
+    let root = h.root_local.clone();
+    let got = std::thread::spawn(move || drive_roundtrip(&cb, &root))
+        .join()
+        .expect("worker");
+    assert_eq!(got, Ok("rt:ping".to_string()));
+    assert_eq!(h.root.echo("after").unwrap(), "after");
+}
+
+/// Configuration rules: r34 has no session id (`BadType`); an attach
+/// (echoed id) gets neither fan-out nor incoming (`BadValue`); the manual
+/// attach helpers reject a config carrying the other option.
+#[test]
+fn b_incoming_config_validation() {
+    let h = boot_held_cfg(
+        "b_cfg",
+        HeldCfg {
+            a13: true,
+            ..Default::default()
+        },
+    );
+    let path = h.server.path().expect("unix path").to_path_buf();
+    let sid = h.client.get_session_id().expect("session id");
+    assert!(matches!(
+        RpcSession::setup_unix_client_android13plus_with_config(
+            RpcUnixClientConfig::path(&path, 2)
+                .session_id(&sid)
+                .incoming_connections(1)
+        ),
+        Err(StatusCode::BadValue)
+    ));
+    assert!(matches!(
+        h.client.add_outgoing_connection_android13plus_with_config(
+            RpcUnixClientConfig::path(&path, 2)
+                .session_id(&sid)
+                .incoming_connections(1)
+        ),
+        Err(StatusCode::BadValue)
+    ));
+    assert!(matches!(
+        h.client.add_incoming_connection_android13plus_with_config(
+            RpcUnixClientConfig::path(&path, 2)
+                .session_id(&sid)
+                .outgoing_connections(2)
+        ),
+        Err(StatusCode::BadValue)
+    ));
+    // Manual attach works and is served.
+    let slot = h
+        .client
+        .add_incoming_connection_android13plus_with_config(
+            RpcUnixClientConfig::path(&path, 2).session_id(&sid),
+        )
+        .expect("manual incoming attach");
+    assert!(slot > 1);
+    assert_eq!(h.client.__incoming_thread_count(), 1);
+    let cb = h.cb_proxy();
+    assert_eq!(
+        std::thread::spawn(move || drive(&cb, false))
+            .join()
+            .unwrap(),
+        Ok(())
+    );
+    // r34: no session id to echo.
+    let r34 = boot_held("b_cfg_r34");
+    assert!(matches!(
+        r34.client
+            .add_incoming_connection_android13plus_with_config(
+                RpcUnixClientConfig::path(&path, 2).session_id(&[7u8; 32])
+            ),
+        Err(StatusCode::BadType)
+    ));
+}
+
+/// The server budgets callback slots at `2 * max_threads`: a third
+/// incoming connection on a default server is refused (and the partially
+/// built session is dropped), two are admitted.
+#[test]
+fn b_incoming_over_server_cap_is_refused() {
+    let h = boot_held_cfg(
+        "b_cap",
+        HeldCfg {
+            a13: true,
+            incoming: 2,
+            ..Default::default()
+        },
+    );
+    let sid: [u8; 32] = h
+        .client
+        .get_session_id()
+        .expect("sid")
+        .as_slice()
+        .try_into()
+        .unwrap();
+    assert!(poll_until(|| h.server.session_slot_count(&sid) == Some(3)));
+    let path = h.server.path().expect("unix path").to_path_buf();
+    let r = RpcSession::setup_unix_client_android13plus_with_config(
+        RpcUnixClientConfig::path(&path, 2).incoming_connections(3),
+    );
+    assert!(
+        r.is_err(),
+        "third callback slot must be refused: {:?}",
+        r.map(|_| ())
+    );
+}
+
+/// The unified entry: `ClientOptions::incoming_connections` reaches the
+/// session; it needs the android-13+ profile.
+#[test]
+fn b_entry_client_open_with_incoming() {
+    let h = boot_held_cfg(
+        "b_entry",
+        HeldCfg {
+            a13: true,
+            ..Default::default()
+        },
+    );
+    let path = h.server.path().expect("unix path").to_path_buf();
+    let uri = format!("unix://{}?profile=android13plus", path.display());
+    let client = rsbinder::Client::open_with(&uri, |o, _| o.incoming_connections = Some(1))
+        .expect("open with incoming");
+    let session = client.session().expect("rpc session");
+    assert_eq!(session.__slot_count(), 2);
+    assert_eq!(session.__incoming_thread_count(), 1);
+    session.shutdown();
+    let r34 = format!("unix://{}", path.display());
+    assert!(matches!(
+        rsbinder::Client::open_with(&r34, |o, _| o.incoming_connections = Some(1)).map(|_| ()),
+        Err(StatusCode::BadValue)
+    ));
+}
+
+/// AC-20.5 — a client with an incoming connection learns of the server's
+/// death from that connection dropping; one without learns only from its
+/// next failed call.
+#[test]
+fn c_server_death_is_eager_with_incoming() {
+    if let Ok(path) = std::env::var("RSB_RPC_DEATH_A13_SERVER") {
+        let server = RpcServer::setup_unix_server(&path).expect("bind");
+        server.set_android13plus(2);
+        server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+        let _ = server.run(); // blocks until killed
+        std::process::exit(0);
+    }
+    let path = tmp_sock("c_death");
+    let exe = std::env::current_exe().expect("current_exe");
+    let mut child = std::process::Command::new(exe)
+        .args([
+            "--exact",
+            "c_server_death_is_eager_with_incoming",
+            "--nocapture",
+        ])
+        .env("RSB_RPC_DEATH_A13_SERVER", &path)
+        .spawn()
+        .expect("spawn server child");
+    wait_for_sock(&path);
+    let eager = RpcSession::setup_unix_client_android13plus_with_config(
+        RpcUnixClientConfig::path(&path, 2).incoming_connections(1),
+    )
+    .expect("eager client");
+    let lazy = RpcSession::setup_unix_client_android13plus(&path, 2).expect("lazy client");
+    let eager_root = eager.get_root().expect("root");
+    let lazy_root = lazy.get_root().expect("root");
+    let (tx_e, rx_e) = std::sync::mpsc::sync_channel::<()>(1);
+    let (tx_l, rx_l) = std::sync::mpsc::sync_channel::<()>(1);
+    let flag_e: Arc<DeathFlag> = Arc::new(DeathFlag(tx_e));
+    let flag_l: Arc<DeathFlag> = Arc::new(DeathFlag(tx_l));
+    eager_root
+        .link_to_death(Arc::downgrade(&flag_e) as _)
+        .expect("link eager");
+    lazy_root
+        .link_to_death(Arc::downgrade(&flag_l) as _)
+        .expect("link lazy");
+    child.kill().expect("kill server child");
+    child.wait().expect("reap server child");
+    assert!(
+        rx_e.recv_timeout(Duration::from_secs(3)).is_ok(),
+        "the incoming connection's drop must fire the obituary at once"
+    );
+    assert!(
+        rx_l.recv_timeout(Duration::from_millis(500)).is_err(),
+        "without an incoming connection nothing observes the drop yet"
+    );
+    assert!(EchoProxy(lazy_root.clone()).echo("x").is_err());
+    assert!(
+        rx_l.recv_timeout(Duration::from_secs(3)).is_ok(),
+        "the failed call declares the session dead"
+    );
+    eager.shutdown();
+    assert_eq!(eager.__incoming_thread_count(), 0);
+    lazy.shutdown();
+    let _ = std::fs::remove_file(&path);
+}
+
+/// AC-20.6 — `shutdown` ends and joins the incoming threads; the server
+/// sees the session go.
+#[test]
+fn c_shutdown_joins_incoming_threads() {
+    let h = boot_held_cfg(
+        "c_join",
+        HeldCfg {
+            a13: true,
+            incoming: 2,
+            ..Default::default()
+        },
+    );
+    let sid: [u8; 32] = h
+        .client
+        .get_session_id()
+        .expect("sid")
+        .as_slice()
+        .try_into()
+        .unwrap();
+    assert_eq!(h.client.__incoming_thread_count(), 2);
+    let t0 = Instant::now();
+    h.client.shutdown();
+    assert!(
+        t0.elapsed() < Duration::from_secs(2),
+        "shutdown took {:?}",
+        t0.elapsed()
+    );
+    assert_eq!(h.client.__incoming_thread_count(), 0);
+    // Idempotent.
+    h.client.shutdown();
+    let server = Arc::clone(&h.server);
+    assert!(
+        poll_until(|| server.session_slot_count(&sid).is_none_or(|n| n == 0)),
+        "the server still holds slots for the shut-down session"
+    );
+    assert!(matches!(h.root.echo("dead"), Err(StatusCode::DeadObject)));
+}
+
+/// A callback whose handler shuts its own session down: the incoming
+/// thread that runs it is not joined by itself (no deadlock), and the
+/// server's call returns.
+struct ShutdownCb(Mutex<Option<RpcSession>>);
+impl Interface for ShutdownCb {}
+impl Remotable for ShutdownCb {
+    fn descriptor() -> &'static str {
+        DESC
+    }
+    fn on_transact(&self, _c: TransactionCode, _r: &mut Parcel, reply: &mut Parcel) -> Result<()> {
+        if let Some(s) = self.0.lock().unwrap().as_ref() {
+            s.shutdown();
+        }
+        reply.write(&Status::from(StatusCode::Ok))
+    }
+    fn on_dump(&self, _w: &mut dyn std::io::Write, _a: &[String]) -> Result<()> {
+        Ok(())
+    }
+}
+#[test]
+fn c_shutdown_from_callback_handler_does_not_self_join() {
+    let holder = Arc::new(ShutdownCb(Mutex::new(None)));
+    let cb: SIBinder = Interface::as_binder(&Binder::new(ShutdownCbRef(Arc::clone(&holder))));
+    let h = boot_held_cfg(
+        "c_selfjoin",
+        HeldCfg {
+            a13: true,
+            incoming: 1,
+            cb: Some(cb),
+            ..Default::default()
+        },
+    );
+    *holder.0.lock().unwrap() = Some(h.client.clone());
+    let server_cb = h.cb_proxy();
+    let t0 = Instant::now();
+    let r = std::thread::spawn(move || drive(&server_cb, false))
+        .join()
+        .expect("worker");
+    assert!(
+        t0.elapsed() < Duration::from_secs(3),
+        "shutdown inside the handler must not deadlock: {:?} ({r:?})",
+        t0.elapsed()
+    );
+    // The detached thread finishes on its own; the second shutdown is a
+    // no-op and the pool is torn down.
+    assert!(poll_until(|| h.client.__incoming_thread_count() == 0));
+    h.client.shutdown();
+    assert!(matches!(h.root.echo("dead"), Err(StatusCode::DeadObject)));
+    *holder.0.lock().unwrap() = None;
+}
+/// `Binder<T>` wants a value; forward to the shared `ShutdownCb`.
+struct ShutdownCbRef(Arc<ShutdownCb>);
+impl Interface for ShutdownCbRef {}
+impl Remotable for ShutdownCbRef {
+    fn descriptor() -> &'static str {
+        DESC
+    }
+    fn on_transact(&self, c: TransactionCode, r: &mut Parcel, reply: &mut Parcel) -> Result<()> {
+        self.0.on_transact(c, r, reply)
+    }
+    fn on_dump(&self, w: &mut dyn std::io::Write, a: &[String]) -> Result<()> {
+        self.0.on_dump(w, a)
     }
 }

--- a/rsbinder/tests/rpc_vsock.rs
+++ b/rsbinder/tests/rpc_vsock.rs
@@ -126,3 +126,99 @@ fn vsock_loopback_e2e() {
     server.shutdown();
     let _ = bg.join();
 }
+
+/// Plan 2-20 (`RpcTransport::shutdown`): a thread blocked in `recv_frame`
+/// on a vsock connection returns once `shutdown()` is called on the same
+/// transport — the primitive that ends a client's incoming-connection
+/// threads and any user `serve_blocking` on session death.
+#[test]
+#[ignore = "needs Linux vsock loopback (modprobe vsock_loopback) or a peer VM"]
+fn vsock_shutdown_wakes_blocked_recv() {
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+    use vsock::VMADDR_CID_LOCAL;
+
+    let port = TEST_PORT + 1;
+    let server = RpcServer::setup_vsock_server(VMADDR_CID_LOCAL, port).expect("setup_vsock_server");
+    server.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+        PingSvc,
+    )))));
+    let bg = server.run_background();
+
+    let t: Arc<dyn RpcTransport> =
+        Arc::new(VsockTransport::connect(VMADDR_CID_LOCAL, port).expect("client connect"));
+    let reader = {
+        let t = Arc::clone(&t);
+        std::thread::spawn(move || t.recv_frame())
+    };
+    // Give the reader time to park in `recv`.
+    std::thread::sleep(Duration::from_millis(200));
+    let t0 = Instant::now();
+    t.shutdown().expect("shutdown");
+    let got = reader.join().expect("reader thread");
+    assert!(
+        got.is_err(),
+        "recv must not return a frame after shutdown: {got:?}"
+    );
+    assert!(
+        t0.elapsed() < Duration::from_secs(2),
+        "shutdown must wake the reader promptly: {:?}",
+        t0.elapsed()
+    );
+    server.shutdown();
+    let _ = bg.join();
+}
+
+/// Plan 2-20 (`RpcSession::shutdown` on a vsock session): a user
+/// `serve_blocking` thread ends, the death recipient fires, and the
+/// server sees the connection go — the whole teardown path over vsock.
+#[test]
+#[ignore = "needs Linux vsock loopback (modprobe vsock_loopback) or a peer VM"]
+fn vsock_session_shutdown_ends_serve_thread() {
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+    use vsock::VMADDR_CID_LOCAL;
+
+    struct Flag(mpsc::SyncSender<()>);
+    impl rsbinder::DeathRecipient for Flag {
+        fn binder_died(&self, _who: &rsbinder::WIBinder) {
+            let _ = self.0.try_send(());
+        }
+    }
+
+    let port = TEST_PORT + 2;
+    let server = RpcServer::setup_vsock_server(VMADDR_CID_LOCAL, port).expect("setup_vsock_server");
+    server.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+        PingSvc,
+    )))));
+    let bg = server.run_background();
+
+    let client_t = VsockTransport::connect(VMADDR_CID_LOCAL, port).expect("client connect");
+    let client = RpcSession::new(Box::new(client_t), rsbinder::rpc::AddressSpace::Initiator)
+        .expect("RpcSession::new");
+    let root = client.get_root().expect("get_root over vsock");
+    assert_eq!(ping_via(&root, "pre").unwrap(), "pong:pre");
+    let (tx, rx) = mpsc::sync_channel::<()>(1);
+    let flag: Arc<Flag> = Arc::new(Flag(tx));
+    root.link_to_death(Arc::downgrade(&flag) as _)
+        .expect("link_to_death");
+    let serving = client.clone();
+    let serve = std::thread::spawn(move || serving.serve_blocking());
+
+    std::thread::sleep(Duration::from_millis(200));
+    client.shutdown();
+    assert!(
+        rx.recv_timeout(Duration::from_secs(3)).is_ok(),
+        "shutdown must fire the linked recipient"
+    );
+    let _ = serve.join().expect("serve thread joins after shutdown");
+    assert!(
+        ping_via(&root, "post").is_err(),
+        "the session is dead after shutdown"
+    );
+    drop(root);
+    drop(client);
+    server.shutdown();
+    server.join_workers();
+    let _ = bg.join();
+}

--- a/rsbinder/tests/source_invariants.rs
+++ b/rsbinder/tests/source_invariants.rs
@@ -55,7 +55,7 @@ fn visit<F: FnMut(&Path, &str)>(dir: &Path, f: &mut F) {
 /// caller counts too: raise the number deliberately rather than route around
 /// it.
 #[test]
-fn remove_slot_has_exactly_three_callers() {
+fn remove_slot_has_exactly_four_callers() {
     let src_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     // `CARGO_MANIFEST_DIR` is baked in at compile time, so a binary copied
     // elsewhere (a device push, for one) cannot see the sources. Skip loudly
@@ -74,11 +74,12 @@ fn remove_slot_has_exactly_three_callers() {
     );
     assert_eq!(
         hits.len(),
-        3,
-        "RpcSessionInner::remove_slot must have exactly three callers. \
+        4,
+        "RpcSessionInner::remove_slot must have exactly four callers. \
          Found {} call sites: {:#?}\n\
-         INVARIANT: only serve_blocking_on's exit path and \
-         client_transact's send-failure / stale-reply poisons may call remove_slot — \
+         INVARIANT: only serve_blocking_on's exit path, \
+         client_transact's send-failure / stale-reply poisons, and the \
+         incoming-connection attach's spawn-failure rollback may call remove_slot — \
          find_conn / find_conn_pinned must return DeadObject (not panic) \
          on a missing slot. A new caller MUST audit every slot-lookup \
          path before being added.",


### PR DESCRIPTION
A server could reach a client's callback only from inside a handler answering that client; a call from any other server thread (timer, worker, oneway notification) blocked forever, because the client had no connection the server could send on. Port AOSP's setMaxIncomingThreads model (plan 2-20):

- Tag connection slots with their direction (SlotRole::{Incoming, Outgoing}, AOSP mOutgoing/mIncoming). A non-nested call claims only an Outgoing slot and fails at once with FailedTransaction (AOSP WOULD_BLOCK) when none exists; DEC_STRONG keeps the lenient pick.
- Add RpcUnixClientConfig::incoming_connections(n), RpcSession::add_incoming_connection_android13plus_with_config, and ClientOptions::incoming_connections: each connection is attached with the INCOMING bit and served by a thread the session owns. A session with one observes the server's death as soon as the connection drops.
- Lifecycle: RpcTransport::shutdown() (unix/tcp/vsock/tls/mem); session death shuts every slot's transport down and empties the pool; RpcSession::shutdown joins the incoming threads (never itself); a partially built session is torn down before the error is returned.
- Server: confirm a callback attach ("cci") only after admitting it, so a refused attach is a client-side error; the callback-slot budget (2 x set_max_threads) counts callback slots only; set_idle_timeout is no longer armed on callback slots.
- STAGE3 against real libbinder on Android 16, both directions: gate (d) in run_rpc_multiconn_interop.sh (libbinder client, rsbinder server calling from a timer thread) and the new run_rpc_incoming_interop.sh (rsbinder client, libbinder RpcServer calling from std::thread).
- Tests: 13 hermetic gates in rpc_server.rs (fast-fail, no served-slot theft, out-of-handler twoway/oneway, parallel, nested, config rules, server cap, entry API, eager death, shutdown/join, self-join), two vsock shutdown tests; remove_slot caller gate raised to four.