### PR TITLE
ci(android): wait for a usable guest before touching the emulator

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -505,10 +505,30 @@ jobs:
       run: |
         echo "Waiting for device..."
         adb wait-for-device
+        # Match `1` exactly: the property is empty until set, so a
+        # non-empty test would also accept a partial read.
         echo "Device detected, waiting for boot completion..."
-        timeout 300 bash -c 'while [[ -z $(adb shell getprop sys.boot_completed 2>/dev/null | tr -d "\r") ]]; do echo "Waiting for boot..."; sleep 5; done'
-        echo "Boot completed, unlocking screen..."
-        adb shell input keyevent 82
+        timeout 300 bash -c 'while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d "\r")" != "1" ]; do echo "Waiting for boot..."; sleep 5; done'
+        # `sys.boot_completed` flips while zygote/system_server are still
+        # warming up, and the guest is short on memory in that window — an
+        # `adb shell` there fails with `fork failed: Out of memory`, which
+        # under `bash -e` kills whichever step ran first. Wait for the boot
+        # animation to stop and for the package manager to answer; together
+        # they mean system_server is actually serving.
+        # Wait while it is *running*, not until it reads `stopped`: the
+        # property is empty on images where the service already exited (or
+        # never registered), and testing for `stopped` there would burn the
+        # whole timeout on every job.
+        echo "Waiting for the boot animation to stop..."
+        timeout 180 bash -c 'while [ "$(adb shell getprop init.svc.bootanim 2>/dev/null | tr -d "\r")" = "running" ]; do sleep 5; done' || echo "bootanim still running at timeout; continuing"
+        echo "Waiting for the package manager..."
+        timeout 180 bash -c 'until adb shell pm path android >/dev/null 2>&1; do sleep 5; done' || echo "pm did not answer; continuing"
+        # Prove a fork actually succeeds in the guest before any step
+        # depends on it.
+        echo "Verifying the guest can fork a shell command..."
+        timeout 120 bash -c 'until adb shell true >/dev/null 2>&1; do sleep 5; done'
+        echo "Unlocking screen..."
+        adb shell input keyevent 82 || true
         echo "Emulator is ready"
 
     - name: Create REMOTE_ANDROID file

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -95,13 +95,32 @@ function read_remote_android() {
 function ndk_prepare() {
     read_remote_android
 
-    adb root
-    if adb shell ls $remote_directory 1>/dev/null 2>&1; then
-        echo "Directory already exists: $remote_directory"
-    else
-        echo "Directory does not exist, creating: $remote_directory"
-        adb shell mkdir -p $remote_directory
-    fi
+    # Not fatal on its own: a production/PlayStore image refuses root, and
+    # the real symptom is then the mkdir below failing with a message that
+    # names the directory. Letting a non-zero exit here abort the caller
+    # (CI runs under `bash -e`) would hide that.
+    adb root || echo "ndk_prepare: 'adb root' failed; $remote_directory may be unwritable"
+    # `adb root` restarts adbd, so the device detaches and re-attaches.
+    # Without this the next command races that reconnect.
+    adb wait-for-device
+
+    # A guest that has just set `sys.boot_completed` is still bringing up
+    # zygote/system_server and can be short on memory, so an `adb shell`
+    # there dies with `fork failed: Out of memory` (exit 126). Retry
+    # instead of letting one transient failure abort the caller — CI runs
+    # this step under `bash -e`, where a single non-zero exit is fatal.
+    # `mkdir -p` is idempotent, so this doubles as the existence check.
+    local tries=0
+    until adb shell "mkdir -p $remote_directory" 2>/dev/null; do
+        tries=$((tries + 1))
+        if [ "$tries" -ge 30 ]; then
+            echo "ndk_prepare: cannot create $remote_directory (gave up after $tries tries)" >&2
+            return 1
+        fi
+        echo "ndk_prepare: guest not ready yet, retrying ($tries/30)..."
+        sleep 2
+    done
+    echo "Directory ready: $remote_directory"
 }
 
 function aidl_gen_rust() {


### PR DESCRIPTION
Root-cause fix for the Android API 34 failure in [run 33754807157](https://github.com/hiking90/rsbinder/actions/runs/33754807157).

## What happened

```
Run ndk_prepare
  restarting adbd as root
  Directory does not exist, creating: /data/rsbinder
  error: fork failed: Out of memory
  ##[error]Process completed with exit code 126
```

`ndk_prepare` only runs `adb root` and `mkdir` — nothing had been built yet, and no Rust code is involved. The guest simply could not fork.

The readiness gate accepted `sys.boot_completed` as "ready", but that property flips while zygote and system_server are still warming up, and the guest is under memory pressure in that window. The first `adb shell` landed there. Under `bash -e` one failure ends the step, and API 32/36 passing on the same commit is what you would expect from a timing race rather than a code defect.

This is not specific to `ndk_prepare` — any adb step could have drawn the short straw. So the fix is in the gate, with `ndk_prepare` hardened as defence in depth.

## Readiness gate

- **Match `sys.boot_completed` against `1` exactly.** The old test only required a non-empty value, which a partial read also satisfies.
- **Wait while `init.svc.bootanim` reads `running`**, rather than until it reads `stopped`. This one is worth calling out: the property is *empty* on images whose service already exited. Measured on live emulators — **Android 16 reports empty, Android 15 reports `stopped`** — so a `!= "stopped"` test would have burned the full 180s timeout on every Android 16 job, i.e. added time to exactly the jobs that needed none.
- **Wait for `pm path android` to answer**, which means system_server is serving rather than merely started.
- **Finally require `adb shell true` to succeed**, proving a fork works in the guest before any step depends on one.

## ndk_prepare

- `adb wait-for-device` after `adb root`, which restarts adbd and detaches the device; the next command otherwise races the reconnect.
- Retry the mkdir, bounded at 30 attempts over ~60s, so a transient guest-side failure no longer aborts the caller. `mkdir -p` is idempotent, so it also replaces the separate existence check.
- Let a failing `adb root` report and continue instead of aborting. A production image refuses root, and the real symptom is then the mkdir failing with a message naming the directory — aborting at `adb root` hid that behind an opaque exit.

## Verification

Run against live emulators on **both Android 15 and 16**:

| Check | Result |
|---|---|
| Full readiness gate on an already-ready device | **0s** — no overhead added |
| `ndk_prepare` (Android 15 and 16, under `bash -e`) | succeeds |
| `ndk_prepare` pointed at an uncreatable path | fails cleanly in 59s, message names the directory |
| `bash -n envsetup.sh`, YAML parse | clean |

The failure path was exercised deliberately rather than assumed, so the bounded retry is known to terminate with a useful message instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
