### PR TITLE
fix(rpc): harden plan 2-20 incoming connections after review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ short form — and the first entry is the only one no compiler will catch.
   it and neither can your build. If you meant the default, pass the newly
   public `DEFAULT_MAX_BINDER_THREADS`. `init_default()` and a `binder://` URI
   without `?threads=` are unchanged.
+- **`rpc::transport::TlsStream` gained a required `shutdown()`.** Custom
+  stream implementations must add `fn shutdown(&self) -> std::io::Result<()>`
+  (shut the underlying stream down in both directions). There is no default
+  body on purpose: silently doing nothing would leave a client's
+  incoming-connection threads blocked in `recv` with nothing to wake them, so
+  `RpcSession::shutdown` would hang on the join. The bundled
+  `TcpStream`/`UnixStream`/`VsockStream` impls are unaffected.
 - **rsbinder-aidl rejects `.aidl` it used to accept.** Five inputs that
   previously generated silently-wrong or non-compiling Rust are now build
   errors: a `@JavaOnlyStableParcelable` / `cpp_header` / `ndk_header`
@@ -97,10 +104,29 @@ short form — and the first entry is the only one no compiler will catch.
   blocked forever. With `n ≥ 1` the client attaches `n` connections the
   server sends on, each served by a thread the session owns, so callbacks
   work from timers, workers, and oneway notifications. Such a session also
-  observes the server's death as soon as the connection drops. The threads
+  observes the server's death as soon as the connection drops — eagerly, not
+  precisely: losing the last incoming connection *is* the session's death,
+  so a server that retires only that connection (its `set_reply_timeout`
+  elapsing on a slow callback, say) tears the whole session down, founding
+  connection included. The threads
   keep the session alive until `RpcSession::shutdown()` (which now shuts
   every connection down and joins them) or the server closes the session.
   Android-13+ profile, Unix sockets.
+- **rsbinder (RPC):** `ClientOptions::handshake_timeout` and
+  `RpcUnixClientConfig::handshake_timeout` — a deadline for the connection
+  **handshake**, the phase `timeout` cannot reach because it is applied to a
+  session that does not exist yet. Covers the founding connect and every
+  fan-out / incoming attach, plus the `tls://` `connect(2)`. `None`
+  (default) keeps the previous unbounded behavior; without it a peer that
+  accepts the socket and then writes nothing hangs `Client::open` forever.
+  The client-side counterpart of `ServeOptions::handshake_timeout`.
+- **rsbinder (RPC):** `RpcServer::set_reply_timeout` — bounds how long this
+  server waits for a reply to a callback it issued, by setting
+  `RpcSession::set_timeout` on every session the server builds. `None`
+  (default) keeps the previous block-forever behavior. Callback connections
+  are exempt from the `set_idle_timeout` *read* deadline (a sticky
+  `SO_RCVTIMEO` would cut this very wait short), so this is the only bound
+  available on that path.
 - **rsbinder (`binder`):** `Strong::try_into_async` — the fallible form of
   `into_async`. A local service published sync-only (`Bn*::new_binder`)
   cannot back the async view; the generated cast reports `BadType`, which
@@ -351,17 +377,56 @@ short form — and the first entry is the only one no compiler will catch.
   remedy, instead of waiting forever (or until `set_timeout`). Connection
   slots are now tagged with the direction they are used in (AOSP
   `mOutgoing`/`mIncoming`), so a serve-driven connection is never claimed
-  by another thread's transaction between two of its messages.
+  by another thread's transaction between two of its messages. A
+  same-thread nested call re-enters a serve-driven connection only while a
+  *twoway* handler is running on it (AOSP `RpcConnection::allowNested`):
+  from inside a **oneway** handler the peer is no longer reading that
+  socket, so the nested call now goes out on a connection the peer does
+  read — or fails with `FailedTransaction` if there is none — instead of
+  blocking forever on a reply that could never arrive.
+  **Breaking for `RpcSession::new(t, AddressSpace::Acceptor)`:** the
+  founding connection of an acceptor session is serve-driven, so such a
+  session can no longer open a transaction of its own — `get_root`,
+  `RpcProxy::transact` and `ping_binder` from outside a dispatch return
+  `FailedTransaction` where they used to round-trip on that connection.
+  Callbacks from inside a twoway handler are unaffected. To call out of
+  an acceptor otherwise the peer must open incoming connections, which
+  needs `?profile=android13plus`; the r34 profile has no such mechanism.
 - **rsbinder (RPC):** the server's callback-slot budget (`2 × set_max_threads`
   per session) now counts callback connections only; a client's outgoing
   fan-out no longer eats into it (before, a default server admitted a single
-  callback connection). The server also no longer arms `set_idle_timeout` on
-  callback slots (it would have cut short a server's own reply wait there),
-  and confirms a callback attach only after admitting it, so a refused
-  attach is an error on the client instead of a silently dead connection.
+  callback connection). The server also no longer arms the `set_idle_timeout`
+  *read* deadline on callback slots (it would have cut short a server's own
+  reply wait there) — the write deadline stays, as the only bound on a
+  callback send to a peer that has stopped reading — and confirms a callback
+  attach only after admitting it, so a refused attach is an error on the
+  client instead of a silently dead connection. With that read deadline gone,
+  `RpcServer::set_reply_timeout` is what bounds a callback's *reply* wait:
+  without it a client that accepts a callback and never answers pins the
+  sending worker — and everything queued behind it on that session — forever.
+- **rsbinder (RPC):** a `DEC_STRONG` no longer takes a **serve-driven**
+  connection slot from the scan; only a slot the calling thread already
+  drives (the reentrant pin) may carry one. This matches AOSP
+  `ExclusiveConnection::find`, which looks `mIncoming` up with
+  `available = nullptr`. The peer reads such a connection only inside its
+  own reply wait, so writing there is not a delayed frame but a send that
+  blocks once the socket buffer fills — while the sender holds the slot's
+  `exclusive_tid`, locking that slot's serve loop out of its own
+  connection. Consequence: on a session with no outgoing connection the
+  reference is released at session end instead of promptly, which is the
+  documented best-effort contract for refcounts. A client that wants
+  prompt release opens an incoming connection
+  (`RpcUnixClientConfig::incoming_connections`).
 - **rsbinder (RPC):** on session death every connection slot's transport is
   shut down and the pool is emptied, releasing callback-slot descriptors at
-  once rather than when the session object is finally dropped.
+  once rather than when the session object is finally dropped. The shutdown
+  now runs *first*, before the obituaries and the local-object drop, so a
+  `binder_died` handler (or a `Drop`) that calls `RpcSession::shutdown` can
+  join the incoming threads instead of deadlocking on them.
+- **rsbinder (RPC):** attaching a connection to a session that died during the
+  attach handshake now fails with `DeadObject` instead of pushing a slot no
+  serve loop will ever retire. The gate moved inside the pool lock, where it
+  is serialized against the death sequence emptying that pool.
 - **rsbinder (`shared_memory`) — breaking:** `IMemoryHeap::base` now returns
   `Option<SharedBytes<'_>>`, a read-only view. A `&[u8]` over a `MAP_SHARED`
   region promises the compiler an immutability the peer process does not
@@ -394,9 +459,12 @@ short form — and the first entry is the only one no compiler will catch.
   seek with nothing written behind it no longer inflates the byte count
   handed to the kernel — see *Fixed*.
 - **rsbinder (entry):** `ClientOptions::tls` / `tls_server_name` on anything
-  but a `tls://` endpoint, and `ServeOptions::tls` on `unix-abstract://`, are
-  `BadValue`. Both were silently ignored — a caller asking for TLS got a
-  plaintext socket and no error. The option types already promised "never
+  but a `tls://` endpoint, and `ServeOptions::tls` likewise, are `BadValue`.
+  Both were silently ignored — a caller asking for TLS got a plaintext socket
+  and no error. `ServeOptions::tls` had also accepted `unix://` and
+  `vsock://`, which no client this facade builds can reach; TLS over those
+  sockets stays available one layer down (`RpcServer::setup_unix_server_tls`
+  / `setup_vsock_server_tls`). The option types already promised "never
   ignored". A `ClientOptions::session_id` on the multi-connection path was
   dropped the same way and opened a fresh session; it is forwarded now (the
   session layer refuses the combination).

--- a/example-hello/cpp/run_rpc_incoming_interop.sh
+++ b/example-hello/cpp/run_rpc_incoming_interop.sh
@@ -62,7 +62,10 @@ sleep 3
 adb -s "$DEVICE" shell "cat /data/local/tmp/rsinc.stderr"
 
 echo "==> running rsbinder client"
-client_out=$(adb -s "$DEVICE" shell "/data/local/tmp/rpc_incoming_interop_client $SOCK 2>&1; echo client-exit=\$?" | tr -d '\r')
+# `timeout` so a wedged client fails the gate instead of hanging it; the
+# client carries its own 60 s watchdog, this is the backstop for a stall
+# before that thread starts (adb itself, a dead device).
+client_out=$(timeout 180 adb -s "$DEVICE" shell "/data/local/tmp/rpc_incoming_interop_client $SOCK 2>&1; echo client-exit=\$?" | tr -d '\r') || true
 printf '%s\n' "$client_out"
 
 echo "==> server log"

--- a/example-hello/src/bin/rpc_incoming_interop_client.rs
+++ b/example-hello/src/bin/rpc_incoming_interop_client.rs
@@ -15,11 +15,17 @@
 //! 2. libbinder's `ExclusiveConnection::find` from a non-handler thread
 //!    picks that connection and the rsbinder incoming thread answers the
 //!    twoway echo and receives the oneway notify;
