### PR TITLE
fix(rpc): keep a write-side disconnect classified as a dead peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -729,28 +729,33 @@ short form — and the first entry is the only one no compiler will catch.
   this used to accept silently; its rustdoc now says so.
 - **rsbinder (RPC) — a write-side disconnect on an android-13+ session
   reported `Unknown` instead of `DeadObject`.** `RawTransportIo` bridges the
-  transport to `std::io`, and its projection stringified every `RpcError`
+  transport to `std::io`, and its write side stringified the `RpcError`
   into `io::Error::other`, so a `PeerClosed` raised while *sending* came
   back from the other side of that boundary as `Io(Other)` — a peer that had
   gone away was reported as an unclassified error, on the send path of every
-  call as well as the handshake. `From<RpcError> for io::Error` is now
+  call on a non-fd session as well as the handshake. `From<RpcError> for io::Error` is now
   kind-preserving for the two variants that have an `io::ErrorKind` meaning
-  the same thing (`PeerClosed` → `BrokenPipe`, `Timeout` → `TimedOut`), so
-  the round trip is lossless in both directions.
+  the same thing (`PeerClosed` → `BrokenPipe`, `Timeout` → `TimedOut`), so a
+  peer close comes back from the bridge as `PeerClosed` and a timeout comes
+  back in the shape the framing reader's deadline arm keys on. The TLS
+  transport's R34 framing adapter (`transport::tls`'s `RawIo`) carried the
+  same stringifying projection on its write side and is fixed with it, so an
+  `rpc-tls` R34 session now reports a dead peer as `DeadObject` too.
 - **rsbinder (RPC) — a wire-profile mismatch never mentioned the profile.**
-  An r34 (default) client's first frame parses as a *valid-looking* v0
-  `RpcConnectionHeader` — its leading `CMD_TRANSACT` reads as protocol
-  version 0 — so an android-13+ server accepted it, answered, and failed at
-  the `"cci"` check with a reject that named nothing an operator could act
-  on; the server's handshake log also flattened every cause into the opaque
-  `RpcError` status name. In the other direction an r34 server hung up
-  mid-handshake and the client got a bare dead-peer status with no log at
-  all. Both rejects now name the r34 profile as the likely cause, in the
-  same shape as the existing `Client::open` diagnostics. Which side of that
-  exchange notices the disconnect first is a host- and timing-dependent race
-  (EOF on the client's response read, or `EPIPE`/`ECONNRESET` on its `"cci"`
-  write), so the client hint covers every transport-level handshake failure
-  rather than the clean-EOF shape alone. An attach whose `max_version` is
+  An android-13+ server clamps whatever version the connection header
+  decodes to (`min(client_version, server_max_version)`, as AOSP does), so an
+  r34 (default) client's leading bytes got past the header: the server
+  accepted the connection, answered, and failed at the `"cci"` check with a
+  reject that named nothing an operator could act on; the server's handshake
+  log also flattened every cause into the opaque `RpcError` status name. In
+  the other direction an r34 server hung up mid-handshake and the client got
+  a bare dead-peer status with no log at all. Both rejects now name the r34
+  profile as the likely cause, in the same shape as the existing
+  `Client::open` diagnostics. Which side of that exchange notices the
+  disconnect first is a host- and timing-dependent race (EOF on the client's
+  response read, or `EPIPE`/`ECONNRESET` on its `"cci"` write), so the client
+  hint covers both — and a stall or a mid-frame cut names the deadline or the
+  partial response instead of guessing. An attach whose `max_version` is
   below the session's negotiated version (which can never work — an attach
   does not negotiate) now logs that `wire_protocol_version()` is the value
   to pass instead of failing with a bare `BadType`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -727,20 +727,33 @@ short form — and the first entry is the only one no compiler will catch.
   client's `RpcSession::session_id()` is a client-local value that is never
   the peer's id (only `get_session_id()` fetches that), which is the mistake
   this used to accept silently; its rustdoc now says so.
+- **rsbinder (RPC) — a write-side disconnect on an android-13+ session
+  reported `Unknown` instead of `DeadObject`.** `RawTransportIo` bridges the
+  transport to `std::io`, and its projection stringified every `RpcError`
+  into `io::Error::other`, so a `PeerClosed` raised while *sending* came
+  back from the other side of that boundary as `Io(Other)` — a peer that had
+  gone away was reported as an unclassified error, on the send path of every
+  call as well as the handshake. `From<RpcError> for io::Error` is now
+  kind-preserving for the two variants that have an `io::ErrorKind` meaning
+  the same thing (`PeerClosed` → `BrokenPipe`, `Timeout` → `TimedOut`), so
+  the round trip is lossless in both directions.
 - **rsbinder (RPC) — a wire-profile mismatch never mentioned the profile.**
   An r34 (default) client's first frame parses as a *valid-looking* v0
   `RpcConnectionHeader` — its leading `CMD_TRANSACT` reads as protocol
   version 0 — so an android-13+ server accepted it, answered, and failed at
   the `"cci"` check with a reject that named nothing an operator could act
   on; the server's handshake log also flattened every cause into the opaque
-  `RpcError` status name. In the other direction an r34 server closed the
-  connection mid-handshake and the client surfaced a bare `DeadObject` with
-  no log at all. Both rejects now name the r34 profile as the likely cause,
-  in the same shape as the existing `Client::open` diagnostics. An attach
-  whose `max_version` is below the session's negotiated version (which can
-  never work — an attach does not negotiate) now logs that
-  `wire_protocol_version()` is the value to pass instead of failing with a
-  bare `BadType`.
+  `RpcError` status name. In the other direction an r34 server hung up
+  mid-handshake and the client got a bare dead-peer status with no log at
+  all. Both rejects now name the r34 profile as the likely cause, in the
+  same shape as the existing `Client::open` diagnostics. Which side of that
+  exchange notices the disconnect first is a host- and timing-dependent race
+  (EOF on the client's response read, or `EPIPE`/`ECONNRESET` on its `"cci"`
+  write), so the client hint covers every transport-level handshake failure
+  rather than the clean-EOF shape alone. An attach whose `max_version` is
+  below the session's negotiated version (which can never work — an attach
+  does not negotiate) now logs that `wire_protocol_version()` is the value
+  to pass instead of failing with a bare `BadType`.
 - **rsbinder (kernel) — a failed reply flush left a `BC_REPLY` pointing at
   freed memory.** `write_transaction_data` stores raw pointers to the reply
   parcel (or the status word on the stack) in the thread's command buffer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -727,6 +727,17 @@ short form — and the first entry is the only one no compiler will catch.
   client's `RpcSession::session_id()` is a client-local value that is never
   the peer's id (only `get_session_id()` fetches that), which is the mistake
   this used to accept silently; its rustdoc now says so.
+- **rsbinder (RPC) — a zero handshake deadline was neither honored nor
+  reported.** `RpcUnixClientConfig::handshake_timeout(Duration::ZERO)` and
+  `ClientOptions::handshake_timeout = Some(Duration::ZERO)` travelled to
+  `set_read_timeout` (and, on `tls://`, `TcpStream::connect_timeout`), both of
+  which document an error for a zero duration, so setup failed with an
+  unexplained `StatusCode::Unknown`. A zero duration cannot be a deadline and
+  `None` already means "no deadline", so it is now refused: the setup and
+  attach entries return `BadValue` naming the option, before any connect, and
+  the one place every handshake deadline is armed refuses it as well — no
+  `RpcTransport` implementation can be handed a value its socket rejects, or
+  quietly turn the caller's bound into no bound at all.
 - **rsbinder (RPC) — a write-side disconnect on an android-13+ session
   reported `Unknown` instead of `DeadObject`.** `RawTransportIo` bridges the
   transport to `std::io`, and its write side stringified the `RpcError`

