### PR TITLE
fix(rpc): report a refused android-13+ attach at the attach call

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,16 @@
+# Keep `cargo update` inside the workspace MSRV (`rust-version = "1.85"`).
+#
+# The workspace is on resolver v2, whose default is
+# `incompatible-rust-versions = "allow"` — a plain `cargo update` would
+# happily pull crates that declare a newer `rust-version` and break the
+# `rust_min` CI jobs. "fallback" makes the resolver prefer the newest
+# release that still builds on 1.85.
+#
+# Caveat: this only works for crates that declare `rust-version`
+# honestly. Known offender, held back by Cargo.lock alone:
+#   * ignore <= 0.4.29 — 0.4.30 declares no `rust-version` at all yet
+#     uses let-chains (needs 1.88). Reached via tera -> globwalk.
+# After a blanket `cargo update`, verify with:
+#   cargo +1.85 check --workspace --all-features
+[resolver]
+incompatible-rust-versions = "fallback"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -705,6 +705,42 @@ short form — and the first entry is the only one no compiler will catch.
 
 ### Fixed
 
+- **rsbinder (RPC) — a refused attach was reported to the client as success.**
+  The outgoing direction of an android-13+ attach carries no acknowledgement
+  (AOSP writes `RpcNewSessionResponse` only for a new session, and an outgoing
+  connection's `"cci"` flows client→server), so a peer that refused the
+  connection — `session_id` unknown or stale, its `set_max_threads`
+  outgoing-slot cap already spent, shutting down — could only close the socket.
+  `RpcSession::add_outgoing_connection_android13plus` returned `Ok(slot)`
+  anyway and left the dead connection in the pool, where it broke one *later,
+  unrelated* call — whichever one the connection picker happened to route onto
+  that slot — and was then reclaimed, so a single-threaded client saw exactly
+  one inexplicable failure per run and a multi-threaded one saw them
+  intermittently. `setup_unix_client_android13plus_with_id` (and
+  `ClientOptions::session_id` over it) likewise handed back a session whose
+  only connection the peer had already closed. Both now confirm admission with
+  one `GET_SESSION_ID` round trip on the fresh connection *before* using it —
+  the reply must carry the id that was echoed — and report the refusal at the
+  attach call. Costs one extra round trip per attached connection; a new
+  session (empty id) is untouched, and so is the incoming (callback)
+  direction, whose post-admission `"cci"` already reported refusals. A
+  client's `RpcSession::session_id()` is a client-local value that is never
+  the peer's id (only `get_session_id()` fetches that), which is the mistake
+  this used to accept silently; its rustdoc now says so.
+- **rsbinder (RPC) — a wire-profile mismatch never mentioned the profile.**
+  An r34 (default) client's first frame parses as a *valid-looking* v0
+  `RpcConnectionHeader` — its leading `CMD_TRANSACT` reads as protocol
+  version 0 — so an android-13+ server accepted it, answered, and failed at
+  the `"cci"` check with a reject that named nothing an operator could act
+  on; the server's handshake log also flattened every cause into the opaque
+  `RpcError` status name. In the other direction an r34 server closed the
+  connection mid-handshake and the client surfaced a bare `DeadObject` with
+  no log at all. Both rejects now name the r34 profile as the likely cause,
+  in the same shape as the existing `Client::open` diagnostics. An attach
+  whose `max_version` is below the session's negotiated version (which can
+  never work — an attach does not negotiate) now logs that
+  `wire_protocol_version()` is the value to pass instead of failing with a
+  bare `BadType`.
 - **rsbinder (kernel) — a failed reply flush left a `BC_REPLY` pointing at
   freed memory.** `write_transaction_data` stores raw pointers to the reply
   parcel (or the status word on the stack) in the thread's command buffer.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -345,7 +345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -706,9 +706,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "owo-colors"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+checksum = "13c45bb4a6ae1280ec0803b1ef9d3455eb50f01efbbe1447ab020f1d54fba9d8"
 
 [[package]]
 name = "parking_lot"
@@ -910,7 +910,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "similar",
- "syn 3.0.3",
+ "syn 3.0.4",
  "tempfile",
  "tera",
  "thiserror",
@@ -924,7 +924,7 @@ dependencies = [
  "quote",
  "rsbinder",
  "rsbinder-aidl",
- "syn 3.0.3",
+ "syn 3.0.4",
  "trybuild",
 ]
 