-//! 3. `RpcSession::shutdown` ends the incoming thread cleanly.
+//! 3. a **nested call made from inside that oneway handler** reaches the
+//!    server. The connection the oneway arrived on is not one libbinder
+//!    reads outside a reply wait, so the nested call has to leave on the
+//!    outgoing (founding) connection instead — AOSP gates this with
+//!    `RpcConnection::allowNested`, and pinning it to the incoming
+//!    connection blocks until the session dies;
+//! 4. `RpcSession::shutdown` ends the incoming thread cleanly.
 //!
 //! Exit code 0 = PASS; non-zero = the failing step.
 use std::sync::atomic::{AtomicI32, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use rsbinder::rpc::{RpcProxy, RpcSession, RpcUnixClientConfig};
@@ -37,6 +43,29 @@ const TX_CALLBACK_NOTIFY: TransactionCode = FIRST_CALL_TRANSACTION + 1;
 struct Cb {
     echo_seen: Arc<AtomicI32>,
     notify_seen: Arc<AtomicI32>,
+    /// The server root, so the oneway handler can call back into the
+    /// session it was dispatched from.
+    root: SIBinder,
+    /// What that nested call returned, shared with `main`. `None` while
+    /// it is still running — the shape of the regression this checks for.
+    nested: Arc<Mutex<Option<std::result::Result<String, StatusCode>>>>,
+}
+
+impl Cb {
+    /// A twoway call to the server, issued from a callback handler.
+    fn call_server(&self, arg: &str) -> Result<String> {
+        let rp = (*self.root)
+            .as_any()
+            .downcast_ref::<RpcProxy>()
+            .ok_or(StatusCode::BadType)?;
+        let mut d = rp.build_request(ROOT_DESC)?;
+        d.write(&arg)?;
+        let mut r = rp
+            .transact(TX_ECHO, &d, 0)?
+            .ok_or(StatusCode::UnexpectedNull)?;
+        read_status(&mut r)?;
+        r.read()
+    }
 }
 impl Interface for Cb {}
 impl Remotable for Cb {
@@ -61,7 +90,15 @@ impl Remotable for Cb {
                 reply.write(&format!("cb-echo:{s}"))
             }
             TX_CALLBACK_NOTIFY => {
-                eprintln!("[rsbinder-cb] notify (oneway)");
+                eprintln!("[rsbinder-cb] notify (oneway); calling the server back");
+                // The nested call must NOT ride the connection this
+                // oneway arrived on: libbinder reads that one only inside
+                // its own reply wait, and it is not waiting for anything.
+                let nested = self.call_server("from-oneway");
+                eprintln!("[rsbinder-cb] nested call from the oneway handler: {nested:?}");
+                *self.nested.lock().expect("nested poisoned") = Some(nested);
+                // Bumped last, so a nested call that never returns leaves
+                // the main thread's wait to time out with a diagnosis.
                 self.notify_seen.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             }
@@ -92,9 +129,26 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(|| "/data/local/tmp/rsinc.sock".to_string());
     eprintln!("[rsbinder-client] plan 2-20 gate (e): sock={sock}");
 
+    // Every wire wait below is unbounded by default, and the attach at
+    // `setup_*` blocks reading the server's connection-init before any
+    // session exists to set a deadline on. A gate that hangs reports
+    // nothing, so bound the whole run from outside.
+    std::thread::spawn(|| {
+        std::thread::sleep(Duration::from_secs(60));
+        eprintln!("[rsbinder-client] FAIL: watchdog — gate still running after 60s");
+        std::process::exit(15);
+    });
+
     let session = RpcSession::setup_unix_client_android13plus_with_config(
-        RpcUnixClientConfig::path(std::path::Path::new(&sock), 2).incoming_connections(1),
+        RpcUnixClientConfig::path(std::path::Path::new(&sock), 2)
+            // Two outgoing slots: the oneway callback handler below calls
+            // the server back, and with a single slot that nested call
+            // would wait on whatever `main` has in flight.
+            .outgoing_connections(2)
+            .incoming_connections(1),
     )?;
+    // Bound every reply wait from here on (the default is to block forever).
+    session.set_timeout(Some(Duration::from_secs(10)));
     eprintln!(
         "[rsbinder-client] session up: wire v{:?}, slots={}, incoming threads={}",
         session.wire_protocol_version(),
@@ -124,9 +178,13 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Schedule.
     let echo_seen = Arc::new(AtomicI32::new(0));
     let notify_seen = Arc::new(AtomicI32::new(0));
+    let nested_result: Arc<Mutex<Option<std::result::Result<String, StatusCode>>>> =
+        Arc::new(Mutex::new(None));
     let cb: SIBinder = Interface::as_binder(&Binder::new(Cb {
         echo_seen: Arc::clone(&echo_seen),
         notify_seen: Arc::clone(&notify_seen),
+        root: root.clone(),
+        nested: Arc::clone(&nested_result),
     }));
     {
         let mut d = rp.build_request(ROOT_DESC)?;
@@ -171,16 +229,35 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         eprintln!("[rsbinder-client] FAIL: server outcome {outcome:?}");
         std::process::exit(12);
     }
+    // (3) The nested call the oneway handler made must have reached the
+    // server. Pinned to the incoming connection it would still be
+    // blocked here, and `notify_seen` above would never have risen.
+    match nested_result.lock().expect("nested poisoned").as_ref() {
+        Some(Ok(got)) if got == "from-oneway" => {
+            eprintln!("[rsbinder-client] (3) nested call from the oneway handler round-tripped")
+        }
+        other => {
+            eprintln!("[rsbinder-client] FAIL: nested call from oneway handler: {other:?}");
+            std::process::exit(14);
+        }
+    }
     eprintln!(
         "[rsbinder-client] (e) callback outside a handler round-tripped after {:?}",
         t0.elapsed()
     );
 
-    // Teardown: the incoming thread is joined here.
-    drop(root);
+    // Teardown: the incoming thread is joined here. `__incoming_thread_
+    // count` cannot witness that — `shutdown` empties the handle list
+    // before joining any of it — so check the join counter and that the
+    // thread really finished.
     session.shutdown();
-    if session.__incoming_thread_count() != 0 {
-        eprintln!("[rsbinder-client] FAIL: incoming thread not joined");
+    if session.__incoming_thread_joined_count() != 1 || session.__incoming_thread_live_count() != 0
+    {
+        eprintln!(
+            "[rsbinder-client] FAIL: incoming thread not joined (joined={}, live={})",
+            session.__incoming_thread_joined_count(),
+            session.__incoming_thread_live_count()
+        );
         std::process::exit(13);
     }
     println!("PASS — plan 2-20 (e): rsbinder incoming connection ↔ real libbinder RpcServer");

--- a/example-hello/src/bin/rpc_multiconn_interop_server.rs
+++ b/example-hello/src/bin/rpc_multiconn_interop_server.rs
@@ -14,7 +14,7 @@
 //!         --features rpc --bin rpc_multiconn_interop_server
 //! adb -s emulator-5556 push <bin> /data/local/tmp/rsmc_srv
 //! adb -s emulator-5556 shell /data/local/tmp/rsmc_srv \
-//!     /data/local/tmp/rsmc.sock 2
+//!     /data/local/tmp/rsmc.sock 3
 //! ```
 //!
 //! What this harness verifies (*hermetic rsbinder↔rsbinder is
@@ -40,6 +40,13 @@
 //!       inside the original twoway (server→client nested call on the
 //!       *same* slot via DRIVING `(sess, slot)` re-entry pin). Reply
 //!       must round-trip the callback's response (`cb-echo:ping`).
+//!
+//!   (d) **Callback from outside any handler** (plan 2-20):
+//!       `TX_SCHEDULE_CALLBACK` parks a callback for a timer thread that
+//!       is answering nothing, then `TX_GET_SCHED` polls the result. The
+//!       server→client call therefore has to travel a connection the
+//!       client opened for incoming traffic (`setMaxIncomingThreads`),
+//!       not the slot some in-flight handler happens to own.
 //!
 //! The launcher is the only side that decides "PASS" — this server
 //! just exposes the transactions and lets the genuine peer drive them.

--- a/rsbinder/src/binderfs.rs
+++ b/rsbinder/src/binderfs.rs
@@ -73,6 +73,8 @@ mod tests {
         _fd: Fd,
         device: &mut binder::binderfs_device,
     ) -> std::result::Result<(), rustix::io::Errno> {
+        // `c_char` is `i8` on x86_64-linux (cast required) and `u8` on
+        // aarch64-android (cast redundant) — only the latter trips the lint.
         #[allow(clippy::unnecessary_cast)]
         let bytes: Vec<u8> = device.name.iter().map(|&c| c as u8).collect();
         let nul = bytes

--- a/rsbinder/src/entry/client.rs
+++ b/rsbinder/src/entry/client.rs
@@ -28,7 +28,16 @@ pub struct ClientOptions {
     /// RPC, android-13+ profile, Unix sockets only: number of incoming
     /// (callback) connections to open — AOSP `setMaxIncomingThreads`.
     /// Needed for the server to call this client's callbacks from
-    /// outside a handler; see
+    /// outside a handler.
+    ///
+    /// Setting this `> 0` makes the resulting [`Client`] one that must be
+    /// shut down explicitly (`client.session().unwrap().shutdown()`):
+    /// the serving threads keep the session alive, so dropping every
+    /// handle reclaims nothing. It also makes the loss of the last such
+    /// connection this session's death — including a connection the
+    /// server retires on its own reply timeout, which closes the
+    /// founding connection and fires `binder_died` on every proxy while
+    /// the peer is still up. See
     // The target only exists with `rpc`, so only link it then.
     #[cfg_attr(
         feature = "rpc",
@@ -45,8 +54,36 @@ pub struct ClientOptions {
     /// [`Endpoint::supports_fd_passing`].
     #[cfg(feature = "rpc")]
     pub fd_mode: Option<crate::rpc::FileDescriptorTransportMode>,
-    /// RPC: reply deadline (`RpcSession::set_timeout`).
+    /// RPC: reply deadline (`RpcSession::set_timeout`). Applied to the
+    /// session as soon as it exists, so besides the calls made
+    /// afterwards it bounds the round trips `open` makes *after* that
+    /// point: the r34 fd-mode negotiation, and the `GET_MAX_THREADS` /
+    /// `GET_SESSION_ID` exchanges a multi-connection setup needs.
+    ///
+    /// It does **not** bound the connection handshake, which runs before
+    /// the session exists — use
+    // The target only exists with `rpc`, so only link it then.
+    #[cfg_attr(
+        feature = "rpc",
+        doc = "[`handshake_timeout`](Self::handshake_timeout) for that phase."
+    )]
+    #[cfg_attr(
+        not(feature = "rpc"),
+        doc = "`handshake_timeout` (`rpc` feature) for that phase."
+    )]
     pub timeout: Option<Duration>,
+    /// RPC: deadline for the connection **handshake** — the phase
+    /// [`timeout`](Self::timeout) cannot reach, because it runs before the
+    /// session exists. Covers the `tls://` `connect(2)` and the android-13+
+    /// session handshake, on the founding connection and on every fan-out
+    /// or incoming attach.
+    ///
+    /// `None` (default) blocks forever, so a peer that accepts the socket
+    /// and then writes nothing hangs `open`. Set it whenever the peer is
+    /// untrusted or merely unreliable. This is the client-side counterpart
+    /// of [`ServeOptions::handshake_timeout`](super::ServeOptions::handshake_timeout).
+    #[cfg(feature = "rpc")]
+    pub handshake_timeout: Option<Duration>,
     /// Kernel: `?driver=` equivalent.
     pub driver: Option<std::path::PathBuf>,
 }
@@ -59,6 +96,14 @@ pub struct ClientOptions {
 /// to issue more lookups on the same session. The kernel form also
 /// starts the binder thread pool so callbacks, death notifications and
 /// registration waits are delivered promptly.
+///
+/// **One exception to "just drop it".** A client opened with
+/// [`ClientOptions::incoming_connections`] `> 0` owns the threads
+/// serving those connections, and each of them holds the session alive:
+/// dropping the `Client` *and* every proxy reclaims nothing, so the
+/// threads, the session and both ends' sockets survive until the process
+/// exits. Call `client.session().unwrap().shutdown()` when you are done
+/// with such a client.
 pub struct Client {
     endpoint: Endpoint,
     inner: Inner,
@@ -86,7 +131,8 @@ impl std::fmt::Debug for ClientOptions {
             .field("outgoing_connections", &self.outgoing_connections)
             .field("incoming_connections", &self.incoming_connections);
         #[cfg(feature = "rpc")]
-        d.field("fd_mode", &self.fd_mode);
+        d.field("fd_mode", &self.fd_mode)
+            .field("handshake_timeout", &self.handshake_timeout);
         d.field("timeout", &self.timeout)
             .field("driver", &self.driver)
             .finish()
@@ -129,8 +175,8 @@ pub(super) fn new_client(uri: Uri, o: ClientOptions) -> Result<Client> {
                 return Err(reject("fd_mode"));
             }
             #[cfg(feature = "rpc-tls")]
-            if o.tls.is_some() {
-                return Err(reject("tls"));
+            if o.tls.is_some() || o.tls_server_name.is_some() {
+                return Err(reject("tls/tls_server_name"));
             }
             let driver = o.driver.as_deref().or(driver.as_deref());
             super::server::kernel_init(driver, *threads)?;
@@ -164,9 +210,6 @@ pub(super) fn new_client(uri: Uri, o: ClientOptions) -> Result<Client> {
                 return Err(StatusCode::BadValue);
             }
             let session = rpc_connect(&uri, &o)?;
-            if let Some(t) = o.timeout {
-                session.set_timeout(Some(t));
-            }
             Ok(Client {
                 endpoint: uri.endpoint.clone(),
                 inner: Inner::Rpc(session),
@@ -186,9 +229,13 @@ fn rpc_connect(uri: &Uri, o: &ClientOptions) -> Result<crate::rpc::RpcSession> {
     use crate::rpc::{AddressSpace, FileDescriptorTransportMode, RpcSession};
 
     let versioned = uri.wire_max_version;
-    let fan_out = o.outgoing_connections.unwrap_or(1);
+    let fan_out = o.outgoing_connections.unwrap_or(1).max(1);
     let incoming = o.incoming_connections.unwrap_or(0);
-    if versioned.is_none() && (o.session_id.is_some() || fan_out > 1 || incoming > 0) {
+    // Gate on `is_some()`, not on the value: `Some(0)`/`Some(1)` is still
+    // the caller asking for an option this endpoint may not have, and
+    // `ClientOptions` promises such an option is `BadValue`, never ignored.
+    let multi_conn = o.outgoing_connections.is_some() || o.incoming_connections.is_some();
+    if versioned.is_none() && (o.session_id.is_some() || multi_conn) {
         log::error!(
             "rsbinder::Client::open: session_id/outgoing_connections/incoming_connections \
              need `?profile=android13plus` ({:?})",
@@ -199,7 +246,7 @@ fn rpc_connect(uri: &Uri, o: &ClientOptions) -> Result<crate::rpc::RpcSession> {
 
     // The unix fan-out / incoming-connection path has its own
     // multi-connection setup.
-    if let (Some(v), true) = (versioned, fan_out > 1 || incoming > 0) {
+    if let (Some(v), true) = (versioned, multi_conn) {
         let mut cfg = match &uri.endpoint {
             Endpoint::Unix(path) => crate::rpc::RpcUnixClientConfig::path(path, v),
             #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -218,6 +265,12 @@ fn rpc_connect(uri: &Uri, o: &ClientOptions) -> Result<crate::rpc::RpcSession> {
         .incoming_connections(incoming);
         if let Some(m) = o.fd_mode {
             cfg = cfg.fd_mode(m);
+        }
+        if let Some(t) = o.timeout {
+            cfg = cfg.timeout(t);
+        }
+        if let Some(t) = o.handshake_timeout {
+            cfg = cfg.handshake_timeout(t);
         }
         // Forward rather than drop: the session layer refuses the
         // combination (`BadValue`), which is the "never ignored" contract.
@@ -283,7 +336,37 @@ fn rpc_connect(uri: &Uri, o: &ClientOptions) -> Result<crate::rpc::RpcSession> {
                     StatusCode::BadValue
                 })?;
                 let name = o.tls_server_name.as_deref().unwrap_or(host);
-                let tcp = std::net::TcpStream::connect((host.as_str(), *port))?;
+                let tcp = match o.handshake_timeout {
+                    // `connect_timeout` takes one resolved address, so try
+                    // each until one connects — what `TcpStream::connect`
+                    // does internally for a `(host, port)` pair.
+                    Some(d) => {
+                        use std::net::ToSocketAddrs;
+                        let mut last = None;
+                        let mut sock = None;
+                        for addr in (host.as_str(), *port).to_socket_addrs()? {
+                            match std::net::TcpStream::connect_timeout(&addr, d) {
+                                Ok(t) => {
+                                    sock = Some(t);
+                                    break;
+                                }
+                                Err(e) => last = Some(e),
+                            }
+                        }
+                        match sock {
+                            Some(t) => t,
+                            None => {
+                                return Err(StatusCode::from(last.unwrap_or_else(|| {
+                                    std::io::Error::new(
+                                        std::io::ErrorKind::NotFound,
+                                        "no address resolved",
+                                    )
+                                })))
+                            }
+                        }
+                    }
+                    None => std::net::TcpStream::connect((host.as_str(), *port))?,
+                };
                 Box::new(crate::rpc::transport::TlsTransport::connect(
                     tcp, name, cfg,
                 )?)
@@ -300,6 +383,9 @@ fn rpc_connect(uri: &Uri, o: &ClientOptions) -> Result<crate::rpc::RpcSession> {
         None => {
             let session =
                 RpcSession::new(transport, AddressSpace::Initiator).map_err(StatusCode::from)?;
+            // Before the negotiation below, not after `rpc_connect`
+            // returns: that transaction reads this value when it runs.
+            session.set_timeout(o.timeout);
             // r34 wire: FD mode is negotiated by a special transaction
             // after connect (versioned profiles do it in the handshake).
             if let Some(mode) = o.fd_mode {
@@ -307,12 +393,17 @@ fn rpc_connect(uri: &Uri, o: &ClientOptions) -> Result<crate::rpc::RpcSession> {
             }
             Ok(session)
         }
-        Some(v) => RpcSession::connect_android13plus_fd_with_id(
-            transport,
-            v,
-            o.fd_mode.unwrap_or(FileDescriptorTransportMode::None),
-            o.session_id.as_deref().unwrap_or(&[]),
-        ),
+        Some(v) => {
+            let session = RpcSession::connect_android13plus_fd_with_id_hs(
+                transport,
+                v,
+                o.fd_mode.unwrap_or(FileDescriptorTransportMode::None),
+                o.session_id.as_deref().unwrap_or(&[]),
+                o.handshake_timeout,
+            )?;
+            session.set_timeout(o.timeout);
+            Ok(session)
+        }
     }
 }
 

--- a/rsbinder/src/entry/server.rs
+++ b/rsbinder/src/entry/server.rs
@@ -19,19 +19,48 @@ pub type Authorizer = Box<dyn Fn(&crate::rpc::PeerIdentity) -> bool + Send + Syn
 #[derive(Default)]
 #[non_exhaustive]
 pub struct ServeOptions {
-    /// Kernel: `ProcessState` max threads (also settable as
-    /// `binder://?threads=`). RPC: `RpcServer::set_max_threads`.
+    /// RPC: `RpcServer::set_max_threads`.
+    ///
+    /// Kernel: **the URI form (`binder://?threads=`) is the only one
+    /// that takes effect.** [`serve`](super::serve) initializes the
+    /// process-wide `ProcessState` — where the kernel pool size is
+    /// fixed, once, for the life of the process — before this option
+    /// can be read, so a value set here is only compared against the
+    /// pool already in force and, on a mismatch, logged as ignored.
     pub threads: Option<u32>,
     /// RPC: `RpcServer::set_max_connections`.
     pub max_connections: Option<usize>,
-    /// RPC: `RpcServer::set_handshake_timeout`.
+    /// RPC: `RpcServer::set_handshake_timeout`. `None` here means
+    /// "leave it alone" — the setter is not called and the server keeps
+    /// its 10 s default. It is *not* the setter's own `None` (deadline
+    /// deliberately disabled), which this facade cannot express.
+    /// `Some(Duration::ZERO)` is passed through and refused by the
+    /// setter, which keeps the 10 s default (`idle_timeout` treats a
+    /// zero the other way — as `None`).
     pub handshake_timeout: Option<Duration>,
-    /// RPC: `RpcServer::set_idle_timeout`.
+    /// RPC: `RpcServer::set_idle_timeout`. `None` here means "leave it
+    /// alone"; the server's own default is already `None` (no idle
+    /// deadline), so the two coincide. `Some(Duration::ZERO)` is passed
+    /// through and the setter treats it as `None`.
     pub idle_timeout: Option<Duration>,
+    /// RPC: `RpcServer::set_reply_timeout` — bounds the wait for a reply
+    /// to a callback this server issues to a client outside a handler.
+    /// The only bound on that wait, so set it on any server that issues
+    /// callbacks to clients it does not control (see
+    /// [`ClientOptions::incoming_connections`](super::ClientOptions::incoming_connections),
+    /// the client side of that path).
+    pub reply_timeout: Option<Duration>,
     /// RPC: `RpcServer::set_authorizer` — accept/reject a peer by identity.
     #[cfg(feature = "rpc")]
     pub authorizer: Option<Authorizer>,
-    /// `tls://` (required there) or any RPC socket: TLS server config.
+    /// `tls://` only, and required there: TLS server config. Refused on
+    /// every other endpoint, because
+    /// [`ClientOptions::tls`](super::ClientOptions::tls) is `tls://`-only
+    /// too — a server this facade wrapped in TLS over a Unix or vsock
+    /// socket could not be reached by a client this facade built. TLS
+    /// over those sockets is still available one layer down
+    /// (`RpcServer::setup_unix_server_tls` / `setup_vsock_server_tls`),
+    /// with a hand-assembled `TlsTransport::connect_stream` client.
     #[cfg(feature = "rpc-tls")]
     pub tls: Option<std::sync::Arc<crate::rpc::rustls::ServerConfig>>,
     /// RPC: `RpcServer::set_supported_fd_modes`. Advertising
@@ -255,9 +284,12 @@ impl Server {
 
     fn apply_kernel_options(&self) -> Result<()> {
         let o = &self.options;
-        if o.max_connections.is_some() || o.handshake_timeout.is_some() || o.idle_timeout.is_some()
+        if o.max_connections.is_some()
+            || o.handshake_timeout.is_some()
+            || o.idle_timeout.is_some()
+            || o.reply_timeout.is_some()
         {
-            return Err(self.reject("max_connections/handshake_timeout/idle_timeout"));
+            return Err(self.reject("max_connections/handshake_timeout/idle_timeout/reply_timeout"));
         }
         #[cfg(feature = "rpc")]
         if o.authorizer.is_some() || o.fd_modes.is_some() {
@@ -295,33 +327,26 @@ impl Server {
         }
         #[cfg(feature = "rpc-tls")]
         let tls = o.tls.clone();
+        // Same gate as `ClientOptions::tls`: the facade has no TLS client
+        // over a Unix or vsock socket, so a TLS server it built there
+        // would be unreachable from it. Refusing is the "never silently
+        // ignored" contract — and it matters most on an abstract socket,
+        // which has no filesystem permissions, so mTLS may be the only
+        // authentication the operator configured.
+        #[cfg(feature = "rpc-tls")]
+        if tls.is_some() && !matches!(uri.endpoint, Endpoint::Tls(..)) {
+            log::error!(
+                "rsbinder::serve: option `tls` does not apply to {:?} \
+                 (only `tls://`; RpcServer::setup_unix_server_tls / \
+                 setup_vsock_server_tls are the direct forms)",
+                uri.endpoint
+            );
+            return Err(StatusCode::BadValue);
+        }
         let server = match &uri.endpoint {
             Endpoint::Kernel { .. } => unreachable!("kernel handled by caller"),
-            Endpoint::Unix(path) => {
-                #[cfg(feature = "rpc-tls")]
-                if let Some(cfg) = tls {
-                    RpcServer::setup_unix_server_tls(path.clone(), cfg)?
-                } else {
-                    RpcServer::setup_unix_server(path.clone())?
-                }
-                #[cfg(not(feature = "rpc-tls"))]
-                RpcServer::setup_unix_server(path.clone())?
-            }
+            Endpoint::Unix(path) => RpcServer::setup_unix_server(path.clone())?,
             Endpoint::UnixAbstract(name) => {
-                // No TLS variant of the abstract listener exists; refusing
-                // is the "never silently ignored" contract — and it matters
-                // more here than anywhere: an abstract socket has no
-                // filesystem permissions, so mTLS may be the only
-                // authentication the operator configured.
-                #[cfg(feature = "rpc-tls")]
-                if tls.is_some() {
-                    log::error!(
-                        "rsbinder::serve: option `tls` does not apply to {:?} \
-                         (no TLS listener for abstract Unix sockets)",
-                        uri.endpoint
-                    );
-                    return Err(StatusCode::BadValue);
-                }
                 #[cfg(any(target_os = "linux", target_os = "android"))]
                 {
                     RpcServer::setup_unix_server_abstract(name)?
@@ -336,13 +361,6 @@ impl Server {
             Endpoint::Vsock(cid, port) => {
                 #[cfg(all(feature = "rpc-vsock", any(target_os = "linux", target_os = "android")))]
                 {
-                    #[cfg(feature = "rpc-tls")]
-                    if let Some(cfg) = tls {
-                        RpcServer::setup_vsock_server_tls(*cid, *port, cfg)?
-                    } else {
-                        RpcServer::setup_vsock_server(*cid, *port)?
-                    }
-                    #[cfg(not(feature = "rpc-tls"))]
                     RpcServer::setup_vsock_server(*cid, *port)?
                 }
                 #[cfg(not(all(
@@ -388,6 +406,12 @@ impl Server {
         }
         if let Some(t) = o.idle_timeout {
             server.set_idle_timeout(Some(t));
+        }
+        // Before `run`/`run_background`, which the caller reaches only
+        // after `build_rpc` returns — the setter is read once per session,
+        // when its founding connection is accepted.
+        if let Some(t) = o.reply_timeout {
+            server.set_reply_timeout(Some(t));
         }
         if let Some(f) = o.authorizer {
             server.set_authorizer(f);

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -358,8 +358,8 @@ pub struct RpcServer {
     wire_max_version: Mutex<Option<u32>>,
     /// Opt-in **server-side admission bound** on the number of
     /// *concurrent* connection-worker threads. `None` (default) ⇒
-    /// unbounded, byte-for-byte the prior behavior (additive
-    /// invariant). `Some(max)` ⇒ the accept loop stops accepting while
+    /// unbounded, byte-for-byte a server that never sets the bound
+    /// (additive invariant). `Some(max)` ⇒ the accept loop stops accepting while
     /// `max` workers are live (excess clients wait in the kernel listen
     /// backlog — clean backpressure, no reactor, no dropped client),
     /// resuming when a worker finishes. This is the rsbinder analogue
@@ -382,7 +382,7 @@ pub struct RpcServer {
     /// Optional per-connection *idle* read deadline applied to the
     /// android-13+ serve loop **after** the handshake completes. `None`
     /// (the default) ⇒ an established session idles between requests
-    /// unbounded (byte-identical to prior behavior). `Some(d)` ⇒ a peer
+    /// unbounded (byte-identical to a server that never sets it). `Some(d)` ⇒ a peer
     /// that completes the handshake and then goes silent surfaces as a
     /// serve-loop read error after `d`, releasing its worker and its
     /// [`set_max_connections`](Self::set_max_connections) admission slot —
@@ -391,13 +391,17 @@ pub struct RpcServer {
     /// phase only) does not cover. Set this only when the protocol has
     /// regular traffic or idle eviction is acceptable.
     idle_timeout: Mutex<Option<std::time::Duration>>,
+    reply_timeout: Mutex<Option<std::time::Duration>>,
     /// Opt-in authorization hook. `None`
     /// (default) ⇒ accept-all = byte-for-byte a server without the hook
-    /// (additive invariant). When set, it runs at
-    /// [`serve_connection`](RpcServer::serve_connection) entry —
-    /// **before** the wire-profile branch, session build, handshake,
-    /// or any `recv_frame` — so a rejected peer receives **zero RPC
-    /// bytes** (the connection is closed). Backend-independent: it is
+    /// (additive invariant). When set, it runs on the connection's own
+    /// worker thread (`run_connection_in_worker`, shared by the accept
+    /// loop and [`serve_connection`](RpcServer::serve_connection)),
+    /// concurrently across connections and never blocking the accept
+    /// loop — but **before** the wire-profile branch, session build,
+    /// handshake, or any `recv_frame`, so a rejected peer receives
+    /// **zero RPC bytes** (the connection is closed).
+    /// Backend-independent: it is
     /// pure on [`RpcTransport::peer_identity`] (unix `SO_PEERCRED`/
     /// `getpeereid`, tls cert, vsock cid, …). `Arc` (not `Box`) so the
     /// hook is cloned out of the lock and invoked **lock-free**, so a
@@ -415,7 +419,7 @@ pub struct RpcServer {
     /// re-reads the now-true flag and takes the reject branch — turning
     /// the otherwise sub-microsecond window into a deterministic test
     /// point. `None` default ⇒ no invocation, byte-identical to the
-    /// pre-hook attach path. `Arc<dyn Fn>` so the closure is cloned out
+    /// attach path without the probe. `Arc<dyn Fn>` so the closure is cloned out
     /// of the lock and invoked **lock-free** (same discipline as
     /// `authorizer` — re-entrant calls into `server` from the probe do
     /// not self-deadlock). Same `__`-prefix unstable-API discipline as
@@ -460,8 +464,9 @@ pub struct RpcServer {
     /// Observability counters. Plain atomics off the per-transaction
     /// path — zero-cost on the default (empty-id) flow.
     /// `session_registered` = new-session mints; `attached_count` =
-    /// id-demux attaches; `rejected_unknown_id` = non-empty ids that
-    /// resolved to no live session.
+    /// id-demux attaches; `rejected_unknown_id` = id-carrying
+    /// connections refused for any reason (see
+    /// [`rejected_unknown_id_count`](RpcServer::rejected_unknown_id_count)).
     session_registered: AtomicUsize,
     attached_count: AtomicUsize,
     rejected_unknown_id: AtomicUsize,
@@ -556,6 +561,7 @@ impl RpcServer {
             max_connections: Mutex::new(None),
             handshake_timeout: Mutex::new(Some(DEFAULT_HANDSHAKE_TIMEOUT)),
             idle_timeout: Mutex::new(None),
+            reply_timeout: Mutex::new(None),
             authorizer: Mutex::new(None),
             attach_shutdown_probe: Mutex::new(None),
             sessions: Mutex::new(HashMap::new()),
@@ -693,8 +699,8 @@ impl RpcServer {
 
     /// Opt-in **server-side admission bound** on concurrent
     /// connection-worker threads (reactor-free backpressure). Default
-    /// (unset) is unbounded — byte-for-byte the prior behavior, so this
-    /// is purely additive. When set, the accept loop stops accepting
+    /// (unset) is unbounded — byte-for-byte a server that never calls
+    /// this, so it is purely additive. When set, the accept loop stops accepting
     /// while `n` workers are live; pending clients wait in the kernel
     /// listen backlog and are served as workers finish (no client is
     /// dropped, `shutdown` is still polled). `n` is clamped to ≥ 1.
@@ -740,7 +746,26 @@ impl RpcServer {
     /// way an established two-way session may then sit idle between requests
     /// unbounded (the per-call reply deadline is managed separately via
     /// [`RpcSession::set_timeout`](super::RpcSession::set_timeout)).
+    ///
+    /// `Some(Duration::ZERO)` is not a valid deadline (`SO_RCVTIMEO`
+    /// rejects it, and every arming site would silently fail, leaving the
+    /// admission phase *unbounded* — worse than never calling this) and is
+    /// refused: it is logged and the default is kept. Pass `None` to
+    /// disable the deadline deliberately.
     pub fn set_handshake_timeout(&self, timeout: Option<std::time::Duration>) {
+        // Zero cannot fall back to `reject_zero_deadline`'s `None` here:
+        // this deadline's default is 10s, so `None` (unbounded) is just as
+        // wrong as zero. Keep the default instead.
+        let timeout = match timeout {
+            Some(d) if d.is_zero() => {
+                log::error!(
+                    "RpcServer::set_handshake_timeout: a zero duration is not a \
+                     valid deadline; keeping the default"
+                );
+                Some(DEFAULT_HANDSHAKE_TIMEOUT)
+            }
+            other => other,
+        };
         *self
             .handshake_timeout
             .lock()
@@ -750,7 +775,7 @@ impl RpcServer {
     /// Set (or disable) the **idle read deadline** applied to the
     /// android-13+ serve loop *after* the handshake completes. Default
     /// `None` ⇒ an established session may idle between requests unbounded
-    /// (byte-identical to prior behavior).
+    /// (byte-identical to a server that never calls this).
     ///
     /// [`set_handshake_timeout`](Self::set_handshake_timeout) only bounds
     /// the handshake/first-contact phase; once a peer completes the
@@ -771,13 +796,71 @@ impl RpcServer {
     /// mid-send (the connection is torn down, not desynced). Size `d`
     /// against the slowest acceptable consumer, not just the idle gap.
     ///
-    /// Callback connections (a client's incoming attaches, which this
-    /// server only ever *sends* on) are exempt: they have no serve loop,
-    /// and a sticky deadline there would cut short the server's own
-    /// reply wait on a callback issued outside a handler. Only the
-    /// session reply deadline bounds those sends.
+    /// On callback connections (a client's incoming attaches, which this
+    /// server only ever *sends* on) the **read** half is exempt: they
+    /// have no serve loop, and a sticky read deadline there would cut
+    /// short the server's own reply wait on a callback issued outside a
+    /// handler. The **write** half still applies, and bounds a callback
+    /// *send* to a peer that has stopped reading. The callback *reply*
+    /// wait is bounded separately by
+    /// [`set_reply_timeout`](Self::set_reply_timeout) — this deadline
+    /// cannot cover it, being a sticky read timeout armed before the send.
+    ///
+    /// `Some(Duration::ZERO)` is not a valid deadline (`SO_RCVTIMEO`
+    /// rejects it) and is refused — logged and treated as `None`.
     pub fn set_idle_timeout(&self, timeout: Option<std::time::Duration>) {
-        *self.idle_timeout.lock().expect("idle_timeout poisoned") = timeout;
+        *self.idle_timeout.lock().expect("idle_timeout poisoned") =
+            super::session::reject_zero_deadline(
+                timeout,
+                "RpcServer::set_idle_timeout: a zero duration is not a valid deadline; ignoring",
+            );
+    }
+
+    /// Bound how long this server waits for a **reply to a callback** it
+    /// issued to a client (`RpcSession::set_timeout` on every session this
+    /// server builds). `None` (default) blocks forever on a callback
+    /// issued *outside* a handler — the case this setter exists for —
+    /// which is byte-identical to not calling this at all.
+    ///
+    /// This is the only bound on **that** wait. The idle deadline cannot
+    /// serve there: callback connections are exempt from its *read* half
+    /// (see [`set_idle_timeout`](Self::set_idle_timeout)), because
+    /// `SO_RCVTIMEO` is sticky and would cut short exactly this wait.
+    ///
+    /// A callback issued from **inside** a handler is not on that path
+    /// and is not unbounded without this: it reuses the serve connection
+    /// it is answering on (the re-entrant nested-call pin), so its reply
+    /// wait already sits under whatever read deadline
+    /// [`set_idle_timeout`](Self::set_idle_timeout) armed there — a
+    /// handler slower than the idle deadline makes such a callback fail
+    /// with `StatusCode::TimedOut`. A value set here replaces that
+    /// deadline for the reply wait and the idle one is restored after.
+    /// Without a value here, a client that attaches an incoming connection,
+    /// accepts a callback and then never replies pins the sending worker
+    /// forever — and every later caller behind it, since they queue on the
+    /// same session's connection pool.
+    ///
+    /// Set it on any server that issues callbacks to clients it does not
+    /// control. Size it against the slowest legitimate handler, not the
+    /// round-trip: it bounds the peer's *think time*. It also bounds the
+    /// wait for a free connection slot on the same session
+    /// ([`RpcSession::set_timeout`](super::RpcSession::set_timeout)), so a
+    /// callback behind a busy pool can take up to twice this value
+    /// end-to-end.
+    ///
+    /// Read **once per session**, when the connection that founds it is
+    /// accepted: call this *before* [`run`](Self::run) /
+    /// [`run_background`](Self::run_background). Sessions already
+    /// established keep the value that was in force when they were built.
+    ///
+    /// `Some(Duration::ZERO)` is not a valid deadline (`SO_RCVTIMEO`
+    /// rejects it) and is refused — logged and treated as `None`.
+    pub fn set_reply_timeout(&self, timeout: Option<std::time::Duration>) {
+        *self.reply_timeout.lock().expect("reply_timeout poisoned") =
+            super::session::reject_zero_deadline(
+                timeout,
+                "RpcServer::set_reply_timeout: a zero duration is not a valid deadline; ignoring",
+            );
     }
 
     /// Reap finished worker handles and return the live (concurrent)
@@ -806,7 +889,11 @@ impl RpcServer {
     /// `rpc-macos-codesign` feature,
     /// `matches!(p, PeerIdentity::CodeSigned(c) if c.team_id() == Some("TEAMID"))`.
     /// Backend-independent (unix/mem/tls/vsock). The hook must not
-    /// block indefinitely (it runs on the accept path).
+    /// block indefinitely: it runs on the connection's own worker
+    /// thread — concurrently across connections, not serialized by the
+    /// accept loop — and holds that connection's
+    /// [`set_max_connections`](Self::set_max_connections) admission slot
+    /// for its whole duration.
     pub fn set_authorizer<F>(&self, f: F)
     where
         F: Fn(&PeerIdentity) -> bool + Send + Sync + 'static,
@@ -822,7 +909,7 @@ impl RpcServer {
     /// (cloned out of the field's mutex first), so it may re-enter
     /// `server` without self-deadlock. `None` (default, no
     /// `__set_attach_shutdown_probe` call) = byte-identical to the
-    /// pre-hook attach path. Same `__`-prefix unstable-API discipline
+    /// attach path without the probe. Same `__`-prefix unstable-API discipline
     /// as `__fuzz_decode_rpc_parcel`; not part of the supported API
     /// surface.
     #[doc(hidden)]
@@ -899,6 +986,7 @@ impl RpcServer {
             session.set_root(root);
         }
         session.set_max_threads(*self.max_threads.lock().expect("max_threads poisoned"));
+        session.set_timeout(*self.reply_timeout.lock().expect("reply_timeout poisoned"));
         if self.fd_unix_supported.load(Ordering::SeqCst) {
             session.set_supported_fd_modes(&[crate::rpc::FileDescriptorTransportMode::Unix]);
         }
@@ -932,8 +1020,8 @@ impl RpcServer {
         // lifetime (random 32-byte ids never collide in practice, so a
         // dead `Weak` would otherwise linger forever). Explicit
         // `unregister_session` is unnecessary — the founding worker's
-        // exit is no longer the session's death (any *last* slot exit
-        // is), so prune-on-register suffices.
+        // exit is not the session's death (any *last* slot exit is), so
+        // prune-on-register suffices.
         map.retain(|_, w| w.strong_count() > 0);
         map.insert(id, Arc::downgrade(inner));
         drop(map);
@@ -957,9 +1045,14 @@ impl RpcServer {
 
     /// Observability counters.
     /// Respectively: new-session ids registered; **id-demux attaches**
-    /// (a 2nd+ connection bound to a pre-existing shared
-    /// session); non-empty ids that resolved to no live session and
-    /// were rejected. All zero on the default (empty-id) flow ⇒ a
+    /// (a 2nd+ connection bound to a pre-existing shared session);
+    /// **id-carrying connections refused for any reason** — an
+    /// unknown/stale id, a codec-version mismatch with the founding
+    /// session, an attach arriving after `shutdown`, or an attach past
+    /// the incoming/callback slot cap. The last one therefore counts
+    /// more than stale ids: a well-behaved client whose
+    /// `incoming_connections` exceeds this server's callback budget also
+    /// raises it. All zero on the default (empty-id) flow ⇒ a
     /// no-regression witness.
     pub fn session_registered_count(&self) -> usize {
         self.session_registered.load(Ordering::SeqCst)
@@ -980,9 +1073,9 @@ impl RpcServer {
     /// Lock ladder: collect the live `Arc<RpcSessionInner>` snapshot
     /// **first** (releasing the `sessions` mutex), then walk each
     /// session's `state` mutex (via the inner's `local_node_count`
-    /// delegate). Avoids the nested-lock pattern (`sessions` → `state`); a
-    /// poisoned `state` lock in one session no longer poisons
-    /// `sessions` as a side-effect.
+    /// delegate). Avoids the nested-lock pattern (`sessions` → `state`), so
+    /// a poisoned `state` lock in one session does not poison `sessions`
+    /// as a side-effect.
     pub fn live_session_node_count(&self) -> usize {
         let sessions: Vec<_> = self
             .sessions
@@ -1140,7 +1233,7 @@ impl RpcServer {
     /// to the long-lived serving phase (best-effort), arming **both** the
     /// read and write deadlines. By default both are lifted (`None`), so an
     /// established two-way session may idle between requests unbounded —
-    /// byte-identical to prior behavior. If
+    /// byte-identical to a server with no idle deadline set. If
     /// [`set_idle_timeout`](Self::set_idle_timeout) was called, the serve
     /// loop inherits that value on each side, so a peer that completes the
     /// handshake and then goes silent (or stops reading our replies) — a
@@ -1154,9 +1247,16 @@ impl RpcServer {
         }
         // Mirror the deadline onto the write side so a peer that idles
         // *and* stops reading can't pin the worker via a blocked reply
-        // send. `None` (the default) leaves writes unbounded — byte-
-        // identical to prior behavior; a configured idle timeout now
-        // bounds both directions.
+        // send. `None` (the default) leaves writes unbounded; a
+        // configured idle timeout bounds both directions.
+        self.arm_write_timeout(transport);
+    }
+
+    /// The write half of [`arm_serve_timeouts`](Self::arm_serve_timeouts),
+    /// on its own for the callback-slot path, which arms the write
+    /// deadline but must leave the read side unbounded.
+    fn arm_write_timeout(&self, transport: &dyn RpcTransport) {
+        let idle = *self.idle_timeout.lock().expect("idle_timeout poisoned");
         if let Err(e) = transport.set_write_timeout(idle) {
             log::debug!("RPC: failed to set serve-phase write timeout: {e:?}");
         }
@@ -1236,28 +1336,17 @@ impl RpcServer {
                             return;
                         }
                     };
-                // Handshake done: transition the admission deadline to the
-                // serve-phase deadline — `None` (default, unbounded idle) or
-                // the configured `set_idle_timeout` so a post-handshake
-                // silent peer is evicted instead of pinning its slot.
                 if incoming {
-                    // Attach + incoming (`server_accept` already
-                    // rejected new + incoming): resolve the session,
-                    // register a callback slot, and exit the worker.
-                    //
-                    // A callback slot is never served, so the serve-phase
-                    // idle deadline must NOT be armed on it: `SO_RCVTIMEO`
-                    // is sticky, and the server's own reply wait on this
-                    // slot (a callback issued outside any handler) would
-                    // otherwise be cut short by `set_idle_timeout`. Lift
-                    // the handshake deadline instead — only the session
-                    // reply deadline bounds sends on this slot.
+                    // Attach + incoming: resolve the session, register a
+                    // callback slot, exit the worker (never served here).
+                    // A callback slot has no serve loop — a sticky
+                    // `SO_RCVTIMEO` here would cut short this server's own
+                    // reply wait, so only the write half is armed (see
+                    // `set_idle_timeout` / `set_reply_timeout`).
                     if let Err(e) = transport.set_read_timeout(None) {
                         log::debug!("RPC: failed to clear callback-slot read timeout: {e:?}");
                     }
-                    if let Err(e) = transport.set_write_timeout(None) {
-                        log::debug!("RPC: failed to clear callback-slot write timeout: {e:?}");
-                    }
+                    server.arm_write_timeout(transport.as_ref());
                     // The slot lives in the pool for server→client
                     // sends; there is no read loop because
                     // client→server traffic only uses outgoing
@@ -1332,6 +1421,10 @@ impl RpcServer {
                     }
                     return;
                 }
+                // Handshake done: transition the admission deadline to the
+                // serve-phase deadline — `None` (default, unbounded idle) or
+                // the configured `set_idle_timeout` so a post-handshake
+                // silent peer is evicted instead of pinning its slot.
                 server.arm_serve_timeouts(transport.as_ref());
                 if client_id.is_empty() {
                     // New session: mint, register, serve. Registry
@@ -1353,6 +1446,13 @@ impl RpcServer {
                     let id = RpcSessionId::new(session.session_id());
                     server.register_session(id, &session.inner_arc());
                     server.configure_session(&session);
+                    // Baseline `arm_serve_timeouts` just armed on this
+                    // connection: a callback's reply deadline must be
+                    // *restored* to it, not cleared, or the first nested
+                    // callback silently disables idle eviction here.
+                    session.set_serve_read_deadline(
+                        *server.idle_timeout.lock().expect("idle_timeout poisoned"),
+                    );
                     if let Err(e) = session.serve_blocking() {
                         log::debug!("RPC session ended: {e:?}");
                     }
@@ -1467,8 +1567,8 @@ impl RpcServer {
             if self.shutdown.load(Ordering::SeqCst) {
                 break;
             }
-            // Admission bound (opt-in; `None` ⇒ skip entirely, prior
-            // behavior bit-identical). At capacity we simply don't
+            // Admission bound (opt-in; `None` ⇒ skip entirely, bit-
+            // identical to an unbounded server). At capacity we simply don't
             // accept this iteration: pending clients wait in the kernel
             // listen backlog (reactor-free backpressure, no client
             // dropped). `continue` re-checks `shutdown` every tick, so
@@ -1588,14 +1688,24 @@ impl RpcServer {
     ///
     /// `Drop` only flips the shutdown flag and removes the socket — it
     /// deliberately does **not** join in-flight session workers (they
-    /// drain on peer close). A worker that panicked is therefore only
-    /// observable through this call: for clean shutdown and worker
-    /// error/panic observability, call `join_workers` explicitly rather
-    /// than relying on `Drop`.
+    /// drain on peer close), so call `join_workers` explicitly rather
+    /// than relying on `Drop` for a clean shutdown.
+    ///
+    /// Panic observability is **best-effort**. Every accept and every
+    /// [`serve_connection`](RpcServer::serve_connection) reaps
+    /// already-finished handles out of `workers` — that is what bounds
+    /// the vector by *concurrent* rather than cumulative connections —
+    /// and reaping drops the `JoinHandle`, which detaches the thread;
+    /// `JoinHandle::is_finished` cannot tell a panicked worker from a
+    /// clean one. This call therefore warns for exactly the workers
+    /// still registered when it runs: a worker that panicked and was
+    /// then reaped by a later connection is not reported.
     pub fn join_workers(&self) {
         let handles: Vec<_> = std::mem::take(&mut *self.workers.lock().expect("workers poisoned"));
         for h in handles {
-            let _ = h.join();
+            if h.join().is_err() {
+                log::warn!("RPC: connection worker panicked");
+            }
         }
     }
 
@@ -1659,12 +1769,21 @@ impl Drop for RpcServer {
     /// reference indefinitely — the last external `Arc<RpcServer>`
     /// going out of scope does **not** trigger this `Drop` until the
     /// worker also releases its clone (peer close, kernel reset,
-    /// etc.). For deterministic teardown call
-    /// [`RpcServer::shutdown`] **and** [`RpcServer::join_workers`]
-    /// explicitly, or impose a `set_read_timeout` so a stalled peer
-    /// surfaces as a worker-loop error instead of an indefinite
-    /// hold. Closing socket-level paths so the kernel times out the
-    /// peer is also sufficient. (Using `Weak<Self>` plus periodic
+    /// etc.).
+    ///
+    /// [`RpcServer::shutdown`] does not help there: the flag it flips is
+    /// polled by the accept loop and read by the android-13+ attach arms
+    /// (which refuse a late attach), but a worker already blocked in
+    /// `recv` never reaches a gate that reads it. Nor does
+    /// [`RpcServer::join_workers`], which waits for exactly the workers
+    /// that are hung. What bounds a stalled peer is a deadline on its
+    /// own connection — [`set_handshake_timeout`](Self::set_handshake_timeout)
+    /// for a peer that stalls at first contact, and
+    /// [`set_idle_timeout`](Self::set_idle_timeout) for one that goes
+    /// silent afterwards (android-13+ serve path only; the default r34
+    /// profile clears its read deadline after the first frame and then
+    /// blocks unbounded) — or closing socket-level paths so the kernel
+    /// times the peer out. (Using `Weak<Self>` plus periodic
     /// upgrade-checks in worker hot paths would remove the hold
     /// entirely, at the cost of a larger refactor.)
     fn drop(&mut self) {

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -16,7 +16,7 @@
 use std::cell::RefCell;
 use std::os::fd::{AsFd, OwnedFd};
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
@@ -54,21 +54,24 @@ enum RpcUnixAddr<'a> {
 
 /// Unix-domain android-13+ RPC client configuration — the builder
 /// consumed by
-/// [`RpcSession::setup_unix_client_android13plus_with_config`] and
-/// [`RpcSession::add_outgoing_connection_android13plus_with_config`].
+/// [`RpcSession::setup_unix_client_android13plus_with_config`],
+/// [`RpcSession::add_outgoing_connection_android13plus_with_config`] and
+/// [`RpcSession::add_incoming_connection_android13plus_with_config`].
 ///
 /// One config expresses everything the per-shape convenience helpers
 /// (`setup_unix_client_android13plus{,_abstract,_with_id,_fan_out}`)
 /// take positionally: the address (filesystem path or Linux/Android
 /// abstract name), the highest wire version to offer, and the optional
-/// session-id attach / fan-out / fd-transport-mode knobs. The defaults
-/// (`session_id = empty`, `outgoing_connections = 1`, `fd_mode = None`)
-/// reproduce the plain single-connection
+/// session-id attach / fan-out / incoming-connection / fd-transport-mode
+/// knobs. The defaults (`session_id = empty`, `outgoing_connections = 1`,
+/// `incoming_connections = 0`, `fd_mode = None`) reproduce the plain
+/// single-connection
 /// [`RpcSession::setup_unix_client_android13plus`] byte-for-byte.
 ///
-/// `session_id` and `outgoing_connections > 1` are mutually exclusive
-/// (attaching joins an existing session; fan-out mints a new one) —
-/// the consuming setup call rejects the combination with `BadValue`.
+/// `session_id` is mutually exclusive with both `outgoing_connections > 1`
+/// and `incoming_connections > 0` (attaching joins a session someone else
+/// owns; growing the pool is the owner's business) — the consuming setup
+/// call rejects the combination with `BadValue`.
 pub struct RpcUnixClientConfig<'a> {
     addr: RpcUnixAddr<'a>,
     max_version: u32,
@@ -76,6 +79,8 @@ pub struct RpcUnixClientConfig<'a> {
     outgoing_connections: u32,
     incoming_connections: u32,
     fd_mode: Option<FileDescriptorTransportMode>,
+    timeout: Option<Duration>,
+    handshake_timeout: Option<Duration>,
 }
 
 impl<'a> RpcUnixClientConfig<'a> {
@@ -87,6 +92,8 @@ impl<'a> RpcUnixClientConfig<'a> {
             outgoing_connections: 1,
             incoming_connections: 0,
             fd_mode: None,
+            timeout: None,
+            handshake_timeout: None,
         }
     }
 
@@ -134,6 +141,23 @@ impl<'a> RpcUnixClientConfig<'a> {
     /// server's death as soon as the connection drops (obituaries fire
     /// from the serving thread), instead of on the next failed call.
     ///
+    /// That detection is **eager, not precise**: the loss of the last
+    /// incoming connection *is* this session's death, whatever the
+    /// cause. A server that retires only that connection — its
+    /// [`RpcServer::set_reply_timeout`](super::RpcServer::set_reply_timeout)
+    /// elapsing on a slow callback handler, or a callback send that
+    /// fails — therefore tears this whole session down: the founding
+    /// connection is closed too, every proxy gets `binder_died`, and
+    /// every local object the peer held is released, even though the
+    /// peer is still up. Nothing on the wire separates the two cases.
+    /// Size the server's reply timeout against the slowest legitimate
+    /// handler, or open no incoming connection and let a failed call
+    /// declare the death instead. (AOSP has no "lost only its callback
+    /// connections" state to be faithful to: its client-side
+    /// `WaitForShutdownListener::onSessionAllIncomingThreadsEnded` is a
+    /// no-op, and an incoming thread that exits without a session
+    /// shutdown aborts the process.)
+    ///
     /// Requires the android-13+ profile (a session id), so it cannot be
     /// combined with [`session_id`](Self::session_id) (attaching to a
     /// session you do not own). Bounded on the server by twice its
@@ -150,6 +174,33 @@ impl<'a> RpcUnixClientConfig<'a> {
     /// `setFileDescriptorTransportMode`). Default is no fd support.
     pub fn fd_mode(mut self, mode: FileDescriptorTransportMode) -> Self {
         self.fd_mode = Some(mode);
+        self
+    }
+
+    /// Apply [`RpcSession::set_timeout`] to the founding session **as
+    /// soon as it exists**, so the deadline also bounds the round trips
+    /// this setup itself performs (`GET_MAX_THREADS` for a fan-out,
+    /// `GET_SESSION_ID` for any additional connection). Setting the
+    /// timeout on the returned session instead leaves those unbounded: a
+    /// peer that completes the handshake and then answers neither would
+    /// block the caller forever. Default `None` (no deadline).
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    /// Deadline for each **connection handshake** this config performs —
+    /// the founding connect and every fan-out / incoming attach.
+    /// Unset (the default) blocks forever, so a peer that accepts the
+    /// socket and then writes nothing hangs the setup call.
+    ///
+    /// Distinct from [`timeout`](Self::timeout), which is the session's
+    /// *reply* deadline and cannot cover this phase: it is applied to the
+    /// session, and the handshake runs before the session exists. This is
+    /// the client-side counterpart of
+    /// [`RpcServer::set_handshake_timeout`](super::RpcServer::set_handshake_timeout).
+    pub fn handshake_timeout(mut self, timeout: Duration) -> Self {
+        self.handshake_timeout = Some(timeout);
         self
     }
 
@@ -250,11 +301,11 @@ impl WireProfile {
 ///
 /// rsbinder's `&str` serializer is already byte-identical to AOSP
 /// `writeString16` (`[i32 char16_count][UTF-16 LE][u16 0][pad 4]`), so
-/// this is now wire-correct against a real libbinder RPC peer for
-/// **every** profile (r34 / android-13 v0 / v1 / android-16 v2). The
-/// prior 3-int header was an rsbinder-ism that only ever round-tripped
-/// hermetically (rsbinder↔rsbinder, symmetric) — now resolved. RPC
-/// never touches `thread_state`.
+/// this is wire-correct against a real libbinder RPC peer for
+/// **every** profile (r34 / android-13 v0 / v1 / android-16 v2). A
+/// 3-int header here would be an rsbinder-ism that only round-trips
+/// hermetically (rsbinder↔rsbinder, symmetric). RPC never touches
+/// `thread_state`.
 pub(crate) fn write_rpc_interface_token(p: &mut Parcel, descriptor: &str) -> Result<()> {
     p.write(&descriptor)?;
     Ok(())
@@ -354,34 +405,104 @@ fn gen_rpc_session_id() -> RpcResult<RpcSessionId> {
     Ok(RpcSessionId::new(id))
 }
 
-/// RAII clear for the `client_transact` reply read-deadline.
+/// Normalize a caller-supplied wait deadline: `Some(Duration::ZERO)` is
+/// rejected (logged as `msg`) and becomes `None`.
+///
+/// A zero deadline cannot be honored — `set_read_timeout` documents an
+/// error for it — and an armed-then-failed deadline is a *post-send*
+/// failure that has to retire the connection (see
+/// [`ReplyDeadlineGuard`]). Refusing it at the setter keeps a mistaken
+/// zero from turning every transaction on the session into a hard error.
+pub(super) fn reject_zero_deadline(timeout: Option<Duration>, msg: &str) -> Option<Duration> {
+    match timeout {
+        Some(d) if d.is_zero() => {
+            log::error!("{msg}");
+            None
+        }
+        other => other,
+    }
+}
+
+/// RAII save-and-restore for the `client_transact` reply read-deadline.
 ///
 /// `set_read_timeout(Some(d))` sets a sticky `SO_RCVTIMEO` on the
-/// shared connection. This guard clears it on **every** exit from the
-/// reply wait — normal return, `?`-propagation, or panic — so the
-/// deadline can never leak onto the next `client_transact`, a nested
-/// inbound dispatch, or a subsequent server-side `recv` on the same
-/// connection.
+/// shared connection. This guard restores the slot's **baseline** read
+/// deadline on **every** exit from the reply wait — normal return,
+/// `?`-propagation, or panic — so the reply deadline can never leak onto
+/// the next `client_transact`, a nested inbound dispatch, or a
+/// subsequent server-side `recv` on the same connection.
+///
+/// Restoring the baseline rather than clearing to `None` is what keeps a
+/// callback issued from inside a handler — which reuses the serve
+/// connection via the `DRIVING` pin — from permanently disabling that
+/// connection's idle read deadline (the serve loop arms it once, not per
+/// frame). See [`SharedSession::serve_read_deadline`].
 struct ReplyDeadlineGuard<'a> {
     transport: &'a dyn RpcTransport,
     armed: bool,
+    restore: Option<Duration>,
 }
 
 impl<'a> ReplyDeadlineGuard<'a> {
-    fn arm(transport: &'a dyn RpcTransport, deadline: Option<Duration>) -> RpcResult<Self> {
+    fn arm(
+        transport: &'a dyn RpcTransport,
+        deadline: Option<Duration>,
+        restore: Option<Duration>,
+    ) -> RpcResult<Self> {
         let armed = deadline.is_some();
         if let Some(d) = deadline {
             transport.set_read_timeout(Some(d))?;
         }
-        Ok(Self { transport, armed })
+        Ok(Self {
+            transport,
+            armed,
+            restore,
+        })
     }
 }
 
 impl Drop for ReplyDeadlineGuard<'_> {
     fn drop(&mut self) {
         if self.armed {
-            // Best-effort: a failure to clear cannot be surfaced from
+            // Best-effort: a failure to restore cannot be surfaced from
             // Drop, and the next caller re-arms/clears explicitly anyway.
+            let _ = self.transport.set_read_timeout(self.restore);
+        }
+    }
+}
+
+/// Read deadline for a connect/attach **handshake**, cleared when the
+/// handshake ends.
+///
+/// The handshake runs before any session exists, so
+/// [`RpcSession::set_timeout`] cannot bound it — without this a peer that
+/// accepts the socket and then writes nothing blocks the caller forever.
+///
+/// Clearing on drop is not optional. [`ReplyDeadlineGuard`] restores only a
+/// deadline it armed itself, and it arms nothing when the session deadline
+/// is `None` (the default), so a handshake deadline left on the socket
+/// would silently bound every later `recv` on that slot — and on a client's
+/// incoming (callback) slot it would break the serve loop outright.
+struct HandshakeDeadline<'a> {
+    transport: &'a dyn RpcTransport,
+    armed: bool,
+}
+
+impl<'a> HandshakeDeadline<'a> {
+    fn arm(transport: &'a dyn RpcTransport, deadline: Option<Duration>) -> RpcResult<Self> {
+        let armed = deadline.is_some();
+        if armed {
+            transport.set_read_timeout(deadline)?;
+        }
+        Ok(Self { transport, armed })
+    }
+}
+
+impl Drop for HandshakeDeadline<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            // Best-effort: a failure cannot be surfaced from `Drop`, and
+            // the slot's next reader arms or clears explicitly.
             let _ = self.transport.set_read_timeout(None);
         }
     }
@@ -468,8 +589,10 @@ thread_local! {
 /// its peer reads it only inside its own reply wait, so a transaction
 /// written there from outside a dispatch would sit unread — and the
 /// worker would be locked out of its own slot for the duration. A
-/// nested call (the `DRIVING` reentrant pin) re-enters whichever slot
-/// the thread already drives, whatever its role.
+/// nested call (the `DRIVING` reentrant pin) re-enters an `Outgoing`
+/// slot unconditionally, but an `Incoming` one only while its dispatch
+/// grants it ([`ConnSlot::allow_nested`]) — a nested call from a
+/// *oneway* handler falls through to an `Outgoing` slot instead.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum SlotRole {
     /// This endpoint serves the connection (AOSP `mIncoming`): the
@@ -480,6 +603,45 @@ enum SlotRole {
     /// client's founding slot and its fan-out, and the callback slots
     /// a server accepted from a client's incoming attaches.
     Outgoing,
+}
+
+/// What an outbound frame needs from a connection slot — AOSP
+/// `RpcSession::ConnectionUse`. Decides whether the [`DRIVING`]
+/// reentrant pin may be reused when the pinned slot is serve-driven.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ConnUse {
+    /// AOSP `ConnectionUse::CLIENT` — a transaction (twoway or oneway).
+    /// May reuse a serve-driven slot only while that slot's
+    /// [`ConnSlot::allow_nested`] holds; otherwise it needs an
+    /// `Outgoing` slot, since nothing would read the frame.
+    Client,
+    /// AOSP `ConnectionUse::CLIENT_REFCOUNT` — a reply-less
+    /// `DEC_STRONG`. Always free to ride the *pinned* slot ("we currently
+    /// allow ref count calls to be nested (so that you can use this
+    /// without having extra threads)") — that connection is one this
+    /// thread already drives, so the peer is in its reply wait and reads
+    /// it. The **scan** is `Outgoing`-only, exactly as for
+    /// [`Client`](Self::Client): AOSP looks `mIncoming` up with
+    /// `available = nullptr`, so a free serve-driven connection is never
+    /// picked there, and writing to one can block rather than merely
+    /// delay the frame.
+    ClientRefcount,
+    /// The reply to a transaction this thread is dispatching. It owes
+    /// its answer to the slot the request arrived on and to no other,
+    /// so it always takes the pin — AOSP replies on the
+    /// `RpcConnection` object it is serving, never through
+    /// `ExclusiveConnection::find` at all.
+    Reply,
+}
+
+impl ConnUse {
+    /// Whether this use opens a *new* exchange with the peer, and so is
+    /// bound by the `Outgoing` / [`ConnSlot::allow_nested`] rules. A
+    /// reply continues an exchange the peer is already waiting on; a
+    /// `DEC_STRONG` opens none.
+    fn is_new_transaction(self) -> bool {
+        matches!(self, ConnUse::Client)
+    }
 }
 
 /// AOSP `RpcConnection::exclusiveTid` equivalent — `std::thread::
@@ -518,6 +680,14 @@ struct ConnSlot {
     /// `setMaxIncomingThreads` caps only `Incoming` slots; the
     /// callback-slot cap counts only `Outgoing` ones.
     role: SlotRole,
+    /// AOSP `RpcConnection::allowNested`. `true` only while a **twoway**
+    /// inbound transaction dispatched on this slot runs its handler:
+    /// the peer is then parked in its own reply wait on this socket, so
+    /// it will read whatever the handler writes back. `false` during a
+    /// oneway dispatch (the peer sent and moved on — nothing reads this
+    /// slot) and whenever no dispatch is running. See
+    /// [`AllowNestedGuard`] and [`ConnUse`].
+    allow_nested: bool,
     /// Replies still owed to this slot by nested client calls that gave up
     /// waiting (`set_timeout`); the next that many `REPLY`s are skipped
     /// instead of being taken for unsolicited ones (see
@@ -608,6 +778,61 @@ impl Drop for ConnGuard<'_> {
     }
 }
 
+/// AOSP `RpcState::processTransactInternal`'s `connection.allowNested =
+/// !oneway` window, as RAII.
+///
+/// While a **twoway** inbound transaction's handler runs, the slot it
+/// arrived on may carry a same-thread nested call: the peer is parked in
+/// its reply wait on that socket and will read what the handler writes.
+/// A **oneway** dispatch grants nothing — the peer sent and moved on, so
+/// a nested transaction written there would sit unread until something
+/// else happens to read the slot (a twoway reply wait), i.e. forever for
+/// a client's incoming (callback) connection. [`ConnUse::Client`] then
+/// declines the pin and takes an `Outgoing` slot instead.
+///
+/// Save-and-restore (not set-and-clear) so a oneway dispatched *inside*
+/// a twoway handler's nested reply wait restores the outer frame's
+/// grant — AOSP's `origAllowNested`.
+struct AllowNestedGuard<'a> {
+    inner: &'a RpcSessionInner,
+    slot_id: u64,
+    prev: bool,
+}
+
+impl<'a> AllowNestedGuard<'a> {
+    /// Arm on the slot this thread currently drives for `inner` (the
+    /// [`DRIVING`] top-of-stack). `None` — nothing to restore — only when
+    /// the pinned slot was already retired
+    /// ([`remove_slot`](RpcSessionInner::remove_slot) racing a dispatch);
+    /// every `dispatch_transact` caller holds a pin.
+    fn arm(inner: &'a RpcSessionInner, allow: bool) -> Option<Self> {
+        let sess_ptr = inner as *const RpcSessionInner as usize;
+        let slot_id = DRIVING.with(|d| {
+            d.borrow()
+                .iter()
+                .rev()
+                .find_map(|&(sp, sid)| if sp == sess_ptr { Some(sid) } else { None })
+        })?;
+        let mut st = inner.conn_state.lock().expect("conn_state poisoned");
+        let slot = st.slots.iter_mut().find(|s| s.id == slot_id)?;
+        let prev = std::mem::replace(&mut slot.allow_nested, allow);
+        Some(Self {
+            inner,
+            slot_id,
+            prev,
+        })
+    }
+}
+
+impl Drop for AllowNestedGuard<'_> {
+    fn drop(&mut self) {
+        let mut st = self.inner.conn_state.lock().expect("conn_state poisoned");
+        if let Some(s) = st.slots.iter_mut().find(|s| s.id == self.slot_id) {
+            s.allow_nested = self.prev;
+        }
+    }
+}
+
 /// The state shared by *all connections of
 /// one logical session* (AOSP `RpcSession` shares this across its
 /// `mOutgoing`/`mIncoming` connections). One per session, behind `Arc`;
@@ -630,6 +855,15 @@ pub(crate) struct SharedSession {
     negotiated: AtomicU32,
     /// Optional reply/handshake wait deadline.
     timeout: Mutex<Option<Duration>>,
+    /// Baseline read deadline a **serve-driven** ([`SlotRole::Incoming`])
+    /// slot of this session must be returned to once a temporarily armed
+    /// reply deadline is lifted — the server's
+    /// [`set_idle_timeout`](super::RpcServer::set_idle_timeout), recorded
+    /// by `configure_session`. Without it, a nested callback issued from a
+    /// handler would clear the serve connection's `SO_RCVTIMEO` for good
+    /// and silently disable idle eviction on it. `None` (client sessions,
+    /// and servers that set no idle timeout) ⇒ byte-identical to clearing.
+    serve_read_deadline: Mutex<Option<Duration>>,
     /// Negotiated FD-over-RPC mode. Default `None` ⇒ the
     /// categorical reject path, and `send/recv` use the unchanged
     /// framed calls (bit-identical).
@@ -661,9 +895,8 @@ pub(crate) struct SharedSession {
     /// [`is_torn_down()`](super::lifecycle::SessionLifecycle::is_torn_down)
     /// `== true` *before* the obituary completes, so `RpcProxy::drop`
     /// best-effort reapers skip immediately instead of blocking on an
-    /// empty slot pool — a strict improvement over the prior
-    /// `obituary_sent.load()` (which only flipped after the callback
-    /// returned).
+    /// empty slot pool — unlike an `obituary_sent`-style flag, which
+    /// would only flip after the callback returned.
     lifecycle: SessionLifecycle,
     /// Which side of the connection this session is: decides the
     /// founding slot's [`SlotRole`] and the client-vs-server teardown
@@ -756,6 +989,19 @@ pub(crate) struct RpcSessionInner {
     /// Threads serving this client's incoming (callback) connections,
     /// keyed by slot id. Joined by [`RpcSession::shutdown`].
     incoming_threads: Mutex<Vec<(u64, std::thread::JoinHandle<()>)>>,
+    /// How many of those threads are still running. Bumped before the
+    /// spawn and dropped by the thread itself as its very last act.
+    /// Tells "the thread finished" apart from "we stopped tracking it" —
+    /// `incoming_threads` is `mem::take`n before the first `join()`, so
+    /// its length is zero either way.
+    incoming_live: AtomicUsize,
+    /// How many of those threads [`RpcSession::shutdown`] has actually
+    /// `join()`ed. `incoming_live` cannot stand in for this: the serve
+    /// threads are woken by the transport shutdown that `shutdown`
+    /// performs first, so they usually finish on their own while it is
+    /// still tearing the session down, and the count would read zero
+    /// even if every handle were dropped instead of joined.
+    incoming_joined: AtomicUsize,
 }
 
 /// The `RpcParcelOps` implementation bound to one session.
@@ -784,8 +1030,14 @@ impl RpcSessionInner {
     ///     nested call **re-enters that slot** (a server
     ///     handler's outbound callback returns on the inbound socket;
     ///     a same-thread recursive `client_transact` reuses the outer
-    ///     slot). No `conn_state` lock — the outer frame holds the
-    ///     slot.
+    ///     slot). A serve-driven ([`SlotRole::Incoming`]) pin is
+    ///     re-entered only while its dispatch grants it
+    ///     ([`ConnSlot::allow_nested`] — AOSP
+    ///     `exclusiveIncoming->allowNested`): a oneway dispatch leaves
+    ///     nobody reading that socket, so the pin is **declined** and
+    ///     the scan below applies. [`ConnUse::ClientRefcount`] ignores
+    ///     the grant (a `DEC_STRONG` awaits no reply) — this is the only
+    ///     place the two uses differ.
     ///  2. **Exclusive** — a slot whose `exclusive_tid == this tid`
     ///     (defensive: should be covered by 1).
     ///  3. **First available `Outgoing` slot** — the first slot with
@@ -800,10 +1052,9 @@ impl RpcSessionInner {
     ///   "Session has no outgoing connections"). This is a server
     ///   calling a client proxy outside any handler while the client
     ///   opened no incoming connection; waiting would never end,
-    ///   since only a peer attach can add an `Outgoing` slot.
-    ///   `send_dec_strong` uses the lenient variant instead (AOSP
-    ///   `CLIENT_REFCOUNT` — a `DEC_STRONG` carries no reply, so it
-    ///   may ride a momentarily free serve-driven slot).
+    ///   since only a peer attach can add an `Outgoing` slot. A
+    ///   `DEC_STRONG` ([`ConnUse::ClientRefcount`]) reaches the same arm
+    ///   and is simply skipped — see [`find_conn_lenient`].
     ///  4. **Pool exhausted** — `wait` on `slot_cv` (released on slot
     ///     drop OR `add_*_slot`). **Block-and-wait, never busy
     ///     try-loop**. Each wakeup (and the first park) rechecks the
@@ -825,72 +1076,105 @@ impl RpcSessionInner {
     /// receive-side priority replay (see [`super::state`]), not by
     /// pinning oneway sends to a fixed slot.
     fn find_conn(&self) -> Result<ConnGuard<'_>> {
-        self.find_conn_impl(true)
+        self.find_conn_impl(ConnUse::Client)
     }
 
-    /// [`find_conn`] for reply-less `DEC_STRONG` sends: any free slot
-    /// qualifies (`Outgoing` preferred) and there is no step 3b. Without
-    /// this a server dropping a client proxy outside a handler, on a
-    /// session with no callback slot, could never release the peer's
-    /// node before session end.
+    /// [`find_conn`] for reply-less `DEC_STRONG` sends. It differs from
+    /// [`find_conn`] only on the **reentrant pin**, which it may re-enter
+    /// without the dispatch's [`ConnSlot::allow_nested`] grant (AOSP
+    /// `CLIENT_REFCOUNT`: "we currently allow ref count calls to be
+    /// nested"). The *scan* is identical — `Outgoing` only.
+    ///
+    /// So a server that drops a client proxy outside a handler, on a
+    /// session where the client opened no incoming connection, does not
+    /// release the peer's node until session end. That is the documented
+    /// best-effort contract, and the alternative is worse: a serve-driven
+    /// slot is read by its peer only inside that peer's own reply wait,
+    /// so writing there is not a delayed frame but a send that blocks
+    /// once the socket buffer fills — with the slot's `exclusive_tid`
+    /// held, which locks its serve loop out of its own connection.
+    /// A client that wants prompt release opens an incoming connection
+    /// ([`RpcUnixClientConfig::incoming_connections`], plan 2-20).
     fn find_conn_lenient(&self) -> Result<ConnGuard<'_>> {
-        self.find_conn_impl(false)
+        self.find_conn_impl(ConnUse::ClientRefcount)
     }
 
-    fn find_conn_impl(&self, outgoing_only: bool) -> Result<ConnGuard<'_>> {
+    /// Shared body of [`find_conn`](Self::find_conn) /
+    /// [`find_conn_lenient`](Self::find_conn_lenient) — see the former
+    /// for the selection order.
+    ///
+    /// The scan's `free` predicate matches `exclusive_tid == Some(tid)`
+    /// only when this thread holds **no** pin: reaching the scan with a
+    /// `pinned` slot means step 1 *declined* it, so this thread still owns
+    /// that slot's `exclusive_tid`. Matching it would hand the slot back
+    /// as non-reentrant, and the new guard's drop would release an
+    /// `exclusive_tid` the outer frame still holds.
+    fn find_conn_impl(&self, use_: ConnUse) -> Result<ConnGuard<'_>> {
+        // The scan below is `Outgoing`-only for **every** use, matching
+        // AOSP `ExclusiveConnection::find`, which looks `mIncoming` up with
+        // `available = nullptr`: only a connection this thread already
+        // holds can match there, never a free one. `ClientRefcount` still
+        // differs from `Client`, but only on the *reentrant* pin above.
+        let refcount = use_ == ConnUse::ClientRefcount;
         let mut wait_until: Option<Instant> = None;
         let tid = current_tid();
         let sess_ptr = self as *const RpcSessionInner as usize;
         // (1) Reentrant: a slot of this session is already driven by
-        //     this thread (innermost first — `rposition`).
-        if let Some(slot_id) = DRIVING.with(|d| {
+        //     this thread (innermost first — `rposition`). A
+        //     serve-driven slot qualifies only while its dispatch
+        //     grants it (`allow_nested`, AOSP's `exclusiveIncoming->
+        //     allowNested`); otherwise the pin is declined and the scan
+        //     below looks for an `Outgoing` slot instead.
+        let pinned = DRIVING.with(|d| {
             d.borrow()
                 .iter()
                 .rev()
                 .find_map(|&(sp, sid)| if sp == sess_ptr { Some(sid) } else { None })
-        }) {
-            let transport = {
+        });
+        if let Some(slot_id) = pinned {
+            let reusable = {
                 let st = self.conn_state.lock().expect("conn_state poisoned");
                 match st.slots.iter().find(|s| s.id == slot_id) {
-                    Some(s) => Arc::clone(&s.transport),
                     // The slot this thread was driving was retired
                     // (`remove_slot` on a worker exit) between the `DRIVING`
                     // push and this reentrant lookup. Surface a typed dead
                     // error rather than panicking on the driver loop.
                     None => return Err(StatusCode::DeadObject),
+                    Some(s)
+                        if s.role == SlotRole::Outgoing
+                            || s.allow_nested
+                            || !use_.is_new_transaction() =>
+                    {
+                        Some(Arc::clone(&s.transport))
+                    }
+                    Some(_) => None,
                 }
             };
-            return Ok(ConnGuard {
-                inner: self,
-                slot_id,
-                transport,
-                reentrant: true,
-            });
+            if let Some(transport) = reusable {
+                return Ok(ConnGuard {
+                    inner: self,
+                    slot_id,
+                    transport,
+                    reentrant: true,
+                });
+            }
         }
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
         loop {
-            // Torn-down/drained recheck (mirrors `find_conn_for_reaper`):
-            // a concurrent peer-close can drain the last slot, and
-            // `add_*_slot` can never refill a dead session, so re-`wait`
-            // would park forever. Surface a typed dead-pool error instead.
+            // Torn-down/drained recheck — re-`wait` on a dead pool would
+            // park forever (mirrors `find_conn_for_reaper`).
             if self.shared.lifecycle.is_torn_down() || st.slots.is_empty() {
                 return Err(StatusCode::DeadObject);
             }
-            // (2) Defensive exclusive match (shouldn't fire if (1) is correct).
-            // (3) First available — `Outgoing` first; any free slot only
-            //     on the lenient (`DEC_STRONG`) path.
-            let free = |s: &ConnSlot| s.exclusive_tid == Some(tid) || s.exclusive_tid.is_none();
+            // (2)/(3) First available — `Outgoing` first; `pinned.is_none()`
+            // guards the self-match (see this fn's rustdoc).
+            let free = |s: &ConnSlot| {
+                s.exclusive_tid.is_none() || (pinned.is_none() && s.exclusive_tid == Some(tid))
+            };
             let pick = st
                 .slots
                 .iter()
-                .position(|s| free(s) && s.role == SlotRole::Outgoing)
-                .or_else(|| {
-                    if outgoing_only {
-                        None
-                    } else {
-                        st.slots.iter().position(free)
-                    }
-                });
+                .position(|s| free(s) && s.role == SlotRole::Outgoing);
             if let Some(idx) = pick {
                 let s = &mut st.slots[idx];
                 s.exclusive_tid = Some(tid);
@@ -906,13 +1190,47 @@ impl RpcSessionInner {
             }
             // (3b) Nothing to wait for: no `Outgoing` slot exists, and only a
             //      peer attach can create one. AOSP `WOULD_BLOCK`.
-            if outgoing_only && !st.slots.iter().any(|s| s.role == SlotRole::Outgoing) {
-                log::error!(
-                    "RPC: session has no outgoing connection — a non-nested call (from \
-                     another thread, or a oneway outside a handler) needs the peer to open \
-                     incoming connections (RpcUnixClientConfig::incoming_connections / \
-                     ARpcSession_setMaxIncomingThreads); refusing instead of waiting forever"
-                );
+            if !st.slots.iter().any(|s| s.role == SlotRole::Outgoing) {
+                if refcount {
+                    // Best-effort by contract, so this is a skip, not an
+                    // error: the peer's node is released at session end
+                    // instead. Riding a serve-driven slot would write to a
+                    // socket the peer reads only inside its own reply wait,
+                    // so a filled buffer would block the send and lock that
+                    // slot's serve loop out of its own connection.
+                    log::debug!(
+                        "RPC: no outgoing connection for a DEC_STRONG; skipping (the node is \
+                         released at session end, or promptly once the peer opens an incoming \
+                         connection)"
+                    );
+                } else if self.shared.space() == AddressSpace::Initiator {
+                    // Not "the peer must open incoming connections": the
+                    // incoming ones may well be up — what is gone is this
+                    // endpoint's own send capability.
+                    log::error!(
+                        "RPC: this client has lost every outgoing connection (a reply \
+                         deadline or a desynced reply retires the slot it rode); the \
+                         surviving callback connections are server→client only, so \
+                         nothing would read a request written on them"
+                    );
+                } else if self.profile.wire_version().is_none() {
+                    // The r34 profile has no attach mechanism at all, so no
+                    // advice about incoming connections applies there.
+                    log::error!(
+                        "RPC: r34 session has no outgoing connection — this endpoint \
+                         accepted the connection, and the r34 profile cannot open or \
+                         attach one. Only a nested call (from inside a twoway handler) \
+                         can transact here; use `?profile=android13plus` for callbacks \
+                         outside a handler"
+                    );
+                } else {
+                    log::error!(
+                        "RPC: session has no outgoing connection — a non-nested call (from \
+                         another thread, or a oneway outside a handler) needs the peer to open \
+                         incoming connections (RpcUnixClientConfig::incoming_connections / \
+                         ARpcSession_setMaxIncomingThreads); refusing instead of waiting forever"
+                    );
+                }
                 return Err(StatusCode::FailedTransaction);
             }
             // (4) Pool exhausted — wait, bounded by the session deadline: a serve-pinned slot is released only by the peer.
@@ -978,14 +1296,18 @@ impl RpcSessionInner {
                 reentrant: true,
             });
         }
-        // (3) First available — only a truly free slot, `Outgoing` first
-        //     (a `DEC_STRONG` may ride a free serve-driven slot: no reply).
+        // (3) First available — only a truly free `Outgoing` slot. A
+        //     serve-driven one is never taken from the scan (AOSP looks
+        //     `mIncoming` up with `available = nullptr`): the peer reads it
+        //     only inside its own reply wait, so an unread frame is not
+        //     merely delayed — once the socket buffer fills, the send
+        //     blocks and this slot's serve loop is locked out of it.
+        //     `None` here just defers to the reaper, then to session end.
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
         let idx = st
             .slots
             .iter()
-            .position(|s| s.exclusive_tid.is_none() && s.role == SlotRole::Outgoing)
-            .or_else(|| st.slots.iter().position(|s| s.exclusive_tid.is_none()))?;
+            .position(|s| s.exclusive_tid.is_none() && s.role == SlotRole::Outgoing)?;
         let s = &mut st.slots[idx];
         s.exclusive_tid = Some(tid);
         let slot_id = s.id;
@@ -1023,11 +1345,15 @@ impl RpcSessionInner {
                 return None;
             }
             let free = |s: &ConnSlot| s.exclusive_tid == Some(tid) || s.exclusive_tid.is_none();
+            // `Outgoing` only, like every other scan. A serve-driven slot is
+            // never taken here: the peer reads it only inside its own reply
+            // wait, so a filled buffer would block this send while the
+            // reaper holds the slot's `exclusive_tid` — starving that
+            // slot's serve loop.
             let pick = st
                 .slots
                 .iter()
-                .position(|s| free(s) && s.role == SlotRole::Outgoing)
-                .or_else(|| st.slots.iter().position(free));
+                .position(|s| free(s) && s.role == SlotRole::Outgoing);
             if let Some(idx) = pick {
                 let s = &mut st.slots[idx];
                 s.exclusive_tid = Some(tid);
@@ -1040,6 +1366,13 @@ impl RpcSessionInner {
                     transport,
                     reentrant: false,
                 });
+            }
+            // Nothing to wait for — only a peer attach could create an
+            // `Outgoing` slot, and parking here would hold the session's
+            // strong `Arc` (the leak this function's doc guards against).
+            // Skipping is the documented best-effort contract.
+            if !st.slots.iter().any(|s| s.role == SlotRole::Outgoing) {
+                return None;
             }
             st = self.slot_cv.wait(st).expect("slot_cv poisoned");
         }
@@ -1166,13 +1499,27 @@ impl RpcSessionInner {
     /// actually for. The thundering-herd cost is bounded by waiter
     /// count and is zero on the default single-slot path (no waiters
     /// at all), so the trade favors mixed-waiter correctness.
-    fn add_slot_inner(&self, transport: Box<dyn RpcTransport>, role: SlotRole) -> u64 {
+    ///
+    /// `None` for a torn-down session. That gate sits in the *same*
+    /// critical section as the push (like
+    /// [`add_slot_inner_capped`](Self::add_slot_inner_capped)): an
+    /// attach's own pre-check is a snapshot taken before a connect +
+    /// handshake round trip, and `on_session_dead` empties the pool under
+    /// this very lock. A slot pushed after that is never shut down by the
+    /// death sequence, so a serve loop on it blocks in `recv` forever,
+    /// pinning the whole session graph.
+    fn add_slot_inner(&self, transport: Box<dyn RpcTransport>, role: SlotRole) -> Option<u64> {
         // `Arc::from(Box<dyn T>)` is the stable std conversion that
         // re-takes the heap allocation under an `Arc` without copying
         // (impl<T: ?Sized> From<Box<T>> for Arc<T>). The slot holds
         // the canonical `Arc`; `ConnGuard`s hand out cheap clones.
         let transport: Arc<dyn RpcTransport> = Arc::from(transport);
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
+        // Anti-resurrection gate — must share the push's critical section
+        // (see this fn's rustdoc).
+        if self.shared.lifecycle.is_torn_down() {
+            return None;
+        }
         let id = st.next_slot_id;
         st.next_slot_id += 1;
         st.slots.push(ConnSlot {
@@ -1180,11 +1527,12 @@ impl RpcSessionInner {
             exclusive_tid: None,
             id,
             role,
+            allow_nested: false,
             stale_replies: 0,
         });
         drop(st);
         self.slot_cv.notify_all();
-        id
+        Some(id)
     }
 
     /// Server attach: add a serve-driven slot, enforcing the
@@ -1220,6 +1568,7 @@ impl RpcSessionInner {
             exclusive_tid: None,
             id,
             role: SlotRole::Incoming,
+            allow_nested: false,
             stale_replies: 0,
         });
         drop(st);
@@ -1231,7 +1580,8 @@ impl RpcSessionInner {
     /// connection slot (no `live_conns` bump — client outgoing slots
     /// are not serve-driven). See
     /// [`RpcSession::add_outgoing_connection_android13plus`].
-    fn add_outgoing_slot(&self, transport: Box<dyn RpcTransport>) -> u64 {
+    /// `None` for a torn-down session.
+    fn add_outgoing_slot(&self, transport: Box<dyn RpcTransport>) -> Option<u64> {
         self.add_slot_inner(transport, SlotRole::Outgoing)
     }
 
@@ -1250,6 +1600,14 @@ impl RpcSessionInner {
     /// `claimed`: push the slot already driven by the calling thread
     /// (`exclusive_tid = current`), so the caller can finish a wire
     /// exchange on it before anyone else may pick it.
+    ///
+    /// The torn-down gate shares that critical section for the same
+    /// reason: a gate read outside this lock is a snapshot, and
+    /// `on_session_dead` empties the pool under this very lock — but only
+    /// *after* firing obituaries and running user `Drop` code, a wide
+    /// window in which a lock-free pre-check would still read `Live` and
+    /// push a slot onto a session that is already dying. The caller then
+    /// confirms the attach to the peer — a promise nothing can keep.
     fn add_slot_inner_capped(
         &self,
         transport: Box<dyn RpcTransport>,
@@ -1257,6 +1615,11 @@ impl RpcSessionInner {
         claimed: bool,
     ) -> Option<u64> {
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
+        // Anti-resurrection gate — same critical section as the cap check,
+        // for the same reason (see this fn's rustdoc).
+        if self.shared.lifecycle.is_torn_down() {
+            return None;
+        }
         if st
             .slots
             .iter()
@@ -1274,6 +1637,7 @@ impl RpcSessionInner {
             exclusive_tid: if claimed { Some(current_tid()) } else { None },
             id,
             role: SlotRole::Outgoing,
+            allow_nested: false,
             stale_replies: 0,
         });
         drop(st);
@@ -1307,16 +1671,20 @@ impl RpcSessionInner {
         }
     }
 
-    /// Remove a slot from the pool. Three legitimate callers: the slot's
-    /// *own* worker on its `serve_blocking_on` exit (self-remove), and
+    /// Remove a slot from the pool. Five legitimate callers: the slot's
+    /// *own* worker on its `serve_blocking_on` exit (self-remove),
     /// `client_transact`'s two poison paths (a non-reentrant slot whose
     /// send failed at the transport, or whose reply read desynced the
-    /// stream). After a poison, the slot's worker finds its slot gone and
+    /// stream), and the two attach rollbacks — an incoming connection
+    /// whose serve thread failed to spawn, and a callback slot whose
+    /// `"cci"` never reached the peer. After a poison, the slot's worker
+    /// finds its slot gone and
     /// gets `DeadObject` from `find_conn_pinned` — an expected exit
     /// signal, not a structural bug. `notify_all` so any `find_conn`
     /// (any-available) waiter re-evaluates against the shrunk pool.
     ///
-    /// **Not a pure pool mutation:** emptying the pool runs the full
+    /// **Not a pure pool mutation:** emptying the pool — or, on an
+    /// initiator, retiring its last `Outgoing` slot — runs the full
     /// death sequence ([`on_session_dead`](Self::on_session_dead)), which
     /// fires obituaries and drops the peer's local objects — i.e. it can
     /// re-enter user `Drop` code. Callers must hold no session lock.
@@ -1324,11 +1692,20 @@ impl RpcSessionInner {
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
         st.slots.retain(|s| s.id != slot_id);
         let empty = st.slots.is_empty();
+        // An initiator that lost every `Outgoing` slot can never transact
+        // again (`find_conn_impl`'s (3b) arm refuses, and only a peer
+        // attach creates one), so its surviving incoming (callback) slots
+        // must not swallow the death declaration by keeping the pool
+        // non-empty. An acceptor legitimately has no `Outgoing` slot until
+        // a client attaches one, so this applies to initiators only.
+        let no_outgoing = !empty
+            && self.shared.space() == AddressSpace::Initiator
+            && !st.slots.iter().any(|s| s.role == SlotRole::Outgoing);
         drop(st);
         self.slot_cv.notify_all();
         // Pool empty ⇒ no connection left; a serve-less client reaches
         // death only here.
-        if empty && self.shared.lifecycle.try_drop_sole_connection() {
+        if (empty || no_outgoing) && self.shared.lifecycle.try_drop_sole_connection() {
             self.on_session_dead();
         }
     }
@@ -1339,7 +1716,28 @@ impl RpcSessionInner {
     /// breaks `session → local service → stored proxy → session`.
     /// Strong refs are dropped outside every lock — user `Drop` code may
     /// re-enter the session.
+    ///
+    /// **Unblock before user code.** Every step that can wake a thread of
+    /// this session runs ahead of the obituaries, because an obituary (or
+    /// a local `Drop`) may call [`RpcSession::shutdown`], which *joins*
+    /// those threads — one still parked would deadlock that join. Two
+    /// steps are needed, not one: `shutdown_all_transports` wakes only
+    /// threads blocked in `recv`/`send`, while a thread waiting on
+    /// `slot_cv` ([`find_conn_impl`](Self::find_conn_impl) with an
+    /// exhausted pool, [`find_conn_pinned`](Self::find_conn_pinned)) wakes
+    /// only when the pool is emptied *and* notified — a bare notify would
+    /// have both re-`wait`. Emptying the pool this early is safe: callback
+    /// slots have no serve loop to retire them anyway, and a dead
+    /// session's pool is only consulted by paths that already answer
+    /// `DeadObject` on `is_torn_down`. Nothing here sends — the death CAS
+    /// already happened, so `send_dec_strong` and friends return early.
     pub(crate) fn on_session_dead(&self) {
+        self.shutdown_all_transports();
+        {
+            let mut st = self.conn_state.lock().expect("conn_state poisoned");
+            st.slots.clear();
+        }
+        self.slot_cv.notify_all();
         self.send_session_obituaries();
         self.shared.lifecycle.mark_dead();
         let root = self.shared.root.lock().expect("root poisoned").take();
@@ -1351,16 +1749,6 @@ impl RpcSessionInner {
             .clear_local();
         drop(locals);
         drop(root);
-        // Last: wake anything still blocked in `recv` on this session (a
-        // client's incoming-connection threads, a user `serve_blocking`)
-        // and drop every slot — callback slots have no serve loop to
-        // retire them, and a dead session's pool is only ever consulted
-        // by paths that already answer `DeadObject` on `is_torn_down`.
-        self.shutdown_all_transports();
-        let mut st = self.conn_state.lock().expect("conn_state poisoned");
-        st.slots.clear();
-        drop(st);
-        self.slot_cv.notify_all();
     }
 
     pub(crate) fn fd_mode(&self) -> FileDescriptorTransportMode {
@@ -1479,14 +1867,6 @@ impl RpcSessionInner {
             .len()
     }
 
-    /// This session's advertised + enforced max-threads
-    /// value. Set by [`RpcSession::set_max_threads`] (default 1) and
-    /// returned to a client on `GET_MAX_THREADS`. AOSP-faithful
-    /// `setMaxIncomingThreads`: the value is *both* the advertise and
-    /// the **incoming slot cap** — the server attach arm refuses an
-    /// id-echoing connection when adding it would push
-    /// `slot_count() > max_threads_value()`. Default 1 ⇒ founding-only
-    /// (multi-conn callers must explicitly `set_max_threads(N >= 2)`).
     /// A client's incoming (callback) slot: served by a thread this
     /// session owns and not counted in `live_conns`.
     fn is_client_incoming_slot(&self, slot_id: u64) -> bool {
@@ -1498,6 +1878,28 @@ impl RpcSessionInner {
                 .slots
                 .iter()
                 .any(|s| s.id == slot_id && s.role == SlotRole::Incoming)
+    }
+
+    /// Baseline read deadline `slot_id` must be returned to when a reply
+    /// deadline armed on it is lifted. Serve-driven slots carry the
+    /// session's [`SharedSession::serve_read_deadline`]; every other slot
+    /// (a client's outgoing fan-out, a server's callback slots) has none.
+    fn slot_baseline_read_deadline(&self, slot_id: u64) -> Option<Duration> {
+        let serve_driven = self
+            .conn_state
+            .lock()
+            .expect("conn_state poisoned")
+            .slots
+            .iter()
+            .any(|s| s.id == slot_id && s.role == SlotRole::Incoming);
+        if !serve_driven {
+            return None;
+        }
+        *self
+            .shared
+            .serve_read_deadline
+            .lock()
+            .expect("serve_read_deadline poisoned")
     }
 
     fn incoming_slot_count(&self) -> usize {
@@ -1539,12 +1941,22 @@ impl RpcSessionInner {
         )
     }
 
+    /// This session's advertised + enforced max-threads
+    /// value. Set by [`RpcSession::set_max_threads`] (default 1) and
+    /// returned to a client on `GET_MAX_THREADS`. AOSP-faithful
+    /// `setMaxIncomingThreads`: the value is *both* the advertise and
+    /// the **incoming slot cap** — the server attach arm refuses an
+    /// id-echoing connection when adding it would push the session's
+    /// `Incoming` slot count past it. Default 1 ⇒ founding-only
+    /// (multi-conn callers must explicitly `set_max_threads(N >= 2)`).
+    /// The client's *callback* connections are budgeted separately, at
+    /// `2 *` this value — see `RpcServer::set_max_threads`.
     pub(crate) fn max_threads_value(&self) -> u32 {
         // `Relaxed` is sufficient: this atomic is a single-cell config
         // value (set by `RpcSession::set_max_threads` before any
         // accept/attach takes place; `std::thread::spawn` then provides
         // the happens-before for worker threads). No multi-atomic
-        // ordering pair to maintain — the prior `SeqCst` was overkill.
+        // ordering pair to maintain, so `SeqCst` would buy nothing here.
         self.shared.max_threads.load(Ordering::Relaxed)
     }
 
@@ -1839,11 +2251,10 @@ impl RpcSessionInner {
             return Ok(None);
         }
         // Apply the configured reply deadline for the duration
-        // of the reply wait only. `ReplyDeadlineGuard` clears the sticky
-        // `SO_RCVTIMEO` on every exit (return / `?` / panic) so it never
-        // leaks onto the next call or a later recv on this connection.
+        // of the reply wait only. `ReplyDeadlineGuard` restores the slot's
+        // baseline `SO_RCVTIMEO` on every exit (return / `?` / panic) so
+        // it never leaks onto the next call or a later recv here.
         let deadline = *self.shared.timeout.lock().expect("timeout poisoned");
-        let _deadline_guard = ReplyDeadlineGuard::arm(transport, deadline)?;
         // The request has already been sent, so any transport/decode error
         // below (timeout, truncation, peer close, malformed frame) leaves the
         // reply in-flight on a now-desynced stream. `WireReply` carries no
@@ -1861,6 +2272,16 @@ impl RpcSessionInner {
                 self.remove_slot(conn.slot_id);
             } else if reply_inbound {
                 self.note_stale_reply(conn.slot_id);
+            }
+        };
+        // Arming is itself post-send, so a failure here desyncs the stream
+        // exactly like a failed recv: poison before propagating.
+        let restore = self.slot_baseline_read_deadline(conn.slot_id);
+        let _deadline_guard = match ReplyDeadlineGuard::arm(transport, deadline, restore) {
+            Ok(g) => g,
+            Err(e) => {
+                poison_slot(true);
+                return Err(e.into());
             }
         };
         loop {
@@ -1925,9 +2346,20 @@ impl RpcSessionInner {
                     // The reply deadline is lifted for the
                     // (unbounded) nested dispatch and restored for the
                     // continued wait *symmetrically via Drop* — a `?` /
-                    // panic out of `dispatch_transact` can no longer
-                    // leave the timeout desynchronized.
-                    let _restore = NestedDeadlineGuard::lift(transport, deadline)?;
+                    // panic out of `dispatch_transact` cannot leave the
+                    // timeout desynchronized.
+                    // Post-send like `ReplyDeadlineGuard::arm`, and worse:
+                    // the nested `Transact` is already off the stream, so a
+                    // bare `?` would drop it undispatched and leave our own
+                    // `REPLY` inbound on a slot the pool would hand out
+                    // again (`WireReply` carries no transaction id).
+                    let _restore = match NestedDeadlineGuard::lift(transport, deadline) {
+                        Ok(g) => g,
+                        Err(e) => {
+                            poison_slot(true);
+                            return Err(e.into());
+                        }
+                    };
                     let peer = transport.peer_identity();
                     if let Err(e) = self.dispatch_transact(t, in_fds, peer) {
                         poison_slot(true);
@@ -2061,11 +2493,13 @@ impl RpcSessionInner {
             object_positions: object_positions.to_vec(),
         })?;
         // Reuse this thread's already-driven slot (the
-        // inbound dispatch slot — `DRIVING` reentrant pin via
-        // `find_conn`). For an outermost server reply
-        // (`serve_once_on_slot` pinned the slot before dispatch) this
-        // is the same slot the request arrived on.
-        let conn = self.find_conn()?;
+        // inbound dispatch slot — `DRIVING` reentrant pin). For an
+        // outermost server reply (`serve_once_on_slot` pinned the slot
+        // before dispatch) this is the same slot the request arrived
+        // on. [`ConnUse::Reply`]: the pin is taken whatever the slot's
+        // role or nesting grant — the peer is waiting for this answer
+        // on that socket and nowhere else.
+        let conn = self.find_conn_impl(ConnUse::Reply)?;
         Ok(self.send_msg(conn.transport(), &frame, fds)?)
     }
 
@@ -2240,6 +2674,10 @@ impl RpcSessionInner {
             self.records_fd_positions(),
         );
 
+        // AOSP `RpcState::processTransactInternal`: this transaction's
+        // connection admits a same-thread nested call only while a
+        // *twoway* handler runs on it — a oneway leaves nobody reading.
+        let _nested = AllowNestedGuard::arm(self, !oneway);
         // Plan 2-16 Phase B/C: stamp the caller's peer identity into the
         // RPC calling context for the duration of the user handler, so
         // `get_calling_uid()`/`get_calling_pid()` work over Unix RPC and
@@ -2520,6 +2958,24 @@ impl RpcSession {
     /// `RpcError::Io` instead of panicking out of an infallible
     /// constructor. The only realistic failure path is early-boot
     /// containers without a working CSPRNG.
+    ///
+    /// # Direction
+    ///
+    /// `space` also fixes the direction the founding connection is used
+    /// in (AOSP `RpcSession::mConnections.{mOutgoing, mIncoming}`):
+    /// `Initiator` sends on it, `Acceptor` serves it. An `Acceptor`
+    /// session therefore **cannot open a transaction of its own** —
+    /// `get_root`, `RpcProxy::transact` and `ping_binder` called on it
+    /// from outside a dispatch fail with
+    /// [`StatusCode::FailedTransaction`], because writing a request into
+    /// a connection the peer only reads inside its own reply wait would
+    /// sit unread. Callbacks *from inside a twoway handler* are
+    /// unaffected (they re-enter the dispatching connection). To call
+    /// out of an acceptor otherwise, the peer must open incoming
+    /// connections, which needs the android-13+ profile
+    /// (`?profile=android13plus`,
+    /// `RpcUnixClientConfig::incoming_connections`); the r34 profile has
+    /// no such mechanism.
     pub fn new(transport: Box<dyn RpcTransport>, space: AddressSpace) -> RpcResult<RpcSession> {
         // Default = android-12 r34, byte-unchanged.
         RpcSession::with_profile(transport, space, WireProfile::R34(R34Codec))
@@ -2552,6 +3008,7 @@ impl RpcSession {
             max_threads: AtomicU32::new(1),
             negotiated: AtomicU32::new(0),
             timeout: Mutex::new(None),
+            serve_read_deadline: Mutex::new(None),
             fd_mode: Mutex::new(FileDescriptorTransportMode::None),
             fd_unix_supported: AtomicBool::new(false),
             rpc_session_id: gen_rpc_session_id()?,
@@ -2593,6 +3050,7 @@ impl RpcSession {
             exclusive_tid: None,
             id: 1,
             role: founding_role,
+            allow_nested: false,
             stale_replies: 0,
         };
         let (dec_strong_tx, dec_strong_rx) = mpsc::channel();
@@ -2607,6 +3065,8 @@ impl RpcSession {
             shared,
             dec_strong_tx,
             incoming_threads: Mutex::new(Vec::new()),
+            incoming_live: AtomicUsize::new(0),
+            incoming_joined: AtomicUsize::new(0),
         });
         *inner.self_weak.lock().expect("self_weak") = Arc::downgrade(&inner);
         // Reaper thread for non-blocking `DEC_STRONG` from
@@ -2664,21 +3124,33 @@ impl RpcSession {
     /// (client, init=true)` for `incoming` headers). Does NOT bump
     /// the lifecycle count (callback slots are not serve-driven; AOSP
     /// also does not gate session lifetime on `mOutgoing.size()`).
-    /// `Err(DeadObject)` if the session is already torn down (the
-    /// lifecycle covers both `Dying` and `Dead` in a single check), or
-    /// `Err(FailedTransaction)` if the pool is already at `cap` slots.
+    /// `Err(DeadObject)` if the session was already torn down when the
+    /// call started (the lifecycle covers both `Dying` and `Dead` in a
+    /// single check), or `Err(FailedTransaction)` if the session already
+    /// holds `cap` callback slots — or died in between, which the
+    /// atomic gate below catches under the same lock as the cap.
     ///
-    /// `cap` is enforced atomically inside [`add_slot_inner_capped`]
-    /// (`RpcSessionInner`) so concurrent attach workers cannot each clear
-    /// an advisory pre-check and overshoot it — callback slots are never
-    /// serve-reclaimed, so an unbounded pool is a peer-driven DoS.
-    /// [`add_callback_slot`](Self::add_callback_slot) followed by the
-    /// server's `"cci"` on the new connection — the admission-then-init
-    /// order that lets a refused client see an error (the accept
-    /// handshake defers that write; see
-    /// `wire_android13::server_write_connection_init`). The slot is
+    /// `cap` and the teardown gate are both enforced atomically inside
+    /// [`add_slot_inner_capped`] (`RpcSessionInner`) so concurrent attach
+    /// workers cannot each clear an advisory pre-check and overshoot the
+    /// budget, nor confirm an attach onto a dying session. `cap` counts
+    /// **callback (`Outgoing`) slots only** — a client's outgoing fan-out
+    /// never eats into it.
+    ///
+    /// Admission first, then the server's `"cci"` on the new connection:
+    /// that order is what lets a refused client see an error instead of a
+    /// silently dead connection (the accept handshake defers the write —
+    /// see `wire_android13::server_write_connection_init`). The slot is
     /// held exclusive by this thread while the init goes out, so no
     /// callback transaction can overtake it on the wire.
+    ///
+    /// A failed init retires the slot immediately rather than leaving it
+    /// for the first send to poison: until something sends on it, a dead
+    /// slot still counts against the callback budget
+    /// (`add_slot_inner_capped` counts `Outgoing` slots), and
+    /// `find_conn` picks the *first* free `Outgoing` slot — so the next
+    /// legitimate callback would draw this corpse and fail before a
+    /// healthy slot is ever tried.
     pub(crate) fn add_callback_slot_and_init(
         &self,
         transport: Box<dyn RpcTransport>,
@@ -2714,10 +3186,11 @@ impl RpcSession {
         match sent {
             Ok(()) => Ok(slot_id),
             Err(e) => {
-                // The client never got its init and will drop the socket;
-                // shut ours so the first send on this slot fails fast and
-                // the send-failure poison retires it.
+                // Retire now, not on the first send: a corpse slot still
+                // eats the callback budget and `find_conn` would draw it
+                // first (see this fn's rustdoc).
                 let _ = transport.shutdown();
+                self.inner.remove_slot(slot_id);
                 Err(StatusCode::from(e))
             }
         }
@@ -2862,6 +3335,19 @@ impl RpcSession {
         fd_mode: FileDescriptorTransportMode,
         session_id: &[u8],
     ) -> Result<RpcSession> {
+        Self::connect_android13plus_fd_with_id_hs(transport, max_version, fd_mode, session_id, None)
+    }
+
+    /// [`connect_android13plus_fd_with_id`](Self::connect_android13plus_fd_with_id)
+    /// with a deadline on the handshake read. `None` blocks forever, which
+    /// is what the public entry point passes.
+    pub(crate) fn connect_android13plus_fd_with_id_hs(
+        transport: Box<dyn RpcTransport>,
+        max_version: u32,
+        fd_mode: FileDescriptorTransportMode,
+        session_id: &[u8],
+        handshake_timeout: Option<Duration>,
+    ) -> Result<RpcSession> {
         // AOSP `kSessionIdBytes == 32`: only empty (new-session) or
         // exactly 32 bytes are wire-legal. Validate here so a
         // misbehaving caller can't trigger the silent `as u16` length-
@@ -2878,6 +3364,10 @@ impl RpcSession {
             FD_MODE_NONE
         };
         let codec = {
+            // Scoped so the deadline is cleared before `transport` moves
+            // into the session below.
+            let _hs = HandshakeDeadline::arm(transport.as_ref(), handshake_timeout)
+                .map_err(StatusCode::from)?;
             let mut io = RawTransportIo(transport.as_ref());
             client_connect_with_id(&mut io, max_version, false, hdr_fd_mode, session_id)
                 .map_err(StatusCode::from)?
@@ -3159,10 +3649,12 @@ impl RpcSession {
         //
         // A client's incoming (callback) slot never bumped `live_conns`,
         // so its exit must not decrement either; instead the session dies
-        // once the **last** such slot is gone (AOSP
-        // `onSessionAllIncomingThreadsEnded`): the founding connection's
+        // once the **last** such slot is gone: the founding connection's
         // `Live(1)` is what the CAS consumes. Its role is read before the
-        // slot is retired.
+        // slot is retired. Eager death by design, *not* AOSP (whose
+        // client-side `onSessionAllIncomingThreadsEnded` is a no-op) —
+        // the trade-off is on
+        // [`RpcUnixClientConfig::incoming_connections`].
         let client_incoming = self.inner.is_client_incoming_slot(slot_id);
         if !client_incoming && self.inner.shared.lifecycle.drop_connection() {
             self.inner.on_session_dead();
@@ -3253,6 +3745,7 @@ impl RpcSession {
             if handle.join().is_err() {
                 log::warn!("RPC: incoming connection {slot_id} thread panicked");
             }
+            self.inner.incoming_joined.fetch_add(1, Ordering::SeqCst);
         }
     }
 
@@ -3264,8 +3757,29 @@ impl RpcSession {
     /// session served on one thread and transacted on another needs more
     /// than one connection, or its calls time out here without ever
     /// reaching the peer.
+    ///
+    /// `Some(Duration::ZERO)` is **not** a valid deadline — the reply wait
+    /// arms it as `SO_RCVTIMEO`, which rejects a zero duration — so it is
+    /// refused (logged) and treated as `None` rather than failing every
+    /// transaction on this session.
     pub fn set_timeout(&self, timeout: Option<Duration>) {
-        *self.inner.shared.timeout.lock().expect("timeout poisoned") = timeout;
+        *self.inner.shared.timeout.lock().expect("timeout poisoned") = reject_zero_deadline(
+            timeout,
+            "RpcSession::set_timeout: a zero duration is not a valid deadline; ignoring",
+        );
+    }
+
+    /// Record the read deadline the server armed on this session's
+    /// serve-driven connections, so a reply deadline lifted on one of
+    /// them is restored to it instead of cleared — see
+    /// [`SharedSession::serve_read_deadline`].
+    pub(crate) fn set_serve_read_deadline(&self, deadline: Option<Duration>) {
+        *self
+            .inner
+            .shared
+            .serve_read_deadline
+            .lock()
+            .expect("serve_read_deadline poisoned") = deadline;
     }
 
     /// `min(local, remote)` worker count established by
@@ -3416,12 +3930,18 @@ impl RpcSession {
             return Err(StatusCode::BadValue);
         }
 
-        let session = RpcSession::connect_android13plus_fd_with_id(
+        let session = RpcSession::connect_android13plus_fd_with_id_hs(
             Box::new(config.connect()?),
             config.max_version,
             config.fd_mode.unwrap_or(FileDescriptorTransportMode::None),
             config.session_id,
+            config.handshake_timeout,
         )?;
+        // Before `negotiate`/`get_session_id` below — those are ordinary
+        // `client_transact` round trips and read this value when they run.
+        if config.timeout.is_some() {
+            session.set_timeout(config.timeout);
+        }
         if local == 1 && incoming == 0 {
             // Single-connection path: byte-identical to
             // `setup_unix_client_android13plus`.
@@ -3444,6 +3964,7 @@ impl RpcSession {
                     config.max_version,
                     &session_id,
                     fd_mode,
+                    config.handshake_timeout,
                 )?;
             }
             for _ in 0..incoming {
@@ -3452,6 +3973,7 @@ impl RpcSession {
                     config.max_version,
                     &session_id,
                     fd_mode,
+                    config.handshake_timeout,
                 )?;
             }
             Ok(())
@@ -3512,6 +4034,7 @@ impl RpcSession {
             config.max_version,
             config.session_id,
             fd_mode,
+            config.handshake_timeout,
         )
     }
 
@@ -3521,6 +4044,7 @@ impl RpcSession {
         max_version: u32,
         session_id: &[u8],
         fd_mode: FileDescriptorTransportMode,
+        handshake_timeout: Option<Duration>,
     ) -> Result<u64> {
         // Profile uniformity (AOSP requires same version across a
         // session). Refuse R34 / a higher caller-supplied `max_version`
@@ -3549,6 +4073,7 @@ impl RpcSession {
         };
         let t = connect()?;
         let codec = {
+            let _hs = HandshakeDeadline::arm(&t, handshake_timeout).map_err(StatusCode::from)?;
             let mut io = RawTransportIo(&t);
             client_connect_with_id(&mut io, effective_max, false, hdr_fd_mode, session_id)
                 .map_err(StatusCode::from)?
@@ -3560,7 +4085,9 @@ impl RpcSession {
             // `RpcSessionInner`; refuse instead.
             return Err(StatusCode::BadType);
         }
-        Ok(self.inner.add_outgoing_slot(Box::new(t)))
+        self.inner
+            .add_outgoing_slot(Box::new(t))
+            .ok_or(StatusCode::DeadObject)
     }
 
     /// Open one *additional* **incoming (callback) connection** to the
@@ -3596,6 +4123,7 @@ impl RpcSession {
             config.max_version,
             config.session_id,
             fd_mode,
+            config.handshake_timeout,
         )
     }
 
@@ -3605,6 +4133,7 @@ impl RpcSession {
         max_version: u32,
         session_id: &[u8],
         fd_mode: FileDescriptorTransportMode,
+        handshake_timeout: Option<Duration>,
     ) -> Result<u64> {
         // Only the side that connected owns incoming threads (a server
         // session's callback slots come from the peer's attaches).
@@ -3629,6 +4158,9 @@ impl RpcSession {
         };
         let t = connect()?;
         let codec = {
+            // Cleared before the slot is pushed: this transport gets a
+            // serve loop, which a lingering read deadline would break.
+            let _hs = HandshakeDeadline::arm(&t, handshake_timeout).map_err(StatusCode::from)?;
             let mut io = RawTransportIo(&t);
             // `incoming = true`: the header carries the INCOMING bit and
             // this side *reads* the server's `"cci"`.
@@ -3638,8 +4170,16 @@ impl RpcSession {
         if codec.version() != session_version {
             return Err(StatusCode::BadType);
         }
-        let slot_id = self.inner.add_slot_inner(Box::new(t), SlotRole::Incoming);
+        // Dropping `t` on refusal closes the socket, so the peer sees EOF
+        // on a connection this session will never serve.
+        let slot_id = self
+            .inner
+            .add_slot_inner(Box::new(t), SlotRole::Incoming)
+            .ok_or(StatusCode::DeadObject)?;
         let inner = Arc::clone(&self.inner);
+        // Bump *before* the spawn so the counter is never observed low
+        // between here and the thread's first instruction.
+        self.inner.incoming_live.fetch_add(1, Ordering::SeqCst);
         let spawned = std::thread::Builder::new()
             .name(format!("rsbinder-rpc-in-{slot_id}"))
             .spawn(move || {
@@ -3647,6 +4187,8 @@ impl RpcSession {
                 if let Err(e) = session.serve_blocking_on(slot_id) {
                     log::debug!("RPC: incoming connection {slot_id} ended: {e:?}");
                 }
+                // Last act of the thread — see `incoming_live`.
+                session.inner.incoming_live.fetch_sub(1, Ordering::SeqCst);
             });
         match spawned {
             Ok(handle) => {
@@ -3661,6 +4203,7 @@ impl RpcSession {
                 // A slot nobody reads would make every server send on it
                 // hang: retire it before reporting.
                 log::error!("RPC: incoming connection thread spawn failed: {e}");
+                self.inner.incoming_live.fetch_sub(1, Ordering::SeqCst);
                 self.inner.remove_slot(slot_id);
                 Err(StatusCode::from(e))
             }
@@ -3848,7 +4391,11 @@ impl RpcSession {
         self.inner.slot_count()
     }
 
-    /// Test/diagnostic: incoming-connection threads not yet joined.
+    /// Test/diagnostic: incoming-connection threads whose `JoinHandle`
+    /// this session still holds. `shutdown` takes the whole set before
+    /// joining any of it, so this drops to zero the moment `shutdown`
+    /// starts — use [`__incoming_thread_live_count`](Self::__incoming_thread_live_count)
+    /// to observe the join itself.
     #[doc(hidden)]
     pub fn __incoming_thread_count(&self) -> usize {
         self.inner
@@ -3856,6 +4403,19 @@ impl RpcSession {
             .lock()
             .expect("incoming_threads poisoned")
             .len()
+    }
+
+    /// Test/diagnostic: incoming-connection threads still running.
+    #[doc(hidden)]
+    pub fn __incoming_thread_live_count(&self) -> usize {
+        self.inner.incoming_live.load(Ordering::SeqCst)
+    }
+
+    /// Test/diagnostic: incoming-connection threads `shutdown` has
+    /// joined. Stays 0 if they are detached instead.
+    #[doc(hidden)]
+    pub fn __incoming_thread_joined_count(&self) -> usize {
+        self.inner.incoming_joined.load(Ordering::SeqCst)
     }
 
     /// Test/diagnostic: live local-node count (leak check).
@@ -4051,6 +4611,59 @@ mod tests {
         );
     }
 
+    /// A `DEC_STRONG` must never take a **serve-driven** slot from the
+    /// scan. AOSP looks `mIncoming` up with `available = nullptr`, so only
+    /// a connection the calling thread already holds can match there; a
+    /// free one is never picked. Writing to one is not a delayed frame but
+    /// a send that blocks once the peer's socket buffer fills — the peer
+    /// reads that connection only inside its own reply wait — while the
+    /// sender holds the slot's `exclusive_tid`, locking its serve loop out.
+    ///
+    /// A serve loop holds its slot across `recv`, so this window is only
+    /// reachable between two of the worker's messages; the unit form below
+    /// makes it deterministic.
+    #[test]
+    fn dec_strong_never_scans_a_serve_driven_slot() {
+        use crate::rpc::transport::MemTransport;
+        // Server-side session: the founding slot is `Incoming` (serve
+        // driven) and, with no worker running, genuinely free.
+        let (t0, _p0) = MemTransport::pair();
+        let session = RpcSession::from_android13plus(
+            Box::new(t0),
+            Android13PlusCodec::android14_15(),
+            FD_MODE_NONE,
+            false,
+        )
+        .expect("build session");
+        assert_eq!(session.inner.slot_count(), 1);
+
+        assert!(
+            matches!(
+                session.inner.find_conn_lenient(),
+                Err(StatusCode::FailedTransaction)
+            ),
+            "a DEC_STRONG must not claim the free serve-driven slot"
+        );
+        assert!(
+            session.inner.try_find_conn().is_none(),
+            "the non-blocking fast path must not claim it either"
+        );
+        assert!(
+            session.inner.find_conn_for_reaper().is_none(),
+            "the reaper must skip rather than take it (or park holding the session)"
+        );
+
+        // An `Outgoing` (callback) slot is what makes the send possible.
+        let (t, _p) = MemTransport::pair();
+        session
+            .add_callback_slot(Box::new(t), 2)
+            .expect("callback slot");
+        assert!(
+            session.inner.find_conn_lenient().is_ok(),
+            "with an outgoing slot the DEC_STRONG goes out normally"
+        );
+    }
+
     /// The incoming callback-slot admission cap is enforced **atomically**
     /// inside `add_callback_slot` (check-and-push under the `conn_state`
     /// lock), so concurrent attaches cannot clear an advisory pre-check and
@@ -4093,6 +4706,78 @@ mod tests {
         );
         assert_eq!(admitted, cap, "exactly cap callback slots admitted");
         assert!(refused >= 1, "attaches past the cap are refused");
+    }
+
+    /// A callback attach whose connection-init write fails must leave no
+    /// trace in the pool. Left behind, the dead slot would (a) hold a
+    /// place in the `2 * max_threads` callback budget until the whole
+    /// session dies, so a client that retried the attach could exhaust it,
+    /// and (b) be picked *first* by `find_conn` (lowest index among free
+    /// `Outgoing` slots), failing the next legitimate callback before any
+    /// healthy slot is tried.
+    #[test]
+    fn callback_slot_init_failure_retires_the_slot() {
+        use crate::rpc::transport::MemTransport;
+        let (t0, _p0) = MemTransport::pair();
+        let codec = Android13PlusCodec::android14_15();
+        let session = RpcSession::from_android13plus(Box::new(t0), codec, FD_MODE_NONE, false)
+            .expect("build session");
+        let base = session.inner.slot_count();
+
+        // `mem` is frame-based and carries no raw handshake byte stream,
+        // so the `"cci"` write fails on it — which is exactly the case
+        // under test (a client that closed the socket right after its
+        // attach header leaves the server's init write failing too).
+        let (t, _p) = MemTransport::pair();
+        assert!(
+            session
+                .add_callback_slot_and_init(Box::new(t), 2, &codec)
+                .is_err(),
+            "a failed connection-init must be reported"
+        );
+        assert_eq!(
+            session.inner.slot_count(),
+            base,
+            "a failed connection-init must leave no slot behind"
+        );
+
+        // …and the callback budget is intact: two slots still fit under
+        // the same cap the failed attach would otherwise have eaten into.
+        let mut peers = Vec::new();
+        for _ in 0..2 {
+            let (t, p) = MemTransport::pair();
+            peers.push(p);
+            session
+                .add_callback_slot(Box::new(t), 2)
+                .expect("callback budget still has room");
+        }
+        assert_eq!(session.inner.slot_count(), base + 2);
+    }
+
+    /// The teardown gate lives in the same critical section as the cap:
+    /// `on_session_dead` empties the pool under the `conn_state` lock, but
+    /// only after firing obituaries and running user `Drop` code, so a
+    /// gate read outside the lock would still see `Live` and push a slot
+    /// onto a session that is already dying — which the caller would then
+    /// confirm to the peer.
+    #[test]
+    fn callback_slot_refused_on_torn_down_session() {
+        use crate::rpc::transport::MemTransport;
+        let (t0, _p0) = MemTransport::pair();
+        let codec = Android13PlusCodec::android14_15();
+        let session = RpcSession::from_android13plus(Box::new(t0), codec, FD_MODE_NONE, false)
+            .expect("build session");
+        session.shutdown();
+
+        let (t, _p) = MemTransport::pair();
+        assert!(
+            session
+                .inner
+                .add_slot_inner_capped(Box::new(t), 2, false)
+                .is_none(),
+            "no slot may be pushed onto a torn-down session"
+        );
+        assert_eq!(session.inner.slot_count(), 0, "the dead pool stays empty");
     }
 
     /// A proxy minted by one session names a node in *that* peer's address

--- a/rsbinder/src/rpc/transport/mem.rs
+++ b/rsbinder/src/rpc/transport/mem.rs
@@ -87,6 +87,14 @@ impl RpcTransport for MemTransport {
                 max: super::MAX_FRAME_LEN,
             });
         }
+        // `shutdown` closed this end in both directions, so a later send
+        // must fail as the socket backends' `shutdown(Both)` makes it
+        // fail (EPIPE) — callers rely on that to retire a slot whose
+        // handshake failed. Without it the frame would queue on an
+        // unbounded channel nobody reads.
+        if self.closed.load(std::sync::atomic::Ordering::SeqCst) {
+            return Err(RpcError::PeerClosed);
+        }
         // A channel send only fails once the peer's receiver is
         // dropped — i.e. the peer is gone. Lock-free (`Sender: Sync`).
         self.tx.send(buf.to_vec()).map_err(|_| RpcError::PeerClosed)
@@ -103,7 +111,11 @@ impl RpcTransport for MemTransport {
         // noticed; a frame or the peer's drop (every sender gone) returns
         // at once, never spinning.
         const TICK: std::time::Duration = std::time::Duration::from_millis(20);
-        let deadline = timeout.map(|d| std::time::Instant::now() + d);
+        // `checked_add`, not `+`: `Instant + Duration` panics on overflow,
+        // and `timeout` is caller-supplied. A duration that cannot be added
+        // to `now` is effectively infinite, which is what `None` already
+        // means here.
+        let deadline = timeout.and_then(|d| std::time::Instant::now().checked_add(d));
         loop {
             let wait = match deadline {
                 Some(at) => {
@@ -168,6 +180,25 @@ mod tests {
         }
     }
 
+    /// `RpcTransport::shutdown` promises both directions: a blocked
+    /// `recv_frame` returns **and** later sends fail. The socket backends
+    /// get the second half from `shutdown(Both)`; `mem` has to model it,
+    /// or a teardown bug that a real transport would surface stays
+    /// invisible to every hermetic test.
+    #[test]
+    fn mem_shutdown_fails_later_sends() {
+        let (a, b) = MemTransport::pair();
+        a.send_frame(b"before").expect("send before shutdown");
+        a.shutdown().expect("shutdown");
+        assert!(
+            matches!(a.send_frame(b"after"), Err(RpcError::PeerClosed)),
+            "a send after shutdown must fail, not queue"
+        );
+        assert!(matches!(a.recv_frame(), Err(RpcError::PeerClosed)));
+        // The peer end is untouched — only this side was shut down.
+        assert_eq!(b.recv_frame().expect("peer still reads"), b"before");
+    }
+
     #[test]
     fn mem_peer_identity_is_current_process() {
         let (a, _b) = MemTransport::pair();
@@ -225,5 +256,16 @@ mod tests {
         }
         a_send.join().unwrap();
         b_send.join().unwrap();
+    }
+
+    /// A read timeout too large to add to `Instant::now()` must read as
+    /// "no deadline", not panic — `set_read_timeout` is public API.
+    #[test]
+    fn unaddable_read_timeout_does_not_panic() {
+        let (a, b) = MemTransport::pair();
+        a.set_read_timeout(Some(std::time::Duration::MAX))
+            .expect("set_read_timeout");
+        b.send_frame(b"hi").expect("send");
+        assert_eq!(a.recv_frame().expect("recv"), b"hi");
     }
 }

--- a/rsbinder/src/rpc/transport/mod.rs
+++ b/rsbinder/src/rpc/transport/mod.rs
@@ -87,7 +87,7 @@ pub trait RpcTransport: Send + Sync {
     /// Set a read deadline for subsequent [`RpcTransport::recv_frame`]
     /// calls. `None` clears it (fully blocking). The
     /// default is a no-op for backends with no read-timeout notion;
-    /// `unix` / `mem` / `tcp_debug` override it. A deadline that
+    /// `unix` / `mem` / `tcp_debug` / `vsock` / `tls` override it. A deadline that
     /// elapses with **nothing consumed** surfaces as
     /// [`RpcError::Timeout`] (the stream stays frame-synchronized); a
     /// deadline that elapses mid-frame is [`RpcError::Truncated`].
@@ -113,6 +113,14 @@ pub trait RpcTransport: Send + Sync {
     /// sends fail. Used to end a client's incoming-connection threads on
     /// session death / `RpcSession::shutdown`. Best-effort; the default
     /// does nothing, for a transport that cannot be interrupted.
+    ///
+    /// **Override it if your transport can be interrupted at all.** With
+    /// the no-op default, `RpcSession::shutdown` has nothing to wake a
+    /// thread parked in `recv_frame` on this transport, so a
+    /// `serve_blocking` or incoming-connection thread on it never exits
+    /// and the documented teardown ("it exits on its own once the
+    /// transport is shut down") does not hold. Every in-tree
+    /// socket-backed transport overrides it.
     fn shutdown(&self) -> RpcResult<()> {
         Ok(())
     }

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -11,6 +11,7 @@
 #![cfg(feature = "rpc")]
 
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::mpsc::RecvTimeoutError;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -298,8 +299,7 @@ fn wait_for_sock(path: &std::path::Path) {
 
 /// Generic bounded polling helper (~2 s budget = 400 × 5 ms). Returns
 /// `true` when `f` first becomes true; the trailing `f()` is a final
-/// race-tightening check after the last sleep. Replaces the three
-/// duplicated local `poll` closures the review flagged.
+/// race-tightening check after the last sleep.
 fn poll_until(mut f: impl FnMut() -> bool) -> bool {
     for _ in 0..400 {
         if f() {
@@ -343,10 +343,9 @@ impl Drop for ServeCleanup {
         if let Some(h) = self.bg.take() {
             // A panic in the background accept loop is a real SUT
             // bug (`RpcServer::run()` is supposed to return cleanly).
-            // The previous `let _ = h.join()` silently discarded that
-            // signal, so a future regression introducing an
-            // `expect("...poisoned")` panic in the accept path would
-            // pass every test green. Surface the payload to stderr —
+            // Discarding the join result would let a regression that
+            // introduces an `expect("...poisoned")` panic in the accept
+            // path pass every test green. Surface the payload to stderr —
             // *not* via `resume_unwind`, because the test's own
             // assertions may already be unwinding and the more useful
             // signal is the first panic, not the cleanup-time
@@ -659,9 +658,9 @@ fn max_connections_admission_bound() {
 /// be torn down by the handshake/admission read deadline so it cannot pin
 /// its worker + admission slot forever.
 ///
-/// Mutant: clearing the read deadline *before* the r34 serve loop (the
-/// pre-fix behavior) leaves the silent c1 worker blocked in `recv` with no
-/// deadline ⇒ the single `max_connections` slot is never freed ⇒ c2's
+/// Mutant: clearing the read deadline *before* the r34 serve loop leaves
+/// the silent c1 worker blocked in `recv` with no deadline ⇒ the single
+/// `max_connections` slot is never freed ⇒ c2's
 /// bounded `get_root` times out, failing this test.
 #[test]
 fn silent_r34_peer_released_by_handshake_deadline() {
@@ -801,7 +800,7 @@ fn client_timeout_on_hung_server() {
 // ---- opt-in android-13+ versioned-wire profile ---------------------
 
 /// The proven android-13+ connection handshake + AOSP-faithful
-/// framing + `Android13PlusCodec` (hermetic) now driving a
+/// framing + `Android13PlusCodec` (hermetic) driving a
 /// **live `RpcServer`/`RpcSession` dispatch path** end-to-end over a
 /// real `UnixTransport`, reusing the existing per-session `RpcState`,
 /// `client_transact`/`serve_blocking`, oneway-FIFO and nested-callback
@@ -1130,7 +1129,7 @@ fn r34_profile_reports_no_wire_version() {
 ///    (`attached/rejected == 0`, `session_registered >= 1`, full
 ///    round-trip);
 ///  - `get_session_id()` round-trips the server-minted 32-byte id
-///    (the previously-missing client half of AOSP `setupClient`);
+///    (the client half of AOSP `setupClient`);
 ///  - client #2 — **echoes that id** ⇒ server resolves the live
 ///    session and **attaches** this connection to it: `c2` speaks the
 ///    *same* `SharedSession` (`c2.get_session_id() == sid1` — the
@@ -1272,9 +1271,9 @@ fn a0b_multi_connection_shared_session() {
     drop(root2);
     drop(c2);
     // **Deterministic** wait for the server's attached worker to
-    // exit (`serve_blocking_on` → `live_conns.fetch_sub`), replacing
-    // the prior `sleep(50ms)` heuristic that raced scheduler jitter
-    // under CI load. `session_live_conns` reads the live-conn ledger
+    // exit (`serve_blocking_on` → `live_conns.fetch_sub`); a fixed
+    // sleep would race scheduler jitter under load.
+    // `session_live_conns` reads the live-conn ledger
     // directly: after `c2` drop the attached worker observes the
     // peer-close and `fetch_sub`s 2→1; once we see 1 the partial-loss
     // path is fully reaped and the *next* liveness check
@@ -1300,7 +1299,7 @@ fn a0b_multi_connection_shared_session() {
     drop(c1);
     drop(c3);
     // _cu's Drop handles shutdown/bg.join/join_workers/remove_file —
-    // a panic above no longer leaks worker threads + socket file.
+    // a panic above does not leak worker threads + socket file.
 }
 
 /// Server-side unification of `RpcSessionInner` into a single inner per
@@ -2053,13 +2052,10 @@ fn pool_exhausted_condvar_blocks_not_busy_loops() {
     // same scheduling/RPC overhead). So the bound floats with slack as
     // long as it stays comfortably below `normal + 200 ms`.
     //
-    // macOS-latest CI under load measured 621 ms on the parallel path
-    // (~221 ms slack — far above the ~50-100 ms assumed in the original
-    // 550 ms bound). On the same loaded runner a serial mutant would land
-    // at ~821 ms (600 + 221). The 700 ms upper bound therefore: (a) clears
-    // the observed normal max with ~79 ms cushion, and (b) still trips on
-    // any mutant whose slack is ≤ ~100 ms (the common case on Linux CI).
-    // Same `1feaf52` pattern as the sibling pool test.
+    // The 700 ms upper bound is sized for a loaded runner: it still
+    // clears the parallel path with ~200 ms of slack, while a serial
+    // mutant paying that same slack lands ~100 ms above it. Measurement
+    // history belongs in `plan/2-12-*.md`, not here.
     //
     // Lower bound 380 ms rejects anything that finished in *one* wave
     // (i.e. a 3-slot pool or a non-blocking 3rd caller).
@@ -2083,14 +2079,14 @@ fn pool_exhausted_condvar_blocks_not_busy_loops() {
 /// under a long-running `slow(...)`, then issues one `roundtrip(cb)`
 /// on slot 2.
 ///
-/// The N-inner-per-connection hybrid had a cross-slot
+/// An N-inner-per-connection hybrid carries a cross-slot
 /// proxy-cache aliasing hazard: two server workers concurrently
 /// unmarshalling the *same* client binder hit `state.remote_proxy`'s
 /// shared cache, so the second caller's nested `proxy.transact`
 /// re-routes through the *first* server inner's socket — wire
-/// interleave / deadlock. The fix is the server-side unification
+/// interleave / deadlock. The server-side unification
 /// ("one `RpcSessionInner` per session, slots in one
-/// pool") so all server-side proxies live in one inner and
+/// pool") rules that out: all server-side proxies live in one inner and
 /// `findConnection` does the slot-pin uniformly. The scoped
 /// single-thread test here exercises the slot-pin without triggering
 /// the aliasing (only slot 2 unmarshals the cb).
@@ -2099,10 +2095,9 @@ fn pool_exhausted_condvar_blocks_not_busy_loops() {
 fn pool_nested_callback_pins_to_forced_slot_single_thread() {
     let path = tmp_sock("a2pin");
     // Deterministic "parker entered slow on the server" signal — set
-    // at the server-side `slow()` handler's entry. The prior version
-    // used `sleep(30 ms)` after spawning the parker thread, which under
-    // CI load could finish *before* the parker reached `find_conn` and
-    // then both threads ended up on slot 1 — a false-pass risk.
+    // at the server-side `slow()` handler's entry. A fixed sleep after
+    // spawning the parker thread could elapse *before* the parker
+    // reached `find_conn`, putting both threads on slot 1 — a false pass.
     let slow_entered = Arc::new(AtomicBool::new(false));
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(1);
@@ -2449,7 +2444,7 @@ impl rsbinder::DeathRecipient for DeathFlag {
 /// NOT fire) and the post-death `link_to_death`→`DeadObject` contract.
 ///
 /// Mutant: dropping the `send_session_obituaries()` call from
-/// `serve_blocking` (or reverting `RpcProxy::link_to_death` to the old
+/// `serve_blocking` (or making `RpcProxy::link_to_death` an
 /// `InvalidOperation` stub) makes `binder_died` never arrive ⇒ the
 /// `recv_timeout` below returns `Err` and the test fails.
 #[test]
@@ -2536,8 +2531,8 @@ fn rpc_death_recipient_fires_on_session_drop() {
 /// The opt-in `set_authorizer` gate runs *before any RPC
 /// byte* and is backend-independent. A rejecting hook closes the
 /// connection (the peer's next op is `DeadObject`, zero payload); an
-/// accepting hook is transparent; unset is accept-all = the prior
-/// behavior (every other test in this suite, unmodified, is the
+/// accepting hook is transparent; unset is accept-all = a server
+/// without the hook (every other test in this suite, unmodified, is the
 /// additive-invariant evidence). The `PeerIdentity` the hook inspects
 /// is the *real* peer.
 ///
@@ -2662,7 +2657,21 @@ fn boot_held_cfg(tag: &str, cfg: HeldCfg) -> HeldSetup {
     } else {
         RpcSession::setup_unix_client(&path).expect("connect")
     };
-    let root = EchoProxy(client.get_root().expect("get_root"));
+    // From here on a panic must still shut the session down: its incoming
+    // threads hold the connection open, and `ServeCleanup`'s `join_workers`
+    // would then wait on a server worker forever — turning a setup failure
+    // into a hang instead of a report.
+    struct ClientGuard(Option<RpcSession>);
+    impl Drop for ClientGuard {
+        fn drop(&mut self) {
+            if let Some(c) = self.0.take() {
+                c.shutdown();
+            }
+        }
+    }
+    let mut guard = ClientGuard(Some(client));
+    let client_ref = guard.0.as_ref().expect("client");
+    let root = EchoProxy(client_ref.get_root().expect("get_root"));
     let cb_counter = Arc::new(AtomicI64::new(0));
     let cb = cfg
         .cb
@@ -2673,6 +2682,8 @@ fn boot_held_cfg(tag: &str, cfg: HeldCfg) -> HeldSetup {
         .unwrap()
         .clone()
         .expect("server parked the callback");
+    // Setup succeeded: hand ownership to `HeldSetup`, which shuts it down.
+    let client = guard.0.take().expect("client");
     HeldSetup {
         client,
         root,
@@ -2745,16 +2756,31 @@ fn drive(cb: &SIBinder, oneway: bool) -> Result<()> {
 fn a_outside_handler_call_without_outgoing_slot_fails_fast() {
     let h = boot_held("a_fastfail");
     for oneway in [false, true] {
-        let t0 = Instant::now();
-        let r = drive(&h.cb_proxy(), oneway);
+        // The deadline has to bound the *wait*, not be measured after it:
+        // the regression this guards is an unbounded park in `find_conn`,
+        // and a server session has no reply deadline of its own, so an
+        // in-line call would hang the run instead of failing it.
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        let cb = h.cb_proxy();
+        let driver = std::thread::spawn(move || {
+            let _ = tx.send(drive(&cb, oneway));
+        });
+        let r = match rx.recv_timeout(Duration::from_millis(500)) {
+            Ok(r) => r,
+            Err(RecvTimeoutError::Timeout) => {
+                panic!("oneway={oneway}: must fail immediately, still blocked")
+            }
+            // `drive` asserts on the reply payload, so a broken channel is
+            // its panic, not a block. Re-raise that instead of blaming a
+            // deadline it never reached.
+            Err(RecvTimeoutError::Disconnected) => match driver.join() {
+                Err(p) => std::panic::resume_unwind(p),
+                Ok(()) => panic!("oneway={oneway}: the driving thread sent no result"),
+            },
+        };
         assert!(
             matches!(r, Err(StatusCode::FailedTransaction)),
             "oneway={oneway}: expected FailedTransaction, got {r:?}"
-        );
-        assert!(
-            t0.elapsed() < Duration::from_millis(500),
-            "oneway={oneway}: must fail immediately, took {:?}",
-            t0.elapsed()
         );
     }
     assert_eq!(h.root.echo("still in sync").unwrap(), "still in sync");
@@ -2762,49 +2788,133 @@ fn a_outside_handler_call_without_outgoing_slot_fails_fast() {
 }
 
 /// AC-20.9 — the served slot is momentarily free between two messages of the
-/// worker's loop. Before the role split a non-nested call could claim it in
-/// that window and write a transaction the idle client would never read. Now
-/// every out-of-handler attempt is refused while the client hammers the same
-/// connection, and the wire stays in sync.
+/// worker's loop. An out-of-handler transact must never claim it there —
+/// it would write a transaction the idle client never reads — so every such
+/// attempt is refused while the client hammers the same connection, and the
+/// wire stays in sync.
 #[test]
 fn a_served_slot_never_taken_by_outside_transact() {
     let h = boot_held("a_theft");
     let stop = Arc::new(AtomicBool::new(false));
+    let progressed = Arc::new(AtomicBool::new(false));
     let hammer = {
         let root = EchoProxy(h.client.get_root().expect("root"));
         let stop = Arc::clone(&stop);
+        let progressed = Arc::clone(&progressed);
         std::thread::spawn(move || {
             let mut n = 0u32;
             while !stop.load(Ordering::SeqCst) {
                 let s = format!("m{n}");
                 assert_eq!(root.echo(&s).expect("echo under contention"), s);
                 n += 1;
+                progressed.store(true, Ordering::SeqCst);
             }
             n
         })
     };
-    let mut refused = 0;
+    // Wait for the first echo before hammering: the loop below is all
+    // fast-fails, so on a loaded machine it can finish and set `stop`
+    // before this thread is ever scheduled, leaving `echoed == 0`.
+    let spun_up = Instant::now();
+    while !progressed.load(Ordering::SeqCst) {
+        assert!(
+            spun_up.elapsed() < Duration::from_secs(10),
+            "the client thread never completed an echo"
+        );
+        std::thread::yield_now();
+    }
     for i in 0..200 {
-        match drive(&h.cb_proxy(), i % 2 == 1) {
-            Err(StatusCode::FailedTransaction) => refused += 1,
+        // Bounded, for the same reason as `..._fails_fast`: a slot the
+        // outside call manages to claim would park here forever.
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        let cb = h.cb_proxy();
+        std::thread::spawn(move || {
+            let _ = tx.send(drive(&cb, i % 2 == 1));
+        });
+        match rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(Err(StatusCode::FailedTransaction)) => {}
             other => panic!("attempt {i}: expected FailedTransaction, got {other:?}"),
         }
     }
     stop.store(true, Ordering::SeqCst);
-    let echoed = hammer.join().expect("hammer thread");
-    assert_eq!(refused, 200);
-    assert!(echoed > 0, "the client thread must have made progress");
+    // Progress is already established by the spin-up gate above; the join
+    // is what surfaces a hammer-thread panic (a failed echo under
+    // contention).
+    hammer.join().expect("hammer thread");
     assert_eq!(h.root.echo("after").unwrap(), "after");
 }
 
+/// The android-13+ connect handshake must be bounded by
+/// `RpcUnixClientConfig::handshake_timeout`. Without it a peer that accepts
+/// the socket and then writes nothing blocks the setup call forever —
+/// `RpcSession::set_timeout` cannot cover this phase, since it is applied to
+/// a session that does not exist yet.
+#[test]
+fn handshake_timeout_bounds_a_silent_peer() {
+    let path = tmp_sock("hs_silent");
+    // A raw listener, not an `RpcServer`: it accepts and then says nothing,
+    // which is exactly the peer this deadline exists for.
+    let listener = std::os::unix::net::UnixListener::bind(&path).expect("bind");
+    let keep = Arc::new(Mutex::new(Vec::new()));
+    let acceptor = {
+        let keep = Arc::clone(&keep);
+        std::thread::spawn(move || {
+            // Hold the accepted sockets open; dropping them would give the
+            // client an EOF and let it fail for the wrong reason.
+            while let Ok((sock, _)) = listener.accept() {
+                keep.lock().unwrap().push(sock);
+            }
+        })
+    };
+    wait_for_sock(&path);
+
+    // Off-thread with a deadline on the *channel*: without the fix this
+    // connect never returns, and measuring `elapsed()` afterwards would
+    // hang the run instead of failing it.
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    let p = path.clone();
+    std::thread::spawn(move || {
+        let r = RpcSession::setup_unix_client_android13plus_with_config(
+            RpcUnixClientConfig::path(&p, 2).handshake_timeout(Duration::from_millis(300)),
+        );
+        let _ = tx.send(r.map(|_| ()));
+    });
+    let r = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("the handshake deadline must bound the connect; still blocked");
+    assert!(r.is_err(), "a silent peer's handshake must not succeed");
+
+    // The deadline must not leak onto the socket of a session that *does*
+    // complete: `ReplyDeadlineGuard` restores only what it armed itself, so
+    // a leftover `SO_RCVTIMEO` would silently bound every later reply wait.
+    let path2 = tmp_sock("hs_ok");
+    let server = RpcServer::setup_unix_server(&path2).expect("bind");
+    server.set_android13plus(2);
+    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    let bg = server.run_background();
+    let _cu = ServeCleanup::new(Arc::clone(&server), bg, path2.clone());
+    wait_for_sock(&path2);
+    let client = RpcSession::setup_unix_client_android13plus_with_config(
+        RpcUnixClientConfig::path(&path2, 2).handshake_timeout(Duration::from_millis(300)),
+    )
+    .expect("connect");
+    let root = EchoProxy(client.get_root().expect("root"));
+    // Longer than the handshake deadline: a leaked deadline fails here.
+    assert_eq!(root.slow(500).map(|_| "ok"), Ok("ok"));
+    client.shutdown();
+
+    drop(keep);
+    std::mem::drop(acceptor);
+    let _ = std::fs::remove_file(&path);
+}
+
 /// AC-20.10 — dropping the parked proxy from a thread inside no handler
-/// must neither block that thread nor desync the wire. The `DEC_STRONG` it
-/// queues has no reply, so it is allowed to ride the served slot (AOSP would
-/// refuse with `WOULD_BLOCK`); but that slot is only free between two of the
-/// worker's messages, so *when* it goes out is best-effort — the node is
-/// released at the latest at session end, and promptly once the client has
-/// an incoming connection (plan 2-20 Phase B). What this gate pins is the
-/// safety property, not the timing.
+/// must neither block that thread nor desync the wire. With no `Outgoing`
+/// slot on this session the `DEC_STRONG` is skipped rather than written to
+/// the served slot (AOSP `WOULD_BLOCK`), so the node is released at session
+/// end — or promptly, once the client opens an incoming connection (plan
+/// 2-20 Phase B). What this gate pins is the safety property, not the
+/// delivery: neither assertion below depends on the DEC going out.
 #[test]
 fn a_dec_strong_outside_handler_does_not_block_or_desync() {
     let h = boot_held("a_dec");
@@ -2827,8 +2937,7 @@ fn a_dec_strong_outside_handler_does_not_block_or_desync() {
         "dropping a proxy outside a handler must not block: {:?}",
         t0.elapsed()
     );
-    // The wire on the served slot is intact whether or not the deferred DEC
-    // has gone out yet.
+    // The wire on the served slot is intact.
     for i in 0..20 {
         let s = format!("tick{i}");
         assert_eq!(h.root.echo(&s).unwrap(), s);
@@ -2902,20 +3011,24 @@ fn b_outside_handler_parallel_callbacks() {
             assert_eq!(r, Ok(()));
         }
     }
-    // Serial on one slot: two 300 ms calls take ≥ 600 ms …
+    // Serial on one slot: two 1000 ms calls take ≥ 2000 ms … The 400 ms
+    // between the parallel ceiling (1600 ms) and the serial floor (2000 ms)
+    // is the discrimination margin; the 600 ms between the parallel ceiling
+    // and the 1000 ms floor is the headroom this binary needs, since it runs
+    // its load tests concurrently.
     let t0 = Instant::now();
     let a = {
         let cb = h.cb_proxy();
-        std::thread::spawn(move || drive_slow(&cb, 300))
+        std::thread::spawn(move || drive_slow(&cb, 1000))
     };
     let b = {
         let cb = h.cb_proxy();
-        std::thread::spawn(move || drive_slow(&cb, 300))
+        std::thread::spawn(move || drive_slow(&cb, 1000))
     };
     assert_eq!(a.join().unwrap(), Ok(()));
     assert_eq!(b.join().unwrap(), Ok(()));
     assert!(
-        t0.elapsed() >= Duration::from_millis(600),
+        t0.elapsed() >= Duration::from_millis(2000),
         "one incoming connection must serialise: {:?}",
         t0.elapsed()
     );
@@ -2933,16 +3046,16 @@ fn b_outside_handler_parallel_callbacks() {
     let t0 = Instant::now();
     let a = {
         let cb = h.cb_proxy();
-        std::thread::spawn(move || drive_slow(&cb, 300))
+        std::thread::spawn(move || drive_slow(&cb, 1000))
     };
     let b = {
         let cb = h.cb_proxy();
-        std::thread::spawn(move || drive_slow(&cb, 300))
+        std::thread::spawn(move || drive_slow(&cb, 1000))
     };
     assert_eq!(a.join().unwrap(), Ok(()));
     assert_eq!(b.join().unwrap(), Ok(()));
     assert!(
-        t0.elapsed() < Duration::from_millis(550),
+        t0.elapsed() < Duration::from_millis(1600),
         "two incoming connections must run in parallel: {:?}",
         t0.elapsed()
     );
@@ -2967,6 +3080,101 @@ fn b_nested_call_from_callback_handler() {
         .join()
         .expect("worker");
     assert_eq!(got, Ok("rt:ping".to_string()));
+    assert_eq!(h.root.echo("after").unwrap(), "after");
+}
+
+/// A callback whose handler calls back into the session it was dispatched
+/// from: a nested call from a *oneway* handler must not pin to the
+/// connection the oneway arrived on (AOSP `RpcConnection::allowNested`).
+struct NestFromHandler {
+    /// The client's proxy back to the server root.
+    root: Mutex<Option<SIBinder>>,
+    /// One slot per dispatch, so the test can tell twoway from oneway.
+    done: std::sync::mpsc::SyncSender<std::result::Result<String, StatusCode>>,
+}
+impl Interface for NestFromHandler {}
+impl Remotable for NestFromHandler {
+    fn descriptor() -> &'static str {
+        DESC
+    }
+    fn on_transact(&self, code: TransactionCode, r: &mut Parcel, reply: &mut Parcel) -> Result<()> {
+        // `TX_ECHO` is twoway (reply expected), `TX_BUMP` oneway.
+        let echoed = if code == TX_ECHO {
+            Some(r.read::<String>()?)
+        } else {
+            None
+        };
+        let root = self.root.lock().unwrap().clone().expect("root installed");
+        let _ = self.done.try_send(EchoProxy(root).echo("nested"));
+        match echoed {
+            Some(a) => {
+                reply.write(&Status::from(StatusCode::Ok))?;
+                reply.write(&a)
+            }
+            None => Ok(()),
+        }
+    }
+    fn on_dump(&self, _w: &mut dyn std::io::Write, _a: &[String]) -> Result<()> {
+        Ok(())
+    }
+}
+/// `Binder<T>` wants a value; forward to the shared `NestFromHandler`.
+struct NestFromHandlerRef(Arc<NestFromHandler>);
+impl Interface for NestFromHandlerRef {}
+impl Remotable for NestFromHandlerRef {
+    fn descriptor() -> &'static str {
+        DESC
+    }
+    fn on_transact(&self, c: TransactionCode, r: &mut Parcel, reply: &mut Parcel) -> Result<()> {
+        self.0.on_transact(c, r, reply)
+    }
+    fn on_dump(&self, w: &mut dyn std::io::Write, a: &[String]) -> Result<()> {
+        self.0.on_dump(w, a)
+    }
+}
+#[test]
+fn b_nested_call_from_oneway_callback_handler() {
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    let holder = Arc::new(NestFromHandler {
+        root: Mutex::new(None),
+        done: tx,
+    });
+    let cb: SIBinder = Interface::as_binder(&Binder::new(NestFromHandlerRef(Arc::clone(&holder))));
+    let h = boot_held_cfg(
+        "b_onenest",
+        HeldCfg {
+            a13: true,
+            incoming: 1,
+            cb: Some(cb),
+            ..Default::default()
+        },
+    );
+    *holder.root.lock().unwrap() = Some(h.root.0.clone());
+
+    // Control: a TWOWAY callback from a plain server thread. The peer is
+    // parked in its reply wait on that connection, so the nested call may
+    // ride it.
+    let cb_tw = h.cb_proxy();
+    let tw = std::thread::spawn(move || drive(&cb_tw, false));
+    assert_eq!(
+        rx.recv_timeout(Duration::from_secs(5)),
+        Ok(Ok("nested".to_string())),
+        "a nested call from a twoway handler must complete"
+    );
+    assert_eq!(tw.join().expect("twoway worker"), Ok(()));
+
+    // Regression: the same handler, reached by a ONEWAY callback.
+    let cb_ow = h.cb_proxy();
+    std::thread::spawn(move || drive(&cb_ow, true))
+        .join()
+        .expect("oneway worker")
+        .expect("oneway send");
+    assert_eq!(
+        rx.recv_timeout(Duration::from_secs(5)),
+        Ok(Ok("nested".to_string())),
+        "a nested call from a oneway handler must not block on the \
+         connection the oneway arrived on"
+    );
     assert_eq!(h.root.echo("after").unwrap(), "after");
 }
 
@@ -3009,14 +3217,18 @@ fn b_incoming_config_validation() {
         Err(StatusCode::BadValue)
     ));
     // Manual attach works and is served.
-    let slot = h
-        .client
+    h.client
         .add_incoming_connection_android13plus_with_config(
             RpcUnixClientConfig::path(&path, 2).session_id(&sid),
         )
         .expect("manual incoming attach");
-    assert!(slot > 1);
+    // 1 is the founding slot; the attach must mint a fresh one.
+    assert!(
+        h.client.__slot_count() >= 2,
+        "the attach must add a slot, not reuse the founding one"
+    );
     assert_eq!(h.client.__incoming_thread_count(), 1);
+    assert_eq!(h.client.__incoming_thread_live_count(), 1);
     let cb = h.cb_proxy();
     assert_eq!(
         std::thread::spawn(move || drive(&cb, false))
@@ -3024,12 +3236,16 @@ fn b_incoming_config_validation() {
             .unwrap(),
         Ok(())
     );
-    // r34: no session id to echo.
+    // r34: no session id to echo. Address the r34 server, not the a13 one
+    // above — the profile check happens before `connect()` today, so the
+    // path is unused, but pointing it at the wrong server would silently
+    // start testing something else if that order ever changed.
     let r34 = boot_held("b_cfg_r34");
+    let r34_path = r34.server.path().expect("r34 server path").to_path_buf();
     assert!(matches!(
         r34.client
             .add_incoming_connection_android13plus_with_config(
-                RpcUnixClientConfig::path(&path, 2).session_id(&[7u8; 32])
+                RpcUnixClientConfig::path(&r34_path, 2).session_id(&[7u8; 32])
             ),
         Err(StatusCode::BadType)
     ));
@@ -3060,9 +3276,17 @@ fn b_incoming_over_server_cap_is_refused() {
     let r = RpcSession::setup_unix_client_android13plus_with_config(
         RpcUnixClientConfig::path(&path, 2).incoming_connections(3),
     );
+    // The regression this guards against *admits* the third slot. Leaking
+    // that session would leave its incoming threads serving, and the panic
+    // below would then hang the whole binary in `ServeCleanup`'s
+    // `join_workers` instead of failing.
+    if let Ok(s) = &r {
+        s.shutdown();
+    }
     assert!(
-        r.is_err(),
-        "third callback slot must be refused: {:?}",
+        matches!(r, Err(StatusCode::DeadObject)),
+        "third callback slot must be refused by the cap (server closes the \
+         connection, so the attach handshake dies): {:?}",
         r.map(|_| ())
     );
 }
@@ -3083,9 +3307,14 @@ fn b_entry_client_open_with_incoming() {
     let client = rsbinder::Client::open_with(&uri, |o, _| o.incoming_connections = Some(1))
         .expect("open with incoming");
     let session = client.session().expect("rpc session");
-    assert_eq!(session.__slot_count(), 2);
-    assert_eq!(session.__incoming_thread_count(), 1);
+    // Read first, shut down, then assert: a session with a live incoming
+    // thread that is never shut down hangs the fixture's `join_workers`,
+    // so a failing assertion here must not skip the `shutdown`.
+    let slots = session.__slot_count();
+    let threads = session.__incoming_thread_count();
     session.shutdown();
+    assert_eq!(slots, 2);
+    assert_eq!(threads, 1);
     let r34 = format!("unix://{}", path.display());
     assert!(matches!(
         rsbinder::Client::open_with(&r34, |o, _| o.incoming_connections = Some(1)).map(|_| ()),
@@ -3105,17 +3334,29 @@ fn c_server_death_is_eager_with_incoming() {
         let _ = server.run(); // blocks until killed
         std::process::exit(0);
     }
+    // Kill + reap the server child even when an assert below panics — its
+    // `server.run()` loop never exits on its own, and `wait_for_sock`
+    // alone can panic before the explicit kill on a loaded machine.
+    struct KillOnDrop(std::process::Child);
+    impl Drop for KillOnDrop {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
     let path = tmp_sock("c_death");
     let exe = std::env::current_exe().expect("current_exe");
-    let mut child = std::process::Command::new(exe)
-        .args([
-            "--exact",
-            "c_server_death_is_eager_with_incoming",
-            "--nocapture",
-        ])
-        .env("RSB_RPC_DEATH_A13_SERVER", &path)
-        .spawn()
-        .expect("spawn server child");
+    let mut child = KillOnDrop(
+        std::process::Command::new(exe)
+            .args([
+                "--exact",
+                "c_server_death_is_eager_with_incoming",
+                "--nocapture",
+            ])
+            .env("RSB_RPC_DEATH_A13_SERVER", &path)
+            .spawn()
+            .expect("spawn server child"),
+    );
     wait_for_sock(&path);
     let eager = RpcSession::setup_unix_client_android13plus_with_config(
         RpcUnixClientConfig::path(&path, 2).incoming_connections(1),
@@ -3134,8 +3375,8 @@ fn c_server_death_is_eager_with_incoming() {
     lazy_root
         .link_to_death(Arc::downgrade(&flag_l) as _)
         .expect("link lazy");
-    child.kill().expect("kill server child");
-    child.wait().expect("reap server child");
+    child.0.kill().expect("kill server child");
+    child.0.wait().expect("reap server child");
     assert!(
         rx_e.recv_timeout(Duration::from_secs(3)).is_ok(),
         "the incoming connection's drop must fire the obituary at once"
@@ -3150,6 +3391,7 @@ fn c_server_death_is_eager_with_incoming() {
         "the failed call declares the session dead"
     );
     eager.shutdown();
+    assert_eq!(eager.__incoming_thread_live_count(), 0);
     assert_eq!(eager.__incoming_thread_count(), 0);
     lazy.shutdown();
     let _ = std::fs::remove_file(&path);
@@ -3175,13 +3417,43 @@ fn c_shutdown_joins_incoming_threads() {
         .try_into()
         .unwrap();
     assert_eq!(h.client.__incoming_thread_count(), 2);
-    let t0 = Instant::now();
-    h.client.shutdown();
-    assert!(
-        t0.elapsed() < Duration::from_secs(2),
-        "shutdown took {:?}",
-        t0.elapsed()
+    assert_eq!(h.client.__incoming_thread_live_count(), 2);
+    // Run `shutdown` off-thread with a deadline on the *channel*: a
+    // deadlocked shutdown must fail the test, not hang it until the CI
+    // timeout (which is what asserting on `elapsed()` after the call
+    // would do — that line is never reached).
+    let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
+    let shutting = h.client.clone();
+    let t = std::thread::spawn(move || {
+        shutting.shutdown();
+        let _ = tx.send(());
+    });
+    match rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(()) => {}
+        // A panicked `shutdown` breaks the channel too; falling through to
+        // the `join` below re-raises it with its own message rather than
+        // reporting a deadlock that did not happen.
+        Err(RecvTimeoutError::Disconnected) => {}
+        Err(RecvTimeoutError::Timeout) => {
+            // Report the failure instead of hanging the runner: dropping `h`
+            // would run `HeldSetup::drop` → `join_workers()`, which a regression
+            // that leaves the transports up would never return from.
+            std::mem::forget(h);
+            panic!("shutdown deadlocked");
+        }
+    }
+    t.join().expect("shutdown thread");
+    // The observable half of "joins". `__incoming_thread_count` is
+    // `mem::take`n before the first `join()`, so it reads 0 either way;
+    // and the live count usually reaches 0 on its own, because
+    // `shutdown` wakes the threads (transport shutdown) before it joins
+    // them. Only the join counter separates joining from detaching.
+    assert_eq!(
+        h.client.__incoming_thread_joined_count(),
+        2,
+        "shutdown must join the incoming threads, not detach them"
     );
+    assert_eq!(h.client.__incoming_thread_live_count(), 0);
     assert_eq!(h.client.__incoming_thread_count(), 0);
     // Idempotent.
     h.client.shutdown();
@@ -3193,20 +3465,93 @@ fn c_shutdown_joins_incoming_threads() {
     assert!(matches!(h.root.echo("dead"), Err(StatusCode::DeadObject)));
 }
 
+/// A `DeathRecipient` that shuts the session down from inside `binder_died`
+/// — the cycle-breaking call the `RpcSession` docs point at.
+struct ShutdownOnDeath(Mutex<Option<RpcSession>>, Arc<AtomicBool>);
+impl rsbinder::DeathRecipient for ShutdownOnDeath {
+    fn binder_died(&self, _who: &rsbinder::WIBinder) {
+        self.1.store(true, Ordering::SeqCst);
+        if let Some(s) = self.0.lock().unwrap().take() {
+            s.shutdown();
+        }
+    }
+}
+
+/// The obituary runs while the incoming threads are still parked in `recv`,
+/// so a `binder_died` that calls `shutdown` would join threads nothing has
+/// woken. Death must shut the transports down before it runs user code.
+#[test]
+fn c_shutdown_from_death_recipient_does_not_deadlock() {
+    let h = boot_held_cfg(
+        "c_death_sd",
+        HeldCfg {
+            a13: true,
+            incoming: 2,
+            ..Default::default()
+        },
+    );
+    assert_eq!(h.client.__incoming_thread_live_count(), 2);
+    let fired = Arc::new(AtomicBool::new(false));
+    let recip: Arc<ShutdownOnDeath> = Arc::new(ShutdownOnDeath(
+        Mutex::new(Some(h.client.clone())),
+        Arc::clone(&fired),
+    ));
+    h.root
+        .0
+        .link_to_death(Arc::downgrade(&recip) as _)
+        .expect("link");
+
+    // Killing the server drives death on the client, which fires the
+    // obituary above. Deadline on the channel, not on `elapsed()` after
+    // the fact: a deadlock must fail this test, not hang the run.
+    let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
+    let victim = h.client.clone();
+    let t = std::thread::spawn(move || {
+        victim.shutdown();
+        let _ = tx.send(());
+    });
+    match rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(()) => {}
+        // A panicked `shutdown` breaks the channel too; the `join` below
+        // re-raises it instead of reporting a deadlock that did not happen.
+        Err(RecvTimeoutError::Disconnected) => {}
+        Err(RecvTimeoutError::Timeout) => {
+            // The session is wedged, so dropping the fixture would block in
+            // `ServeCleanup`'s `join_workers` and turn this failure into a CI
+            // timeout. Leak it and report instead.
+            std::mem::forget(h);
+            panic!("shutdown from a death recipient deadlocked");
+        }
+    }
+    t.join().expect("shutdown thread");
+    assert_eq!(h.client.__incoming_thread_live_count(), 0);
+    // Without this the test passes on a regression that never fires the
+    // obituary at all: the outer `shutdown` would join the threads itself
+    // and every assertion above would still hold.
+    assert!(
+        fired.load(Ordering::SeqCst),
+        "the obituary never ran; this test would gate nothing"
+    );
+}
+
 /// A callback whose handler shuts its own session down: the incoming
 /// thread that runs it is not joined by itself (no deadlock), and the
-/// server's call returns.
+/// server's call returns (`DeadObject` — the session the reply owed its
+/// answer to is gone by then) instead of hanging.
 struct ShutdownCb(Mutex<Option<RpcSession>>);
 impl Interface for ShutdownCb {}
 impl Remotable for ShutdownCb {
     fn descriptor() -> &'static str {
         DESC
     }
-    fn on_transact(&self, _c: TransactionCode, _r: &mut Parcel, reply: &mut Parcel) -> Result<()> {
+    fn on_transact(&self, _c: TransactionCode, r: &mut Parcel, reply: &mut Parcel) -> Result<()> {
+        // Echo like `EchoSvc` so `drive(.., false)` can assert on the reply.
+        let a: String = r.read()?;
         if let Some(s) = self.0.lock().unwrap().as_ref() {
             s.shutdown();
         }
-        reply.write(&Status::from(StatusCode::Ok))
+        reply.write(&Status::from(StatusCode::Ok))?;
+        reply.write(&a)
     }
     fn on_dump(&self, _w: &mut dyn std::io::Write, _a: &[String]) -> Result<()> {
         Ok(())
@@ -3227,18 +3572,40 @@ fn c_shutdown_from_callback_handler_does_not_self_join() {
     );
     *holder.0.lock().unwrap() = Some(h.client.clone());
     let server_cb = h.cb_proxy();
-    let t0 = Instant::now();
-    let r = std::thread::spawn(move || drive(&server_cb, false))
-        .join()
-        .expect("worker");
-    assert!(
-        t0.elapsed() < Duration::from_secs(3),
-        "shutdown inside the handler must not deadlock: {:?} ({r:?})",
-        t0.elapsed()
+    // Deadline on the channel, not on `elapsed()` after the join: a
+    // self-join deadlock must fail here rather than hang the run.
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Result<()>>(1);
+    let worker = std::thread::spawn(move || {
+        let r = drive(&server_cb, false);
+        let _ = tx.send(r);
+    });
+    let r = match rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(r) => r,
+        Err(RecvTimeoutError::Timeout) => {
+            panic!("shutdown inside the handler deadlocked")
+        }
+        // `drive` asserts on the reply, so a broken channel is the
+        // worker's panic. Re-raise that instead of reporting a deadlock
+        // that never happened.
+        Err(RecvTimeoutError::Disconnected) => match worker.join() {
+            Err(p) => std::panic::resume_unwind(p),
+            Ok(()) => panic!("the driving thread sent no result"),
+        },
+    };
+    // The handler tore its own session down before the reply could go
+    // out, so the call comes back `DeadObject` — the point is that it
+    // *comes back* rather than deadlocking on a self-join.
+    assert_eq!(
+        r,
+        Err(StatusCode::DeadObject),
+        "the server's call must return once the handler's shutdown lands"
     );
-    // The detached thread finishes on its own; the second shutdown is a
-    // no-op and the pool is torn down.
-    assert!(poll_until(|| h.client.__incoming_thread_count() == 0));
+    worker.join().expect("worker");
+    // The thread that ran the handler was left to finish on its own
+    // (joining itself would deadlock), so it ends slightly after
+    // `shutdown` returned — poll for it.
+    assert!(poll_until(|| h.client.__incoming_thread_live_count() == 0));
+    assert_eq!(h.client.__incoming_thread_count(), 0);
     h.client.shutdown();
     assert!(matches!(h.root.echo("dead"), Err(StatusCode::DeadObject)));
     *holder.0.lock().unwrap() = None;
@@ -3256,4 +3623,36 @@ impl Remotable for ShutdownCbRef {
     fn on_dump(&self, w: &mut dyn std::io::Write, a: &[String]) -> Result<()> {
         self.0.on_dump(w, a)
     }
+}
+
+/// A client with `incoming_connections > 0` that loses its only
+/// `Outgoing` slot to a reply-deadline poison must still declare the
+/// session dead: the surviving callback slot keeps the pool non-empty,
+/// but nothing reads a request written on it, so without the
+/// last-outgoing check the session stayed `Live` forever — every later
+/// transact answered `FailedTransaction` with no obituary and no
+/// `RpcState::clear`.
+#[test]
+fn c_losing_the_last_outgoing_slot_declares_death_with_incoming() {
+    let h = boot_held_cfg(
+        "c_lastout",
+        HeldCfg {
+            a13: true,
+            incoming: 1,
+            max_threads: 2,
+            ..Default::default()
+        },
+    );
+    assert_eq!(h.client.__slot_count(), 2, "founding outgoing + callback");
+    // Deadline far below the handler's sleep: the reply arrives too late,
+    // which desyncs and retires the founding `Outgoing` slot.
+    h.client.set_timeout(Some(Duration::from_millis(50)));
+    assert_eq!(h.root.slow(400), Err(StatusCode::TimedOut));
+    // Death, not a live session with only callback slots left.
+    assert_eq!(
+        h.client.__slot_count(),
+        0,
+        "losing the last outgoing slot must run the death sequence"
+    );
+    assert_eq!(h.root.echo("after"), Err(StatusCode::DeadObject));
 }

--- a/rsbinder/tests/rpc_vsock.rs
+++ b/rsbinder/tests/rpc_vsock.rs
@@ -135,7 +135,7 @@ fn vsock_loopback_e2e() {
 #[ignore = "needs Linux vsock loopback (modprobe vsock_loopback) or a peer VM"]
 fn vsock_shutdown_wakes_blocked_recv() {
     use std::sync::Arc;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
     use vsock::VMADDR_CID_LOCAL;
 
     let port = TEST_PORT + 1;
@@ -147,26 +147,36 @@ fn vsock_shutdown_wakes_blocked_recv() {
 
     let t: Arc<dyn RpcTransport> =
         Arc::new(VsockTransport::connect(VMADDR_CID_LOCAL, port).expect("client connect"));
+    // The reader reports through a channel, so "shutdown must wake it"
+    // is a `recv_timeout` that *fails* on regression. Asserting on
+    // `elapsed()` after `reader.join()` cannot: if `shutdown` stops
+    // waking the reader, the join never returns and the test hangs
+    // until the CI timeout instead of failing here.
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
     let reader = {
         let t = Arc::clone(&t);
-        std::thread::spawn(move || t.recv_frame())
+        std::thread::spawn(move || {
+            let _ = tx.send(t.recv_frame());
+        })
     };
     // Give the reader time to park in `recv`.
     std::thread::sleep(Duration::from_millis(200));
-    let t0 = Instant::now();
     t.shutdown().expect("shutdown");
-    let got = reader.join().expect("reader thread");
+    let got = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("shutdown must wake the blocked reader");
     assert!(
         got.is_err(),
         "recv must not return a frame after shutdown: {got:?}"
     );
-    assert!(
-        t0.elapsed() < Duration::from_secs(2),
-        "shutdown must wake the reader promptly: {:?}",
-        t0.elapsed()
-    );
+    reader.join().expect("reader thread");
     server.shutdown();
-    let _ = bg.join();
+    // Join the workers before the accept loop, as the sibling test does:
+    // a worker still serving this client would otherwise outlive the test.
+    server.join_workers();
+    if let Err(p) = bg.join() {
+        eprintln!("WARNING: vsock accept loop panicked: {p:?}");
+    }
 }
 
 /// Plan 2-20 (`RpcSession::shutdown` on a vsock session): a user
@@ -220,5 +230,9 @@ fn vsock_session_shutdown_ends_serve_thread() {
     drop(client);
     server.shutdown();
     server.join_workers();
-    let _ = bg.join();
+    // Surface an accept-loop panic instead of discarding it — a future
+    // regression there would otherwise leave every test green.
+    if let Err(p) = bg.join() {
+        eprintln!("WARNING: vsock accept loop panicked: {p:?}");
+    }
 }

--- a/rsbinder/tests/source_invariants.rs
+++ b/rsbinder/tests/source_invariants.rs
@@ -39,15 +39,18 @@ fn visit<F: FnMut(&Path, &str)>(dir: &Path, f: &mut F) {
     }
 }
 
-/// `RpcSessionInner::remove_slot` is `pub(crate)` and safe to call from more
+/// `RpcSessionInner::remove_slot` is private to `rpc/session.rs` and safe to call from more
 /// than one site now that `find_conn` / `find_conn_pinned` return
 /// `Err(StatusCode::DeadObject)` (not `expect`-panic) when their reentrant
-/// slot lookup misses. The three sanctioned callers are the slot's own
-/// `serve_blocking_on` exit and `client_transact`'s two poison paths (a
+/// slot lookup misses. The five sanctioned callers are the slot's own
+/// `serve_blocking_on` exit; `client_transact`'s two poison paths (a
 /// transport-level send failure, and a stale-reply read failure) — both
 /// retire a slot whose peer is gone / stream is desynced so it is never
 /// reused, and the send-failure one is what lets a serve-less client session
-/// reach death detection (`remove_slot`'s empty-pool hook, Plan 2-17 A.1b).
+/// reach death detection (`remove_slot`'s empty-pool hook, Plan 2-17 A.1b);
+/// and the two attach rollbacks, which un-push a slot the peer will never be
+/// able to use — an incoming connection whose serve thread failed to spawn,
+/// and a callback slot whose connection-init write never reached the client.
 /// A NEW caller MUST re-audit that every slot-lookup path tolerates a missing
 /// slot before being added — this bound guards against accidentally
 /// reintroducing a lookup that assumes the slot is always present. The scan is
@@ -55,7 +58,7 @@ fn visit<F: FnMut(&Path, &str)>(dir: &Path, f: &mut F) {
 /// caller counts too: raise the number deliberately rather than route around
 /// it.
 #[test]
-fn remove_slot_has_exactly_four_callers() {
+fn remove_slot_has_exactly_five_callers() {
     let src_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     // `CARGO_MANIFEST_DIR` is baked in at compile time, so a binary copied
     // elsewhere (a device push, for one) cannot see the sources. Skip loudly
@@ -74,12 +77,13 @@ fn remove_slot_has_exactly_four_callers() {
     );
     assert_eq!(
         hits.len(),
-        4,
-        "RpcSessionInner::remove_slot must have exactly four callers. \
+        5,
+        "RpcSessionInner::remove_slot must have exactly five callers. \
          Found {} call sites: {:#?}\n\
          INVARIANT: only serve_blocking_on's exit path, \
-         client_transact's send-failure / stale-reply poisons, and the \
-         incoming-connection attach's spawn-failure rollback may call remove_slot — \
+         client_transact's send-failure / stale-reply poisons, the \
+         incoming-connection attach's spawn-failure rollback, and the \
+         callback attach's init-write-failure rollback may call remove_slot — \
          find_conn / find_conn_pinned must return DeadObject (not panic) \
          on a missing slot. A new caller MUST audit every slot-lookup \
          path before being added.",


### PR DESCRIPTION
Post-merge review pass over the plan 2-20 client incoming-connection work (#191). Four review rounds over `session.rs`, `server.rs`, the transport layer and the entry facade, plus the two design decisions those rounds deferred.

## Correctness

**Reply theft (the one that could corrupt a call).** `client_transact` returned a `ReplyDeadlineGuard::arm` failure through `?` without poisoning the slot. `WireReply` carries no transaction id, so the next call on that slot would have read the previous `REPLY` as its own answer. Now routed through `poison_slot`; `Duration::ZERO` is rejected at both setters, since a zero `SO_RCVTIMEO` was never a working configuration. `NestedDeadlineGuard::lift` had the same unpoisoned error path.

**Teardown deadlock.** `on_session_dead` ran the obituaries and local `Drop` *before* shutting the transports down. The only thing that wakes an incoming thread parked in `recv` is that shutdown, so a `binder_died` handler calling `RpcSession::shutdown` — the cycle-breaking call the docs point at — deadlocked joining threads nothing had woken. Transports are shut down first now.

**Attach resurrection race.** `add_slot_inner` gained the anti-resurrection gate its capped sibling already carried, with a comment describing exactly this hazard. An attach's own check is a snapshot taken before a connect and a handshake round trip, so a slot could land on a session whose death sequence had already emptied the pool — its transport never shut down, its serve loop blocked forever holding the session graph. Gated inside the `conn_state` lock; both attach paths report `DeadObject`.

**`DEC_STRONG` scan.** A refcount send no longer takes a serve-driven slot from the scan, matching AOSP `ExclusiveConnection::find`, which looks `mIncoming` up with `available = nullptr` — only a connection the calling thread already holds can match there. The peer reads such a connection only inside its own reply wait, so writing there is not a delayed frame but a send that can block once the socket buffer fills, while the sender holds the slot's `exclusive_tid` and locks that slot's serve loop out of its own connection. The reaper keeps its "nothing to wait for" bail, or removing the fallback would have parked it holding the session's strong `Arc`.

**Panic path.** `MemTransport::recv_frame` used `Instant + Duration`, which panics on overflow for a caller-supplied timeout. Uses `checked_add`.

## New knobs (both default to the previous behavior)

- **`RpcServer::set_reply_timeout`** / `ServeOptions::reply_timeout` — bounds a callback's reply wait. Callback slots are exempt from the idle *read* deadline (a sticky `SO_RCVTIMEO` would cut that very wait short), so nothing else could bound it: a client that accepts a callback and never answers pinned the sending worker and everything queued behind it.
- **`ClientOptions::handshake_timeout`** / `RpcUnixClientConfig::handshake_timeout` — bounds the connection handshake, which runs before the session exists and so cannot be covered by `timeout`. Also bounds the `tls://` `connect(2)`. The client-side counterpart of `ServeOptions::handshake_timeout`.

Clearing the handshake deadline is enforced by RAII, not convention: `ReplyDeadlineGuard` restores only a deadline it armed itself and arms nothing when the session deadline is `None` (the default), so a leftover would silently bound every later `recv` — and break a client's incoming serve loop outright.

## Tests

- Fixed a start race that failed **2/20** under CPU contention (0/20 after).
- Converted tests that would *hang* rather than fail on regression to bounded channel waits — a server session has no reply deadline, so an in-line call parks forever.
- New gates: the death-recipient deadlock, the handshake deadline, and the `DEC_STRONG` scan. Each was verified in both directions — it fails without its fix and passes with it.
- Stripped commit SHAs and dated CI figures from comments per the project comment policy.

## Verification

| Environment | Result |
|---|---|
| macOS (arm64) | 427 passed / 0 failed |
| Linux (kernel binder) | lib 374, rpc_server 45, TLS 13, vsock 3, AOSP-ported 163, mesh_kernel 1 — all pass |
| Android 16 (API 36) | 436 passed / 0 failed |
| Android 15 (API 35) | 436 passed / 0 failed |

`clippy --workspace --all-features --all-targets -D warnings`, `fmt --check`, `cargo doc` and five feature combinations are clean on both macOS and Linux. Linux additionally covers vsock and TLS, which cannot be exercised on macOS. Full suite repeated 10× under CPU load on Linux with no flakes.

## Not included

Two items were deliberately left out; neither is a defect introduced here.

- `find_conn`'s pool-exhausted wait is bounded by the session deadline, which is `None` by default. Widening that is a separate decision.
- The `Incoming`-slot symmetry question for oneway sends, which AC-20.9/20.10 deliberately pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