--- a/rsbinder/src/entry/client.rs
+++ b/rsbinder/src/entry/client.rs
@@ -82,6 +82,11 @@ pub struct ClientOptions {
     /// and then writes nothing hangs `open`. Set it whenever the peer is
     /// untrusted or merely unreliable. This is the client-side counterpart
     /// of [`ServeOptions::handshake_timeout`](super::ServeOptions::handshake_timeout).
+    ///
+    /// `Some(Duration::ZERO)` is not a deadline and `open` refuses it with
+    /// [`StatusCode::BadValue`](crate::StatusCode::BadValue) rather than
+    /// silently dropping the bound; use `None` to wait indefinitely on
+    /// purpose.
     #[cfg(feature = "rpc")]
     pub handshake_timeout: Option<Duration>,
     /// Kernel: `?driver=` equivalent.
@@ -228,6 +233,14 @@ fn rpc_connect(uri: &Uri, o: &ClientOptions) -> Result<crate::rpc::RpcSession> {
     use crate::rpc::transport::RpcTransport;
     use crate::rpc::{AddressSpace, FileDescriptorTransportMode, RpcSession};
 
+    // Before any connect: this value reaches a read deadline on every
+    // RPC endpoint and `TcpStream::connect_timeout` on `tls://`, and
+    // both reject a zero duration — refuse it here, where the option
+    // that carries it can still be named.
+    crate::rpc::session::reject_zero_handshake_timeout(
+        o.handshake_timeout,
+        "ClientOptions::handshake_timeout",
+    )?;
     let versioned = uri.wire_max_version;
     let fan_out = o.outgoing_connections.unwrap_or(1).max(1);
     let incoming = o.incoming_connections.unwrap_or(0);

--- a/rsbinder/src/rpc/mod.rs
+++ b/rsbinder/src/rpc/mod.rs
@@ -215,11 +215,21 @@ impl From<RpcError> for std::io::Error {
     /// `RpcServer::run` is the motivating site — its `accept_transport`
     /// helper must surface a `from_stream`-side `RpcError` through the
     /// same `io::ErrorKind` matching as the underlying `accept()`).
-    /// `RpcError::Io` round-trips the original `io::Error` unchanged;
-    /// other variants are wrapped with [`std::io::ErrorKind::Other`].
+    /// `RpcError::Io` round-trips the original `io::Error` unchanged.
+    /// [`RpcError::PeerClosed`] and [`RpcError::Timeout`] project onto
+    /// the `io::ErrorKind` they came from (`BrokenPipe` / `TimedOut`),
+    /// so `RpcError -> io::Error -> RpcError` is lossless for them:
+    /// wrapping a peer close as `Other` used to turn every write-side
+    /// disconnect on an android-13+ session into `RpcError::Io(Other)`
+    /// — i.e. `StatusCode::Unknown` instead of `DeadObject`, and a
+    /// handshake diagnosis that could no longer tell a dead peer from a
+    /// malformed one. The remaining variants have no `io::ErrorKind`
+    /// that means what they mean, so they stay `Other`.
     fn from(e: RpcError) -> Self {
         match e {
             RpcError::Io(io) => io,
+            RpcError::PeerClosed => std::io::ErrorKind::BrokenPipe.into(),
+            RpcError::Timeout => std::io::ErrorKind::TimedOut.into(),
             other => std::io::Error::other(format!("{other}")),
         }
     }
@@ -341,6 +351,49 @@ mod tests {
         assert_eq!(
             StatusCode::from(RpcError::Protocol("bad")),
             StatusCode::RpcError
+        );
+    }
+
+    /// `RpcError -> io::Error -> RpcError` must be lossless for the two
+    /// variants that have an `io::ErrorKind` meaning the same thing.
+    /// `RawTransportIo` crosses that boundary on every android-13+ read
+    /// and write, so a variant that degrades to `Other` there comes back
+    /// as `Io(Other)`: a peer that closed before our write then reported
+    /// `StatusCode::Unknown` instead of `DeadObject`, and the handshake
+    /// diagnosis could no longer recognize a dead peer. Which side of an
+    /// exchange notices a disconnect first is a host- and timing-
+    /// dependent race, so both directions have to classify alike.
+    ///
+    /// **Mutant gate**: restoring `other => io::Error::other(...)` for
+    /// `PeerClosed` fails the round trip below (and the timeout arm
+    /// guards `read_exact_into`'s `is_timeout` path the same way).
+    #[test]
+    fn peer_closed_and_timeout_round_trip_through_io_error() {
+        let io = std::io::Error::from(RpcError::PeerClosed);
+        assert_eq!(io.kind(), std::io::ErrorKind::BrokenPipe);
+        assert!(matches!(RpcError::from(io), RpcError::PeerClosed));
+        assert_eq!(
+            StatusCode::from(RpcError::from(std::io::Error::from(RpcError::PeerClosed))),
+            StatusCode::DeadObject,
+            "a write-side disconnect must stay DeadObject, not Unknown"
+        );
+
+        let io = std::io::Error::from(RpcError::Timeout);
+        assert_eq!(io.kind(), std::io::ErrorKind::TimedOut);
+        assert!(
+            transport::is_timeout(&io),
+            "read_exact_into's deadline arm keys on this kind"
+        );
+
+        // An `Io` payload still round-trips unchanged, and a variant
+        // with no matching kind still degrades to `Other`.
+        let io = std::io::Error::from(RpcError::Io(std::io::Error::from(
+            std::io::ErrorKind::PermissionDenied,
+        )));
+        assert_eq!(io.kind(), std::io::ErrorKind::PermissionDenied);
+        assert_eq!(
+            std::io::Error::from(RpcError::Protocol("bad")).kind(),
+            std::io::ErrorKind::Other
         );
     }
 

--- a/rsbinder/src/rpc/mod.rs
+++ b/rsbinder/src/rpc/mod.rs
@@ -211,20 +211,28 @@ impl From<std::io::Error> for RpcError {
 
 impl From<RpcError> for std::io::Error {
     /// Boundary projection back to `std::io::Error` for callers that
-    /// hold an `io::Result<_>` accumulator (the accept-loop dispatch in
-    /// `RpcServer::run` is the motivating site — its `accept_transport`
-    /// helper must surface a `from_stream`-side `RpcError` through the
-    /// same `io::ErrorKind` matching as the underlying `accept()`).
-    /// `RpcError::Io` round-trips the original `io::Error` unchanged.
-    /// [`RpcError::PeerClosed`] and [`RpcError::Timeout`] project onto
-    /// the `io::ErrorKind` they came from (`BrokenPipe` / `TimedOut`),
-    /// so `RpcError -> io::Error -> RpcError` is lossless for them:
-    /// wrapping a peer close as `Other` used to turn every write-side
-    /// disconnect on an android-13+ session into `RpcError::Io(Other)`
-    /// — i.e. `StatusCode::Unknown` instead of `DeadObject`, and a
-    /// handshake diagnosis that could no longer tell a dead peer from a
-    /// malformed one. The remaining variants have no `io::ErrorKind`
-    /// that means what they mean, so they stay `Other`.
+    /// hold an `io::Result<_>` accumulator. Its consumers are the
+    /// adapters that bridge an [`transport::RpcTransport`] to a
+    /// `std::io` `Read`/`Write` — `RawTransportIo`
+    /// (`rpc::wire_android13`, the android-13+ raw framing) and `RawIo`
+    /// (`rpc::transport::tls`, R34 framing over TLS).
+    ///
+    /// `RpcError::Io` hands its payload back as-is, but the reverse
+    /// direction folds the disconnect kinds, so an `Io` carrying one of
+    /// them returns as `PeerClosed`.
+    /// [`RpcError::PeerClosed`] projects onto a single representative
+    /// disconnect kind (`BrokenPipe`): the four kinds `From<io::Error>`
+    /// folds into `PeerClosed` are not distinguished, and a
+    /// `PeerClosed` raised from a 0-byte read never had one. That kind
+    /// folds back into `PeerClosed`, so a write-side disconnect on an
+    /// android-13+ session stays `StatusCode::DeadObject` rather than
+    /// degrading to an unclassified `Io(Other)` (`StatusCode::Unknown`)
+    /// — the status a caller's dead-peer check keys on.
+    /// [`RpcError::Timeout`] projects onto `TimedOut`
+    /// — kind-preserving rather than variant-preserving, since
+    /// `From<io::Error>` folds that kind into `Io(TimedOut)`. The
+    /// remaining variants have no `io::ErrorKind` that means what they
+    /// mean, so they stay `Other`.
     fn from(e: RpcError) -> Self {
         match e {
             RpcError::Io(io) => io,
@@ -354,15 +362,17 @@ mod tests {
         );
     }
 
-    /// `RpcError -> io::Error -> RpcError` must be lossless for the two
-    /// variants that have an `io::ErrorKind` meaning the same thing.
-    /// `RawTransportIo` crosses that boundary on every android-13+ read
-    /// and write, so a variant that degrades to `Other` there comes back
-    /// as `Io(Other)`: a peer that closed before our write then reported
-    /// `StatusCode::Unknown` instead of `DeadObject`, and the handshake
-    /// diagnosis could no longer recognize a dead peer. Which side of an
+    /// `RpcError -> io::Error` must preserve the `io::ErrorKind` for the
+    /// two variants that have one meaning the same thing.
+    /// `RawTransportIo` crosses that boundary on every android-13+
+    /// handshake and on every read and write of a non-fd session, so a
+    /// variant that degrades to `Other` there comes back
+    /// as `Io(Other)`: a peer that closes before our write has to report
+    /// `StatusCode::DeadObject`, not `Unknown`. Which side of an
     /// exchange notices a disconnect first is a host- and timing-
     /// dependent race, so both directions have to classify alike.
+    /// `PeerClosed` returns as the same variant; `Timeout` is only
+    /// kind-preserving — it comes back as `Io(TimedOut)`.
     ///
     /// **Mutant gate**: restoring `other => io::Error::other(...)` for
     /// `PeerClosed` fails the round trip below (and the timeout arm
@@ -383,6 +393,12 @@ mod tests {
         assert!(
             transport::is_timeout(&io),
             "read_exact_into's deadline arm keys on this kind"
+        );
+        // Reverse: `From<io::Error>` folds only the disconnect kinds, so
+        // a timeout comes back as `Io(TimedOut)`, not `Timeout` itself.
+        assert!(
+            matches!(RpcError::from(io), RpcError::Io(ref e) if transport::is_timeout(e)),
+            "a timeout stays recognizable as one across the round trip"
         );
 
         // An `Io` payload still round-trips unchanged, and a variant

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -573,9 +573,17 @@ fn confirm_attach(
     }
 }
 
-/// One line explaining what a refused attach looks like, shared by the
-/// two attach entries so the diagnosis does not drift between them.
+/// Explain a failed attach, shared by the two attach entries so the
+/// diagnosis does not drift between them.
 fn log_attach_refused(e: &RpcError) {
+    if matches!(e, RpcError::Timeout | RpcError::Truncated) {
+        log::error!(
+            "android-13+ RPC: the attach admission probe (GET_SESSION_ID) did not complete \
+             ({e}) — a read deadline armed by this caller ends it this way too, so this is \
+             not necessarily a refusal"
+        );
+        return;
+    }
     log::error!(
         "android-13+ RPC: the peer refused this attach ({e}) — the session id is unknown or \
          stale, the peer's outgoing-slot cap (`set_max_threads`) is spent, or it is shutting \
@@ -585,36 +593,43 @@ fn log_attach_refused(e: &RpcError) {
     );
 }
 
-/// Map an android-13+ **client** handshake failure to a [`StatusCode`],
-/// logging the profile-mismatch hint when a *new-session* handshake
-/// dies at the transport. That is what an r34 (default profile) server
-/// looks like from here: it reads our 16-byte `RpcConnectionHeader` as
-/// an r34 frame, fails to decode it and closes — leaving the client
-/// with a bare dead-peer status and the server with no log at all.
-///
-/// The peer already accepted the connection (a refused `connect()`
-/// never reaches the handshake), so a transport failure *here* means it
-/// hung up or stalled mid-handshake, and a wire-profile mismatch is by
-/// far the likeliest cause — whichever side of the exchange notices
-/// first. Which side that is, is a race: the same mismatch surfaces as
-/// EOF on our response read (the peer closed before we wrote) or as
-/// `EPIPE`/`ECONNRESET` on our `"cci"` write, and the second shape is
-/// what a Linux host usually produces. A `Protocol` error is excluded:
-/// there the peer demonstrably speaks android-13+ and the error already
-/// says what was wrong with its answer.
+/// Map an android-13+ **client** handshake failure to a [`StatusCode`].
+/// A new-session handshake logs a hint first: an r34 (default profile)
+/// peer is the likeliest cause and the returned status cannot say so.
 fn client_handshake_err(e: RpcError, requesting_new_session: bool) -> StatusCode {
-    if requesting_new_session
-        && matches!(
-            e,
-            RpcError::PeerClosed | RpcError::Truncated | RpcError::Timeout | RpcError::Io(_)
-        )
-    {
-        log::error!(
-            "rsbinder RPC: the android-13+ handshake failed at the transport ({e}) after the \
-             peer accepted the connection — it may be speaking the r34 (default) profile. \
-             Connect without `?profile=android13plus`, or enable the android-13+ wire on the \
-             server (`RpcServer::set_android13plus`)"
-        );
+    if requesting_new_session {
+        match &e {
+            RpcError::PeerClosed => log::error!(
+                "rsbinder RPC: the android-13+ handshake failed at the transport ({e}) after \
+                 the peer accepted the connection — it may be speaking the r34 (default) \
+                 profile. Connect without `?profile=android13plus`, or enable the android-13+ \
+                 wire on the server (`RpcServer::set_android13plus`)"
+            ),
+            RpcError::Truncated => log::error!(
+                "rsbinder RPC: the android-13+ handshake failed part-way through a response \
+                 ({e}) — the peer may be speaking the r34 (default) profile, or a read \
+                 deadline armed on this connection landed mid-frame. Connect without \
+                 `?profile=android13plus`, or enable the android-13+ wire on the server \
+                 (`RpcServer::set_android13plus`)"
+            ),
+            RpcError::Timeout => log::error!(
+                "rsbinder RPC: the android-13+ handshake stalled and a read deadline armed on \
+                 this connection elapsed — that deadline is the caller's own \
+                 (`RpcUnixClientConfig::handshake_timeout`, the 10s \
+                 `RpcSession::from_preconnected_fd` arms, or one set on the transport \
+                 directly), so it may simply be shorter than this peer's legitimate response \
+                 time. A peer that should have answered well within it may be speaking the \
+                 r34 (default) profile instead"
+            ),
+            // The returned status drops the reason string, so this log
+            // is the only description of the violation a caller gets.
+            RpcError::Protocol(_) => log::error!(
+                "rsbinder RPC: the android-13+ handshake failed ({e}) — either the peer's \
+                 answer violated the wire or the caller offered a `max_version` this build \
+                 does not implement"
+            ),
+            _ => {}
+        }
     }
     StatusCode::from(e)
 }

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -586,17 +586,32 @@ fn log_attach_refused(e: &RpcError) {
 }
 
 /// Map an android-13+ **client** handshake failure to a [`StatusCode`],
-/// logging the profile-mismatch hint when the peer hung up where its
-/// `RpcNewSessionResponse` was due. That is what an r34 (default
-/// profile) server looks like from here: it reads our 16-byte
-/// `RpcConnectionHeader` as an r34 frame, fails to decode it and
-/// closes — leaving the client with a bare `DeadObject` and the server
-/// with no log at all.
+/// logging the profile-mismatch hint when a *new-session* handshake
+/// dies at the transport. That is what an r34 (default profile) server
+/// looks like from here: it reads our 16-byte `RpcConnectionHeader` as
+/// an r34 frame, fails to decode it and closes — leaving the client
+/// with a bare dead-peer status and the server with no log at all.
+///
+/// The peer already accepted the connection (a refused `connect()`
+/// never reaches the handshake), so a transport failure *here* means it
+/// hung up or stalled mid-handshake, and a wire-profile mismatch is by
+/// far the likeliest cause — whichever side of the exchange notices
+/// first. Which side that is, is a race: the same mismatch surfaces as
+/// EOF on our response read (the peer closed before we wrote) or as
+/// `EPIPE`/`ECONNRESET` on our `"cci"` write, and the second shape is
+/// what a Linux host usually produces. A `Protocol` error is excluded:
+/// there the peer demonstrably speaks android-13+ and the error already
+/// says what was wrong with its answer.
 fn client_handshake_err(e: RpcError, requesting_new_session: bool) -> StatusCode {
-    if requesting_new_session && matches!(e, RpcError::PeerClosed | RpcError::Truncated) {
+    if requesting_new_session
+        && matches!(
+            e,
+            RpcError::PeerClosed | RpcError::Truncated | RpcError::Timeout | RpcError::Io(_)
+        )
+    {
         log::error!(
-            "rsbinder RPC: the peer closed the connection during the android-13+ handshake, \
-             before its RpcNewSessionResponse — it may be speaking the r34 (default) profile. \
+            "rsbinder RPC: the android-13+ handshake failed at the transport ({e}) after the \
+             peer accepted the connection — it may be speaking the r34 (default) profile. \
              Connect without `?profile=android13plus`, or enable the android-13+ wire on the \
              server (`RpcServer::set_android13plus`)"
         );

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -199,6 +199,11 @@ impl<'a> RpcUnixClientConfig<'a> {
     /// session, and the handshake runs before the session exists. This is
     /// the client-side counterpart of
     /// [`RpcServer::set_handshake_timeout`](super::RpcServer::set_handshake_timeout).
+    ///
+    /// `Duration::ZERO` is not a deadline: the setup call this config is
+    /// passed to refuses it with [`StatusCode::BadValue`] rather than
+    /// silently dropping the bound the caller asked for. Leave the option
+    /// unset to wait indefinitely on purpose.
     pub fn handshake_timeout(mut self, timeout: Duration) -> Self {
         self.handshake_timeout = Some(timeout);
         self
@@ -490,12 +495,42 @@ struct HandshakeDeadline<'a> {
 
 impl<'a> HandshakeDeadline<'a> {
     fn arm(transport: &'a dyn RpcTransport, deadline: Option<Duration>) -> RpcResult<Self> {
+        // Every handshake deadline funnels through here, so this is the
+        // one place that can promise a zero duration never reaches a
+        // transport. `set_read_timeout` is documented to reject it, but
+        // that is the *socket*'s promise, not the `RpcTransport` trait's:
+        // an implementation free to accept `Some(ZERO)` would leave the
+        // phase unbounded, which is worse than the deadline the caller
+        // asked for. `None` is how "no deadline" is spelled.
+        if deadline.is_some_and(|d| d.is_zero()) {
+            log::error!(
+                "rsbinder RPC: a zero handshake deadline is not a deadline — pass a positive                  duration, or `None` to wait indefinitely on purpose"
+            );
+            return Err(RpcError::Io(std::io::Error::from(
+                std::io::ErrorKind::InvalidInput,
+            )));
+        }
         let armed = deadline.is_some();
         if armed {
             transport.set_read_timeout(deadline)?;
         }
         Ok(Self { transport, armed })
     }
+}
+
+/// A zero handshake deadline, rejected where the caller can still be
+/// named. `HandshakeDeadline::arm` refuses it too, but only once the
+/// connect has happened and only as a transport error; here it is the
+/// `BadValue` every other invalid field of these builders yields.
+pub(crate) fn reject_zero_handshake_timeout(timeout: Option<Duration>, setter: &str) -> Result<()> {
+    if timeout.is_some_and(|d| d.is_zero()) {
+        log::error!(
+            "rsbinder RPC: {setter} was given a zero duration, which is not a deadline; pass a \
+             positive duration, or leave it unset to wait indefinitely"
+        );
+        return Err(StatusCode::BadValue);
+    }
+    Ok(())
 }
 
 impl Drop for HandshakeDeadline<'_> {
@@ -4090,6 +4125,10 @@ impl RpcSession {
     pub fn setup_unix_client_android13plus_with_config(
         config: RpcUnixClientConfig,
     ) -> Result<RpcSession> {
+        reject_zero_handshake_timeout(
+            config.handshake_timeout,
+            "RpcUnixClientConfig::handshake_timeout",
+        )?;
         let local = config.outgoing_connections.max(1);
         let incoming = config.incoming_connections;
         // Fan-out and incoming connections are a session *owner*'s
@@ -4200,6 +4239,10 @@ impl RpcSession {
         &self,
         config: RpcUnixClientConfig,
     ) -> Result<u64> {
+        reject_zero_handshake_timeout(
+            config.handshake_timeout,
+            "RpcUnixClientConfig::handshake_timeout",
+        )?;
         if config.outgoing_connections.max(1) != 1
             || config.incoming_connections != 0
             || config.session_id.len() != 32
@@ -4311,6 +4354,10 @@ impl RpcSession {
         &self,
         config: RpcUnixClientConfig,
     ) -> Result<u64> {
+        reject_zero_handshake_timeout(
+            config.handshake_timeout,
+            "RpcUnixClientConfig::handshake_timeout",
+        )?;
         if config.outgoing_connections.max(1) != 1
             || config.incoming_connections != 0
             || config.session_id.len() != 32
@@ -4688,6 +4735,43 @@ mod tests {
             None,
         )
         .expect("socketpair")
+    }
+
+    /// A zero handshake deadline is refused at the one point every
+    /// arming site funnels through, so no transport can be handed a
+    /// deadline it is documented to reject — and no implementation that
+    /// accepts one can leave the phase unbounded instead.
+    ///
+    /// **Mutant gate**: dropping the guard in `HandshakeDeadline::arm`
+    /// makes this `Ok` for any transport whose `set_read_timeout`
+    /// tolerates zero, and turns the caller's bound into no bound.
+    #[test]
+    fn zero_handshake_deadline_is_refused_before_it_reaches_a_transport() {
+        let (a, _b) = super::super::transport::MemTransport::pair();
+        assert!(
+            HandshakeDeadline::arm(&a, Some(Duration::ZERO)).is_err(),
+            "a zero duration is not a deadline"
+        );
+        // The two shapes that are deadlines still arm.
+        assert!(HandshakeDeadline::arm(&a, None).is_ok());
+        assert!(HandshakeDeadline::arm(&a, Some(Duration::from_millis(50))).is_ok());
+    }
+
+    /// The same value refused where the caller can still be named: the
+    /// builder's setup and attach entries report it as the `BadValue`
+    /// every other invalid field of that builder yields, before any
+    /// connect happens.
+    #[test]
+    fn zero_handshake_timeout_is_bad_value_at_the_config_entries() {
+        let path = std::path::Path::new("/nonexistent/rsb-zero-handshake.sock");
+        assert_eq!(
+            RpcSession::setup_unix_client_android13plus_with_config(
+                RpcUnixClientConfig::path(path, 2).handshake_timeout(Duration::ZERO),
+            )
+            .err(),
+            Some(StatusCode::BadValue),
+            "rejected before the connect — the path is never touched"
+        );
     }
 
     /// `from_preconnected_fd` on an `AF_UNIX` socketpair half: family

--- a/rsbinder/src/rpc/transport/tls.rs
+++ b/rsbinder/src/rpc/transport/tls.rs
@@ -511,9 +511,10 @@ impl Write for RawIo<'_> {
         Ok(buf.len())
     }
     fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
-        self.0
-            .send_raw(buf)
-            .map_err(|e| std::io::Error::other(e.to_string()))
+        // Kind-preserving like `RawTransportIo`: a write to a peer that
+        // already closed must reach `write_frame`'s `?` as `PeerClosed`
+        // (`DeadObject`), not an unclassified `Io(Other)`.
+        self.0.send_raw(buf).map_err(std::io::Error::from)
     }
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(()) // send_raw already flushes the socket

--- a/rsbinder/src/rpc/wire_android13.rs
+++ b/rsbinder/src/rpc/wire_android13.rs
@@ -1214,13 +1214,12 @@ pub struct RawTransportIo<'a>(pub &'a dyn super::transport::RpcTransport);
 
 impl Read for RawTransportIo<'_> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.0.recv_raw(buf).map_err(|e| match e {
-            // Preserve the timeout kind across the `Read` boundary so
-            // `read_exact_raw` can honor the `Timeout`/`Truncated`
-            // contract; other errors keep their string form.
-            RpcError::Timeout => std::io::Error::from(std::io::ErrorKind::TimedOut),
-            other => std::io::Error::other(other.to_string()),
-        })
+        // `From<RpcError>` is kind-preserving (`Timeout` -> `TimedOut`
+        // for `read_exact_into`'s `is_timeout` arm, `PeerClosed` ->
+        // `BrokenPipe`), so the `map_io` on the other side of this
+        // boundary recovers the same variant instead of a stringified
+        // `Io(Other)`.
+        self.0.recv_raw(buf).map_err(std::io::Error::from)
     }
 }
 
@@ -1230,9 +1229,10 @@ impl Write for RawTransportIo<'_> {
         Ok(buf.len())
     }
     fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
-        self.0
-            .send_raw(buf)
-            .map_err(|e| std::io::Error::other(e.to_string()))
+        // Kind-preserving, as on the read side: a peer that closed
+        // before our write must surface as `PeerClosed` (`DeadObject`),
+        // not as the `Io(Other)` a stringified error produced.
+        self.0.send_raw(buf).map_err(std::io::Error::from)
     }
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(()) // `send_raw` already flushes the underlying stream.

--- a/rsbinder/src/rpc/wire_android13.rs
+++ b/rsbinder/src/rpc/wire_android13.rs
@@ -483,12 +483,12 @@ impl Android13PlusCodec {
     /// Verify an `RpcOutgoingConnectionInit` (`strncmp(msg,"cci",4)`).
     ///
     /// The rejects name the r34 profile because that is what this check
-    /// catches in practice: an r34 client's first frame
-    /// (`[command|bodySize|reserved]`) parses as a *valid-looking*
-    /// v0 `RpcConnectionHeader` — `command == CMD_TRANSACT == 0` reads
-    /// as protocol version 0 — so a profile mismatch survives the header
-    /// and first fails here, where the `"cci"` magic cannot be faked by
-    /// an r34 transaction body.
+    /// catches in practice: [`server_accept_deferred_init`] clamps the
+    /// version the connection header decodes to
+    /// (`min(client_version, server_max_version)`, as AOSP does) instead
+    /// of rejecting it, so a profile mismatch survives the header and
+    /// first fails here, where the `"cci"` magic cannot be faked by an
+    /// r34 transaction body.
     pub fn decode_connection_init(&self, buf: &[u8]) -> RpcResult<()> {
         if buf.len() < A13_CONN_INIT_LEN {
             return Err(RpcError::Protocol(
@@ -771,9 +771,22 @@ fn map_io(e: std::io::Error) -> RpcError {
     RpcError::from(e)
 }
 
+/// Classify a failed read by `progress`, the amount the **caller**
+/// counts as already arrived (this call's bytes for
+/// [`read_exact_into`], the whole message for the FD reader): at zero a
+/// clean close or an elapsed deadline stands as itself; above zero
+/// either one leaves the stream desynchronized ⇒
+/// [`RpcError::Truncated`].
+fn classify_short_read(e: RpcError, progress: usize) -> RpcError {
+    match e {
+        RpcError::PeerClosed | RpcError::Timeout if progress > 0 => RpcError::Truncated,
+        other => other,
+    }
+}
+
 /// Read exactly `n` bytes. Zero bytes before any progress ⇒ a clean
 /// [`RpcError::PeerClosed`]; a short read after partial progress ⇒
-/// [`RpcError::Truncated`] (mirrors `transport::read_frame`).
+/// [`RpcError::Truncated`].
 fn read_exact_raw<R: Read>(r: &mut R, n: usize) -> RpcResult<Vec<u8>> {
     let mut buf = vec![0u8; n];
     read_exact_into(r, &mut buf)?;
@@ -788,30 +801,19 @@ fn read_exact_into<R: Read>(r: &mut R, buf: &mut [u8]) -> RpcResult<()> {
     let mut got = 0;
     while got < n {
         match r.read(&mut buf[got..]) {
-            Ok(0) => {
-                return Err(if got == 0 {
-                    RpcError::PeerClosed
-                } else {
-                    RpcError::Truncated
-                })
-            }
+            Ok(0) => return Err(classify_short_read(RpcError::PeerClosed, got)),
             Ok(k) => got += k,
             // A signal interrupted the read; retry like every other reader.
             Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
             // A read deadline elapsed (`RawTransportIo` surfaces
             // `recv_raw`'s `Timeout` as `ErrorKind::TimedOut`; a bare
-            // socket reader yields `WouldBlock`): a clean `Timeout` before
-            // any byte of this read, else mid-frame `Truncated` — honoring
-            // the `set_read_timeout` contract rather than collapsing to a
+            // socket reader yields `WouldBlock`): honor the
+            // `set_read_timeout` contract rather than collapsing to a
             // generic `Io` via `map_io`.
             Err(ref e) if super::transport::is_timeout(e) => {
-                return Err(if got == 0 {
-                    RpcError::Timeout
-                } else {
-                    RpcError::Truncated
-                });
+                return Err(classify_short_read(RpcError::Timeout, got))
             }
-            Err(e) => return Err(map_io(e)),
+            Err(e) => return Err(classify_short_read(map_io(e), got)),
         }
     }
     Ok(())
@@ -856,17 +858,12 @@ pub fn read_aosp_message<R: Read>(r: &mut R) -> RpcResult<Vec<u8>> {
     let mut out = vec![0u8; WIRE_HEADER_LEN + body_size];
     out[..WIRE_HEADER_LEN].copy_from_slice(&header);
     if body_size > 0 {
-        // The header is already consumed, so either a deadline that elapses at
-        // the start of the body (`Timeout`) or a clean EOF before the body
-        // (`PeerClosed`, which `read_exact_into` reports for a 0-byte read) is
-        // mid-message, not frame-synchronized: report `Truncated` in both
-        // cases (matches `read_aosp_message_with_fds`, which carries
-        // `total_read` across header+body). Without the `PeerClosed` arm a peer
-        // that sends only a header and dies would be recorded as a clean close.
-        read_exact_into(r, &mut out[WIRE_HEADER_LEN..]).map_err(|e| match e {
-            RpcError::Timeout | RpcError::PeerClosed => RpcError::Truncated,
-            other => other,
-        })?;
+        // The header is already consumed, so a deadline or a clean EOF at the
+        // start of the body is mid-message, not frame-synchronized: pass the
+        // header as progress so both become `Truncated`, the same value the FD
+        // reader's `total_read` yields there.
+        read_exact_into(r, &mut out[WIRE_HEADER_LEN..])
+            .map_err(|e| classify_short_read(e, WIRE_HEADER_LEN))?;
     }
     Ok(out)
 }
@@ -910,28 +907,17 @@ pub fn read_aosp_message_with_fds(
 ) -> RpcResult<(Vec<u8>, Vec<std::os::fd::OwnedFd>)> {
     let mut fds: Vec<std::os::fd::OwnedFd> = Vec::new();
     let mut total_read = 0usize;
-    // Read exactly `want` bytes via `recvmsg`, accumulating any fds
-    // into `fds`. `total_read` tracks progress across header+body so a
-    // 0-byte recv distinguishes a clean pre-message close (PeerClosed)
-    // from a mid-message truncation (Truncated) — same contract as
-    // `read_exact_raw`.
-    let mut fill = |want: usize| -> RpcResult<Vec<u8>> {
-        let mut buf = vec![0u8; want];
+    // Fill `dst` via `recvmsg`, accumulating any fds into `fds`.
+    // `total_read` tracks progress across header+body so a 0-byte recv
+    // distinguishes a clean pre-message close (PeerClosed) from a
+    // mid-message truncation (Truncated) — same contract as
+    // `read_exact_raw`, through the same `classify_short_read`.
+    let mut fill = |dst: &mut [u8]| -> RpcResult<()> {
         let mut got = 0;
-        while got < want {
-            let (n, mut more) = match t.recv_raw_with_fds(&mut buf[got..]) {
+        while got < dst.len() {
+            let (n, mut more) = match t.recv_raw_with_fds(&mut dst[got..]) {
                 Ok(v) => v,
-                // A read deadline elapsed: a clean `Timeout` only before any
-                // byte of the message was read; otherwise the message is
-                // mid-flight ⇒ `Truncated` (same split as the EOF case below).
-                Err(RpcError::Timeout) => {
-                    return Err(if total_read == 0 {
-                        RpcError::Timeout
-                    } else {
-                        RpcError::Truncated
-                    });
-                }
-                Err(e) => return Err(e),
+                Err(e) => return Err(classify_short_read(e, total_read)),
             };
             fds.append(&mut more);
             // Enforce the per-message `MAX_FDS_PER_FRAME` cap *across*
@@ -948,19 +934,16 @@ pub fn read_aosp_message_with_fds(
                 ));
             }
             if n == 0 {
-                return Err(if total_read == 0 {
-                    RpcError::PeerClosed
-                } else {
-                    RpcError::Truncated
-                });
+                return Err(classify_short_read(RpcError::PeerClosed, total_read));
             }
             got += n;
             total_read += n;
         }
-        Ok(buf)
+        Ok(())
     };
 
-    let header = fill(WIRE_HEADER_LEN)?;
+    let mut header = [0u8; WIRE_HEADER_LEN];
+    fill(&mut header)?;
     let body_size = u32::from_le_bytes([header[4], header[5], header[6], header[7]]) as usize;
     if body_size > MAX_FRAME_LEN {
         return Err(RpcError::FrameTooLarge {
@@ -968,10 +951,14 @@ pub fn read_aosp_message_with_fds(
             max: MAX_FRAME_LEN,
         });
     }
-    let mut out = Vec::with_capacity(WIRE_HEADER_LEN + body_size);
-    out.extend_from_slice(&header);
+    // One allocation for header + body, read into in place: `bodySize`
+    // is peer-chosen up to `MAX_FRAME_LEN`, so a temporary body buffer
+    // would let a 16-byte header commit twice that (as `read_aosp_message`
+    // notes).
+    let mut out = vec![0u8; WIRE_HEADER_LEN + body_size];
+    out[..WIRE_HEADER_LEN].copy_from_slice(&header);
     if body_size > 0 {
-        out.extend_from_slice(&fill(body_size)?);
+        fill(&mut out[WIRE_HEADER_LEN..])?;
     }
     Ok((out, fds))
 }
@@ -1214,11 +1201,10 @@ pub struct RawTransportIo<'a>(pub &'a dyn super::transport::RpcTransport);
 
 impl Read for RawTransportIo<'_> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        // `From<RpcError>` is kind-preserving (`Timeout` -> `TimedOut`
-        // for `read_exact_into`'s `is_timeout` arm, `PeerClosed` ->
-        // `BrokenPipe`), so the `map_io` on the other side of this
-        // boundary recovers the same variant instead of a stringified
-        // `Io(Other)`.
+        // `From<RpcError>` is kind-preserving (`Timeout` -> `TimedOut`,
+        // `PeerClosed` -> `BrokenPipe`), so on the other side of this
+        // boundary `map_io` recovers `PeerClosed` and the `is_timeout`
+        // arm recovers `Timeout`, instead of a stringified `Io(Other)`.
         self.0.recv_raw(buf).map_err(std::io::Error::from)
     }
 }
@@ -1231,7 +1217,7 @@ impl Write for RawTransportIo<'_> {
     fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
         // Kind-preserving, as on the read side: a peer that closed
         // before our write must surface as `PeerClosed` (`DeadObject`),
-        // not as the `Io(Other)` a stringified error produced.
+        // not as an unclassified `Io(Other)`.
         self.0.send_raw(buf).map_err(std::io::Error::from)
     }
     fn flush(&mut self) -> std::io::Result<()> {
@@ -1446,10 +1432,10 @@ mod tests {
         let init = c1.encode_connection_init();
         assert_eq!(&init[0..4], b"cci\0");
         c1.decode_connection_init(&init).expect("\"cci\"");
-        // A profile mismatch first fails here (an r34 client's leading
-        // `CMD_TRANSACT == 0` passes as protocol version 0), so both
-        // rejects have to name r34 — that string is the only thing the
-        // server's handshake log can show an operator.
+        // A profile mismatch first fails here (the header read clamps
+        // the peer's version instead of rejecting it), so both rejects
+        // have to name r34 — that string is the only thing the server's
+        // handshake log can show an operator.
         for bad in [&[0u8; 8][..], &[0u8; 2][..]] {
             let why = match c1.decode_connection_init(bad) {
                 Err(RpcError::Protocol(why)) => why,

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -515,9 +515,7 @@ fn concurrent_calls_single_shared_session() {
     // 8 client threads on the SAME session.
     // ONE client session, its root proxy shared (Arc) across 8 threads
     // — exactly how a generated `Bp*` stub is used concurrently
-    // (`SIBinder` is `Send`/`Sync`). Before the per-connection lock
-    // this interleaved the framed stream / cross-delivered replies.
-    // Calls are internally serialized on the one
+    // (`SIBinder` is `Send`/`Sync`). Calls are internally serialized on the one
     // connection (the documented model: parallelism = multiple
     // connections), so wall time is also bounded well below a hang.
     let client = RpcSession::setup_unix_client(&path).expect("connect");
@@ -1219,35 +1217,23 @@ fn a0b_multi_connection_shared_session() {
     // Strengthen the unknown-id reject assertion: a plain `is_err()`
     // would also pass for an unrelated
     // error (e.g. handshake itself failed). Lock the contract to the
-    // actual post-handshake-reject status set observed on UDS:
-    //
-    //  - **DeadObject** — the canonical path: server `drop(transport)`
-    //    closes the socket; the client's next send/recv surfaces
-    //    `io::ErrorKind::{BrokenPipe,ConnectionReset,UnexpectedEof,…}`
-    //    which `RpcError::from(io)` maps to `PeerClosed` and then
-    //    `StatusCode::DeadObject` (see `rsbinder/src/rpc/mod.rs`
-    //    `From<io::Error> for RpcError` and the `PeerClosed →
-    //    DeadObject` arm).
-    //  - **TimedOut** — `set_timeout(3s)` fires before the close
-    //    propagates.
-    //  - **Unknown** — host-OS dependent: macOS in particular can
-    //    surface a socket-close as an `io::Error` whose
-    //    `raw_os_error() == None` (e.g. `ErrorKind::Other`), which
-    //    `StatusCode::from(io::Error)` maps to `Unknown` rather than
-    //    `PeerClosed`. Accepted as a reject status.
-    //
-    // Anything outside this set means a different bug (and `Ok` is
-    // the true mutant: server honored the unknown id).
+    // single status this reject produces: the server `drop(transport)`
+    // closes the socket, and a disconnect folds to `PeerClosed` and
+    // then `StatusCode::DeadObject` (see `rsbinder/src/rpc/mod.rs`,
+    // `From<io::Error> for RpcError`, kind-preserving in both
+    // directions per
+    // `rpc::tests::peer_closed_and_timeout_round_trip_through_io_error`).
+    // This path arms no deadline (`RpcUnixClientConfig`'s
+    // `handshake_timeout` defaults to `None`), so a `TimedOut` or an
+    // unclassified `Unknown` here means a different bug — as does `Ok`,
+    // the true mutant: server honored the unknown id.
     let err = RpcSession::setup_unix_client_android13plus_with_id(&path, 1, &bogus)
         .err()
         .expect("unknown id rejected");
-    assert!(
-        matches!(
-            err,
-            StatusCode::DeadObject | StatusCode::TimedOut | StatusCode::Unknown
-        ),
-        "unknown id reject should surface as DeadObject (PeerClosed path) / \
-         TimedOut (deadline wins) / Unknown (host-OS-dependent close), got {err:?}"
+    assert_eq!(
+        err,
+        StatusCode::DeadObject,
+        "unknown id reject must surface as DeadObject (the PeerClosed path)"
     );
     assert!(
         poll_until(|| server.rejected_unknown_id_count() == 1),
@@ -1464,13 +1450,11 @@ fn ac_12_4_set_max_threads_caps_incoming_slots() {
     let err = RpcSession::setup_unix_client_android13plus_with_id(&path, 1, &sid)
         .err()
         .expect("3rd attach must be rejected by the per-session cap");
-    assert!(
-        matches!(
-            err,
-            StatusCode::DeadObject | StatusCode::TimedOut | StatusCode::Unknown
-        ),
-        "cap-reject surfaces as the same reject set as unknown-id reject \
-         (post-handshake socket close), got {err:?}"
+    assert_eq!(
+        err,
+        StatusCode::DeadObject,
+        "cap-reject surfaces as the same status as the unknown-id reject \
+         (post-handshake socket close)"
     );
     assert!(
         poll_until(|| server.rejected_unknown_id_count() == rejected_before + 1),
@@ -1659,12 +1643,8 @@ fn b2_local_max_outgoing_one_skips_fan_out_byte_identical_to_founding_only() {
 /// admission with one `GET_SESSION_ID` round trip on the fresh
 /// connection.
 ///
-/// Reported from a downstream project (2026-09-03): with a wrong id the
-/// attach returned `Ok`, the dead slot stayed in the pool, and one
-/// later unrelated call — whichever one `find_conn` routed onto that
-/// slot — failed. Single-threaded clients always draw slot 1 first, so
-/// this drives 4 threads to make the pool actually reach the attached
-/// slot.
+/// Single-threaded clients always draw slot 1 first, so this drives 4
+/// threads to make the pool actually reach the attached slot.
 ///
 /// **Mutant gate**: dropping the `confirm_attach` call restores
 /// `Ok(2)` for both bogus ids and re-poisons the pool (the echo loop
@@ -1717,8 +1697,7 @@ fn attach_with_a_bogus_session_id_is_refused_at_attach_time() {
     );
 
     // (c) The control: the server-minted id attaches, and the pool is
-    //     clean — 200 calls across 4 threads, zero failures. Before the
-    //     fix a bogus attach made ~1 in 4 of these fail.
+    //     clean — 200 calls across 4 threads, zero failures.
     assert_eq!(
         client
             .add_outgoing_connection_android13plus(&path, 1, &sid)
@@ -1832,28 +1811,12 @@ fn attach_max_version_below_the_session_version_is_bad_type() {
 /// The r34-server / android-13+-client half of a wire-profile
 /// mismatch. The server is the default (r34) wire, so it reads the
 /// client's 16-byte `RpcConnectionHeader` as an r34 frame, fails to
-/// decode it and closes.
-///
-/// Two things are gated here, both reported from downstream:
-///
-/// 1. **The status is `DeadObject` on every host.** Which side notices
-///    the disconnect first is a race — the client either reads EOF
-///    where `RpcNewSessionResponse` was due (macOS, typically) or takes
-///    `EPIPE`/`ECONNRESET` on its `"cci"` write (Linux, typically) —
-///    and the write side used to lose the classification across
-///    `RawTransportIo`, reporting `StatusCode::Unknown`.
-/// 2. **A hint is logged naming the r34 profile** (the log itself is
-///    not asserted here; `client_handshake_err` keys it on exactly the
-///    transport-level variants this status covers, and
-///    `peer_closed_and_timeout_round_trip_through_io_error` pins the
-///    classification that gets it there).
+/// decode it and closes. The client must report `DeadObject`, not an
+/// unclassified `StatusCode::Unknown`.
 ///
 /// The opposite direction (r34 client, android-13+ server) is covered
 /// by the `"cci"` reject string in
-/// `wire_android13::tests::codec_roundtrip_and_handshake_frames`.
-///
-/// **Mutant gate**: stringifying `PeerClosed` in `From<RpcError> for
-/// io::Error` again turns the write-side race into `Unknown` here.
+/// `wire_android13::tests::android13plus_spec_golden_vectors`.
 #[test]
 fn r34_server_reports_an_android13plus_client_as_a_dead_peer() {
     let path = tmp_sock("profmix");
@@ -2007,13 +1970,11 @@ fn shutdown_gate_e2e_rejects_attach_during_handshake_stall() {
         .join()
         .expect("attach thread should not panic");
     let err = attach_result.expect_err("attach during shutdown must be rejected (mutant: success)");
-    assert!(
-        matches!(
-            err,
-            StatusCode::DeadObject | StatusCode::TimedOut | StatusCode::Unknown
-        ),
-        "shutdown-reject surfaces as the same reject set as cap/unknown-id reject \
-         (post-handshake socket close), got {err:?}"
+    assert_eq!(
+        err,
+        StatusCode::DeadObject,
+        "shutdown-reject surfaces as the same status as the cap/unknown-id reject \
+         (post-handshake socket close)"
     );
     assert!(
         poll_until(|| server.rejected_unknown_id_count() == rejected_before + 1),

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -1829,6 +1829,54 @@ fn attach_max_version_below_the_session_version_is_bad_type() {
     );
 }
 
+/// The r34-server / android-13+-client half of a wire-profile
+/// mismatch. The server is the default (r34) wire, so it reads the
+/// client's 16-byte `RpcConnectionHeader` as an r34 frame, fails to
+/// decode it and closes.
+///
+/// Two things are gated here, both reported from downstream:
+///
+/// 1. **The status is `DeadObject` on every host.** Which side notices
+///    the disconnect first is a race — the client either reads EOF
+///    where `RpcNewSessionResponse` was due (macOS, typically) or takes
+///    `EPIPE`/`ECONNRESET` on its `"cci"` write (Linux, typically) —
+///    and the write side used to lose the classification across
+///    `RawTransportIo`, reporting `StatusCode::Unknown`.
+/// 2. **A hint is logged naming the r34 profile** (the log itself is
+///    not asserted here; `client_handshake_err` keys it on exactly the
+///    transport-level variants this status covers, and
+///    `peer_closed_and_timeout_round_trip_through_io_error` pins the
+///    classification that gets it there).
+///
+/// The opposite direction (r34 client, android-13+ server) is covered
+/// by the `"cci"` reject string in
+/// `wire_android13::tests::codec_roundtrip_and_handshake_frames`.
+///
+/// **Mutant gate**: stringifying `PeerClosed` in `From<RpcError> for
+/// io::Error` again turns the write-side race into `Unknown` here.
+#[test]
+fn r34_server_reports_an_android13plus_client_as_a_dead_peer() {
+    let path = tmp_sock("profmix");
+    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    // No `set_android13plus`: the default r34 wire.
+    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    let bg = server.run_background();
+    let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
+    wait_for_sock(&path);
+
+    for v in [0u32, 1, 2] {
+        match RpcSession::setup_unix_client_android13plus(&path, v) {
+            Ok(_) => panic!("an r34 server must not complete an android-13+ handshake (v{v})"),
+            Err(e) => assert_eq!(
+                e,
+                StatusCode::DeadObject,
+                "profile mismatch at max_version={v} must report the peer as dead, whichever \
+                 side of the handshake notices first"
+            ),
+        }
+    }
+}
+
 /// A standalone attach *session*
 /// ([`RpcSession::setup_unix_client_android13plus_with_id`], and the
 /// `ClientOptions::session_id` path over it) is confirmed the same way:

--- a/tests/tests/entry_rpc.rs
+++ b/tests/tests/entry_rpc.rs
@@ -169,6 +169,40 @@ fn entry_options_apply_to_rpc_server() {
     drop(keep);
 }
 
+/// `ClientOptions::handshake_timeout` is a plain public field, so a zero
+/// duration can only be caught where the options are consumed. `open`
+/// refuses it there with `BadValue` — before any connect — instead of
+/// carrying it to a `set_read_timeout`/`connect_timeout` that rejects it
+/// as an opaque I/O error, or (worse) dropping the caller's bound.
+///
+/// **Mutant gate**: removing the check in `rpc_connect` turns this into
+/// a connect attempt whose failure names neither the option nor the
+/// reason.
+#[test]
+fn entry_zero_handshake_timeout_is_refused() {
+    let sock = SockPath::new("zerohs");
+    let _guard = rsbinder::serve(&sock.uri(""))
+        .expect("serve")
+        .add("svc", tagged("svc"))
+        .expect("add")
+        .spawn()
+        .expect("spawn");
+
+    let err = rsbinder::Client::open_with(&sock.uri(""), |o, _| {
+        o.handshake_timeout = Some(std::time::Duration::ZERO)
+    })
+    .err()
+    .expect("a zero handshake deadline must be refused");
+    assert_eq!(err, rsbinder::StatusCode::BadValue);
+
+    // Control: a positive deadline on the same endpoint connects.
+    let ok = rsbinder::Client::open_with(&sock.uri(""), |o, _| {
+        o.handshake_timeout = Some(std::time::Duration::from_secs(5))
+    })
+    .and_then(|c| c.binder("svc"));
+    assert!(ok.is_ok(), "a positive deadline still connects");
+}
+
 /// `connect_async` (feature `tokio`) resolves through `spawn_blocking`
 /// and hands back a proxy the async stub can drive with `.await`.
 #[test]

--- a/tests/tests/entry_rpc.rs
+++ b/tests/tests/entry_rpc.rs
@@ -191,8 +191,7 @@ fn entry_zero_handshake_timeout_is_refused() {
     let err = rsbinder::Client::open_with(&sock.uri(""), |o, _| {
         o.handshake_timeout = Some(std::time::Duration::ZERO)
     })
-    .err()
-    .expect("a zero handshake deadline must be refused");
+    .expect_err("a zero handshake deadline must be refused");
     assert_eq!(err, rsbinder::StatusCode::BadValue);
 
     // Control: a positive deadline on the same endpoint connects.


### PR DESCRIPTION
Follow-up to #196. The profile-mismatch hint that PR added turned out to fire in only one direction, and the reason was a layer below it.

## The bug

`RawTransportIo` bridges an `RpcTransport` to `std::io` for every android-13+ read and write, and its projection stringified the error: `send_raw`'s `RpcError` became `io::Error::other(e.to_string())`, which `map_io` on the other side of that boundary could only read back as `RpcError::Io(Other)`. A peer that closed before our write was therefore reported as `StatusCode::Unknown` rather than `DeadObject` — on the send path of every call, not just the handshake.

That is also why the r34-mismatch hint looked host-dependent. An r34 server reads the client's 16-byte `RpcConnectionHeader` as an r34 frame, fails to decode it and closes; whether the client notices as EOF on its response read or as `EPIPE`/`ECONNRESET` on its `"cci"` write is a timing race. Measured, entry API and low-level API, at v0/v1/v2:

| | macOS | Linux |
|---|---|---|
| before | `Err(DeadObject)` + hint | `Err(Unknown)`, no log at all |
| after | `Err(DeadObject)` + hint | `Err(DeadObject)` + hint |

## The fix

`From<RpcError> for io::Error` is now kind-preserving for the two variants that have an `io::ErrorKind` meaning the same thing (`PeerClosed` → `BrokenPipe`, `Timeout` → `TimedOut`), and both `RawTransportIo` directions use it. The remaining variants have no such kind and stay `Other`. The accept loop that motivated this projection matches `ConnectionAborted`/`ConnectionReset`/`Interrupted`, so a `BrokenPipe` still falls through to its default arm exactly as `Other` did.

`client_handshake_err` then branches per cause — a peer close, a mid-frame cut, a stalled deadline (named as the caller's own) and a wire violation each say something a reader can act on.

## What the review pass added (2nd commit)

A `/review-fix` loop over the first commit ran six rounds and found two things the fix had missed:

- **`transport::tls`'s `RawIo::write_all` carried the same stringifying projection**, so an `rpc-tls` R34 session still reported a dead peer as `Unknown`. Same one-line swap.
- **The fd read path (`read_aosp_message_with_fds`) never got the partial-progress rule**, so with the kind-preserving projection in place a reset mid-message classified as `PeerClosed` where the contract says `Truncated`. Both read paths now share one `classify_short_read` helper instead of three hand-rolled copies that had already drifted, and the fd reader fills a caller-owned buffer rather than allocating the body twice.

It also corrected claims this work had introduced: the `Timeout` round trip is kind-preserving, not variant-lossless; the projection has two consumers, not one; and an r34 sender's leading bytes are a frame-length prefix, not a command word — what carries a mismatched header past the version check is the server's `min(client_version, server_max_version)` clamp, and the `"cci"` check is what then catches it.

## Zero handshake deadline (3rd commit)

Found while reviewing the above. `handshake_timeout` carried `Duration::ZERO` to `set_read_timeout` — which documents an error for it — so setup failed with an unexplained `Unknown`; on `tls://` the same value also reached `TcpStream::connect_timeout`. Zero cannot be a deadline and `None` already spells "no deadline", so it is refused in two places: at `HandshakeDeadline::arm`, the one point every arming site funnels through (a transport free to accept `Some(ZERO)` would leave the phase unbounded — worse than the bound the caller asked for), and at the config/`ClientOptions` consume points as `BadValue`, the same shape those entries already use for a bad `session_id` length. `ClientOptions::handshake_timeout` is a public field with no setter to guard, which is why the check lives where the options are consumed.

The session's *reply* deadline keeps its existing behavior — there zero falls back to `None`, because `None` is that deadline's documented default. What zero should fall back to depends on what the default is, and the client handshake's default is unbounded.

## Tests

- `peer_closed_and_timeout_round_trip_through_io_error` pins the projection without depending on the race.
- `r34_server_reports_an_android13plus_client_as_a_dead_peer` gates the end-to-end status across the three max versions. Note it only gates on a host that takes the write-side shape (Linux, and CI); on macOS the read-side shape already produced `DeadObject`.
- Three for the zero deadline: the choke point, the config entries, and `Client::open_with` at the entry layer.

## Verification

macOS and Linux suites green (lib `rpc::`, rpc_server, scenarios, e2e, fd, shared_memory, and the `tests` crate's entry_rpc), clippy `-D warnings`, rustfmt, `RUSTDOCFLAGS=-D warnings cargo doc`. STAGE3 `run_rpc_incoming_interop.sh` still PASS against a real libbinder `RpcServer` on the Android 16 emulator.

## Known follow-up

The review flagged `client_transact`'s `poison_slot(false)` on a decode failure as a possible reply-theft path. It is unchanged from `master`, its surrounding comment argues the split deliberately, and the reply-theft class was decided in #191/#194 — so it is left alone here rather than folded into this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)