@@ -974,7 +974,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1065,7 +1065,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1159,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "socket2"
@@ -1219,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1244,7 +1244,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1322,7 +1322,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1359,7 +1359,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1379,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1486,7 +1486,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -1581,7 +1581,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/book/src/rpc-transport.md
+++ b/book/src/rpc-transport.md
@@ -269,6 +269,15 @@ let session = RpcSession::setup_unix_client_android13plus_with_config(
 )?;
 ```
 
+> **The id you echo must come from `RpcSession::get_session_id()`** — one
+> round trip that asks the server for it. `RpcSession::session_id()` is a
+> *different* method: on a client session it returns a client-local value
+> that the server has never seen, so echoing it is always wrong. Both
+> return 32 opaque bytes, so nothing but the method name distinguishes
+> them; an attach that echoes the wrong id (or one the server refuses for
+> any other reason, such as more connections than its `set_max_threads`
+> allows) fails at the attach call.
+
 > **Security.** An abstract socket has **no filesystem permissions**:
 > any process in the same network namespace can connect (subject only to
 > LSM policy such as SELinux), so the directory-mode access control a

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -1332,7 +1332,10 @@ impl RpcServer {
                             // Abnormal interop/security event
                             // (version mismatch, truncated header,
                             // hostile peer) — `warn!` not `debug!`.
-                            log::warn!("android-13+ RPC handshake failed: {e:?}");
+                            // `{e}` not `{e:?}`: the `RpcError` Display
+                            // carries the wire-level reason, which is
+                            // what names a profile mismatch.
+                            log::warn!("android-13+ RPC handshake failed: {e}");
                             return;
                         }
                     };

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -508,6 +508,102 @@ impl Drop for HandshakeDeadline<'_> {
     }
 }
 
+/// Confirm that a peer actually **admitted** an android-13+ *attach* —
+/// a connection whose `RpcConnectionHeader` echoes a server-minted
+/// `session_id` instead of requesting a new session.
+///
+/// The attach wire carries no server→client acknowledgement in the
+/// outgoing direction: AOSP `RpcServer.cpp` writes an
+/// `RpcNewSessionResponse` only for `requestingNewSession`, and the
+/// `"cci"` of an outgoing connection flows client→server. A peer that
+/// refuses the attach — unknown or stale session id, its
+/// `set_max_threads` outgoing-slot cap already spent, shutdown, a
+/// teardown race — can only close the socket. Without this probe the
+/// refusal is invisible at attach time: the client keeps a dead
+/// connection (a dead pool slot, or a whole dead session) and the
+/// failure resurfaces much later, on whichever unrelated call
+/// [`RpcSessionInner::find_conn`] happens to route onto that slot.
+///
+/// The probe is one ordinary `GET_SESSION_ID` special transact on the
+/// fresh connection — the same round trip [`RpcSession::get_session_id`]
+/// makes, which a real libbinder server answers on any connection — and
+/// the reply must carry the very id we echoed: that is what proves the
+/// peer put *this* connection into *that* session. The incoming
+/// (callback) direction needs no probe: there the server writes `"cci"`
+/// *after* admitting the connection, which is already the
+/// acknowledgement (plan 2-20).
+fn confirm_attach(
+    transport: &dyn RpcTransport,
+    codec: &Android13PlusCodec,
+    session_id: &[u8],
+) -> RpcResult<()> {
+    let txn = WireTransaction {
+        address: RpcAddress::zero(),
+        code: SpecialTransaction::GetSessionId.code(),
+        flags: 0,
+        async_number: 0,
+        data: Vec::new(),
+        object_positions: Vec::new(),
+    };
+    let frame = codec.encode_transact(&txn)?;
+    let mut io = RawTransportIo(transport);
+    write_aosp_message(&mut io, &frame)?;
+    let reply = read_aosp_message(&mut io)?;
+    let peer_id = match codec.decode_message(&reply)? {
+        WireMessage::Reply(WireReply {
+            status: 0, data, ..
+        }) => {
+            let mut p = Parcel::from_vec(data);
+            p.set_data_position(0);
+            p.read::<Vec<u8>>()
+                .map_err(|_| RpcError::Protocol("malformed GET_SESSION_ID reply on an attach"))?
+        }
+        _ => {
+            return Err(RpcError::Protocol(
+                "peer did not answer GET_SESSION_ID on an attach",
+            ))
+        }
+    };
+    if peer_id == session_id {
+        Ok(())
+    } else {
+        Err(RpcError::Protocol(
+            "peer put this attach in a different session than the id it echoed",
+        ))
+    }
+}
+
+/// One line explaining what a refused attach looks like, shared by the
+/// two attach entries so the diagnosis does not drift between them.
+fn log_attach_refused(e: &RpcError) {
+    log::error!(
+        "android-13+ RPC: the peer refused this attach ({e}) — the session id is unknown or \
+         stale, the peer's outgoing-slot cap (`set_max_threads`) is spent, or it is shutting \
+         down. The id must be the server-minted one from `RpcSession::get_session_id()` (NOT \
+         `session_id()`, which is a client-local value), and the connection count must stay \
+         within `RpcSession::negotiate()`"
+    );
+}
+
+/// Map an android-13+ **client** handshake failure to a [`StatusCode`],
+/// logging the profile-mismatch hint when the peer hung up where its
+/// `RpcNewSessionResponse` was due. That is what an r34 (default
+/// profile) server looks like from here: it reads our 16-byte
+/// `RpcConnectionHeader` as an r34 frame, fails to decode it and
+/// closes — leaving the client with a bare `DeadObject` and the server
+/// with no log at all.
+fn client_handshake_err(e: RpcError, requesting_new_session: bool) -> StatusCode {
+    if requesting_new_session && matches!(e, RpcError::PeerClosed | RpcError::Truncated) {
+        log::error!(
+            "rsbinder RPC: the peer closed the connection during the android-13+ handshake, \
+             before its RpcNewSessionResponse — it may be speaking the r34 (default) profile. \
+             Connect without `?profile=android13plus`, or enable the android-13+ wire on the \
+             server (`RpcServer::set_android13plus`)"
+        );
+    }
+    StatusCode::from(e)
+}
+
 /// RAII pair for the *nested-dispatch* deadline window inside
 /// `client_transact`.
 ///
@@ -3241,13 +3337,18 @@ impl RpcSession {
     /// the session build is what lets the server inspect the id and decide
     /// **new vs. attach** *before* committing the connection to a
     /// `SharedSession`.
+    ///
+    /// The error keeps its [`RpcError`] form so the caller's log carries
+    /// the wire-level reason (`StatusCode::RpcError` would flatten every
+    /// cause into one opaque name — including the `"cci"` reject that
+    /// names a profile mismatch).
     pub(crate) fn android13plus_accept_handshake(
         transport: Box<dyn RpcTransport>,
         server_max_version: u32,
-    ) -> Result<Android13PlusAccept> {
+    ) -> RpcResult<Android13PlusAccept> {
         let (codec, client_fd_mode, client_id, incoming) = {
             let mut io = RawTransportIo(transport.as_ref());
-            server_accept_deferred_init(&mut io, server_max_version).map_err(StatusCode::from)?
+            server_accept_deferred_init(&mut io, server_max_version)?
         };
         Ok((transport, codec, client_fd_mode, client_id, incoming))
     }
@@ -3370,8 +3471,23 @@ impl RpcSession {
                 .map_err(StatusCode::from)?;
             let mut io = RawTransportIo(transport.as_ref());
             client_connect_with_id(&mut io, max_version, false, hdr_fd_mode, session_id)
-                .map_err(StatusCode::from)?
+                .map_err(|e| client_handshake_err(e, session_id.is_empty()))?
         };
+        if !session_id.is_empty() {
+            // Attach: no `RpcNewSessionResponse` and no server-written
+            // `"cci"` acknowledge it, so confirm admission here rather
+            // than hand the caller a session whose only connection the
+            // peer already closed (see `confirm_attach`). A new session
+            // (empty id) needs no probe — its `RpcNewSessionResponse`
+            // *is* the acknowledgement, so that path stays byte- and
+            // round-trip-identical.
+            let _hs = HandshakeDeadline::arm(transport.as_ref(), handshake_timeout)
+                .map_err(StatusCode::from)?;
+            if let Err(e) = confirm_attach(transport.as_ref(), &codec, session_id) {
+                log_attach_refused(&e);
+                return Err(StatusCode::from(e));
+            }
+        }
         let negotiated = codec.version();
         let session = RpcSession::with_profile(
             transport,
@@ -3434,7 +3550,8 @@ impl RpcSession {
         server_fd_unix: bool,
     ) -> Result<RpcSession> {
         let (transport, codec, client_fd_mode, _client_id, incoming) =
-            Self::android13plus_accept_handshake(transport, server_max_version)?;
+            Self::android13plus_accept_handshake(transport, server_max_version)
+                .map_err(StatusCode::from)?;
         // This wrapper has no callback-slot path; incoming-direction
         // attaches go through `super::RpcServer::serve_connection`.
         if incoming {
@@ -3460,6 +3577,22 @@ impl RpcSession {
     /// minted at session build and replied by the `GET_SESSION_ID`
     /// special transact; the multi-connection path uses it as the
     /// [`super::RpcServer`] registry key. Per-session, never global.
+    ///
+    /// **On a client session this is NOT the peer's session id.** A
+    /// client mints this value locally and never puts it on the wire —
+    /// it exists so a client session that serves callbacks can answer
+    /// `GET_SESSION_ID` — and the server's id is a different 32 bytes
+    /// that only [`RpcSession::get_session_id`] (one round trip, AOSP
+    /// `RpcSession::setupClient` → `readId()`) can tell you. Passing
+    /// this accessor's value to an attach API
+    /// ([`add_outgoing_connection_android13plus`](Self::add_outgoing_connection_android13plus),
+    /// [`add_incoming_connection_android13plus_with_config`](Self::add_incoming_connection_android13plus_with_config),
+    /// [`setup_unix_client_android13plus_with_id`](Self::setup_unix_client_android13plus_with_id),
+    /// `ClientOptions::session_id`) is therefore always wrong; those
+    /// entries refuse it (the peer never admits the connection, and the
+    /// refusal is reported — see `confirm_attach`), but the value
+    /// itself is indistinguishable from any other 32 random bytes, so
+    /// read the id you echo from `get_session_id()`.
     pub fn session_id(&self) -> [u8; 32] {
         *self.inner.shared.rpc_session_id.as_bytes()
     }
@@ -3908,6 +4041,11 @@ impl RpcSession {
     /// [`RpcSession::get_session_id`], then open the remaining
     /// connections here echoing that id. An **empty** `session_id` is
     /// byte-identical to `setup_unix_client_android13plus`.
+    ///
+    /// A non-empty id makes this an *attach*, and the server's
+    /// admission is confirmed before the session is returned (see
+    /// `confirm_attach`) — a refused attach is an error here, not a
+    /// session whose every call fails.
     pub fn setup_unix_client_android13plus_with_id(
         path: impl AsRef<std::path::Path>,
         max_version: u32,
@@ -3998,7 +4136,20 @@ impl RpcSession {
     /// id-demuxes the echo onto the same `SharedSession`, so
     /// state/root/proxies are shared with the founding connection.
     /// Profile uniformity is enforced: the additional connection's
-    /// negotiated wire version must equal this session's (else error).
+    /// negotiated wire version must equal this session's, so
+    /// `max_version` must be **at least**
+    /// [`wire_protocol_version()`](Self::wire_protocol_version) —
+    /// passing less can never attach ([`StatusCode::BadType`]), because
+    /// an attach gets no version negotiation of its own (the founding
+    /// connection already pinned it).
+    ///
+    /// The server's admission is confirmed before the new slot joins
+    /// the pool (one `GET_SESSION_ID` round trip on the fresh
+    /// connection, see `confirm_attach`): a refused attach — `session_id`
+    /// unknown or stale, the server's `set_max_threads` outgoing-slot
+    /// cap spent, server shutting down — is an error **here**, never a
+    /// dead slot that fails some unrelated call later. Stay within
+    /// [`negotiate()`](Self::negotiate) connections to avoid the cap.
     ///
     /// The default single-connection sessions never call this ⇒ the
     /// pool stays at one slot ⇒ `find_conn` is byte-identical to the
@@ -4083,7 +4234,29 @@ impl RpcSession {
             // connection's negotiation). A mixed-version pool would
             // silently route incompatible wire across one
             // `RpcSessionInner`; refuse instead.
+            log::error!(
+                "android-13+ RPC: this attach negotiated wire v{} but the session runs v{} — \
+                 a caller-supplied `max_version` below the session's negotiated version can \
+                 never attach; pass `RpcSession::wire_protocol_version()`",
+                codec.version(),
+                session_version
+            );
             return Err(StatusCode::BadType);
+        }
+        {
+            // Confirm the server admitted the attach before the slot
+            // joins the pool: an unadmitted slot would sit there until
+            // some unrelated later call drew it and failed
+            // (see `confirm_attach`). The probe is a reply wait, so it
+            // honors the session's `set_timeout` when no explicit
+            // handshake timeout is configured.
+            let probe_deadline = handshake_timeout
+                .or(*self.inner.shared.timeout.lock().expect("timeout poisoned"));
+            let _hs = HandshakeDeadline::arm(&t, probe_deadline).map_err(StatusCode::from)?;
+            if let Err(e) = confirm_attach(&t, &codec, session_id) {
+                log_attach_refused(&e);
+                return Err(StatusCode::from(e));
+            }
         }
         self.inner
             .add_outgoing_slot(Box::new(t))

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -4250,8 +4250,8 @@ impl RpcSession {
             // (see `confirm_attach`). The probe is a reply wait, so it
             // honors the session's `set_timeout` when no explicit
             // handshake timeout is configured.
-            let probe_deadline = handshake_timeout
-                .or(*self.inner.shared.timeout.lock().expect("timeout poisoned"));
+            let probe_deadline =
+                handshake_timeout.or(*self.inner.shared.timeout.lock().expect("timeout poisoned"));
             let _hs = HandshakeDeadline::arm(&t, probe_deadline).map_err(StatusCode::from)?;
             if let Err(e) = confirm_attach(&t, &codec, session_id) {
                 log_attach_refused(&e);

--- a/rsbinder/src/rpc/wire_android13.rs
+++ b/rsbinder/src/rpc/wire_android13.rs
@@ -481,12 +481,25 @@ impl Android13PlusCodec {
     }
 
     /// Verify an `RpcOutgoingConnectionInit` (`strncmp(msg,"cci",4)`).
+    ///
+    /// The rejects name the r34 profile because that is what this check
+    /// catches in practice: an r34 client's first frame
+    /// (`[command|bodySize|reserved]`) parses as a *valid-looking*
+    /// v0 `RpcConnectionHeader` — `command == CMD_TRANSACT == 0` reads
+    /// as protocol version 0 — so a profile mismatch survives the header
+    /// and first fails here, where the `"cci"` magic cannot be faked by
+    /// an r34 transaction body.
     pub fn decode_connection_init(&self, buf: &[u8]) -> RpcResult<()> {
         if buf.len() < A13_CONN_INIT_LEN {
-            return Err(RpcError::Protocol("RpcOutgoingConnectionInit truncated"));
+            return Err(RpcError::Protocol(
+                "RpcOutgoingConnectionInit truncated (peer may be speaking the r34 profile)",
+            ));
         }
         if buf[0..4] != CONN_INIT_OKAY {
-            return Err(RpcError::Protocol("bad RpcOutgoingConnectionInit msg"));
+            return Err(RpcError::Protocol(
+                "expected RpcOutgoingConnectionInit \"cci\" — the peer may be speaking the \
+                 r34 (default) profile, not android-13+",
+            ));
         }
         Ok(())
     }
@@ -1433,6 +1446,20 @@ mod tests {
         let init = c1.encode_connection_init();
         assert_eq!(&init[0..4], b"cci\0");
         c1.decode_connection_init(&init).expect("\"cci\"");
+        // A profile mismatch first fails here (an r34 client's leading
+        // `CMD_TRANSACT == 0` passes as protocol version 0), so both
+        // rejects have to name r34 — that string is the only thing the
+        // server's handshake log can show an operator.
+        for bad in [&[0u8; 8][..], &[0u8; 2][..]] {
+            let why = match c1.decode_connection_init(bad) {
+                Err(RpcError::Protocol(why)) => why,
+                other => panic!("expected a protocol reject, got {other:?}"),
+            };
+            assert!(
+                why.contains("r34"),
+                "the \"cci\" reject must name the r34 profile: {why}"
+            );
+        }
 
         // Version acceptance (AOSP rule @ android-16.0.0_r4, _NEXT = 3):
         // accept 0,1,2,EXPERIMENTAL; reject 3 and above.

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -1211,9 +1211,11 @@ fn a0b_multi_connection_shared_session() {
         &sid1[..],
         "bogus id differs from the minted one"
     );
-    let c3 = RpcSession::setup_unix_client_android13plus_with_id(&path, 1, &bogus)
-        .expect("handshake completes (reject is post-handshake — A0b residual)");
-    c3.set_timeout(Some(Duration::from_secs(3)));
+    // The reject lands past the handshake (the wire acknowledges an
+    // attach with nothing), so the attach confirmation round trip —
+    // `GET_SESSION_ID` on the fresh connection — is what makes the
+    // *constructor* fail instead of some later call on a dead
+    // connection.
     // Strengthen the unknown-id reject assertion: a plain `is_err()`
     // would also pass for an unrelated
     // error (e.g. handshake itself failed). Lock the contract to the
@@ -1236,7 +1238,9 @@ fn a0b_multi_connection_shared_session() {
     //
     // Anything outside this set means a different bug (and `Ok` is
     // the true mutant: server honored the unknown id).
-    let err = c3.get_root().expect_err("unknown id rejected");
+    let err = RpcSession::setup_unix_client_android13plus_with_id(&path, 1, &bogus)
+        .err()
+        .expect("unknown id rejected");
     assert!(
         matches!(
             err,
@@ -1297,7 +1301,6 @@ fn a0b_multi_connection_shared_session() {
 
     drop(root1);
     drop(c1);
-    drop(c3);
     // _cu's Drop handles shutdown/bg.join/join_workers/remove_file —
     // a panic above does not leak worker threads + socket file.
 }
@@ -1453,13 +1456,14 @@ fn ac_12_4_set_max_threads_caps_incoming_slots() {
     let rejected_before = server.rejected_unknown_id_count();
 
     // 3rd attach with the same session id ⇒ would push slot_count to
-    // 3 > max_threads(2) ⇒ refused at the attach arm (cap).
-    let c3 = RpcSession::setup_unix_client_android13plus_with_id(&path, 1, &sid)
-        .expect("handshake completes (reject is post-handshake — A0b/B.1 residual)");
-    c3.set_timeout(Some(Duration::from_secs(3)));
-    let err = c3
-        .get_root()
-        .expect_err("3rd attach must be rejected by the per-session cap");
+    // 3 > max_threads(2) ⇒ refused at the attach arm (cap). The reject
+    // is post-handshake, and the attach confirmation round trip
+    // (`GET_SESSION_ID` on the fresh connection) reports it from the
+    // constructor — a valid id refused by the cap is the case no
+    // client-side id check could catch.
+    let err = RpcSession::setup_unix_client_android13plus_with_id(&path, 1, &sid)
+        .err()
+        .expect("3rd attach must be rejected by the per-session cap");
     assert!(
         matches!(
             err,
@@ -1648,6 +1652,213 @@ fn b2_local_max_outgoing_one_skips_fan_out_byte_identical_to_founding_only() {
     );
 }
 
+/// A **refused** outgoing attach must be an error at attach time, not
+/// an `Ok` slot the pool keeps. The outgoing attach wire has no
+/// server→client acknowledgement (the server refuses by closing), so
+/// `RpcSession::add_outgoing_connection_android13plus` confirms
+/// admission with one `GET_SESSION_ID` round trip on the fresh
+/// connection.
+///
+/// Reported from a downstream project (2026-09-03): with a wrong id the
+/// attach returned `Ok`, the dead slot stayed in the pool, and one
+/// later unrelated call — whichever one `find_conn` routed onto that
+/// slot — failed. Single-threaded clients always draw slot 1 first, so
+/// this drives 4 threads to make the pool actually reach the attached
+/// slot.
+///
+/// **Mutant gate**: dropping the `confirm_attach` call restores
+/// `Ok(2)` for both bogus ids and re-poisons the pool (the echo loop
+/// then fails ~1/4 of its calls).
+#[test]
+fn attach_with_a_bogus_session_id_is_refused_at_attach_time() {
+    let path = tmp_sock("badattach");
+    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    server.set_android13plus(1);
+    server.set_max_threads(4);
+    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    let bg = server.run_background();
+    let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
+    wait_for_sock(&path);
+
+    let client = Arc::new(RpcSession::setup_unix_client_android13plus(&path, 1).expect("connect"));
+    let sid = client.get_session_id().expect("get_session_id");
+    let sid_arr: [u8; 32] = sid.as_slice().try_into().expect("32-byte session id");
+
+    // (a) The client-local `session_id()` accessor is NOT the
+    //     server-minted id — the exact confusion that started this.
+    assert_ne!(
+        client.session_id().as_slice(),
+        sid.as_slice(),
+        "a client session's `session_id()` is a local value, never the peer's"
+    );
+    assert!(
+        client
+            .add_outgoing_connection_android13plus(&path, 1, &client.session_id())
+            .is_err(),
+        "attaching with the client-local id must fail here, not later"
+    );
+    // (b) Plain garbage.
+    assert!(
+        client
+            .add_outgoing_connection_android13plus(&path, 1, &[0xABu8; 32])
+            .is_err(),
+        "attaching with an unknown id must fail here, not later"
+    );
+    // Neither reached the server's pool, and the founding connection is
+    // untouched.
+    assert_eq!(
+        server.session_slot_count(&sid_arr),
+        Some(1),
+        "both refused attaches left the server session at its founding slot"
+    );
+    assert!(
+        poll_until(|| server.rejected_unknown_id_count() == 2),
+        "server counted exactly the two unknown-id rejects"
+    );
+
+    // (c) The control: the server-minted id attaches, and the pool is
+    //     clean — 200 calls across 4 threads, zero failures. Before the
+    //     fix a bogus attach made ~1 in 4 of these fail.
+    assert_eq!(
+        client
+            .add_outgoing_connection_android13plus(&path, 1, &sid)
+            .expect("attach with the server-minted id"),
+        2
+    );
+    let mut handles = Vec::new();
+    for t in 0..4 {
+        let c = Arc::clone(&client);
+        handles.push(std::thread::spawn(move || {
+            let root = EchoProxy(c.get_root().expect("get_root"));
+            for i in 0..50 {
+                let msg = format!("clean-{t}-{i}");
+                assert_eq!(root.echo(&msg).expect("echo on a confirmed pool"), msg);
+            }
+        }));
+    }
+    for h in handles {
+        h.join().expect("client thread");
+    }
+}
+
+/// The same confirmation covers a refusal that is **nobody's mistake**:
+/// a perfectly valid session id attached past the server's
+/// `set_max_threads` outgoing-slot cap. No client-side id check could
+/// catch this one — only the round trip can — and a caller that skips
+/// `negotiate()` has no other way to learn the cap.
+///
+/// **Mutant gate**: without `confirm_attach` the over-cap attaches
+/// return `Ok(3)`/`Ok(4)` while the server stays at 2 slots.
+#[test]
+fn attach_past_the_server_slot_cap_is_refused_at_attach_time() {
+    let path = tmp_sock("capattach");
+    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    server.set_android13plus(1);
+    // Founding + exactly one attach.
+    server.set_max_threads(2);
+    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    let bg = server.run_background();
+    let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
+    wait_for_sock(&path);
+
+    let client = RpcSession::setup_unix_client_android13plus(&path, 1).expect("connect");
+    let sid = client.get_session_id().expect("get_session_id");
+    let sid_arr: [u8; 32] = sid.as_slice().try_into().expect("32-byte session id");
+
+    assert_eq!(
+        client
+            .add_outgoing_connection_android13plus(&path, 1, &sid)
+            .expect("first attach is under the cap"),
+        2
+    );
+    for n in 0..2 {
+        assert!(
+            client
+                .add_outgoing_connection_android13plus(&path, 1, &sid)
+                .is_err(),
+            "attach #{n} past max_threads=2 must be refused at attach time"
+        );
+    }
+    assert_eq!(
+        server.session_slot_count(&sid_arr),
+        Some(2),
+        "the server never went past its cap"
+    );
+    // The pool the client kept is exactly the pool the server has, so
+    // every call lands on a live slot.
+    let root = EchoProxy(client.get_root().expect("get_root"));
+    for i in 0..20 {
+        let msg = format!("cap-{i}");
+        assert_eq!(root.echo(&msg).expect("echo after refused attaches"), msg);
+    }
+}
+
+/// An attach cannot negotiate its own version, so a `max_version`
+/// below the session's negotiated one can never work — that is
+/// `BadType`, and the log names `wire_protocol_version()` as the value
+/// to pass. Complements the R34 case in
+/// `real_process_e2e_and_negotiation`.
+#[test]
+fn attach_max_version_below_the_session_version_is_bad_type() {
+    let path = tmp_sock("attachver");
+    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    server.set_android13plus(2);
+    server.set_max_threads(3);
+    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    let bg = server.run_background();
+    let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
+    wait_for_sock(&path);
+
+    let client = RpcSession::setup_unix_client_android13plus(&path, 2).expect("connect");
+    assert_eq!(client.wire_protocol_version(), Some(2));
+    let sid = client.get_session_id().expect("get_session_id");
+    assert!(matches!(
+        client.add_outgoing_connection_android13plus(&path, 1, &sid),
+        Err(StatusCode::BadType)
+    ));
+    // `wire_protocol_version()` is the value that works.
+    assert_eq!(
+        client
+            .add_outgoing_connection_android13plus(
+                &path,
+                client.wire_protocol_version().expect("versioned"),
+                &sid,
+            )
+            .expect("attach at the session's version"),
+        2
+    );
+}
+
+/// A standalone attach *session*
+/// ([`RpcSession::setup_unix_client_android13plus_with_id`], and the
+/// `ClientOptions::session_id` path over it) is confirmed the same way:
+/// a refused attach is an error from the constructor, not a session
+/// whose every call fails somewhere else.
+#[test]
+fn standalone_attach_session_with_a_bogus_id_fails_to_build() {
+    let path = tmp_sock("standalone");
+    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    server.set_android13plus(1);
+    server.set_max_threads(3);
+    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    let bg = server.run_background();
+    let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
+    wait_for_sock(&path);
+
+    let founding = RpcSession::setup_unix_client_android13plus(&path, 1).expect("connect");
+    let sid = founding.get_session_id().expect("get_session_id");
+    assert!(
+        RpcSession::setup_unix_client_android13plus_with_id(&path, 1, &[0xCDu8; 32]).is_err(),
+        "an unknown id must not yield a session object"
+    );
+    // Control: the real id builds a usable second session handle on the
+    // same server-side session.
+    let attached = RpcSession::setup_unix_client_android13plus_with_id(&path, 1, &sid)
+        .expect("attach session with the server-minted id");
+    let root = EchoProxy(attached.get_root().expect("get_root"));
+    assert_eq!(root.echo("standalone").unwrap(), "standalone");
+}
+
 /// Shutdown-reject e2e. The android-13+ attach arm sits past a
 /// successful handshake but before the per-slot enqueue; in production
 /// the `shutdown.load()` gate at that point sees a *sub-microsecond*
@@ -1722,8 +1933,12 @@ fn shutdown_gate_e2e_rejects_attach_during_handshake_stall() {
     let attach_path = path.clone();
     let attach_sid = sid.clone();
     let attach_handle = std::thread::spawn(move || -> std::result::Result<(), StatusCode> {
-        let c2 = RpcSession::setup_unix_client_android13plus_with_id(&attach_path, 1, &attach_sid)
-            .expect("handshake completes (reject is post-handshake — A0b/B.1 residual)");
+        // The reject lands past the handshake, where the attach
+        // confirmation round trip (`GET_SESSION_ID` on the fresh
+        // connection) now sees it — so the constructor itself fails.
+        // Folded into one result with the first call so the test still
+        // holds if a future reject arm moves to either side of it.
+        let c2 = RpcSession::setup_unix_client_android13plus_with_id(&attach_path, 1, &attach_sid)?;
         c2.set_timeout(Some(Duration::from_secs(3)));
         c2.get_root().map(|_| ())
     });


### PR DESCRIPTION
Reported by a downstream project: attaching an extra outgoing connection with a session id the server rejects returned `Ok(slot)`, and the failure surfaced much later as one unrelated call failing on a dead pool slot.

## The bug

The outgoing direction of an android-13+ attach carries **no server→client acknowledgement** — AOSP writes `RpcNewSessionResponse` only for a new session, and an outgoing connection's `"cci"` flows client→server. A peer that refuses the connection can only close the socket, so `add_outgoing_connection_android13plus` returned `Ok(slot)` and left the dead connection in the pool. `find_conn` picks the first *free* `Outgoing` slot, so a single-threaded client keeps drawing slot 1 and only occasionally lands on the dead one — and the failed send then reclaims it, which is why the reporter saw exactly one inexplicable failure per run.

Reproduced, with the server-side slot count as the control:

| id echoed by the client | attach returned | server slots | 200 calls / 4 threads |
|---|---|---|---|
| `get_session_id()` (correct) | `Ok(2)` | 2 | 0 failures |
| `session_id()` (client-local accessor) | `Ok(2)` | **1** | **50 failures** |
| 32 garbage bytes | `Ok(2)` | **1** | **50 failures** |

Two cases the report did not cover turned up while confirming it:

- A **valid** session id refused by the server's `set_max_threads` slot cap behaves identically (`Ok(3)`, `Ok(4)` against a server stuck at 2 slots) — nobody's mistake, and no client-side id check could catch it.
- `setup_unix_client_android13plus_with_id` (and `ClientOptions::session_id` over it) had the same hole, returning a session whose only connection the peer had already closed.

The incoming (callback) direction was already correct: plan 2-20 moved the server's `"cci"` after admission, so a refused callback attach is an error. The two directions were simply asymmetric.

## The fix

Both attach entries now confirm admission before using the connection: one `GET_SESSION_ID` round trip on the fresh connection, whose reply must carry the id that was echoed — that is what proves the peer put *this* connection into *that* session. AOSP `RpcState` answers that special transact on any connection, so the probe is wire-legal against real libbinder.

Costs one round trip per attached connection. A new session (empty id) is untouched — its `RpcNewSessionResponse` is already the acknowledgement — and so is the incoming direction.

## Diagnostics (same report)

- `RpcSession::session_id()` now documents that a client's value is client-local and **never** the peer's id (only `get_session_id()` fetches that). Both return 32 opaque bytes, so nothing but the method name distinguished them.
- A wire-profile mismatch names the profile on both sides. An r34 client's first frame parses as a valid-looking v0 `RpcConnectionHeader` (its leading `CMD_TRANSACT` reads as version 0), so the mismatch first fails at the `"cci"` check, whose reject now says so; `android13plus_accept_handshake` keeps the `RpcError` instead of flattening every cause into `StatusCode::RpcError`, so the server log carries it. In the other direction the client logs the same hint when the peer hangs up where `RpcNewSessionResponse` was due.
- An attach whose `max_version` is below the session's negotiated version can never work (an attach does not negotiate) and now logs that `wire_protocol_version()` is the value to pass.

## Tests

Four new tests in `rpc_server.rs` — the reported symptom (client-local id and garbage, with a 4-thread 200-call control that used to fail ~1 in 4), the slot-cap refusal, the `max_version` reject, and the standalone attach entry — plus a wire unit test pinning the `"cci"` reject to naming r34.

Three existing tests asserted the old behavior (`expect("handshake completes (reject is post-handshake — residual)")`) and now expect the refusal from the constructor.

## Verification

- macOS: full `rsbinder` suite, `clippy --all-targets` across `rpc` / `rpc-tcp-debug` / `rpc-tls` / `macros`, `RUSTDOCFLAGS="-D warnings" cargo doc`.
- Linux box: `rpc_server` 49/49, `rpc_fd` 5/5 — covers the Linux-only abstract-socket fan-out with `fd_mode(Unix)`.
- **STAGE3, real libbinder**: `example-hello/cpp/run_rpc_incoming_interop.sh` on the Android 16 emulator (SDK 36) PASS. That harness runs a real libbinder `RpcServer` against an rsbinder client with `outgoing_connections(2)`, so the new confirmation transact goes to libbinder and is answered (`slots=3`).

## Note

The second commit (`chore(deps)`) is unrelated to the fix: it adds `.cargo/config.toml` holding `cargo update` to the 1.85 MSRV and refreshes the lockfile accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)