### PR TITLE
rpc: type the connection end, contract the transport shutdown, rename the teardown vocabulary (plan 2-21)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,24 @@ jobs:
       - name: Build release
         run: cargo build --workspace --release
       - name: Check test builds
+        # The only workspace-wide enumeration this workflow has — but it
+        # compiles, it does not run, and a target gated on a feature the run
+        # does not enable compiles to *zero* tests. So every test target is
+        # either named on a `--test` line in `rpc-suite` / `macos-build`, or
+        # run whole-package (`-p rsbinder-aidl`, `-p rsbinder-macros`, whose
+        # targets are ungated), or excluded here on purpose:
+        #   * rsbinder/tests/rpc_vsock.rs — every test in it is `#[ignore]`d
+        #     (needs a peer VM or the `vsock_loopback` module), so running it
+        #     yields nothing; `rpc-suite` still builds it via the
+        #     `--features rpc-vsock` matrix step.
+        #   * rsbinder/tests/loom_cache_pin.rs — `cfg(loom)`, empty without
+        #     `RUSTFLAGS="--cfg loom"`; a loom run is a manual exercise.
+        #   * tests/tests/mesh_rpc.rs, tests/tests/mesh_kernel.rs — the
+        #     multi-process mesh: minutes-expensive, and `mesh_kernel` needs
+        #     /dev/binder plus a live rsb_hub, so integration-test.yml owns
+        #     both.
+        # Adding a test target means adding it to one of those lines, or to
+        # this list with the reason it cannot run here.
         run: |
           cargo test --workspace --no-run
       - name: AIDL compiler tests (hermetic — plan 3 AC-3.4)
@@ -151,10 +169,21 @@ jobs:
           cargo build -p rsbinder --features rpc-tls
           cargo build -p rsbinder --features rpc-vsock
       - name: RPC unit + e2e (rsbinder, hermetic — multi-conn now default per AC-12.6)
+        # `rpc_transport_conformance` is what makes the
+        # `RpcTransport::shutdown` contract measured rather than merely
+        # written, and the behaviour it pins differs by platform — so it
+        # runs here *and* in `macos-build`. The file is
+        # `#![cfg(feature = "rpc")]` with `#[cfg(feature =
+        # "rpc-tcp-debug")]` / `#[cfg(feature = "rpc-tls")]` submodules:
+        # the plain `rpc` run covers the unix/unix-fd/mem cases, and the
+        # TLS run adds `rpc-tcp-debug` so the tcp and tls cases run too.
+        # `source_invariants` is ungated (it scans `src/`); it runs here so
+        # the PR gate covers it, not only the manual integration-test
+        # workflow.
         run: |
           cargo test -p rsbinder --features rpc --lib rpc::
-          cargo test -p rsbinder --features rpc --test rpc_e2e --test rpc_server --test rpc_fd
-          cargo test -p rsbinder --features rpc-tls --test rpc_tls
+          cargo test -p rsbinder --features rpc --test rpc_e2e --test rpc_scenarios --test rpc_server --test rpc_fd --test rpc_shared_memory --test rpc_transport_conformance --test source_invariants
+          cargo test -p rsbinder --features rpc-tls,rpc-tcp-debug --test rpc_tls --test rpc_transport_conformance
       - name: RPC accessor (hermetic, requires android_16 — gap-fill)
         # `rpc_accessor.rs` is `#![cfg(all(feature = "rpc", feature =
         # "android_16"))]`; without `android_16` the file compiles to
@@ -163,9 +192,20 @@ jobs:
         # interaction), so default-features cover it fully.
         run: |
           cargo test -p rsbinder --features rpc,android_16 --test rpc_accessor
-      - name: Generated-stub e2e (tests crate)
+      - name: Generated-stub + entry-API e2e (tests crate)
+        # The `tests` crate has no `default` feature and every file below is
+        # `#![cfg(feature = "rpc")]`, so a target left off this line compiles
+        # to zero tests everywhere else in the workflow — `cargo test
+        # --workspace --no-run` included. Every hermetic `rpc` target of the
+        # crate is therefore named here: `entry_rpc` (the
+        # `serve`/`connect`/`Client` gate), `codegen_shapes`, the async stub
+        # adapter, `get_calling_uid` over RPC, and the `@EnforcePermission`
+        # deny. `macro_cross` needs `macros` too and is on the next step; the
+        # two mesh targets are integration-test.yml's (see the ledger on
+        # `linux-build`'s "Check test builds").
         run: |
-          cargo test -p tests --features rpc --test rpc_generated_stub
+          cargo test -p tests --features rpc --test rpc_generated_stub --test entry_rpc --test codegen_shapes \
+            --test rpc_async --test rpc_calling_identity --test rpc_enforce_permission_deny
           cargo test -p tests --features rpc-tcp-debug --test rpc_generated_stub
       - name: Interface macro (plan 2-19 — golden equivalence, UI, e2e, interop)
         # `rsbinder-macros` holds the contract this feature rests on: a trait
@@ -209,10 +249,15 @@ jobs:
       - name: rsb_device unit (mounts parser)
         run: cargo test -p rsbinder-tools --bin rsb_device
       - name: RPC hermetic (multi-conn now default per AC-12.6)
+        # The macOS half of the `shutdown` conformance gate: this is the
+        # platform that drops its receive queue on a local shutdown and
+        # accepts the peer's first send afterwards, so the suite has to
+        # run on both runners to pin the split. See the matching step in
+        # `rpc-suite` for the feature-gate reasoning.
         run: |
           cargo test -p rsbinder --features rpc --lib rpc::
-          cargo test -p rsbinder --features rpc --test rpc_e2e --test rpc_server --test rpc_fd
-          cargo test -p rsbinder --features rpc-tls --test rpc_tls
+          cargo test -p rsbinder --features rpc --test rpc_e2e --test rpc_scenarios --test rpc_server --test rpc_fd --test rpc_shared_memory --test rpc_transport_conformance --test source_invariants
+          cargo test -p rsbinder --features rpc-tls,rpc-tcp-debug --test rpc_tls --test rpc_transport_conformance
           cargo test -p rsbinder --features rpc,android_16 --test rpc_accessor
       - name: AIDL compiler tests (hermetic — plan 3 AC-3.4)
         # See the matching step in `linux-build` — plan 3 AC-3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,19 +24,41 @@ short form — and the first entry is the only one no compiler will catch.
   it and neither can your build. If you meant the default, pass the newly
   public `DEFAULT_MAX_BINDER_THREADS`. `init_default()` and a `binder://` URI
   without `?threads=` are unchanged.
-- **`rpc::transport::TlsStream` gained a required `shutdown()`.** Custom
-  stream implementations must add `fn shutdown(&self) -> std::io::Result<()>`
-  (shut the underlying stream down in both directions). There is no default
-  body on purpose: silently doing nothing would leave a client's
-  incoming-connection threads blocked in `recv` with nothing to wake them, so
-  `RpcSession::shutdown` would hang on the join. The bundled
-  `TcpStream`/`UnixStream`/`VsockStream` impls are unaffected.
+- **`rpc::transport::TlsStream` gained a required `shutdown_stream()`.**
+  Custom stream implementations must add
+  `fn shutdown_stream(&self) -> std::io::Result<()>` (shut the underlying
+  stream down in both directions). There is no default body on purpose:
+  silently doing nothing would leave a client's incoming-connection threads
+  blocked in `recv` with nothing to wake them, so `RpcSession::close_session`
+  would hang on the join. The bundled `TcpStream`/`UnixStream`/`VsockStream`
+  impls are unaffected.
+- **`shutdown` now names one operation; four methods are renamed.** Five
+  public methods shared the name with five meanings — two of them, on the
+  adjacent `RpcServer` and `ServerGuard`, with opposite join semantics. Only
+  the transport half-close keeps it (`rpc::transport::RpcTransport::shutdown`,
+  the same operation as `TcpStream::shutdown`). The rest are renamed, with no
+  deprecated aliases:
+  - `RpcServer::shutdown` → `RpcServer::stop_accepting`: raise the accept
+    flag; connected sessions drain as their peers leave; nothing is joined.
+    To end connected sessions too, `RpcServer::terminate`.
+  - `ServerGuard::shutdown` → `ServerGuard::stop_and_join`: stop accepting,
+    end every session, join the threads — what dropping the guard does.
+  - `RpcSession::shutdown` → `RpcSession::close_session`: declare the session
+    dead, shut every connection down, join its incoming threads.
+  - `TlsStream::shutdown` → `TlsStream::shutdown_stream` (above).
+- **`RpcError::PeerClosed` is now `RpcError::EndOfStream`.** The variant never
+  knew who ended the stream: this end's own write failing after its own
+  `shutdown` folded into it exactly as a peer's EOF did, so the name and the
+  `Display` text ("RPC peer closed the connection", now "RPC stream ended")
+  put a false attribution in logs. Who decided is `SessionEnd::by`; whether
+  the transport's close signal arrived is `UncleanEndOfStream`. Match arms
+  need the new name; a wildcard arm is unaffected.
 - **A TLS stream that ends without `close_notify` is no longer a clean close.**
   `rpc::RpcError` gained `UncleanEndOfStream` for it (projects to
   `StatusCode::DeadObject`), and a serve loop that reaches it ends with
   `Err(DeadObject)` where it used to return `Ok(())`. `TlsTransport::shutdown`
   now sends `close_notify` before the socket shutdown, so a deliberate close
-  on one end is still the clean `PeerClosed` on the other; only a cut stream
+  on one end is still the clean `EndOfStream` on the other; only a cut stream
   is unclean. Plain-socket backends are unaffected — they have no close signal
   to miss. Code that treated every TLS end of stream as clean now sees the
   difference; code matching `RpcError` with a wildcard arm is unaffected.
@@ -51,15 +73,15 @@ short form — and the first entry is the only one no compiler will catch.
   intact stream and is now `Ok(())` where it was `Err(TimedOut)`; and every
   lost stream is `DeadObject` — an unexpected `REPLY` (`BadType`) and a frame
   that was cut (`NotEnoughData`) are told apart by `reason`, not by the code.
-  A local `RpcSession::shutdown` or `RpcServer::terminate` now ends every
+  A local `RpcSession::close_session` or `RpcServer::terminate` now ends every
   serve loop of the session as `EndedBy::Local` with an intact stream; it
   used to come back as `Ok(())` or `Err(DeadObject)` depending on whether the
   worker was parked in `recv` or inside a handler at the time.
 - **`rpc::transport::RpcTransport::shutdown` is a required method.** The
   default did nothing and returned `Ok(())`, so a transport that inherited it
   left every serve loop and incoming-connection thread parked in `recv` with
-  nothing to wake them, and `RpcSession::shutdown` hung on the join — the
-  reason `TlsStream::shutdown` was already required. Every in-tree backend
+  nothing to wake them, and `RpcSession::close_session` hung on the join — the
+  reason `TlsStream::shutdown_stream` was already required. Every in-tree backend
   overrides it; a custom transport must now implement it (or return an
   error and accept that its session cannot be joined). Its rustdoc now
   states the contract in full: what happens to bytes already received is
@@ -99,10 +121,11 @@ short form — and the first entry is the only one no compiler will catch.
   dropped the guard before the client hung there. `RpcServer::terminate` is
   new: it stops accepting, ends every session the server minted (their
   transports are shut down, so workers parked in `recv` wake and exit) and
-  joins the workers; the guard's drop calls it. `RpcServer::shutdown` keeps
-  its drain meaning — stop accepting, let peers leave — and reaches nothing a
-  peer keeps open; code that relied on it to end a server wants `terminate`.
-  `RpcSession::shutdown` now ends a session whatever its connection count; it
+  joins the workers; the guard's drop calls it. `RpcServer::stop_accepting`
+  keeps its drain meaning — stop accepting, let peers leave — and reaches
+  nothing a peer keeps open; code that relied on it to end a server wants
+  `terminate`. `RpcSession::close_session` now ends a session whatever its
+  connection count; it
   used to log a warning and do nothing on a session driven by more than one
   connection.
 - **rsbinder-aidl rejects `.aidl` it used to accept.** Five inputs that
@@ -183,7 +206,7 @@ short form — and the first entry is the only one no compiler will catch.
   so a server that retires only that connection (its `set_reply_timeout`
   elapsing on a slow callback, say) tears the whole session down, founding
   connection included. The threads
-  keep the session alive until `RpcSession::shutdown()` (which now shuts
+  keep the session alive until `RpcSession::close_session()` (which now shuts
   every connection down and joins them) or the server closes the session.
   Android-13+ profile, Unix sockets.
 - **rsbinder (RPC):** `ClientOptions::handshake_timeout` and
@@ -377,7 +400,7 @@ short form — and the first entry is the only one no compiler will catch.
   `Endpoint::supports_fd_passing()` names the one predicate behind fd-mode
   validation, so transport-conditional options never need URI string matching.
   `CallRestriction` is documented, `#[non_exhaustive]`, and `PartialEq`.
-- **rsbinder (rpc):** `RpcSession::shutdown()` — declare a session dead now
+- **rsbinder (rpc):** `RpcSession::close_session()` — declare a session dead now
   (obituaries + release of the peer's local objects, AOSP `RpcState::clear`).
   This is the only way to break the `session → local object → stored proxy →
   session` cycle for a session that has no serve loop and will never transact
@@ -495,7 +518,7 @@ short form — and the first entry is the only one no compiler will catch.
   shut down and the pool is emptied, releasing callback-slot descriptors at
   once rather than when the session object is finally dropped. The shutdown
   now runs *first*, before the obituaries and the local-object drop, so a
-  `binder_died` handler (or a `Drop`) that calls `RpcSession::shutdown` can
+  `binder_died` handler (or a `Drop`) that calls `RpcSession::close_session` can
   join the incoming threads instead of deadlocking on them.
 - **rsbinder (RPC):** attaching a connection to a session that died during the
   attach handshake now fails with `DeadObject` instead of pushing a slot no
@@ -550,7 +573,7 @@ short form — and the first entry is the only one no compiler will catch.
   `REPLY` now ends the session (AOSP `processCommand` does the same) instead
   of being logged and skipped at wire speed. `find_conn` waits are bounded by
   `RpcSession::set_timeout` (`TimedOut`) instead of parking forever when
-  every slot is driven by another thread. `RpcSession::shutdown` logs when it
+  every slot is driven by another thread. `RpcSession::close_session` logs when it
   finds nothing to tear down.
 - **rsbinder (`lazy_service`):** `force_persist` may **not** be called from
   the active-services callback — the docs listed it as allowed, but it
@@ -816,7 +839,7 @@ short form — and the first entry is the only one no compiler will catch.
   `EndedBy::Local` — and right after a read, so a frame that a kernel which
   keeps its queue hands over after the shutdown ends the loop
   (`EndReason::Interrupted`) instead of being dispatched on a dead session.
-  The frame-boundary guarantee (`PeerClosed`/`Timeout` only) that the reply
+  The frame-boundary guarantee (`EndOfStream`/`Timeout` only) that the reply
   wait and the serve loop both classify by now has one owner,
   `RpcError::leaves_frame_boundary_intact`; the two had already diverged on
   `Truncated`.
@@ -836,7 +859,7 @@ short form — and the first entry is the only one no compiler will catch.
   `vsock` had been broken and fixed the same way; `tcp_debug` was not fixed
   with it. Both raw methods are now implemented.
 - **rsbinder (RPC) — `ServerGuard::drop` blocked for as long as a client
-  stayed connected.** `RpcServer::shutdown` only sets a flag the accept loop
+  stayed connected.** `RpcServer::stop_accepting` only sets a flag the accept loop
   polls; a worker already parked in `recv` never reads it, and the server had
   no path that shut a session's transports down, so `join_workers` waited on
   exactly the workers that were hung. The guard's own rustdoc promised
@@ -847,7 +870,7 @@ short form — and the first entry is the only one no compiler will catch.
   finds nothing, so a connection accepted as the flag went up is ended too
   (its worker ends the session itself on seeing the flag). Calling it from a
   handler skips that worker's own handle instead of self-joining.
-  `RpcSession::shutdown` on a session with more than one live connection
+  `RpcSession::close_session` on a session with more than one live connection
   used to warn and return without tearing anything down;
   `SessionLifecycle::force_dying` takes `Live(n) → Dying` for any `n`, so it
   — and `terminate` through it — ends the session whole.
@@ -921,13 +944,13 @@ short form — and the first entry is the only one no compiler will catch.
 - **rsbinder (RPC) — a write-side disconnect on an android-13+ session
   reported `Unknown` instead of `DeadObject`.** `RawTransportIo` bridges the
   transport to `std::io`, and its write side stringified the `RpcError`
-  into `io::Error::other`, so a `PeerClosed` raised while *sending* came
+  into `io::Error::other`, so an `EndOfStream` raised while *sending* came
   back from the other side of that boundary as `Io(Other)` — a peer that had
   gone away was reported as an unclassified error, on the send path of every
   call on a non-fd session as well as the handshake. `From<RpcError> for io::Error` is now
   kind-preserving for the two variants that have an `io::ErrorKind` meaning
-  the same thing (`PeerClosed` → `BrokenPipe`, `Timeout` → `TimedOut`), so a
-  peer close comes back from the bridge as `PeerClosed` and a timeout comes
+  the same thing (`EndOfStream` → `BrokenPipe`, `Timeout` → `TimedOut`), so a
+  peer close comes back from the bridge as `EndOfStream` and a timeout comes
   back in the shape the framing reader's deadline arm keys on. The TLS
   transport's R34 framing adapter (`transport::tls`'s `RawIo`) carried the
   same stringifying projection on its write side and is fixed with it, so an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,21 @@ short form — and the first entry is the only one no compiler will catch.
   is unclean. Plain-socket backends are unaffected — they have no close signal
   to miss. Code that treated every TLS end of stream as clean now sees the
   difference; code matching `RpcError` with a wildcard arm is unaffected.
+- **`RpcSession::serve_blocking`, `serve_blocking_on` and
+  `serve_blocking_clearing_deadline_after_first` return `rpc::SessionEnd`,
+  not `Result<()>`.** The value says how the loop ended on three axes —
+  `stream` (still intact?), `by` (did this end decide?), `reason` (what
+  happened) — and `SessionEnd::into_result()` is the one projection back:
+  `Ok(())` for an intact stream, `Err(StatusCode::DeadObject)` for a lost one.
+  Migration is `.into_result()` on the call. Two ends project differently
+  from before: a deadline that elapsed between frames (idle eviction) is an
+  intact stream and is now `Ok(())` where it was `Err(TimedOut)`; and every
+  lost stream is `DeadObject` — an unexpected `REPLY` (`BadType`) and a frame
+  that was cut (`NotEnoughData`) are told apart by `reason`, not by the code.
+  A local `RpcSession::shutdown` or `RpcServer::terminate` now ends every
+  serve loop of the session as `EndedBy::Local` with an intact stream; it
+  used to come back as `Ok(())` or `Err(DeadObject)` depending on whether the
+  worker was parked in `recv` or inside a handler at the time.
 - **Dropping a `ServerGuard` now ends the server, connected clients
   included.** It used to flip the accept flag and join the workers, which
   blocked for as long as any client stayed connected — a `?` or a panic that
@@ -726,6 +741,21 @@ short form — and the first entry is the only one no compiler will catch.
 
 ### Fixed
 
+- **rsbinder (RPC) — a local shutdown ended a serve loop as `Ok(())` or
+  `Err(DeadObject)` by race.** `on_session_dead` shuts the transports down
+  and then clears the slot pool; a worker parked in `recv` woke with end of
+  stream (`Ok(())`), while one inside a handler found its slot gone on the
+  next pass (`Err(DeadObject)`). No contract could be written for that, and
+  four attempts at one were each wrong in a new way. The session now records
+  the local decision (`ended_locally`) before the transports go down, and
+  the serve loop reads it both at its exit — every end after the decision is
+  `EndedBy::Local` — and right after a read, so a frame that a kernel which
+  keeps its queue hands over after the shutdown ends the loop
+  (`EndReason::Interrupted`) instead of being dispatched on a dead session.
+  The frame-boundary guarantee (`PeerClosed`/`Timeout` only) that the reply
+  wait and the serve loop both classify by now has one owner,
+  `RpcError::leaves_frame_boundary_intact`; the two had already diverged on
+  `Truncated`.
 - **rsbinder (RPC, fd-mode) — `UnixTransport::shutdown` left a buffered frame
   for the next reader.** An fd-mode connection reads with `recvmsg` into its
   own buffer, and two frames that arrive together leave the second there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -727,6 +727,26 @@ short form — and the first entry is the only one no compiler will catch.
   client's `RpcSession::session_id()` is a client-local value that is never
   the peer's id (only `get_session_id()` fetches that), which is the mistake
   this used to accept silently; its rustdoc now says so.
+- **rsbinder (RPC) — a nested call that lost track of the stream left the
+  connection for the outer call to read.** A reentrant frame borrows the outer
+  frame's slot, so it cannot retire it, and the stale-reply marker it uses
+  instead does not fit bytes that came off the wire without yielding a frame:
+  whether this call's `REPLY` is still coming is then exactly what is unknown.
+  If it was, the outer frame read it next and — `WireReply` carrying no
+  transaction id — took it as its own answer. The slot is now marked
+  unreadable, so its owner retires it instead of interpreting another frame —
+  the path a non-reentrant frame already used; AOSP ends the whole session here
+  (`RpcState::waitForReply`: "processCommand must shutdown on failure"). The
+  connection is shut down too, but only to wake a blocked reader: what a
+  shutdown does to bytes already received is platform- and backend-dependent,
+  so the flag is what holds. A frame that does not decode is one way in (only
+  a peer that violates the wire reaches that: AOSP's command set is exactly the
+  three rsbinder decodes); a read that fails without the guarantee of having
+  stopped at a frame boundary — truncated, over-large, an I/O or protocol
+  error — is another, and is now classified the same way. A serve loop that
+  ends this way reports `StatusCode::DeadObject`, not the `Ok(())` of end of
+  stream, so `RpcSession::serve_blocking` callers and the `RpcServer` worker
+  log can still tell the two apart.
 - **rsbinder (RPC) — a zero handshake deadline was neither honored nor
   reported.** `RpcUnixClientConfig::handshake_timeout(Duration::ZERO)` and
   `ClientOptions::handshake_timeout = Some(Duration::ZERO)` travelled to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,10 +59,13 @@ short form — and the first entry is the only one no compiler will catch.
   `Err(DeadObject)` where it used to return `Ok(())`. `TlsTransport::shutdown`
   now sends `close_notify` before the socket shutdown, so a deliberate close
   on one end is the clean `EndOfStream` on the other; only a cut stream is
-  unclean. A shutdown racing another thread's in-flight send on the same
-  connection waits briefly for it — only the sending thread may transmit —
-  and that wait is bounded, so a peer that has stopped reading still cannot
-  hold teardown and still reads the unclean end it was heading for.
+  unclean. From the moment `shutdown` is called, this end's own sends fail
+  at once with `EndOfStream` — the contract every other backend already
+  met by cutting the socket — and the one send already in flight is
+  allowed to finish before the alert goes out, so every frame a sender was
+  told went out is one the peer reads. That wait is bounded, so a peer
+  that has stopped reading cannot hold teardown; it reads the unclean end
+  it was heading for.
   Plain-socket backends are unaffected — they have no close signal
   to miss. Code that treated every TLS end of stream as clean now sees the
   difference; code matching `RpcError` with a wildcard arm is unaffected.
@@ -903,10 +906,12 @@ short form — and the first entry is the only one no compiler will catch.
   (`StatusCode::DeadObject`, with a `warn!`), carried through the `Read`
   adapters as the `io::Error` payload so the framing readers hand it back
   unchanged; and `TlsTransport::shutdown` sends `close_notify` first, so
-  rsbinder's own deliberate close is the clean end on the peer. A send
-  another thread has in flight holds the write lock, and only its holder
-  may transmit, so the shutdown waits for it — bounded, so a peer that has
-  stopped reading cannot hold teardown. No
+  rsbinder's own deliberate close is the clean end on the peer. Only the
+  thread holding the write lock may transmit, so `shutdown` refuses every
+  new send, waits for the one in flight, and only then queues and sends the
+  alert — a frame can no longer be encrypted behind it, where the peer would
+  discard it after the sender was told it went out. The wait is bounded, so
+  a peer that has stopped reading cannot hold teardown. No
   transaction was ever misdelivered by this — a truncated reply already failed
   the caller's wait; what was lost was the signal.
 - **rsbinder (RPC) — a refused attach was reported to the client as success.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,12 @@ short form — and the first entry is the only one no compiler will catch.
   `StatusCode::DeadObject`), and a serve loop that reaches it ends with
   `Err(DeadObject)` where it used to return `Ok(())`. `TlsTransport::shutdown`
   now sends `close_notify` before the socket shutdown, so a deliberate close
-  on one end is still the clean `EndOfStream` on the other; only a cut stream
-  is unclean. Plain-socket backends are unaffected — they have no close signal
+  on one end is the clean `EndOfStream` on the other; only a cut stream is
+  unclean. A shutdown racing another thread's in-flight send on the same
+  connection waits briefly for it — only the sending thread may transmit —
+  and that wait is bounded, so a peer that has stopped reading still cannot
+  hold teardown and still reads the unclean end it was heading for.
+  Plain-socket backends are unaffected — they have no close signal
   to miss. Code that treated every TLS end of stream as clean now sees the
   difference; code matching `RpcError` with a wildcard arm is unaffected.
 - **`RpcSession::serve_blocking`, `serve_blocking_on` and
@@ -112,9 +116,13 @@ short form — and the first entry is the only one no compiler will catch.
   reply wait that expired after the peer may already have executed the
   request. Both are now `WouldBlock`, AOSP's `WOULD_BLOCK` for exactly this:
   nothing was sent, so the call is safe to retry. `TimedOut` from a transact
-  now means only that the request went out and no reply came in time;
-  `FailedTransaction` keeps its other meanings (an oneway backlog flushed, an
-  attach past the incoming-slot cap).
+  means the reply wait expired after the request went out — with one
+  exception: on an android-13+ connection whose write deadline is armed
+  (`RpcServer::set_idle_timeout`, which the server applies to its serve-phase
+  and callback slots), a send deadline that expires before the first byte is
+  `TimedOut` too, and nothing was sent in that case either (see the
+  send-failure entry below). `FailedTransaction` keeps its other meanings (an
+  oneway backlog flushed, an attach past the incoming-slot cap).
 - **Dropping a `ServerGuard` now ends the server, connected clients
   included.** It used to flip the accept flag and join the workers, which
   blocked for as long as any client stayed connected — a `?` or a panic that
@@ -213,10 +221,15 @@ short form — and the first entry is the only one no compiler will catch.
   `RpcUnixClientConfig::handshake_timeout` — a deadline for the connection
   **handshake**, the phase `timeout` cannot reach because it is applied to a
   session that does not exist yet. Covers the founding connect and every
-  fan-out / incoming attach, plus the `tls://` `connect(2)`. `None`
-  (default) keeps the previous unbounded behavior; without it a peer that
-  accepts the socket and then writes nothing hangs `Client::open` forever.
-  The client-side counterpart of `ServeOptions::handshake_timeout`.
+  fan-out / incoming attach on `?profile=android13plus`, plus the `tls://`
+  `connect(2)` and TLS handshake. `None` (default) keeps the previous
+  unbounded behavior; without it a peer that accepts the socket and then
+  writes nothing hangs `Client::open` forever. The r34 wire has no
+  connection handshake for it to bound, so setting it on a plain
+  (non-`tls://`, non-versioned) endpoint is `StatusCode::BadValue` — per
+  `ClientOptions`' rule that an option which does not apply is refused,
+  never ignored. The client-side counterpart of
+  `ServeOptions::handshake_timeout`.
 - **rsbinder (RPC):** `RpcServer::set_reply_timeout` — bounds how long this
   server waits for a reply to a callback it issued, by setting
   `RpcSession::set_timeout` on every session the server builds. `None`
@@ -404,7 +417,10 @@ short form — and the first entry is the only one no compiler will catch.
   (obituaries + release of the peer's local objects, AOSP `RpcState::clear`).
   This is the only way to break the `session → local object → stored proxy →
   session` cycle for a session that has no serve loop and will never transact
-  again; unlike AOSP `shutdownAndWait` it does not join workers.
+  again. It shuts every connection down and joins the session's own incoming
+  (callback) threads; unlike AOSP `shutdownAndWait` it does not join a
+  user-driven `serve_blocking` on the founding slot — that loop exits on its
+  own once the transport is shut down.
 - **rsbinder (shared memory):** `shared_memory` is now a working
   implementation instead of a trait skeleton. `MemoryHeapBase` allocates an
   anonymous shared region (`memfd_create` + `F_ADD_SEALS` on Linux/Android,
@@ -470,7 +486,7 @@ short form — and the first entry is the only one no compiler will catch.
 - **rsbinder (RPC):** a non-nested call on a session with no connection to
   send on — a server calling a client callback outside any handler, the
   client having opened no incoming connection — now fails immediately with
-  `FailedTransaction` (AOSP `WOULD_BLOCK`) and a log line naming the
+  `WouldBlock` (AOSP `WOULD_BLOCK`) and a log line naming the
   remedy, instead of waiting forever (or until `set_timeout`). Connection
   slots are now tagged with the direction they are used in (AOSP
   `mOutgoing`/`mIncoming`), so a serve-driven connection is never claimed
@@ -479,13 +495,13 @@ short form — and the first entry is the only one no compiler will catch.
   *twoway* handler is running on it (AOSP `RpcConnection::allowNested`):
   from inside a **oneway** handler the peer is no longer reading that
   socket, so the nested call now goes out on a connection the peer does
-  read — or fails with `FailedTransaction` if there is none — instead of
+  read — or fails with `WouldBlock` if there is none — instead of
   blocking forever on a reply that could never arrive.
   **Breaking for `RpcSession::new(t, AddressSpace::Acceptor)`:** the
   founding connection of an acceptor session is serve-driven, so such a
   session can no longer open a transaction of its own — `get_root`,
   `RpcProxy::transact` and `ping_binder` from outside a dispatch return
-  `FailedTransaction` where they used to round-trip on that connection.
+  `WouldBlock` where they used to round-trip on that connection.
   Callbacks from inside a twoway handler are unaffected. To call out of
   an acceptor otherwise the peer must open incoming connections, which
   needs `?profile=android13plus`; the r34 profile has no such mechanism.
@@ -572,7 +588,7 @@ short form — and the first entry is the only one no compiler will catch.
   profile, desynchronising the fd-aware receive buffer. An unsolicited
   `REPLY` now ends the session (AOSP `processCommand` does the same) instead
   of being logged and skipped at wire speed. `find_conn` waits are bounded by
-  `RpcSession::set_timeout` (`TimedOut`) instead of parking forever when
+  `RpcSession::set_timeout` (`WouldBlock`) instead of parking forever when
   every slot is driven by another thread. `RpcSession::close_session` logs when it
   finds nothing to tear down.
 - **rsbinder (`lazy_service`):** `force_persist` may **not** be called from
@@ -843,14 +859,16 @@ short form — and the first entry is the only one no compiler will catch.
   wait and the serve loop both classify by now has one owner,
   `RpcError::leaves_frame_boundary_intact`; the two had already diverged on
   `Truncated`.
-- **rsbinder (RPC, fd-mode) — `UnixTransport::shutdown` left a buffered frame
+- **rsbinder (RPC, fd-mode) — `UnixTransport::shutdown` left buffered bytes
   for the next reader.** An fd-mode connection reads with `recvmsg` into its
-  own buffer, and two frames that arrive together leave the second there.
-  `shutdown` shut the socket down and left that buffer alone, so a serve loop
-  woken by a session teardown was handed a frame of the connection just
-  ended — before it touched the socket — and dispatched it on a dead session,
-  on every platform, since the bytes were already in userspace. The buffer is
-  now cleared before the socket shutdown.
+  own buffer, and an error that cut a frame short leaves that frame's prefix
+  there. `shutdown` shut the socket down and left that buffer alone, so a
+  serve loop woken by a session teardown could go on decoding the connection
+  just ended out of it — before it touched the socket — on every platform,
+  since the bytes were already in userspace. The socket now goes down first
+  (a reader parked in `recvmsg` holds that buffer's lock for the whole call,
+  so taking the lock first would deadlock against it) and the buffer is
+  cleared right after.
 - **rsbinder (RPC, `rpc-tcp-debug`) — a preconnected `AF_INET` fd could not
   complete the android-13+ handshake.** `RpcSession::from_preconnected_fd`
   wraps such an fd in `TcpDebugTransport`, whose first handshake byte is a
@@ -885,7 +903,10 @@ short form — and the first entry is the only one no compiler will catch.
   (`StatusCode::DeadObject`, with a `warn!`), carried through the `Read`
   adapters as the `io::Error` payload so the framing readers hand it back
   unchanged; and `TlsTransport::shutdown` sends `close_notify` first, so
-  rsbinder's own deliberate close is still the clean end on the peer. No
+  rsbinder's own deliberate close is the clean end on the peer. A send
+  another thread has in flight holds the write lock, and only its holder
+  may transmit, so the shutdown waits for it — bounded, so a peer that has
+  stopped reading cannot hold teardown. No
   transaction was ever misdelivered by this — a truncated reply already failed
   the caller's wait; what was lost was the signal.
 - **rsbinder (RPC) — a refused attach was reported to the client as success.**
@@ -930,6 +951,26 @@ short form — and the first entry is the only one no compiler will catch.
   ends this way reports `StatusCode::DeadObject`, not the `Ok(())` of end of
   stream, so `RpcSession::serve_blocking` callers and the `RpcServer` worker
   log can still tell the two apart.
+- **rsbinder (RPC) — a send that stopped part-way left its connection in the
+  pool.** A write that stops mid-frame leaves the peer a header it will
+  complete out of whatever arrives next, and no transport makes such a
+  failure sticky, so the slot must never carry another frame — but only a
+  client call's request send acted on it: a reply, and a `DEC_STRONG` from
+  any of its three senders, discarded the error and returned the connection
+  for the next frame to be written on. Every send now funnels through one
+  rule — the frame that owns the slot retires it, a reentrant frame (which
+  owns nothing, the outer frame holds the slot) marks it unreadable and shuts
+  the transport down. A failure that put nothing on the wire is exempt: a
+  codec or protocol error, raised before the first byte, and a send deadline
+  that expired before the first byte, which the socket backends' android-13+
+  senders now report as `RpcError::Timeout` (`StatusCode::TimedOut`) rather
+  than as a transport error.
+  Both leave the stream frame-synchronized and the connection serving, so a
+  best-effort `DEC_STRONG` timing out on a socket-backed server with
+  `set_idle_timeout` no longer takes a live connection down. `rpc-tls` is the
+  exception, and deliberately so: a record its socket write dropped is gone
+  from the AEAD sequence however far it got, so a TLS send failure always
+  retires its slot.
 - **rsbinder (RPC) — a zero handshake deadline was neither honored nor
   reported.** `RpcUnixClientConfig::handshake_timeout(Duration::ZERO)` and
   `ClientOptions::handshake_timeout = Some(Duration::ZERO)` travelled to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,18 @@ short form — and the first entry is the only one no compiler will catch.
   is unclean. Plain-socket backends are unaffected — they have no close signal
   to miss. Code that treated every TLS end of stream as clean now sees the
   difference; code matching `RpcError` with a wildcard arm is unaffected.
+- **Dropping a `ServerGuard` now ends the server, connected clients
+  included.** It used to flip the accept flag and join the workers, which
+  blocked for as long as any client stayed connected — a `?` or a panic that
+  dropped the guard before the client hung there. `RpcServer::terminate` is
+  new: it stops accepting, ends every session the server minted (their
+  transports are shut down, so workers parked in `recv` wake and exit) and
+  joins the workers; the guard's drop calls it. `RpcServer::shutdown` keeps
+  its drain meaning — stop accepting, let peers leave — and reaches nothing a
+  peer keeps open; code that relied on it to end a server wants `terminate`.
+  `RpcSession::shutdown` now ends a session whatever its connection count; it
+  used to log a warning and do nothing on a session driven by more than one
+  connection.
 - **rsbinder-aidl rejects `.aidl` it used to accept.** Five inputs that
   previously generated silently-wrong or non-compiling Rust are now build
   errors: a `@JavaOnlyStableParcelable` / `cpp_header` / `ndk_header`
@@ -714,6 +726,22 @@ short form — and the first entry is the only one no compiler will catch.
 
 ### Fixed
 
+- **rsbinder (RPC) — `ServerGuard::drop` blocked for as long as a client
+  stayed connected.** `RpcServer::shutdown` only sets a flag the accept loop
+  polls; a worker already parked in `recv` never reads it, and the server had
+  no path that shut a session's transports down, so `join_workers` waited on
+  exactly the workers that were hung. The guard's own rustdoc promised
+  "workers joined"; `join_workers`' said not to rely on `Drop`.
+  `RpcServer::terminate` now ends every minted session — an r34 session has
+  no id and was never in the id registry, so the server keeps a second,
+  `Weak` list of all of them — and joins the workers, repeating until a pass
+  finds nothing, so a connection accepted as the flag went up is ended too
+  (its worker ends the session itself on seeing the flag). Calling it from a
+  handler skips that worker's own handle instead of self-joining.
+  `RpcSession::shutdown` on a session with more than one live connection
+  used to warn and return without tearing anything down;
+  `SessionLifecycle::force_dying` takes `Live(n) → Dying` for any `n`, so it
+  — and `terminate` through it — ends the session whole.
 - **rsbinder (RPC, TLS) — a TCP end without `close_notify` read as a clean
   close.** `TlsTransport::recv_raw` folded rustls's `UnexpectedEof` — the one
   signal it gives for a stream that ended without the TLS close alert — into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ short form — and the first entry is the only one no compiler will catch.
   incoming-connection threads blocked in `recv` with nothing to wake them, so
   `RpcSession::shutdown` would hang on the join. The bundled
   `TcpStream`/`UnixStream`/`VsockStream` impls are unaffected.
+- **A TLS stream that ends without `close_notify` is no longer a clean close.**
+  `rpc::RpcError` gained `UncleanEndOfStream` for it (projects to
+  `StatusCode::DeadObject`), and a serve loop that reaches it ends with
+  `Err(DeadObject)` where it used to return `Ok(())`. `TlsTransport::shutdown`
+  now sends `close_notify` before the socket shutdown, so a deliberate close
+  on one end is still the clean `PeerClosed` on the other; only a cut stream
+  is unclean. Plain-socket backends are unaffected — they have no close signal
+  to miss. Code that treated every TLS end of stream as clean now sees the
+  difference; code matching `RpcError` with a wildcard arm is unaffected.
 - **rsbinder-aidl rejects `.aidl` it used to accept.** Five inputs that
   previously generated silently-wrong or non-compiling Rust are now build
   errors: a `@JavaOnlyStableParcelable` / `cpp_header` / `ndk_header`
@@ -705,6 +714,20 @@ short form — and the first entry is the only one no compiler will catch.
 
 ### Fixed
 
+- **rsbinder (RPC, TLS) — a TCP end without `close_notify` read as a clean
+  close.** `TlsTransport::recv_raw` folded rustls's `UnexpectedEof` — the one
+  signal it gives for a stream that ended without the TLS close alert — into
+  a 0-byte read, and `pump_incoming` never told rustls about the EOF at all,
+  so the framing reader saw an ordinary end of stream and a serve loop
+  returned `Ok(())`. On the one backend built for untrusted networks that is
+  what a truncation attack at a frame boundary looks like (mid-frame it was
+  already `Truncated`). It is now `RpcError::UncleanEndOfStream`
+  (`StatusCode::DeadObject`, with a `warn!`), carried through the `Read`
+  adapters as the `io::Error` payload so the framing readers hand it back
+  unchanged; and `TlsTransport::shutdown` sends `close_notify` first, so
+  rsbinder's own deliberate close is still the clean end on the peer. No
+  transaction was ever misdelivered by this — a truncated reply already failed
+  the caller's wait; what was lost was the signal.
 - **rsbinder (RPC) — a refused attach was reported to the client as success.**
   The outgoing direction of an android-13+ attach carries no acknowledgement
   (AOSP writes `RpcNewSessionResponse` only for a new session, and an outgoing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,18 @@ short form — and the first entry is the only one no compiler will catch.
   serve loop of the session as `EndedBy::Local` with an intact stream; it
   used to come back as `Ok(())` or `Err(DeadObject)` depending on whether the
   worker was parked in `recv` or inside a handler at the time.
+- **A transaction that could not be sent fails with `StatusCode::WouldBlock`.**
+  Two cases that never reached the wire reported other codes: a call on a
+  session with no outgoing connection (a server calling a client proxy
+  outside any handler, the client having opened no incoming connection)
+  returned `FailedTransaction`, and a call whose wait for a free connection
+  slot hit the session deadline returned `TimedOut` — the same code as a
+  reply wait that expired after the peer may already have executed the
+  request. Both are now `WouldBlock`, AOSP's `WOULD_BLOCK` for exactly this:
+  nothing was sent, so the call is safe to retry. `TimedOut` from a transact
+  now means only that the request went out and no reply came in time;
+  `FailedTransaction` keeps its other meanings (an oneway backlog flushed, an
+  attach past the incoming-slot cap).
 - **Dropping a `ServerGuard` now ends the server, connected clients
   included.** It used to flip the accept flag and join the workers, which
   blocked for as long as any client stayed connected — a `?` or a panic that
@@ -741,6 +753,17 @@ short form — and the first entry is the only one no compiler will catch.
 
 ### Fixed
 
+- **rsbinder (RPC) — a slot a nested call had marked unreadable could still
+  be handed out for writing.** The mark gated only the two readers; the slot
+  selectors did not look at it, so a handler that swallowed the nested
+  call's error and returned normally had its reply written on the lost
+  stream, and a concurrent caller could claim the slot and send a request
+  the reply wait would then refuse — executed by the peer, answer thrown
+  away. The selectors now refuse it: the frame that owns it gets
+  `DeadObject` before writing, a scan for a free outgoing slot skips it (a
+  session whose only outgoing slot is unreadable fails fast with
+  `WouldBlock` rather than waiting), and the non-blocking selector declines
+  it.
 - **rsbinder (RPC) — a local shutdown ended a serve loop as `Ok(())` or
   `Err(DeadObject)` by race.** `on_session_dead` shuts the transports down
   and then clears the slot pool; a worker parked in `recv` woke with end of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -726,6 +726,21 @@ short form — and the first entry is the only one no compiler will catch.
 
 ### Fixed
 
+- **rsbinder (RPC, fd-mode) — `UnixTransport::shutdown` left a buffered frame
+  for the next reader.** An fd-mode connection reads with `recvmsg` into its
+  own buffer, and two frames that arrive together leave the second there.
+  `shutdown` shut the socket down and left that buffer alone, so a serve loop
+  woken by a session teardown was handed a frame of the connection just
+  ended — before it touched the socket — and dispatched it on a dead session,
+  on every platform, since the bytes were already in userspace. The buffer is
+  now cleared before the socket shutdown.
+- **rsbinder (RPC, `rpc-tcp-debug`) — a preconnected `AF_INET` fd could not
+  complete the android-13+ handshake.** `RpcSession::from_preconnected_fd`
+  wraps such an fd in `TcpDebugTransport`, whose first handshake byte is a
+  raw write; the transport had no `send_raw`/`recv_raw`, so the trait default
+  refused it with `Protocol("this transport has no raw byte access")`.
+  `vsock` had been broken and fixed the same way; `tcp_debug` was not fixed
+  with it. Both raw methods are now implemented.
 - **rsbinder (RPC) — `ServerGuard::drop` blocked for as long as a client
   stayed connected.** `RpcServer::shutdown` only sets a flag the accept loop
   polls; a worker already parked in `recv` never reads it, and the server had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,32 @@ short form — and the first entry is the only one no compiler will catch.
   serve loop of the session as `EndedBy::Local` with an intact stream; it
   used to come back as `Ok(())` or `Err(DeadObject)` depending on whether the
   worker was parked in `recv` or inside a handler at the time.
+- **`rpc::transport::RpcTransport::shutdown` is a required method.** The
+  default did nothing and returned `Ok(())`, so a transport that inherited it
+  left every serve loop and incoming-connection thread parked in `recv` with
+  nothing to wake them, and `RpcSession::shutdown` hung on the join — the
+  reason `TlsStream::shutdown` was already required. Every in-tree backend
+  overrides it; a custom transport must now implement it (or return an
+  error and accept that its session cannot be joined). Its rustdoc now
+  states the contract in full: what happens to bytes already received is
+  platform- and backend-dependent and must not be assumed; a reader woken
+  by it returns the end of stream; it is idempotent; its `Err` is
+  diagnostic; it is not `close`.
+- **`rpc::transport::MemTransport::shutdown` models a Linux socket.** Frames
+  already queued on either side are still delivered, then the end of
+  stream, and sends on either side fail — where it used to drop what was
+  queued on its own side and leave the peer untouched. Linux is the
+  deployment target and the platform where a caller that assumes a
+  shutdown discards the queue is wrong; the hermetic backend now exercises
+  that case instead of certifying the assumption. A test that relied on a
+  queued frame vanishing at `shutdown`, or on the peer reading on after it,
+  sees the difference.
+- **`rpc::RpcError` gained `DeadlineMidFrame`.** A read deadline that
+  elapses part-way through a frame was `Truncated` (`NotEnoughData`), the
+  same as a stream that ended mid-frame; it is now `DeadlineMidFrame`
+  (`TimedOut`), and a serve loop that hits it ends with
+  `EndReason::DeadlineMidFrame` — this end's own policy, a lost position.
+  Code matching `RpcError::Truncated` for a deadline case needs the new arm.
 - **A transaction that could not be sent fails with `StatusCode::WouldBlock`.**
   Two cases that never reached the wire reported other codes: a call on a
   session with no outgoing connection (a server calling a client proxy
@@ -753,6 +779,21 @@ short form — and the first entry is the only one no compiler will catch.
 
 ### Fixed
 
+- **rsbinder (RPC, TLS) — a session's own shutdown read as a truncation on
+  its own side.** With `UncleanEndOfStream` in place, the end of stream
+  rsbinder's own `shutdown()` produced for its own reader — no
+  `close_notify` from the peer, by construction — would have been reported
+  as a cut, and a session this end shut down would have ended its serve loop
+  with a lost stream. The transport remembers that it shut itself down and
+  reports the clean end.
+- **rsbinder (RPC) — a second `shutdown()` on a socket transport failed on
+  macOS.** `shutdown(2)` raises `ENOTCONN` the second time there (Linux
+  returns `Ok`), and a normal teardown calls it twice on the same slot —
+  `on_session_dead` shuts every transport down, then the unreadable-slot
+  path shuts its own — so every such teardown logged a failure. The socket
+  backends absorb it; `shutdown` is idempotent on every backend, and the
+  failures that remain are logged at `warn!` with what the backend said,
+  not at `debug!` with a guess.
 - **rsbinder (RPC) — a slot a nested call had marked unreadable could still
   be handed out for writing.** The mark gated only the two readers; the slot
   selectors did not look at it, so a handler that swallowed the nested

--- a/book/src/cross-transport-services.md
+++ b/book/src/cross-transport-services.md
@@ -58,7 +58,7 @@ tls://<host>:<port>[#<service>]             feature rpc-tls (TCP is TLS-only)
 | `add(name, svc)` | publish `svc` (anything `Into<SIBinder>`, e.g. `BnFoo::new_binder(..)`). Kernel: registered with the service manager right away. RPC: queued until the server starts. |
 | `with(\|o\| ..)` | set [`ServeOptions`](#options) |
 | `run()` | serve and block. Kernel: start the thread pool and join it (never returns normally). RPC: the accept loop, until shut down. |
-| `spawn()` | serve in the background; returns a `ServerGuard`. RPC: dropping the guard shuts the server down. Kernel: the guard is inert (the process thread pool has no shutdown). |
+| `spawn()` | serve in the background; returns a `ServerGuard`. RPC: dropping the guard (or `ServerGuard::stop_and_join()`) ends the server — every session is closed and the threads are joined. Kernel: the guard is inert (the process thread pool has no shutdown). |
 
 Kernel `serve("binder://")` initializes the process-wide `ProcessState`
 idempotently; a second kernel server in the same process reuses it and logs
@@ -145,7 +145,7 @@ Moving a service between transports changes its trust boundary — read
 | `get_calling_uid()` | kernel-vouched | kernel-vouched on `unix://`, fail-closed sentinel elsewhere |
 | death | process death | session disconnect |
 | `list_services`, notifications, lazy services | via [`hub`](./service-manager.md) | not available |
-| abandoning a session | nothing to do | call `RpcSession::shutdown()` if a service you exported holds a proxy back into it (`client.session()`) |
+| abandoning a session | nothing to do | call `RpcSession::close_session()` if a service you exported holds a proxy back into it (`client.session()`) |
 
 ## Async
 

--- a/book/src/rpc-transport.md
+++ b/book/src/rpc-transport.md
@@ -481,7 +481,7 @@ that client* — the nested call rides the connection the request came
 in on. Calling it from anywhere else (a timer, a worker thread, a
 oneway notification fired later) needs a connection the server can
 *send* on, and by default a session has none: the server fails such a
-call at once with `FailedTransaction` (AOSP `WOULD_BLOCK`) rather than
+call at once with `WouldBlock` (AOSP `WOULD_BLOCK`) rather than
 waiting for a slot that will never free up.
 
 The client provides that connection, exactly as libbinder's
@@ -545,10 +545,13 @@ Each call on the ending side means one thing:
 | `ServerGuard::stop_and_join()` | `terminate`, after joining the accept thread — the same as dropping the guard |
 | `RpcTransport::shutdown()` | the transport half-close itself (`shutdown(2)` in both directions): wakes a reader blocked on this end, fails this end's later sends |
 
-What the *peer* sees after this end's `shutdown` is platform-dependent —
-Linux delivers frames already queued ahead of the EOF, macOS discards
-them — so code must not assume a queued frame arrives, or that it does
-not.
+What **this end's own reader** sees after its `shutdown` is
+platform-dependent — Linux delivers frames already queued ahead of the
+end of stream, macOS discards them — so code must not assume a queued
+frame arrives, or that it does not. The peer reads the end of stream on
+either platform; what differs is the peer's *next send* (Linux
+`AF_UNIX`: `EPIPE` at once; macOS: accepted and discarded; TCP: a reset
+on a later write).
 
 ## Bridging RPC and the service manager: the Accessor pattern
 
@@ -649,9 +652,8 @@ works exactly like it does on the kernel path. See
 [Async Service](./async-service.md).
 
 There is intentionally **no** non-blocking `RpcTransport` /
-reactor-based async serve loop. Decision record:
-[`plans/2-10-async-rpc-io.md`](https://github.com/hiking90/rsbinder/blob/master/plans/2-10-async-rpc-io.md)
-in the repo.
+reactor-based async serve loop: async support is these adapters over
+the blocking stack, not a second I/O engine underneath it.
 
 ## Platform support
 

--- a/book/src/rpc-transport.md
+++ b/book/src/rpc-transport.md
@@ -85,7 +85,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Publish a root binder. Clients fetch this via get_root().
     server.set_root(BnHello::new_binder(IHelloService {}).as_binder());
 
-    // Accept loop runs on this thread until shutdown().
+    // Accept loop runs on this thread until stop_accepting().
     server.run()?;
     Ok(())
 }
@@ -102,9 +102,13 @@ Key points:
   equivalent of `hub::wait_for_interface(name)` for kernel binder, just
   without a service manager.
 - **`server.run()`** runs the accept loop until
-  [`RpcServer::shutdown`] is called. Use
+  [`RpcServer::stop_accepting`] is called from another thread. Use
   [`RpcServer::run_background`] to spawn it on a dedicated thread
-  instead.
+  instead. `stop_accepting` only raises the flag — sessions already
+  connected drain as their peers leave. [`RpcServer::terminate`] ends
+  those too (every session closed, every worker joined); it is what
+  dropping a `ServerGuard` does. See [How a connection
+  ends](#how-a-connection-ends).
 
 ### Client
 
@@ -507,11 +511,44 @@ Two consequences worth knowing:
   the session no longer waits for its next failed call to notice.
 - **Stop the session explicitly.** The serving threads keep the session
   alive; dropping the `RpcSession` handle and every proxy does not end
-  them. Call `RpcSession::shutdown()` when you are done — it shuts the
-  connections down and joins the threads.
+  them. Call `RpcSession::close_session()` when you are done — it shuts
+  the connections down and joins the threads.
 
 This needs the android-13+ profile (the attach echoes the session id)
 and is currently offered for Unix-domain sockets.
+
+### How a connection ends
+
+A serve loop — `RpcSession::serve_blocking` and its variants — returns
+`rpc::SessionEnd`, not `Result<()>`. It answers three questions a
+status code cannot hold at once:
+
+- **`stream`** — is the stream still at a frame boundary
+  (`StreamState::InSync`), or is its position lost (`Lost`: a cut
+  frame, a TLS stream that ended without `close_notify`, a deadline
+  that expired part-way through a frame)?
+- **`by`** — did this end decide (`EndedBy::Local`: `close_session`,
+  `terminate`, an idle deadline this end armed), or not (`NotLocal`)?
+- **`reason`** — what happened (`EndReason`), for logs.
+
+`SessionEnd::into_result()` is the one projection back to a `Result`:
+`Ok(())` for an intact stream, `Err(DeadObject)` for a lost one. Only
+`stream` decides it; `by` is attribution.
+
+Each call on the ending side means one thing:
+
+| call | does |
+|---|---|
+| `RpcSession::close_session()` | declare the session dead: every connection's transport is shut down, cached proxies get `binder_died`, the session's incoming threads are joined |
+| `RpcServer::stop_accepting()` | raise the accept flag; connected sessions drain as their peers leave; nothing is joined |
+| `RpcServer::terminate()` | stop accepting, close every session the server minted, join the workers |
+| `ServerGuard::stop_and_join()` | `terminate`, after joining the accept thread — the same as dropping the guard |
+| `RpcTransport::shutdown()` | the transport half-close itself (`shutdown(2)` in both directions): wakes a reader blocked on this end, fails this end's later sends |
+
+What the *peer* sees after this end's `shutdown` is platform-dependent —
+Linux delivers frames already queued ahead of the EOF, macOS discards
+them — so code must not assume a queued frame arrives, or that it does
+not.
 
 ## Bridging RPC and the service manager: the Accessor pattern
 

--- a/example-hello/src/bin/rpc_incoming_interop_client.rs
+++ b/example-hello/src/bin/rpc_incoming_interop_client.rs
@@ -21,7 +21,7 @@
 //!    outgoing (founding) connection instead — AOSP gates this with
 //!    `RpcConnection::allowNested`, and pinning it to the incoming
 //!    connection blocks until the session dies;
-//! 4. `RpcSession::shutdown` ends the incoming thread cleanly.
+//! 4. `RpcSession::close_session` ends the incoming thread cleanly.
 //!
 //! Exit code 0 = PASS; non-zero = the failing step.
 use std::sync::atomic::{AtomicI32, Ordering};
@@ -247,10 +247,10 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     );
 
     // Teardown: the incoming thread is joined here. `__incoming_thread_
-    // count` cannot witness that — `shutdown` empties the handle list
+    // count` cannot witness that — `close_session` empties the handle list
     // before joining any of it — so check the join counter and that the
     // thread really finished.
-    session.shutdown();
+    session.close_session();
     if session.__incoming_thread_joined_count() != 1 || session.__incoming_thread_live_count() != 0
     {
         eprintln!(

--- a/rsbinder/src/entry/client.rs
+++ b/rsbinder/src/entry/client.rs
@@ -74,9 +74,21 @@ pub struct ClientOptions {
     pub timeout: Option<Duration>,
     /// RPC: deadline for the connection **handshake** — the phase
     /// [`timeout`](Self::timeout) cannot reach, because it runs before the
-    /// session exists. Covers the `tls://` `connect(2)` and the android-13+
-    /// session handshake, on the founding connection and on every fan-out
-    /// or incoming attach.
+    /// session exists. Covers `tls://`'s `connect(2)` and TLS handshake,
+    /// and the android-13+ session handshake, on the founding connection
+    /// and on every fan-out or incoming attach. The r34 wire (no
+    /// `?profile=`) has no such phase at all, so on a plain r34 endpoint
+    /// the option does not apply and `open` refuses it with
+    /// [`StatusCode::BadValue`](crate::StatusCode::BadValue) rather than
+    /// ignore it.
+    ///
+    /// It bounds each blocking step of that phase — one `connect(2)` per
+    /// address the host resolves to, then each handshake read and write —
+    /// and is not a budget for the phase as a whole, so `open` can take a
+    /// multiple of it before returning. What it guarantees is that no
+    /// single step waits on a silent peer forever. Resolving the host name
+    /// is the one step it cannot reach: that blocks in the platform's
+    /// resolver, which takes no deadline from here.
     ///
     /// `None` (default) blocks forever, so a peer that accepts the socket
     /// and then writes nothing hangs `open`. Set it whenever the peer is
@@ -176,8 +188,8 @@ pub(super) fn new_client(uri: Uri, o: ClientOptions) -> Result<Client> {
                 ));
             }
             #[cfg(feature = "rpc")]
-            if o.fd_mode.is_some() {
-                return Err(reject("fd_mode"));
+            if o.fd_mode.is_some() || o.handshake_timeout.is_some() {
+                return Err(reject("fd_mode/handshake_timeout"));
             }
             #[cfg(feature = "rpc-tls")]
             if o.tls.is_some() || o.tls_server_name.is_some() {
@@ -252,6 +264,23 @@ fn rpc_connect(uri: &Uri, o: &ClientOptions) -> Result<crate::rpc::RpcSession> {
         log::error!(
             "rsbinder::Client::open: session_id/outgoing_connections/incoming_connections \
              need `?profile=android13plus` ({:?})",
+            uri.endpoint
+        );
+        return Err(StatusCode::BadValue);
+    }
+    // Same contract for the handshake deadline. The r34 wire has no
+    // connection handshake at all — the session exists as soon as the
+    // socket does, and what `open` does after that is bounded by
+    // `timeout` — so on a plain r34 endpoint there is nothing for this
+    // option to bound. `tls://` is the exception either way: its
+    // `connect(2)` and TLS handshake below are bounded by it.
+    if versioned.is_none()
+        && o.handshake_timeout.is_some()
+        && !matches!(uri.endpoint, Endpoint::Tls(..))
+    {
+        log::error!(
+            "rsbinder::Client::open: handshake_timeout needs `?profile=android13plus` \
+             (or a `tls://` endpoint) ({:?})",
             uri.endpoint
         );
         return Err(StatusCode::BadValue);
@@ -380,9 +409,26 @@ fn rpc_connect(uri: &Uri, o: &ClientOptions) -> Result<crate::rpc::RpcSession> {
                     }
                     None => std::net::TcpStream::connect((host.as_str(), *port))?,
                 };
-                Box::new(crate::rpc::transport::TlsTransport::connect(
-                    tcp, name, cfg,
-                )?)
+                // The TLS handshake is the rest of this phase, and it is
+                // blocking I/O on the socket: bound it too, or a peer that
+                // accepts the connection and never sends a ServerHello
+                // hangs `open` — the very failure this option promises to
+                // cut. The server side bounds its half the same way,
+                // before `wrap_accepted`.
+                if let Some(d) = o.handshake_timeout {
+                    tcp.set_read_timeout(Some(d))?;
+                    tcp.set_write_timeout(Some(d))?;
+                }
+                let t = crate::rpc::transport::TlsTransport::connect(tcp, name, cfg)?;
+                if o.handshake_timeout.is_some() {
+                    // Handshake over: what follows (the android-13+
+                    // handshake, then the session's own traffic) arms its
+                    // own deadlines, and a sticky one here would cut an
+                    // idle session short.
+                    t.set_read_timeout(None).map_err(StatusCode::from)?;
+                    t.set_write_timeout(None).map_err(StatusCode::from)?;
+                }
+                Box::new(t)
             }
             #[cfg(not(feature = "rpc-tls"))]
             {

--- a/rsbinder/src/entry/client.rs
+++ b/rsbinder/src/entry/client.rs
@@ -31,7 +31,7 @@ pub struct ClientOptions {
     /// outside a handler.
     ///
     /// Setting this `> 0` makes the resulting [`Client`] one that must be
-    /// shut down explicitly (`client.session().unwrap().shutdown()`):
+    /// shut down explicitly (`client.session().unwrap().close_session()`):
     /// the serving threads keep the session alive, so dropping every
     /// handle reclaims nothing. It also makes the loss of the last such
     /// connection this session's death — including a connection the
@@ -107,7 +107,7 @@ pub struct ClientOptions {
 /// serving those connections, and each of them holds the session alive:
 /// dropping the `Client` *and* every proxy reclaims nothing, so the
 /// threads, the session and both ends' sockets survive until the process
-/// exits. Call `client.session().unwrap().shutdown()` when you are done
+/// exits. Call `client.session().unwrap().close_session()` when you are done
 /// with such a client.
 pub struct Client {
     endpoint: Endpoint,

--- a/rsbinder/src/entry/server.rs
+++ b/rsbinder/src/entry/server.rs
@@ -88,10 +88,12 @@ pub struct Server {
     pending: Vec<(String, SIBinder)>,
 }
 
-/// Handle for a [`Server::spawn`]ed server. Dropping it shuts an RPC
-/// server down (listener closed, workers joined). For the kernel there
-/// is nothing to stop — the process thread pool has no shutdown — so
-/// the guard is inert.
+/// Handle for a [`Server::spawn`]ed server. Dropping it ends an RPC
+/// server: the listener is closed, every session is ended (connected
+/// clients see the connection go) and the workers are joined — so a
+/// drop returns whether or not clients are still attached. For the
+/// kernel there is nothing to stop — the process thread pool has no
+/// shutdown — so the guard is inert.
 pub struct ServerGuard {
     #[cfg(feature = "rpc")]
     rpc: Option<(
@@ -113,7 +115,8 @@ impl std::fmt::Debug for ServerGuard {
 }
 
 impl ServerGuard {
-    /// Stop the server now (RPC) and wait for its threads. Kernel: no-op.
+    /// End the server now (RPC): stop accepting, end every session, join
+    /// the threads. Same as dropping the guard. Kernel: no-op.
     pub fn shutdown(mut self) {
         self.stop();
     }
@@ -131,9 +134,11 @@ impl ServerGuard {
     fn stop(&mut self) {
         #[cfg(feature = "rpc")]
         if let Some((server, jh)) = self.rpc.take() {
+            // Flag first so the accept loop exits; join it so nothing is
+            // accepted past this point; then end what is connected.
             server.shutdown();
             let _ = jh.join();
-            server.join_workers();
+            server.terminate();
         }
     }
 }

--- a/rsbinder/src/entry/server.rs
+++ b/rsbinder/src/entry/server.rs
@@ -117,7 +117,7 @@ impl std::fmt::Debug for ServerGuard {
 impl ServerGuard {
     /// End the server now (RPC): stop accepting, end every session, join
     /// the threads. Same as dropping the guard. Kernel: no-op.
-    pub fn shutdown(mut self) {
+    pub fn stop_and_join(mut self) {
         self.stop();
     }
 
@@ -136,7 +136,7 @@ impl ServerGuard {
         if let Some((server, jh)) = self.rpc.take() {
             // Flag first so the accept loop exits; join it so nothing is
             // accepted past this point; then end what is connected.
-            server.shutdown();
+            server.stop_accepting();
             let _ = jh.join();
             server.terminate();
         }
@@ -237,7 +237,7 @@ impl Server {
 
     /// Start serving and block. Kernel: starts the thread pool and joins
     /// it (never returns normally). RPC: runs the accept loop until
-    /// `RpcServer::shutdown` is called from another thread
+    /// `RpcServer::stop_accepting` is called from another thread
     /// (reachable via [`spawn`](Self::spawn)'s guard instead).
     pub fn run(self) -> Result<()> {
         match self.uri.endpoint {

--- a/rsbinder/src/entry/server.rs
+++ b/rsbinder/src/entry/server.rs
@@ -137,7 +137,9 @@ impl ServerGuard {
             // Flag first so the accept loop exits; join it so nothing is
             // accepted past this point; then end what is connected.
             server.stop_accepting();
-            let _ = jh.join();
+            if jh.join().is_err() {
+                log::warn!("RPC: accept loop thread panicked");
+            }
             server.terminate();
         }
     }

--- a/rsbinder/src/rpc/end.rs
+++ b/rsbinder/src/rpc/end.rs
@@ -25,7 +25,7 @@ use crate::StatusCode;
 #[non_exhaustive]
 pub enum EndedBy {
     /// This end decided to: an explicit
-    /// [`RpcSession::shutdown`](super::RpcSession::shutdown) or
+    /// [`RpcSession::close_session`](super::RpcSession::close_session) or
     /// [`RpcServer::terminate`](super::RpcServer::terminate), or a
     /// deadline this end armed and let expire between frames (idle
     /// eviction). Every end observed after that decision is `Local`,

--- a/rsbinder/src/rpc/end.rs
+++ b/rsbinder/src/rpc/end.rs
@@ -8,10 +8,9 @@
 //! asks about them are few: *is the stream still intact where the loop
 //! left it?* (decides whether anything more can be read), *did this end
 //! decide to stop?* (decides whether the end was expected), and *what
-//! happened?* (goes in the log). Before this type those three answers
-//! were spread over a `Result<bool>`, a `StatusCode` and a per-slot
-//! flag, and whatever none of them could carry ended up in prose. Here
-//! each is an axis: [`StreamState`], [`EndedBy`], [`EndReason`].
+//! happened?* (goes in the log). Each is one axis of this value, and no
+//! axis is derivable from another: [`StreamState`], [`EndedBy`],
+//! [`EndReason`].
 //!
 //! [`SessionEnd::into_result`] is the one projection back to
 //! `Result<()>`, and it reads a single axis — see its table.
@@ -27,9 +26,9 @@ pub enum EndedBy {
     /// This end decided to: an explicit
     /// [`RpcSession::close_session`](super::RpcSession::close_session) or
     /// [`RpcServer::terminate`](super::RpcServer::terminate), or a
-    /// deadline this end armed and let expire between frames (idle
-    /// eviction). Every end observed after that decision is `Local`,
-    /// whichever side's bytes reached the loop first.
+    /// deadline this end armed and let expire — between frames (idle
+    /// eviction) or part-way through one. Every end observed after that
+    /// decision is `Local`, whichever side's bytes reached the loop first.
     Local,
     /// Not this end's decision: the peer closed, went away, or the
     /// stream failed. Whether the *peer* chose it is not knowable at the
@@ -43,13 +42,22 @@ pub enum EndedBy {
 #[non_exhaustive]
 pub enum StreamState {
     /// The read stopped at a frame boundary with nothing unaccounted
-    /// for: an end of stream that was signaled, a deadline that elapsed
-    /// between frames, or a slot this end had already retired.
+    /// for: an end of stream that was signaled, a deadline *of this
+    /// end's* that elapsed between frames, or an end this loop reached
+    /// after this end had already decided to stop — a frame it
+    /// discarded, a slot it had already retired, or a dispatch that
+    /// failed.
     InSync,
     /// Not known to be intact — a frame stopped part-way or did not
-    /// decode, a nested call lost the position, or the stream ended
-    /// without its close signal. Nothing further should be read from it,
-    /// and the peer's side of the story is not known either.
+    /// decode, a nested call lost the position, the stream ended
+    /// without its close signal, or a read timed out with none of this
+    /// end's deadlines armed (the kernel's `ETIMEDOUT`, a peer whose
+    /// host went away). Also the ends this loop cannot place — a slot
+    /// already gone from the pool, a dispatch that failed — when this
+    /// end had not decided to stop, since whatever retired the slot or
+    /// failed the dispatch may have left a frame half-written. Nothing
+    /// further should be read from it, and the peer's side of the story
+    /// is not known either.
     Lost,
 }
 
@@ -73,13 +81,24 @@ pub enum EndReason {
     /// This end ended the session while the loop held a frame it had
     /// just read; the frame was not dispatched.
     Interrupted,
-    /// A deadline this end armed elapsed part-way through a frame
+    /// A read deadline elapsed part-way through a frame
     /// ([`RpcError::DeadlineMidFrame`](super::RpcError::DeadlineMidFrame)):
-    /// this end's own decision, and a lost position.
+    /// a lost position. Not by itself this end's decision — with none of
+    /// this end's deadlines armed it is the kernel's `ETIMEDOUT`, a peer
+    /// whose host went away, which is why [`SessionEnd::by`] is decided
+    /// with that knowledge.
     DeadlineMidFrame,
-    /// Reading or decoding a frame failed; the code is what the read or
-    /// the decoder produced (`TimedOut` for a deadline that elapsed
-    /// between frames, `NotEnoughData` for one that cut a frame, …).
+    /// A frame did not become a message this loop could act on; the code
+    /// is what the read or the decoder produced (`TimedOut` for a deadline
+    /// that elapsed between frames, `NotEnoughData` for one that cut a
+    /// frame, …). The loop also raises it on the one wire violation it
+    /// judges itself: an unsolicited `REPLY` no call is waiting for, which
+    /// AOSP's `RpcState::processCommand` likewise ends the session for, as
+    /// `Frame(BadType)`. That frame read and decoded cleanly, so it is the
+    /// one case here whose stream position is not in fact lost.
+    /// `TimedOut` is not by itself this end's deadline: with none armed
+    /// it is the kernel's `ETIMEDOUT` — a TCP peer whose host went away
+    /// — which is why the axes below are decided with that knowledge.
     Frame(StatusCode),
     /// Dispatching a frame failed — the handler, or writing its reply.
     Dispatch(StatusCode),
@@ -94,6 +113,7 @@ pub enum EndReason {
 /// this value says how it ended.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
+#[must_use = "the serve loop's end says whether the stream was lost; call into_result() or is_clean()"]
 pub struct SessionEnd {
     /// Who ended it.
     pub by: EndedBy,
@@ -104,16 +124,19 @@ pub struct SessionEnd {
 }
 
 impl SessionEnd {
-    /// Build the value from the mechanism and whether this end had
-    /// already decided to end the session. The two axes follow from
+    /// Build the value from the mechanism, whether this end had already
+    /// decided to end the session, and whether a read deadline of this
+    /// end's was armed when the loop ended. The two axes follow from
     /// those; the rules are the whole contract, so they are listed:
     ///
     /// | reason | `by` | `stream` |
     /// |---|---|---|
     /// | `EndOfStream` | local decision? | `InSync` |
-    /// | `UncleanEndOfStream`, `Unreadable`, `Frame(_)` (a frame cut or undecodable) | local decision? | `Lost` |
-    /// | `Frame(TimedOut)` (a deadline between frames) | `Local` | `InSync` |
-    /// | `DeadlineMidFrame` (a deadline inside one) | `Local` | `Lost` |
+    /// | `UncleanEndOfStream`, `Unreadable`, `Frame(_)` (a frame cut, undecodable, or a wire violation) | local decision? | `Lost` |
+    /// | `Frame(TimedOut)`, a deadline armed (idle eviction) | `Local` | `InSync` |
+    /// | `Frame(TimedOut)`, no deadline armed (the kernel's `ETIMEDOUT`) | local decision? | `Lost` |
+    /// | `DeadlineMidFrame`, a deadline armed (one of ours cut the frame) | `Local` | `Lost` |
+    /// | `DeadlineMidFrame`, no deadline armed (the kernel's `ETIMEDOUT`) | local decision? | `Lost` |
     /// | `Interrupted` | `Local` | `InSync` |
     /// | `Retired`, `Dispatch(_)` | local decision? | `InSync` if this end decided, else `Lost` |
     ///
@@ -122,21 +145,34 @@ impl SessionEnd {
     /// undecodable frame, a lost position) is `Lost` whoever decided;
     /// only the ambiguous ends — a slot already gone, a dispatch that
     /// failed — are read in the light of who ended the session.
-    pub(crate) fn new(reason: EndReason, ended_locally: bool) -> Self {
+    ///
+    /// The two timeout reasons need `deadline_armed` because by the time
+    /// they reach here the two kinds of timeout have become one. A socket
+    /// read deadline arrives as `EAGAIN` and the kernel's `ETIMEDOUT` as
+    /// itself, but every backend folds both into `RpcError::Timeout` /
+    /// `RpcError::DeadlineMidFrame` (`transport::is_timeout`, which has to
+    /// stay that wide: the `Read` adapters carry this end's own deadline
+    /// with the `TimedOut` kind). So with a deadline armed a `TimedOut`
+    /// between frames reads as this end evicting an idle peer — clean,
+    /// local — and one inside a frame as this end's own cut; including a
+    /// kernel `ETIMEDOUT` that happens to arrive while one is armed. With
+    /// none armed either can only be the kernel's, a TCP/TLS peer whose
+    /// host stopped answering, which is not this end's decision. The
+    /// position is lost inside a frame whichever it was.
+    pub(crate) fn new(reason: EndReason, ended_locally: bool, deadline_armed: bool) -> Self {
         use EndReason::*;
         use StreamState::*;
-        let decided = ended_locally
-            || matches!(
-                reason,
-                Interrupted | DeadlineMidFrame | Frame(StatusCode::TimedOut)
-            );
+        let idle_eviction = deadline_armed && matches!(reason, Frame(StatusCode::TimedOut));
+        let our_cut = deadline_armed && matches!(reason, DeadlineMidFrame);
+        let decided = ended_locally || idle_eviction || our_cut || matches!(reason, Interrupted);
         let by = if decided {
             EndedBy::Local
         } else {
             EndedBy::NotLocal
         };
         let stream = match reason {
-            EndOfStream | Interrupted | Frame(StatusCode::TimedOut) => InSync,
+            EndOfStream | Interrupted => InSync,
+            Frame(StatusCode::TimedOut) if idle_eviction => InSync,
             UncleanEndOfStream | Unreadable | DeadlineMidFrame | Frame(_) => Lost,
             Retired | Dispatch(_) => {
                 if ended_locally {
@@ -211,43 +247,66 @@ pub(crate) enum ServeStep {
 mod tests {
     use super::*;
 
-    /// The projection table, cell by cell — every combination
-    /// [`SessionEnd::new`] can produce, and what it projects to.
+    /// The projection table, cell by cell — every `(by, stream)` pair
+    /// [`SessionEnd::new`] can produce for each reason, and what it
+    /// projects to. `deadline_armed` is varied only where `new` reads it.
     #[test]
     fn projection_reads_the_stream_axis_only() {
         use EndReason::*;
         use EndedBy::{Local, NotLocal};
         use StatusCode::{BadType, DeadObject, NotEnoughData, TimedOut};
         use StreamState::{InSync, Lost};
-        // (reason, this end had decided, expected by, expected stream, clean?)
-        let cases: &[(EndReason, bool, EndedBy, StreamState, bool)] = &[
-            (EndOfStream, false, NotLocal, InSync, true),
-            (EndOfStream, true, Local, InSync, true),
-            (UncleanEndOfStream, false, NotLocal, Lost, false),
-            (UncleanEndOfStream, true, Local, Lost, false),
-            (Unreadable, false, NotLocal, Lost, false),
-            (Unreadable, true, Local, Lost, false),
-            (Retired, false, NotLocal, Lost, false),
-            (Retired, true, Local, InSync, true),
-            (Interrupted, true, Local, InSync, true),
-            (DeadlineMidFrame, false, Local, Lost, false),
-            (Frame(TimedOut), false, Local, InSync, true),
-            (Frame(NotEnoughData), false, NotLocal, Lost, false),
-            (Frame(BadType), true, Local, Lost, false),
-            (Dispatch(DeadObject), false, NotLocal, Lost, false),
-            (Dispatch(DeadObject), true, Local, InSync, true),
+        // (reason, this end had decided, a deadline was armed,
+        //  expected by, expected stream, clean?)
+        let cases: &[(EndReason, bool, bool, EndedBy, StreamState, bool)] = &[
+            (EndOfStream, false, false, NotLocal, InSync, true),
+            (EndOfStream, true, false, Local, InSync, true),
+            (UncleanEndOfStream, false, false, NotLocal, Lost, false),
+            (UncleanEndOfStream, true, false, Local, Lost, false),
+            (Unreadable, false, false, NotLocal, Lost, false),
+            (Unreadable, true, false, Local, Lost, false),
+            (Retired, false, false, NotLocal, Lost, false),
+            (Retired, true, false, Local, InSync, true),
+            (Interrupted, true, false, Local, InSync, true),
+            // `Interrupted` is `Local` on its own: this end interrupted the
+            // loop whether or not it had already decided elsewhere. Only
+            // this row holds `new`'s `Interrupted` arm — the one above is
+            // already decided by `ended_locally`.
+            (Interrupted, false, false, Local, InSync, true),
+            // A deadline this end armed cut the frame: local, position lost.
+            (DeadlineMidFrame, false, true, Local, Lost, false),
+            // With none armed the same cut is the kernel's `ETIMEDOUT`,
+            // which this end did not decide.
+            (DeadlineMidFrame, false, false, NotLocal, Lost, false),
+            (DeadlineMidFrame, true, false, Local, Lost, false),
+            // A deadline this end armed elapsed between frames: idle
+            // eviction, clean and local.
+            (Frame(TimedOut), false, true, Local, InSync, true),
+            // The same code with no deadline armed is the kernel's
+            // `ETIMEDOUT` — the peer host went away; not this end's
+            // decision, and not a stream anything more can be read from.
+            (Frame(TimedOut), false, false, NotLocal, Lost, false),
+            (Frame(TimedOut), true, false, Local, Lost, false),
+            (Frame(NotEnoughData), false, false, NotLocal, Lost, false),
+            (Frame(BadType), true, false, Local, Lost, false),
+            (Dispatch(DeadObject), false, false, NotLocal, Lost, false),
+            (Dispatch(DeadObject), true, false, Local, InSync, true),
         ];
-        for &(reason, local, by, stream, ok) in cases {
-            let end = SessionEnd::new(reason, local);
-            assert_eq!(end.by, by, "{reason:?} local={local}");
-            assert_eq!(end.stream, stream, "{reason:?} local={local}");
-            assert_eq!(end.is_clean(), ok, "{reason:?} local={local}");
+        for &(reason, local, armed, by, stream, ok) in cases {
+            let end = SessionEnd::new(reason, local, armed);
+            assert_eq!(end.by, by, "{reason:?} local={local} armed={armed}");
+            assert_eq!(end.stream, stream, "{reason:?} local={local} armed={armed}");
+            assert_eq!(end.is_clean(), ok, "{reason:?} local={local} armed={armed}");
             let expected = if ok {
                 Ok(())
             } else {
                 Err(StatusCode::DeadObject)
             };
-            assert_eq!(end.into_result(), expected, "{reason:?} local={local}");
+            assert_eq!(
+                end.into_result(),
+                expected,
+                "{reason:?} local={local} armed={armed}"
+            );
         }
     }
 }

--- a/rsbinder/src/rpc/end.rs
+++ b/rsbinder/src/rpc/end.rs
@@ -1,0 +1,243 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Why a serve loop ended — the value [`RpcSession::serve_blocking`] and
+//! its siblings return.
+//!
+//! A serve loop can end for a dozen reasons, and the questions a caller
+//! asks about them are few: *is the stream still intact where the loop
+//! left it?* (decides whether anything more can be read), *did this end
+//! decide to stop?* (decides whether the end was expected), and *what
+//! happened?* (goes in the log). Before this type those three answers
+//! were spread over a `Result<bool>`, a `StatusCode` and a per-slot
+//! flag, and whatever none of them could carry ended up in prose. Here
+//! each is an axis: [`StreamState`], [`EndedBy`], [`EndReason`].
+//!
+//! [`SessionEnd::into_result`] is the one projection back to
+//! `Result<()>`, and it reads a single axis — see its table.
+//!
+//! [`RpcSession::serve_blocking`]: super::RpcSession::serve_blocking
+
+use crate::StatusCode;
+
+/// Who ended the connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum EndedBy {
+    /// This end decided to: an explicit
+    /// [`RpcSession::shutdown`](super::RpcSession::shutdown) or
+    /// [`RpcServer::terminate`](super::RpcServer::terminate), or a
+    /// deadline this end armed and let expire between frames (idle
+    /// eviction). Every end observed after that decision is `Local`,
+    /// whichever side's bytes reached the loop first.
+    Local,
+    /// Not this end's decision: the peer closed, went away, or the
+    /// stream failed. Whether the *peer* chose it is not knowable at the
+    /// transport — a close, a reset and a cut all arrive as an end of
+    /// stream — so this says only what it can.
+    NotLocal,
+}
+
+/// Whether the stream is still known to be intact where the loop left it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum StreamState {
+    /// The read stopped at a frame boundary with nothing unaccounted
+    /// for: an end of stream that was signaled, a deadline that elapsed
+    /// between frames, or a slot this end had already retired.
+    InSync,
+    /// Not known to be intact — a frame stopped part-way or did not
+    /// decode, a nested call lost the position, or the stream ended
+    /// without its close signal. Nothing further should be read from it,
+    /// and the peer's side of the story is not known either.
+    Lost,
+}
+
+/// What ended the loop — the mechanism, for the log and for telling
+/// apart ends the two axes above fold together.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum EndReason {
+    /// The read reached end of stream at a frame boundary.
+    EndOfStream,
+    /// The stream ended without the transport's close signal
+    /// ([`RpcError::UncleanEndOfStream`](super::RpcError::UncleanEndOfStream)).
+    UncleanEndOfStream,
+    /// A nested call made from a handler on this connection lost track
+    /// of what the peer sends next and marked the slot unreadable.
+    Unreadable,
+    /// The slot was gone from the pool when the loop went to pin it —
+    /// retired by a transaction that failed on it, or by the session
+    /// ending.
+    Retired,
+    /// This end ended the session while the loop held a frame it had
+    /// just read; the frame was not dispatched.
+    Interrupted,
+    /// Reading or decoding a frame failed; the code is what the read or
+    /// the decoder produced (`TimedOut` for a deadline that elapsed
+    /// between frames, `NotEnoughData` for one that cut a frame, …).
+    Frame(StatusCode),
+    /// Dispatching a frame failed — the handler, or writing its reply.
+    Dispatch(StatusCode),
+}
+
+/// Why a serve loop ended. Returned by
+/// [`RpcSession::serve_blocking`](super::RpcSession::serve_blocking),
+/// [`serve_blocking_on`](super::RpcSession::serve_blocking_on) and
+/// [`serve_blocking_clearing_deadline_after_first`](super::RpcSession::serve_blocking_clearing_deadline_after_first).
+/// Whatever the reason, every remote object reachable over the session
+/// is dead once the loop has ended and its death recipients have fired;
+/// this value says how it ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub struct SessionEnd {
+    /// Who ended it.
+    pub by: EndedBy,
+    /// Whether the stream is still known to be intact.
+    pub stream: StreamState,
+    /// What happened.
+    pub reason: EndReason,
+}
+
+impl SessionEnd {
+    /// Build the value from the mechanism and whether this end had
+    /// already decided to end the session. The two axes follow from
+    /// those; the rules are the whole contract, so they are listed:
+    ///
+    /// | reason | `by` | `stream` |
+    /// |---|---|---|
+    /// | `EndOfStream` | local decision? | `InSync` |
+    /// | `UncleanEndOfStream`, `Unreadable`, `Frame(_)` (a frame cut or undecodable) | local decision? | `Lost` |
+    /// | `Frame(TimedOut)` (a deadline between frames) | `Local` | `InSync` |
+    /// | `Interrupted` | `Local` | `InSync` |
+    /// | `Retired`, `Dispatch(_)` | local decision? | `InSync` if this end decided, else `Lost` |
+    ///
+    /// "Local decision?" is `Local` when this end had decided, else
+    /// `NotLocal`. A fault this loop observed itself (a cut, an
+    /// undecodable frame, a lost position) is `Lost` whoever decided;
+    /// only the ambiguous ends — a slot already gone, a dispatch that
+    /// failed — are read in the light of who ended the session.
+    pub(crate) fn new(reason: EndReason, ended_locally: bool) -> Self {
+        use EndReason::*;
+        use StreamState::*;
+        let decided = ended_locally || matches!(reason, Interrupted | Frame(StatusCode::TimedOut));
+        let by = if decided {
+            EndedBy::Local
+        } else {
+            EndedBy::NotLocal
+        };
+        let stream = match reason {
+            EndOfStream | Interrupted | Frame(StatusCode::TimedOut) => InSync,
+            UncleanEndOfStream | Unreadable | Frame(_) => Lost,
+            Retired | Dispatch(_) => {
+                if ended_locally {
+                    InSync
+                } else {
+                    Lost
+                }
+            }
+        };
+        SessionEnd { by, stream, reason }
+    }
+
+    /// The one projection to `Result<()>`, for a caller that only wants
+    /// "did it end well". It reads a single axis:
+    ///
+    /// | `stream` | result |
+    /// |---|---|
+    /// | `InSync` | `Ok(())` — the end was clean, whoever ended it |
+    /// | `Lost` | `Err(`[`StatusCode::DeadObject`]`)` — the stream is not to be trusted, and the session is over |
+    ///
+    /// Who ended it does not change the result — a session this end shut
+    /// down and one whose peer closed both end cleanly — and the
+    /// specific cause is in [`reason`](Self::reason), not in the code:
+    /// every lost stream is one `DeadObject`, because that is the state
+    /// the session is in, and a log line wants the reason, not the code.
+    pub fn into_result(self) -> crate::Result<()> {
+        match self.stream {
+            StreamState::InSync => Ok(()),
+            StreamState::Lost => Err(StatusCode::DeadObject),
+        }
+    }
+
+    /// `true` when the stream was intact at the end —
+    /// [`into_result`](Self::into_result) would be `Ok(())`.
+    pub fn is_clean(&self) -> bool {
+        matches!(self.stream, StreamState::InSync)
+    }
+
+    /// Log this end at the level it deserves — a lost stream is worth a
+    /// `warn!`, every clean end is `debug!` however it came about.
+    pub(crate) fn log(&self, what: &str) {
+        match self.stream {
+            StreamState::Lost => log::warn!("{what}: {self}"),
+            StreamState::InSync => log::debug!("{what}: {self}"),
+        }
+    }
+}
+
+impl std::fmt::Display for SessionEnd {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let by = match self.by {
+            EndedBy::Local => "ended by this end",
+            EndedBy::NotLocal => "ended by the peer or the stream",
+        };
+        let stream = match self.stream {
+            StreamState::InSync => "stream intact",
+            StreamState::Lost => "stream lost",
+        };
+        write!(f, "{by}, {stream} ({:?})", self.reason)
+    }
+}
+
+/// One step of the serve loop.
+pub(crate) enum ServeStep {
+    /// A frame was handled; read the next one.
+    Continue,
+    /// The loop is over, for this reason.
+    Ended(EndReason),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The projection table, cell by cell — every combination
+    /// [`SessionEnd::new`] can produce, and what it projects to.
+    #[test]
+    fn projection_reads_the_stream_axis_only() {
+        use EndReason::*;
+        use EndedBy::{Local, NotLocal};
+        use StatusCode::{BadType, DeadObject, NotEnoughData, TimedOut};
+        use StreamState::{InSync, Lost};
+        // (reason, this end had decided, expected by, expected stream, clean?)
+        let cases: &[(EndReason, bool, EndedBy, StreamState, bool)] = &[
+            (EndOfStream, false, NotLocal, InSync, true),
+            (EndOfStream, true, Local, InSync, true),
+            (UncleanEndOfStream, false, NotLocal, Lost, false),
+            (UncleanEndOfStream, true, Local, Lost, false),
+            (Unreadable, false, NotLocal, Lost, false),
+            (Unreadable, true, Local, Lost, false),
+            (Retired, false, NotLocal, Lost, false),
+            (Retired, true, Local, InSync, true),
+            (Interrupted, true, Local, InSync, true),
+            (Frame(TimedOut), false, Local, InSync, true),
+            (Frame(NotEnoughData), false, NotLocal, Lost, false),
+            (Frame(BadType), true, Local, Lost, false),
+            (Dispatch(DeadObject), false, NotLocal, Lost, false),
+            (Dispatch(DeadObject), true, Local, InSync, true),
+        ];
+        for &(reason, local, by, stream, ok) in cases {
+            let end = SessionEnd::new(reason, local);
+            assert_eq!(end.by, by, "{reason:?} local={local}");
+            assert_eq!(end.stream, stream, "{reason:?} local={local}");
+            assert_eq!(end.is_clean(), ok, "{reason:?} local={local}");
+            let expected = if ok {
+                Ok(())
+            } else {
+                Err(StatusCode::DeadObject)
+            };
+            assert_eq!(end.into_result(), expected, "{reason:?} local={local}");
+        }
+    }
+}

--- a/rsbinder/src/rpc/end.rs
+++ b/rsbinder/src/rpc/end.rs
@@ -73,6 +73,10 @@ pub enum EndReason {
     /// This end ended the session while the loop held a frame it had
     /// just read; the frame was not dispatched.
     Interrupted,
+    /// A deadline this end armed elapsed part-way through a frame
+    /// ([`RpcError::DeadlineMidFrame`](super::RpcError::DeadlineMidFrame)):
+    /// this end's own decision, and a lost position.
+    DeadlineMidFrame,
     /// Reading or decoding a frame failed; the code is what the read or
     /// the decoder produced (`TimedOut` for a deadline that elapsed
     /// between frames, `NotEnoughData` for one that cut a frame, …).
@@ -109,6 +113,7 @@ impl SessionEnd {
     /// | `EndOfStream` | local decision? | `InSync` |
     /// | `UncleanEndOfStream`, `Unreadable`, `Frame(_)` (a frame cut or undecodable) | local decision? | `Lost` |
     /// | `Frame(TimedOut)` (a deadline between frames) | `Local` | `InSync` |
+    /// | `DeadlineMidFrame` (a deadline inside one) | `Local` | `Lost` |
     /// | `Interrupted` | `Local` | `InSync` |
     /// | `Retired`, `Dispatch(_)` | local decision? | `InSync` if this end decided, else `Lost` |
     ///
@@ -120,7 +125,11 @@ impl SessionEnd {
     pub(crate) fn new(reason: EndReason, ended_locally: bool) -> Self {
         use EndReason::*;
         use StreamState::*;
-        let decided = ended_locally || matches!(reason, Interrupted | Frame(StatusCode::TimedOut));
+        let decided = ended_locally
+            || matches!(
+                reason,
+                Interrupted | DeadlineMidFrame | Frame(StatusCode::TimedOut)
+            );
         let by = if decided {
             EndedBy::Local
         } else {
@@ -128,7 +137,7 @@ impl SessionEnd {
         };
         let stream = match reason {
             EndOfStream | Interrupted | Frame(StatusCode::TimedOut) => InSync,
-            UncleanEndOfStream | Unreadable | Frame(_) => Lost,
+            UncleanEndOfStream | Unreadable | DeadlineMidFrame | Frame(_) => Lost,
             Retired | Dispatch(_) => {
                 if ended_locally {
                     InSync
@@ -221,6 +230,7 @@ mod tests {
             (Retired, false, NotLocal, Lost, false),
             (Retired, true, Local, InSync, true),
             (Interrupted, true, Local, InSync, true),
+            (DeadlineMidFrame, false, Local, Lost, false),
             (Frame(TimedOut), false, Local, InSync, true),
             (Frame(NotEnoughData), false, NotLocal, Lost, false),
             (Frame(BadType), true, Local, Lost, false),

--- a/rsbinder/src/rpc/lifecycle.rs
+++ b/rsbinder/src/rpc/lifecycle.rs
@@ -13,6 +13,7 @@
 //!     ┌─── new() ──→  Live(n: NonZeroUsize) ───drop_connection (n==1)──→  Dying ──mark_dead──→ Dead
 //!                           │  ▲
 //!                           │  └─── drop_connection (n>1) decrements
+//!                           │       force_dying (any n) ─────────────→  Dying   (explicit shutdown)
 //!                           │
 //!                           └─── try_bump_live increments
 //! ```
@@ -211,6 +212,33 @@ impl SessionLifecycle {
             .is_ok()
     }
 
+    /// Explicit-shutdown counterpart of [`drop_connection`](Self::drop_connection),
+    /// which only ever takes the `1→0` edge: declare death from **any**
+    /// `Live(n)`. Exactly one caller gets `true` (`Live(n) → Dying`) and
+    /// owns the death sequence + [`mark_dead`](Self::mark_dead);
+    /// `Dying`/`Dead` return `false`. The live count is discarded on
+    /// purpose — the caller is shutting those connections down, and their
+    /// workers' later `drop_connection` calls find a settled state and
+    /// return `false` quietly, as they already do after a
+    /// [`try_drop_sole_connection`](Self::try_drop_sole_connection).
+    pub(crate) fn force_dying(&self) -> bool {
+        let mut v = self.inner.load(Ordering::SeqCst);
+        loop {
+            if v >> STATE_SHIFT != STATE_LIVE_TAG {
+                return false;
+            }
+            match self.inner.compare_exchange_weak(
+                v,
+                encode_dying(),
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => v = actual,
+            }
+        }
+    }
+
     /// Transition `Dying → Dead`. The caller MUST have just fired
     /// session obituaries (the only path that reaches `Dying`).
     pub(crate) fn mark_dead(&self) {
@@ -404,6 +432,30 @@ mod tests {
         assert!(lc.drop_connection(), "Live(1) -> Dying");
         assert!(!lc.try_drop_sole_connection());
         lc.mark_dead();
+    }
+
+    /// `force_dying` takes the edge from any live count, once; the
+    /// connections' own later `drop_connection`s are then quiet.
+    #[test]
+    fn force_dying_from_live_n_takes_the_edge_exactly_once() {
+        let lc = SessionLifecycle::new();
+        assert!(lc.try_bump_live());
+        assert!(lc.try_bump_live());
+        assert_eq!(lc.live_count(), 3);
+        assert!(lc.force_dying(), "Live(3) -> Dying");
+        assert_eq!(lc.snapshot(), SessionLifecycleSnapshot::Dying);
+        assert!(
+            !lc.force_dying(),
+            "a second caller does not own the death sequence"
+        );
+        assert!(
+            !lc.drop_connection(),
+            "the shut-down workers' exits are quiet"
+        );
+        assert!(!lc.try_bump_live(), "no attach after an explicit shutdown");
+        lc.mark_dead();
+        assert!(!lc.force_dying());
+        assert_eq!(lc.snapshot(), SessionLifecycleSnapshot::Dead);
     }
 
     #[test]

--- a/rsbinder/src/rpc/mod.rs
+++ b/rsbinder/src/rpc/mod.rs
@@ -145,6 +145,16 @@ pub enum RpcError {
     /// The peer closed the connection cleanly with no frame pending
     /// (EOF / `BrokenPipe` / `ConnectionReset` before any header bytes).
     PeerClosed,
+    /// The stream ended at a frame boundary without the transport's own
+    /// close signal — a TLS session whose TCP stream ended with no
+    /// `close_notify`. Kept apart from [`PeerClosed`](Self::PeerClosed)
+    /// because on the one backend built for untrusted networks this is
+    /// exactly what a truncation attack looks like; a plain socket has no
+    /// close signal to miss and never reports it. The transport's own
+    /// [`shutdown`](transport::RpcTransport::shutdown) sends the signal,
+    /// so a deliberate close on this end is still `PeerClosed` on the
+    /// other. Projects to [`StatusCode::DeadObject`](crate::StatusCode).
+    UncleanEndOfStream,
     /// A frame length header was fully received but the body was
     /// truncated (peer closed mid-body, or declared more than it sent).
     Truncated,
@@ -171,6 +181,9 @@ impl fmt::Display for RpcError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RpcError::PeerClosed => write!(f, "RPC peer closed the connection"),
+            RpcError::UncleanEndOfStream => {
+                write!(f, "RPC stream ended without a close signal (truncated?)")
+            }
             RpcError::Truncated => write!(f, "RPC frame truncated (incomplete body)"),
             RpcError::FrameTooLarge { declared, max } => {
                 write!(
@@ -197,9 +210,16 @@ impl std::error::Error for RpcError {
 impl From<std::io::Error> for RpcError {
     /// Map a clean disconnect to [`RpcError::PeerClosed`]; everything
     /// else stays [`RpcError::Io`]. A truncated *body* is classified by
-    /// the framing reader, not here.
+    /// the framing reader, not here. An `RpcError` that travelled as the
+    /// `io::Error`'s payload (how the `Read` adapters carry
+    /// [`RpcError::UncleanEndOfStream`] through the framing readers)
+    /// comes back as itself rather than folded by kind.
     fn from(e: std::io::Error) -> Self {
         use std::io::ErrorKind::*;
+        let e = match e.downcast::<RpcError>() {
+            Ok(rpc) => return rpc,
+            Err(e) => e,
+        };
         match e.kind() {
             UnexpectedEof | BrokenPipe | ConnectionReset | ConnectionAborted => {
                 RpcError::PeerClosed
@@ -230,14 +250,21 @@ impl From<RpcError> for std::io::Error {
     /// — the status a caller's dead-peer check keys on.
     /// [`RpcError::Timeout`] projects onto `TimedOut`
     /// — kind-preserving rather than variant-preserving, since
-    /// `From<io::Error>` folds that kind into `Io(TimedOut)`. The
-    /// remaining variants have no `io::ErrorKind` that means what they
-    /// mean, so they stay `Other`.
+    /// `From<io::Error>` folds that kind into `Io(TimedOut)`.
+    /// [`RpcError::UncleanEndOfStream`] must survive the round trip —
+    /// folding it by kind would turn it back into `PeerClosed`, the very
+    /// thing it exists to be told apart from — so it goes out as an
+    /// `UnexpectedEof` carrying itself as the payload, which
+    /// `From<io::Error>` recovers first. The remaining variants have no
+    /// `io::ErrorKind` that means what they mean, so they stay `Other`.
     fn from(e: RpcError) -> Self {
         match e {
             RpcError::Io(io) => io,
             RpcError::PeerClosed => std::io::ErrorKind::BrokenPipe.into(),
             RpcError::Timeout => std::io::ErrorKind::TimedOut.into(),
+            e @ RpcError::UncleanEndOfStream => {
+                std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e)
+            }
             other => std::io::Error::other(format!("{other}")),
         }
     }
@@ -252,6 +279,7 @@ impl From<RpcError> for crate::StatusCode {
     fn from(e: RpcError) -> Self {
         match e {
             RpcError::PeerClosed => crate::StatusCode::DeadObject,
+            RpcError::UncleanEndOfStream => crate::StatusCode::DeadObject,
             RpcError::Truncated => crate::StatusCode::NotEnoughData,
             RpcError::FrameTooLarge { .. } => crate::StatusCode::BadValue,
             RpcError::Io(io) => crate::StatusCode::from(io),

--- a/rsbinder/src/rpc/mod.rs
+++ b/rsbinder/src/rpc/mod.rs
@@ -170,13 +170,14 @@ pub enum RpcError {
     /// because on the one backend built for untrusted networks this is
     /// exactly what a truncation attack looks like; a plain socket has no
     /// close signal to miss and never reports it. The transport's own
-    /// [`shutdown`](transport::RpcTransport::shutdown) sends the signal
-    /// before it cuts the socket, waiting briefly for a send another
-    /// thread has in flight (only the thread holding the write side may
-    /// transmit), so a deliberate close on this end is `EndOfStream` on
-    /// the other. That wait is bounded so teardown stays finite: a peer
-    /// that has stopped reading holds its sender past it, and reads the
-    /// unclean end it was heading for anyway. Projects to
+    /// [`shutdown`](transport::RpcTransport::shutdown) refuses every send
+    /// from that point, lets the one already in flight finish, and only
+    /// then sends the signal and cuts the socket — so a deliberate close
+    /// on this end is `EndOfStream` on the other, and every frame a sender
+    /// was told went out is one the peer reads before it. The wait for
+    /// that send is bounded so teardown stays finite: a peer that has
+    /// stopped reading holds its sender past it, and reads the unclean end
+    /// it was heading for anyway. Projects to
     /// [`StatusCode::DeadObject`](crate::StatusCode).
     UncleanEndOfStream,
     /// A frame was cut short: the length header itself arrived incomplete,

--- a/rsbinder/src/rpc/mod.rs
+++ b/rsbinder/src/rpc/mod.rs
@@ -160,6 +160,12 @@ pub enum RpcError {
     /// A frame length header was fully received but the body was
     /// truncated (peer closed mid-body, or declared more than it sent).
     Truncated,
+    /// A read deadline this end armed elapsed part-way through a frame.
+    /// The stream position is as lost as after [`Truncated`](Self::Truncated),
+    /// but the cause is this end's own policy (a reply deadline, a
+    /// server's idle timeout), not the peer — so a log can say which.
+    /// Projects to [`StatusCode::TimedOut`](crate::StatusCode).
+    DeadlineMidFrame,
     /// A declared frame length exceeds [`transport::MAX_FRAME_LEN`].
     /// Rejected *before* any allocation (anti-OOM).
     FrameTooLarge {
@@ -187,6 +193,9 @@ impl fmt::Display for RpcError {
                 write!(f, "RPC stream ended without a close signal (truncated?)")
             }
             RpcError::Truncated => write!(f, "RPC frame truncated (incomplete body)"),
+            RpcError::DeadlineMidFrame => {
+                write!(f, "RPC read deadline elapsed part-way through a frame")
+            }
             RpcError::FrameTooLarge { declared, max } => {
                 write!(
                     f,
@@ -281,6 +290,9 @@ impl From<RpcError> for std::io::Error {
             e @ RpcError::UncleanEndOfStream => {
                 std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e)
             }
+            // Same carriage: by kind alone it would come back as a
+            // boundary `Timeout`, the opposite of what it means.
+            e @ RpcError::DeadlineMidFrame => std::io::Error::new(std::io::ErrorKind::TimedOut, e),
             other => std::io::Error::other(format!("{other}")),
         }
     }
@@ -297,6 +309,7 @@ impl From<RpcError> for crate::StatusCode {
             RpcError::PeerClosed => crate::StatusCode::DeadObject,
             RpcError::UncleanEndOfStream => crate::StatusCode::DeadObject,
             RpcError::Truncated => crate::StatusCode::NotEnoughData,
+            RpcError::DeadlineMidFrame => crate::StatusCode::TimedOut,
             RpcError::FrameTooLarge { .. } => crate::StatusCode::BadValue,
             RpcError::Io(io) => crate::StatusCode::from(io),
             RpcError::Protocol(_) => crate::StatusCode::RpcError,

--- a/rsbinder/src/rpc/mod.rs
+++ b/rsbinder/src/rpc/mod.rs
@@ -144,36 +144,53 @@ pub type RpcResult<T> = std::result::Result<T, RpcError>;
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum RpcError {
-    /// The stream ended at a frame boundary: EOF with no frame pending,
-    /// or a disconnect kind (`BrokenPipe` / `ConnectionReset` /
-    /// `ConnectionAborted`) from a read or a write. It says nothing about
+    /// The stream ended: EOF with no frame pending, or a disconnect kind
+    /// (`BrokenPipe` / `ConnectionReset` / `ConnectionAborted`) from a
+    /// read or a write. It says nothing about
     /// **who** ended the stream or whether the end was **clean**: this
     /// end's own write failing after its own
     /// [`shutdown`](transport::RpcTransport::shutdown) folds here just as
     /// a peer's EOF does, and so does a reset. Whether this end decided
     /// is [`SessionEnd::by`]; whether the transport's close signal
-    /// arrived is [`UncleanEndOfStream`](Self::UncleanEndOfStream). A
-    /// disconnect part-way through a frame is
-    /// [`Truncated`](Self::Truncated), never this. Projects to
-    /// [`StatusCode::DeadObject`](crate::StatusCode).
+    /// arrived is [`UncleanEndOfStream`](Self::UncleanEndOfStream). The
+    /// frame-boundary guarantee is **read-side only**: a read that
+    /// disconnects part-way through a frame is
+    /// [`Truncated`](Self::Truncated), never this. A *send* that
+    /// disconnects past its first byte is this variant with the position
+    /// lost — no writer can report how much of the frame went out — which
+    /// is why the session's send-failure rule retires a slot on it.
+    /// Projects to [`StatusCode::DeadObject`](crate::StatusCode).
     EndOfStream,
-    /// The stream ended at a frame boundary without the transport's own
-    /// close signal — a TLS session whose TCP stream ended with no
-    /// `close_notify`. Kept apart from [`EndOfStream`](Self::EndOfStream)
+    /// The stream ended without the transport's own close signal — a TLS
+    /// session whose TCP stream ended with no `close_notify`. It arrives at
+    /// a frame boundary or part-way through one, and the position is not
+    /// assumed intact either way (the r34 framing readers promote it to
+    /// [`Truncated`](Self::Truncated) mid-frame; the android-13+ ones leave
+    /// it as itself). Kept apart from [`EndOfStream`](Self::EndOfStream)
     /// because on the one backend built for untrusted networks this is
     /// exactly what a truncation attack looks like; a plain socket has no
     /// close signal to miss and never reports it. The transport's own
-    /// [`shutdown`](transport::RpcTransport::shutdown) sends the signal,
-    /// so a deliberate close on this end is still `EndOfStream` on the
-    /// other. Projects to [`StatusCode::DeadObject`](crate::StatusCode).
+    /// [`shutdown`](transport::RpcTransport::shutdown) sends the signal
+    /// before it cuts the socket, waiting briefly for a send another
+    /// thread has in flight (only the thread holding the write side may
+    /// transmit), so a deliberate close on this end is `EndOfStream` on
+    /// the other. That wait is bounded so teardown stays finite: a peer
+    /// that has stopped reading holds its sender past it, and reads the
+    /// unclean end it was heading for anyway. Projects to
+    /// [`StatusCode::DeadObject`](crate::StatusCode).
     UncleanEndOfStream,
-    /// A frame length header was fully received but the body was
-    /// truncated (peer closed mid-body, or declared more than it sent).
+    /// A frame was cut short: the length header itself arrived incomplete,
+    /// or the header arrived in full and the body did not (peer closed
+    /// mid-body, or declared more than it sent).
     Truncated,
-    /// A read deadline this end armed elapsed part-way through a frame.
-    /// The stream position is as lost as after [`Truncated`](Self::Truncated),
-    /// but the cause is this end's own policy (a reply deadline, a
-    /// server's idle timeout), not the peer — so a log can say which.
+    /// A read deadline elapsed part-way through a frame. The stream
+    /// position is as lost as after [`Truncated`](Self::Truncated). Whose
+    /// deadline it was is not knowable here: a read deadline of this end's
+    /// (a reply deadline, a server's idle timeout) and the kernel's own
+    /// `ETIMEDOUT` from a peer whose host went away arrive as the same
+    /// io error kind and are not told apart. Attribution is
+    /// [`SessionEnd::by`], which is decided with the knowledge of whether
+    /// a deadline of this end's was armed at all.
     /// Projects to [`StatusCode::TimedOut`](crate::StatusCode).
     DeadlineMidFrame,
     /// A declared frame length exceeds [`transport::MAX_FRAME_LEN`].
@@ -188,10 +205,15 @@ pub enum RpcError {
     Io(std::io::Error),
     /// A protocol-level violation (used by the wire codec).
     Protocol(&'static str),
-    /// A configured wait deadline elapsed with no frame boundary
-    /// reached (reply / negotiation timeout). Reported
-    /// only when nothing partial was consumed, so the stream stays
-    /// frame-synchronized.
+    /// A wait deadline elapsed with no frame boundary crossed: a read that
+    /// consumed nothing (a reply or negotiation deadline), or a send that
+    /// put nothing on the wire. The stream stays frame-synchronized either
+    /// way, which is what lets the connection keep serving. Whose deadline
+    /// it was is not knowable here — one of this end's and the kernel's own
+    /// `ETIMEDOUT` arrive as the same io error kind; attribution is
+    /// [`SessionEnd::by`], decided with the knowledge of whether a deadline
+    /// of this end's was armed at all.
+    /// Projects to [`StatusCode::TimedOut`](crate::StatusCode).
     Timeout,
 }
 
@@ -231,12 +253,16 @@ impl std::error::Error for RpcError {
 impl RpcError {
     /// Whether a read that failed with this error is documented to have
     /// left the stream at a frame boundary: [`EndOfStream`](Self::EndOfStream)
-    /// ("no frame pending") and [`Timeout`](Self::Timeout) ("reported only
-    /// when nothing partial was consumed"). Every other read failure lacks
+    /// ("no frame pending") and [`Timeout`](Self::Timeout) ("no frame
+    /// boundary crossed"). Every other read failure lacks
     /// that guarantee — including ones that in fact consumed nothing — and
-    /// is treated as a lost position. The single owner of the distinction:
-    /// the framing readers (promoting a mid-frame case to `Truncated`),
-    /// the reply wait and the serve loop all ask here.
+    /// is treated as a lost position. Two callers ask: the android-13+
+    /// reader, which promotes a mid-frame case to `Truncated` /
+    /// `DeadlineMidFrame`, and `client_transact`'s reply wait, which decides
+    /// whether an abandoned nested call left its `REPLY` inbound. The r34
+    /// framing readers and the serve loop reimplement the same split inline
+    /// — against the io error kind and the `RpcError` variants
+    /// respectively — so a change to the set here has to be made there too.
     pub(crate) fn leaves_frame_boundary_intact(&self) -> bool {
         matches!(self, RpcError::EndOfStream | RpcError::Timeout)
     }
@@ -300,8 +326,11 @@ impl From<RpcError> for std::io::Error {
             e @ RpcError::UncleanEndOfStream => {
                 std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e)
             }
-            // Same carriage: by kind alone it would come back as a
-            // boundary `Timeout`, the opposite of what it means.
+            // Same carriage, so the variant is at least recoverable on the
+            // far side: by kind alone it would come back as a boundary
+            // `Timeout`, the opposite of what it means. No reader takes it
+            // yet — each checks `is_timeout` by kind before the downcast —
+            // and no producer sends this variant across this boundary.
             e @ RpcError::DeadlineMidFrame => std::io::Error::new(std::io::ErrorKind::TimedOut, e),
             other => std::io::Error::other(format!("{other}")),
         }

--- a/rsbinder/src/rpc/mod.rs
+++ b/rsbinder/src/rpc/mod.rs
@@ -83,6 +83,7 @@
 //! macOS) no longer panics on an uninitialized `ProcessState`.
 
 pub mod address;
+pub mod end;
 pub mod fd_mode;
 pub(crate) mod lifecycle;
 pub mod proxy;
@@ -109,6 +110,7 @@ pub use wire::{__fuzz_decode_address, __fuzz_decode_wire, __fuzz_session_handsha
 pub(crate) mod wire_android13;
 
 pub use address::{AddressSpace, RpcAddress, SpecialTransaction, RPC_SESSION_ID_NEW};
+pub use end::{EndReason, EndedBy, SessionEnd, StreamState};
 pub use fd_mode::FileDescriptorTransportMode;
 pub use proxy::RpcProxy;
 pub use server::RpcServer;
@@ -204,6 +206,20 @@ impl std::error::Error for RpcError {
             RpcError::Io(e) => Some(e),
             _ => None,
         }
+    }
+}
+
+impl RpcError {
+    /// Whether a read that failed with this error is documented to have
+    /// left the stream at a frame boundary: [`PeerClosed`](Self::PeerClosed)
+    /// ("no frame pending") and [`Timeout`](Self::Timeout) ("reported only
+    /// when nothing partial was consumed"). Every other read failure lacks
+    /// that guarantee — including ones that in fact consumed nothing — and
+    /// is treated as a lost position. The single owner of the distinction:
+    /// the framing readers (promoting a mid-frame case to `Truncated`),
+    /// the reply wait and the serve loop all ask here.
+    pub(crate) fn leaves_frame_boundary_intact(&self) -> bool {
+        matches!(self, RpcError::PeerClosed | RpcError::Timeout)
     }
 }
 

--- a/rsbinder/src/rpc/mod.rs
+++ b/rsbinder/src/rpc/mod.rs
@@ -144,17 +144,27 @@ pub type RpcResult<T> = std::result::Result<T, RpcError>;
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum RpcError {
-    /// The peer closed the connection cleanly with no frame pending
-    /// (EOF / `BrokenPipe` / `ConnectionReset` before any header bytes).
-    PeerClosed,
+    /// The stream ended at a frame boundary: EOF with no frame pending,
+    /// or a disconnect kind (`BrokenPipe` / `ConnectionReset` /
+    /// `ConnectionAborted`) from a read or a write. It says nothing about
+    /// **who** ended the stream or whether the end was **clean**: this
+    /// end's own write failing after its own
+    /// [`shutdown`](transport::RpcTransport::shutdown) folds here just as
+    /// a peer's EOF does, and so does a reset. Whether this end decided
+    /// is [`SessionEnd::by`]; whether the transport's close signal
+    /// arrived is [`UncleanEndOfStream`](Self::UncleanEndOfStream). A
+    /// disconnect part-way through a frame is
+    /// [`Truncated`](Self::Truncated), never this. Projects to
+    /// [`StatusCode::DeadObject`](crate::StatusCode).
+    EndOfStream,
     /// The stream ended at a frame boundary without the transport's own
     /// close signal — a TLS session whose TCP stream ended with no
-    /// `close_notify`. Kept apart from [`PeerClosed`](Self::PeerClosed)
+    /// `close_notify`. Kept apart from [`EndOfStream`](Self::EndOfStream)
     /// because on the one backend built for untrusted networks this is
     /// exactly what a truncation attack looks like; a plain socket has no
     /// close signal to miss and never reports it. The transport's own
     /// [`shutdown`](transport::RpcTransport::shutdown) sends the signal,
-    /// so a deliberate close on this end is still `PeerClosed` on the
+    /// so a deliberate close on this end is still `EndOfStream` on the
     /// other. Projects to [`StatusCode::DeadObject`](crate::StatusCode).
     UncleanEndOfStream,
     /// A frame length header was fully received but the body was
@@ -188,7 +198,7 @@ pub enum RpcError {
 impl fmt::Display for RpcError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RpcError::PeerClosed => write!(f, "RPC peer closed the connection"),
+            RpcError::EndOfStream => write!(f, "RPC stream ended"),
             RpcError::UncleanEndOfStream => {
                 write!(f, "RPC stream ended without a close signal (truncated?)")
             }
@@ -220,7 +230,7 @@ impl std::error::Error for RpcError {
 
 impl RpcError {
     /// Whether a read that failed with this error is documented to have
-    /// left the stream at a frame boundary: [`PeerClosed`](Self::PeerClosed)
+    /// left the stream at a frame boundary: [`EndOfStream`](Self::EndOfStream)
     /// ("no frame pending") and [`Timeout`](Self::Timeout) ("reported only
     /// when nothing partial was consumed"). Every other read failure lacks
     /// that guarantee — including ones that in fact consumed nothing — and
@@ -228,12 +238,12 @@ impl RpcError {
     /// the framing readers (promoting a mid-frame case to `Truncated`),
     /// the reply wait and the serve loop all ask here.
     pub(crate) fn leaves_frame_boundary_intact(&self) -> bool {
-        matches!(self, RpcError::PeerClosed | RpcError::Timeout)
+        matches!(self, RpcError::EndOfStream | RpcError::Timeout)
     }
 }
 
 impl From<std::io::Error> for RpcError {
-    /// Map a clean disconnect to [`RpcError::PeerClosed`]; everything
+    /// Map a clean disconnect to [`RpcError::EndOfStream`]; everything
     /// else stays [`RpcError::Io`]. A truncated *body* is classified by
     /// the framing reader, not here. An `RpcError` that travelled as the
     /// `io::Error`'s payload (how the `Read` adapters carry
@@ -247,7 +257,7 @@ impl From<std::io::Error> for RpcError {
         };
         match e.kind() {
             UnexpectedEof | BrokenPipe | ConnectionReset | ConnectionAborted => {
-                RpcError::PeerClosed
+                RpcError::EndOfStream
             }
             _ => RpcError::Io(e),
         }
@@ -264,12 +274,12 @@ impl From<RpcError> for std::io::Error {
     ///
     /// `RpcError::Io` hands its payload back as-is, but the reverse
     /// direction folds the disconnect kinds, so an `Io` carrying one of
-    /// them returns as `PeerClosed`.
-    /// [`RpcError::PeerClosed`] projects onto a single representative
+    /// them returns as `EndOfStream`.
+    /// [`RpcError::EndOfStream`] projects onto a single representative
     /// disconnect kind (`BrokenPipe`): the four kinds `From<io::Error>`
-    /// folds into `PeerClosed` are not distinguished, and a
-    /// `PeerClosed` raised from a 0-byte read never had one. That kind
-    /// folds back into `PeerClosed`, so a write-side disconnect on an
+    /// folds into `EndOfStream` are not distinguished, and a
+    /// `EndOfStream` raised from a 0-byte read never had one. That kind
+    /// folds back into `EndOfStream`, so a write-side disconnect on an
     /// android-13+ session stays `StatusCode::DeadObject` rather than
     /// degrading to an unclassified `Io(Other)` (`StatusCode::Unknown`)
     /// — the status a caller's dead-peer check keys on.
@@ -277,7 +287,7 @@ impl From<RpcError> for std::io::Error {
     /// — kind-preserving rather than variant-preserving, since
     /// `From<io::Error>` folds that kind into `Io(TimedOut)`.
     /// [`RpcError::UncleanEndOfStream`] must survive the round trip —
-    /// folding it by kind would turn it back into `PeerClosed`, the very
+    /// folding it by kind would turn it back into `EndOfStream`, the very
     /// thing it exists to be told apart from — so it goes out as an
     /// `UnexpectedEof` carrying itself as the payload, which
     /// `From<io::Error>` recovers first. The remaining variants have no
@@ -285,7 +295,7 @@ impl From<RpcError> for std::io::Error {
     fn from(e: RpcError) -> Self {
         match e {
             RpcError::Io(io) => io,
-            RpcError::PeerClosed => std::io::ErrorKind::BrokenPipe.into(),
+            RpcError::EndOfStream => std::io::ErrorKind::BrokenPipe.into(),
             RpcError::Timeout => std::io::ErrorKind::TimedOut.into(),
             e @ RpcError::UncleanEndOfStream => {
                 std::io::Error::new(std::io::ErrorKind::UnexpectedEof, e)
@@ -306,7 +316,7 @@ impl From<RpcError> for crate::StatusCode {
     /// [`StatusCode::RpcError`]: crate::StatusCode::RpcError
     fn from(e: RpcError) -> Self {
         match e {
-            RpcError::PeerClosed => crate::StatusCode::DeadObject,
+            RpcError::EndOfStream => crate::StatusCode::DeadObject,
             RpcError::UncleanEndOfStream => crate::StatusCode::DeadObject,
             RpcError::Truncated => crate::StatusCode::NotEnoughData,
             RpcError::DeadlineMidFrame => crate::StatusCode::TimedOut,
@@ -389,7 +399,7 @@ mod tests {
             std::io::ErrorKind::ConnectionAborted,
         ] {
             let e: RpcError = std::io::Error::from(kind).into();
-            assert!(matches!(e, RpcError::PeerClosed), "{kind:?} -> {e:?}");
+            assert!(matches!(e, RpcError::EndOfStream), "{kind:?} -> {e:?}");
         }
         // A non-disconnect I/O error stays Io(..).
         let other: RpcError = std::io::Error::from(std::io::ErrorKind::PermissionDenied).into();
@@ -399,7 +409,7 @@ mod tests {
     #[test]
     fn rpc_error_projects_onto_status_code() {
         assert_eq!(
-            StatusCode::from(RpcError::PeerClosed),
+            StatusCode::from(RpcError::EndOfStream),
             StatusCode::DeadObject
         );
         assert_eq!(
@@ -428,19 +438,19 @@ mod tests {
     /// `StatusCode::DeadObject`, not `Unknown`. Which side of an
     /// exchange notices a disconnect first is a host- and timing-
     /// dependent race, so both directions have to classify alike.
-    /// `PeerClosed` returns as the same variant; `Timeout` is only
+    /// `EndOfStream` returns as the same variant; `Timeout` is only
     /// kind-preserving — it comes back as `Io(TimedOut)`.
     ///
     /// **Mutant gate**: restoring `other => io::Error::other(...)` for
-    /// `PeerClosed` fails the round trip below (and the timeout arm
+    /// `EndOfStream` fails the round trip below (and the timeout arm
     /// guards `read_exact_into`'s `is_timeout` path the same way).
     #[test]
     fn peer_closed_and_timeout_round_trip_through_io_error() {
-        let io = std::io::Error::from(RpcError::PeerClosed);
+        let io = std::io::Error::from(RpcError::EndOfStream);
         assert_eq!(io.kind(), std::io::ErrorKind::BrokenPipe);
-        assert!(matches!(RpcError::from(io), RpcError::PeerClosed));
+        assert!(matches!(RpcError::from(io), RpcError::EndOfStream));
         assert_eq!(
-            StatusCode::from(RpcError::from(std::io::Error::from(RpcError::PeerClosed))),
+            StatusCode::from(RpcError::from(std::io::Error::from(RpcError::EndOfStream))),
             StatusCode::DeadObject,
             "a write-side disconnect must stay DeadObject, not Unknown"
         );

--- a/rsbinder/src/rpc/proxy.rs
+++ b/rsbinder/src/rpc/proxy.rs
@@ -47,7 +47,7 @@ pub struct RpcProxy {
     /// *local* object the peer holds; that is broken by
     /// [`RpcSessionInner::on_session_dead`], which runs when a serve loop
     /// ends, when a transaction fails on a lost connection, or on an
-    /// explicit [`RpcSession::shutdown`](super::RpcSession::shutdown) —
+    /// explicit [`RpcSession::close_session`](super::RpcSession::close_session) —
     /// the last being the only break available to a session that neither
     /// serves nor transacts again.
     session: Arc<RpcSessionInner>,

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -415,7 +415,7 @@ pub struct RpcServer {
     /// `server.shutdown.load()` gate (the very race window the test
     /// targets, otherwise un-bound by code observability alone). An integration
     /// test acquires the worker at this barrier, calls
-    /// [`shutdown`](RpcServer::shutdown), then releases the worker so it
+    /// [`stop_accepting`](RpcServer::stop_accepting), then releases the worker so it
     /// re-reads the now-true flag and takes the reject branch — turning
     /// the otherwise sub-microsecond window into a deterministic test
     /// point. `None` default ⇒ no invocation, byte-identical to the
@@ -1028,7 +1028,7 @@ impl RpcServer {
     fn minted_after_terminate(&self, session: &RpcSession) -> bool {
         if self.shutdown.load(Ordering::SeqCst) {
             log::debug!("RPC: connection accepted as the server was terminating; ending it");
-            session.shutdown();
+            session.close_session();
             return true;
         }
         false
@@ -1601,7 +1601,7 @@ impl RpcServer {
         }
     }
 
-    /// Run the accept loop until [`RpcServer::shutdown`]. Each accepted
+    /// Run the accept loop until [`RpcServer::stop_accepting`]. Each accepted
     /// connection gets its own session + worker thread.
     pub fn run(self: &Arc<Self>) -> Result<()> {
         loop {
@@ -1720,19 +1720,20 @@ impl RpcServer {
     }
 
     /// Stop accepting and let in-flight sessions drain as their peers
-    /// disconnect — the graceful form. This reaches nothing a peer keeps
-    /// open: a worker parked in `recv` never reads the flag, so a client
-    /// that stays connected keeps its worker alive. To end those too,
-    /// use [`terminate`](Self::terminate).
-    pub fn shutdown(&self) {
+    /// disconnect — the graceful form. Only the accept flag is raised;
+    /// nothing is joined. This reaches nothing a peer keeps open: a
+    /// worker parked in `recv` never reads the flag, so a client that
+    /// stays connected keeps its worker alive. To end those too, use
+    /// [`terminate`](Self::terminate).
+    pub fn stop_accepting(&self) {
         self.shutdown.store(true, Ordering::SeqCst);
     }
 
     /// End the server now: stop accepting, end every session it serves,
     /// and join the workers. This is what a dropped
     /// [`ServerGuard`](crate::ServerGuard) does. Where
-    /// [`shutdown`](Self::shutdown) waits for peers to leave, this ends
-    /// each session as [`RpcSession::shutdown`] would — whatever its
+    /// [`stop_accepting`](Self::stop_accepting) waits for peers to leave,
+    /// this ends each session as [`RpcSession::close_session`] would — whatever its
     /// connection count — so every slot's transport is shut down, the
     /// workers wake out of `recv`, exit, and are joined. Peers see the
     /// connection end.
@@ -1868,7 +1869,7 @@ impl Drop for RpcServer {
     /// worker also releases its clone (peer close, kernel reset,
     /// etc.).
     ///
-    /// [`RpcServer::shutdown`] does not help there: the flag it flips is
+    /// [`RpcServer::stop_accepting`] does not help there: the flag it flips is
     /// polled by the accept loop and read by the android-13+ attach arms
     /// (which refuse a late attach), but a worker already blocked in
     /// `recv` never reaches a gate that reads it. Nor does

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -472,6 +472,12 @@ pub struct RpcServer {
     rejected_unknown_id: AtomicUsize,
     shutdown: Arc<AtomicBool>,
     workers: Mutex<Vec<JoinHandle<()>>>,
+    /// Every session this server minted, for
+    /// [`terminate`](RpcServer::terminate). The id-keyed `sessions` map
+    /// above knows only android-13+ sessions — an r34 session has no id
+    /// — so this is the list that can end them all. `Weak`, pruned on
+    /// push; an attach adds a slot to an inner already listed here.
+    live_sessions: Mutex<Vec<std::sync::Weak<RpcSessionInner>>>,
 }
 
 impl RpcServer {
@@ -570,6 +576,7 @@ impl RpcServer {
             rejected_unknown_id: AtomicUsize::new(0),
             shutdown: Arc::new(AtomicBool::new(false)),
             workers: Mutex::new(Vec::new()),
+            live_sessions: Mutex::new(Vec::new()),
         })
     }
 
@@ -998,7 +1005,33 @@ impl RpcServer {
         // The server accepted this connection ⇒ Acceptor subspace.
         let session = RpcSession::new(transport, super::address::AddressSpace::Acceptor)?;
         self.configure_session(&session);
+        self.track_session(&session.inner_arc());
         Ok(session)
+    }
+
+    /// List a freshly minted session for [`terminate`](Self::terminate).
+    /// Both minting paths call this (r34 [`make_session`](Self::make_session),
+    /// android-13+ new session); an attach lands on an inner already
+    /// listed. The worker checks the shutdown flag right after, so a
+    /// session minted as `terminate` runs is either in the list it takes
+    /// or ends itself.
+    fn track_session(&self, inner: &Arc<RpcSessionInner>) {
+        let mut live = self.live_sessions.lock().expect("live_sessions poisoned");
+        live.retain(|w| w.strong_count() > 0);
+        live.push(Arc::downgrade(inner));
+    }
+
+    /// The worker's half of the [`terminate`](Self::terminate) handshake:
+    /// once listed, a session minted after the flag went up ends itself
+    /// instead of serving — `terminate` stored the flag *before* taking
+    /// the list, so a session it did not take always sees it here.
+    fn minted_after_terminate(&self, session: &RpcSession) -> bool {
+        if self.shutdown.load(Ordering::SeqCst) {
+            log::debug!("RPC: connection accepted as the server was terminating; ending it");
+            session.shutdown();
+            return true;
+        }
+        false
     }
 
     // --- session-id → shared-session registry
@@ -1448,6 +1481,10 @@ impl RpcServer {
                     };
                     let id = RpcSessionId::new(session.session_id());
                     server.register_session(id, &session.inner_arc());
+                    server.track_session(&session.inner_arc());
+                    if server.minted_after_terminate(&session) {
+                        return;
+                    }
                     server.configure_session(&session);
                     // Baseline `arm_serve_timeouts` just armed on this
                     // connection: a callback's reply deadline must be
@@ -1556,6 +1593,9 @@ impl RpcServer {
                         return;
                     }
                 };
+                if server.minted_after_terminate(&session) {
+                    return;
+                }
                 if let Err(e) = session.serve_blocking_clearing_deadline_after_first() {
                     log::debug!("RPC session ended: {e:?}");
                 }
@@ -1681,18 +1721,60 @@ impl RpcServer {
         })
     }
 
-    /// Request shutdown: stop accepting and let in-flight sessions
-    /// drain as their peers disconnect.
+    /// Stop accepting and let in-flight sessions drain as their peers
+    /// disconnect — the graceful form. This reaches nothing a peer keeps
+    /// open: a worker parked in `recv` never reads the flag, so a client
+    /// that stays connected keeps its worker alive. To end those too,
+    /// use [`terminate`](Self::terminate).
     pub fn shutdown(&self) {
         self.shutdown.store(true, Ordering::SeqCst);
     }
 
-    /// Join all session workers (call after the clients disconnect).
+    /// End the server now: stop accepting, end every session it serves,
+    /// and join the workers. This is what a dropped
+    /// [`ServerGuard`](crate::ServerGuard) does. Where
+    /// [`shutdown`](Self::shutdown) waits for peers to leave, this ends
+    /// each session as [`RpcSession::shutdown`] would — whatever its
+    /// connection count — so every slot's transport is shut down, the
+    /// workers wake out of `recv`, exit, and are joined. Peers see the
+    /// connection end.
+    ///
+    /// Repeats until a pass finds no session and no worker, so a
+    /// connection accepted just as the flag went up is ended too (its
+    /// worker ends the session itself on seeing the flag). Callable from
+    /// a handler — a service stopping its own server: the worker it runs
+    /// on is skipped rather than self-joined and exits when the handler
+    /// returns. Idempotent. The accept loop's thread is the caller's to
+    /// join ([`run_background`](Self::run_background) returned it); join
+    /// it before this for a fully joined server, as `ServerGuard` does.
+    pub fn terminate(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        loop {
+            let live: Vec<Arc<RpcSessionInner>> =
+                std::mem::take(&mut *self.live_sessions.lock().expect("live_sessions poisoned"))
+                    .iter()
+                    .filter_map(std::sync::Weak::upgrade)
+                    .collect();
+            let handles: Vec<JoinHandle<()>> =
+                std::mem::take(&mut *self.workers.lock().expect("workers poisoned"));
+            if live.is_empty() && handles.is_empty() {
+                return;
+            }
+            for session in &live {
+                session.close();
+            }
+            drop(live);
+            Self::join_handles(handles);
+        }
+    }
+
+    /// Join all session workers (call after the clients disconnect, or
+    /// use [`terminate`](Self::terminate), which ends the sessions first
+    /// and then joins).
     ///
     /// `Drop` only flips the shutdown flag and removes the socket — it
     /// deliberately does **not** join in-flight session workers (they
-    /// drain on peer close), so call `join_workers` explicitly rather
-    /// than relying on `Drop` for a clean shutdown.
+    /// drain on peer close).
     ///
     /// Panic observability is **best-effort**. Every accept and every
     /// [`serve_connection`](RpcServer::serve_connection) reaps
@@ -1705,7 +1787,21 @@ impl RpcServer {
     /// then reaped by a later connection is not reported.
     pub fn join_workers(&self) {
         let handles: Vec<_> = std::mem::take(&mut *self.workers.lock().expect("workers poisoned"));
+        Self::join_handles(handles);
+    }
+
+    /// Join `handles`, skipping the calling thread's own — a handler that
+    /// ends its server would otherwise deadlock on itself; that worker
+    /// exits when the handler returns, and dropping the handle detaches it.
+    fn join_handles(handles: Vec<JoinHandle<()>>) {
+        let me = std::thread::current().id();
         for h in handles {
+            if h.thread().id() == me {
+                log::debug!(
+                    "RPC: server ended from a connection worker; not joining its own thread"
+                );
+                continue;
+            }
             if h.join().is_err() {
                 log::warn!("RPC: connection worker panicked");
             }
@@ -1779,7 +1875,9 @@ impl Drop for RpcServer {
     /// (which refuse a late attach), but a worker already blocked in
     /// `recv` never reaches a gate that reads it. Nor does
     /// [`RpcServer::join_workers`], which waits for exactly the workers
-    /// that are hung. What bounds a stalled peer is a deadline on its
+    /// that are hung. [`RpcServer::terminate`] is the answer: it shuts
+    /// every session's transports down, which wakes those workers.
+    /// Short of that, what bounds a stalled peer is a deadline on its
     /// own connection — [`set_handshake_timeout`](Self::set_handshake_timeout)
     /// for a peer that stalls at first contact, and
     /// [`set_idle_timeout`](Self::set_idle_timeout) for one that goes

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -1493,9 +1493,7 @@ impl RpcServer {
                     session.set_serve_read_deadline(
                         *server.idle_timeout.lock().expect("idle_timeout poisoned"),
                     );
-                    if let Err(e) = session.serve_blocking() {
-                        log::debug!("RPC session ended: {e:?}");
-                    }
+                    session.serve_blocking().log("RPC session ended");
                 } else if let Some(inner) = server.resolve_session(&client_id) {
                     // Attach: add a slot on the founding inner so
                     // proxy-cache + slot-pool stay unified (no
@@ -1565,9 +1563,9 @@ impl RpcServer {
                     // so external observers never see a count for
                     // a slot that never reached the pool.
                     server.attached_count.fetch_add(1, Ordering::SeqCst);
-                    if let Err(e) = session.serve_blocking_on(slot_id) {
-                        log::debug!("RPC attached connection ended: {e:?}");
-                    }
+                    session
+                        .serve_blocking_on(slot_id)
+                        .log("RPC attached connection ended");
                 } else {
                     server.rejected_unknown_id.fetch_add(1, Ordering::SeqCst);
                     log::warn!(
@@ -1596,9 +1594,9 @@ impl RpcServer {
                 if server.minted_after_terminate(&session) {
                     return;
                 }
-                if let Err(e) = session.serve_blocking_clearing_deadline_after_first() {
-                    log::debug!("RPC session ended: {e:?}");
-                }
+                session
+                    .serve_blocking_clearing_deadline_after_first()
+                    .log("RPC session ended");
             }
         }
     }

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -471,6 +471,19 @@ pub struct RpcServer {
     attached_count: AtomicUsize,
     rejected_unknown_id: AtomicUsize,
     shutdown: Arc<AtomicBool>,
+    /// Raised by [`terminate`](RpcServer::terminate) only, and stored
+    /// before it takes `live_sessions` — that order alone is what makes
+    /// the store-before-take handshake in `minted_after_terminate` hold
+    /// (`track_session` and the take share the `live_sessions` mutex, so a
+    /// session the take missed was listed after this store). Separate from
+    /// `shutdown`
+    /// because that flag is also raised by the graceful
+    /// [`stop_accepting`](RpcServer::stop_accepting), which must leave a
+    /// just-accepted session serving. The two flags carry no cross
+    /// invariant in either direction — they are independent stores, so a
+    /// worker can read one raised and the other not, and a check on one is
+    /// never a substitute for a check on the other.
+    terminating: Arc<AtomicBool>,
     workers: Mutex<Vec<JoinHandle<()>>>,
     /// Every session this server minted, for
     /// [`terminate`](RpcServer::terminate). The id-keyed `sessions` map
@@ -575,6 +588,7 @@ impl RpcServer {
             attached_count: AtomicUsize::new(0),
             rejected_unknown_id: AtomicUsize::new(0),
             shutdown: Arc::new(AtomicBool::new(false)),
+            terminating: Arc::new(AtomicBool::new(false)),
             workers: Mutex::new(Vec::new()),
             live_sessions: Mutex::new(Vec::new()),
         })
@@ -813,6 +827,14 @@ impl RpcServer {
     /// [`set_reply_timeout`](Self::set_reply_timeout) — this deadline
     /// cannot cover it, being a sticky read timeout armed before the send.
     ///
+    /// Read on every accepted android-13+ connection, and the value the last
+    /// of them read is the one a session restores its serve connections to after a
+    /// nested callback's reply deadline is lifted — one value per session,
+    /// not per connection. Call this *before* [`run`](Self::run) /
+    /// [`run_background`](Self::run_background): changing it while a
+    /// multi-connection session is live leaves that session restoring the
+    /// newest value on connections whose socket carries an older one.
+    ///
     /// `Some(Duration::ZERO)` is not a valid deadline (`SO_RCVTIMEO`
     /// rejects it) and is refused — logged and treated as `None`.
     pub fn set_idle_timeout(&self, timeout: Option<std::time::Duration>) {
@@ -992,8 +1014,10 @@ impl RpcServer {
         if let Some(root) = root {
             session.set_root(root);
         }
-        session.set_max_threads(*self.max_threads.lock().expect("max_threads poisoned"));
-        session.set_timeout(*self.reply_timeout.lock().expect("reply_timeout poisoned"));
+        let max_threads = *self.max_threads.lock().expect("max_threads poisoned");
+        session.set_max_threads(max_threads);
+        let reply_timeout = *self.reply_timeout.lock().expect("reply_timeout poisoned");
+        session.set_timeout(reply_timeout);
         if self.fd_unix_supported.load(Ordering::SeqCst) {
             session.set_supported_fd_modes(&[crate::rpc::FileDescriptorTransportMode::Unix]);
         }
@@ -1012,7 +1036,7 @@ impl RpcServer {
     /// List a freshly minted session for [`terminate`](Self::terminate).
     /// Both minting paths call this (r34 [`make_session`](Self::make_session),
     /// android-13+ new session); an attach lands on an inner already
-    /// listed. The worker checks the shutdown flag right after, so a
+    /// listed. The worker checks the terminate flag right after, so a
     /// session minted as `terminate` runs is either in the list it takes
     /// or ends itself.
     fn track_session(&self, inner: &Arc<RpcSessionInner>) {
@@ -1024,9 +1048,12 @@ impl RpcServer {
     /// The worker's half of the [`terminate`](Self::terminate) handshake:
     /// once listed, a session minted after the flag went up ends itself
     /// instead of serving — `terminate` stored the flag *before* taking
-    /// the list, so a session it did not take always sees it here.
+    /// the list, so a session it did not take always sees it here. Reads
+    /// `terminating`, not `shutdown`: the graceful
+    /// [`stop_accepting`](Self::stop_accepting) raises only the latter and
+    /// must leave a session that was just accepted serving.
     fn minted_after_terminate(&self, session: &RpcSession) -> bool {
-        if self.shutdown.load(Ordering::SeqCst) {
+        if self.terminating.load(Ordering::SeqCst) {
             log::debug!("RPC: connection accepted as the server was terminating; ending it");
             session.close_session();
             return true;
@@ -1147,14 +1174,21 @@ impl RpcServer {
     /// connection would leave the founding inner at one slot, so a
     /// test that establishes (founding + attached = 2) and asserts
     /// `Some(2)` here is satisfied only by the unified topology.
+    ///
+    /// Lock ladder: upgrade the `Weak` **first** (releasing the `sessions`
+    /// mutex), then take the session's `conn_state` mutex, as
+    /// [`live_session_node_count`](Self::live_session_node_count) does — a
+    /// poisoned `conn_state` in one session must not poison `sessions` as a
+    /// side-effect and take every attach down with it.
     pub fn session_slot_count(&self, id: &[u8; 32]) -> Option<usize> {
         let key = RpcSessionId::new(*id);
-        self.sessions
+        let inner = self
+            .sessions
             .lock()
             .expect("sessions poisoned")
             .get(&key)
-            .and_then(std::sync::Weak::upgrade)
-            .map(|s| s.slot_count())
+            .and_then(std::sync::Weak::upgrade);
+        inner.map(|s| s.slot_count())
     }
 
     /// Serve one already-connected transport on its own worker thread
@@ -1490,9 +1524,12 @@ impl RpcServer {
                     // connection: a callback's reply deadline must be
                     // *restored* to it, not cleared, or the first nested
                     // callback silently disables idle eviction here.
-                    session.set_serve_read_deadline(
-                        *server.idle_timeout.lock().expect("idle_timeout poisoned"),
-                    );
+                    // Bind the value first, as `configure_session` does: an
+                    // argument temporary lives to the end of the statement,
+                    // which would hold the server's lock while taking the
+                    // session's.
+                    let idle = *server.idle_timeout.lock().expect("idle_timeout poisoned");
+                    session.set_serve_read_deadline(idle);
                     session.serve_blocking().log("RPC session ended");
                 } else if let Some(inner) = server.resolve_session(&client_id) {
                     // Attach: add a slot on the founding inner so
@@ -1540,6 +1577,16 @@ impl RpcServer {
                     // connections this client opened toward us.
                     let cap = inner.max_threads_value() as usize;
                     let session = RpcSession::wrap_inner(inner);
+                    // Record what `arm_serve_timeouts` just armed, as the
+                    // founding connection does: the baseline is what a reply
+                    // deadline is restored to, and what says whether a
+                    // `TimedOut` between frames is our own idle eviction.
+                    // It is one cell per session — see `set_idle_timeout`
+                    // on why the value must not change while one is live.
+                    // Bound first so the server's lock is not held while the
+                    // session's is taken (see `configure_session`).
+                    let idle = *server.idle_timeout.lock().expect("idle_timeout poisoned");
+                    session.set_serve_read_deadline(idle);
                     let slot_id = match session.add_incoming_slot_capped(transport, cap) {
                         Ok(id) => id,
                         Err(StatusCode::FailedTransaction) => {
@@ -1595,7 +1642,11 @@ impl RpcServer {
                     return;
                 }
                 session
-                    .serve_blocking_clearing_deadline_after_first()
+                    // Pass the deadline this worker actually armed above:
+                    // with `set_handshake_timeout(None)` the first frame is
+                    // waited for with none, and a `TimedOut` there is the
+                    // kernel's `ETIMEDOUT`, not an idle eviction of ours.
+                    .serve_blocking_clearing_admission_deadline(handshake_timeout.is_some())
                     .log("RPC session ended");
             }
         }
@@ -1725,6 +1776,15 @@ impl RpcServer {
     /// worker parked in `recv` never reads the flag, so a client that
     /// stays connected keeps its worker alive. To end those too, use
     /// [`terminate`](Self::terminate).
+    ///
+    /// **The android-13+ attach gate closes with it.** From this point a
+    /// connection echoing a live session's id is refused — both the
+    /// further connections a client transacts on and the ones it opens
+    /// for callbacks — so a multi-connection session already established
+    /// cannot grow, and a client still fanning its connections out when
+    /// the flag goes up fails to build one. Each such refusal is counted
+    /// by [`rejected_unknown_id_count`](Self::rejected_unknown_id_count).
+    /// The connections a session already holds keep serving.
     pub fn stop_accepting(&self) {
         self.shutdown.store(true, Ordering::SeqCst);
     }
@@ -1735,18 +1795,45 @@ impl RpcServer {
     /// [`stop_accepting`](Self::stop_accepting) waits for peers to leave,
     /// this ends each session as [`RpcSession::close_session`] would — whatever its
     /// connection count — so every slot's transport is shut down, the
-    /// workers wake out of `recv`, exit, and are joined. Peers see the
-    /// connection end.
+    /// workers serving those slots wake out of `recv`, exit, and are
+    /// joined. Peers see the connection end.
+    ///
+    /// **A worker that has no session yet is not reachable that way, and
+    /// this call waits for it.** Ending a session shuts the transports of
+    /// *its* slots down, and a connection still in the handshake — or, on
+    /// the r34 path, waiting for its first frame — has neither: its
+    /// transport is a local of the worker thread. What bounds such a
+    /// worker is [`set_handshake_timeout`](Self::set_handshake_timeout),
+    /// so this call is bounded by that deadline; with it set to `None`
+    /// nothing bounds it, and a peer that connects and then says nothing
+    /// holds this call — and the [`ServerGuard`](crate::ServerGuard) drop
+    /// or `stop_and_join` behind it — for as long as it stays silent.
     ///
     /// Repeats until a pass finds no session and no worker, so a
     /// connection accepted just as the flag went up is ended too (its
     /// worker ends the session itself on seeing the flag). Callable from
     /// a handler — a service stopping its own server: the worker it runs
     /// on is skipped rather than self-joined and exits when the handler
-    /// returns. Idempotent. The accept loop's thread is the caller's to
-    /// join ([`run_background`](Self::run_background) returned it); join
-    /// it before this for a fully joined server, as `ServerGuard` does.
+    /// returns. Idempotent.
+    ///
+    /// **The join is guaranteed only against a stopped accept loop.** Its
+    /// thread is the caller's to join
+    /// ([`run_background`](Self::run_background) returned it), and joining
+    /// it *before* this call is the precondition, as `ServerGuard` does:
+    /// a still-running accept loop spawns a worker before it registers the
+    /// handle, so a connection accepted mid-pass can leave a worker behind
+    /// that no pass ever sees. Such a worker is not joined, so the
+    /// `Arc<RpcServer>` it holds (and this server's `Drop`, which unlinks
+    /// the bound socket path) outlives the call; it ends itself once it
+    /// reaches the point of minting a session and finds the flag, and
+    /// until then it is bounded only by
+    /// [`set_handshake_timeout`](Self::set_handshake_timeout).
     pub fn terminate(&self) {
+        // `terminating` before the `live_sessions` take below: that is the
+        // whole handshake with `minted_after_terminate`. The order against
+        // `shutdown` carries no invariant — two independent stores are not
+        // an atomic pair, and a worker may see either without the other.
+        self.terminating.store(true, Ordering::SeqCst);
         self.shutdown.store(true, Ordering::SeqCst);
         loop {
             let live: Vec<Arc<RpcSessionInner>> =

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -3939,6 +3939,10 @@ impl RpcSession {
         slot_id: u64,
         clear_deadline_after_first: bool,
     ) -> Result<()> {
+        // Read the slot's role now: a `RpcSession::shutdown` racing this
+        // loop clears the pool, and a role read after the loop would come
+        // back `false` for a slot that is simply gone.
+        let client_incoming = self.inner.is_client_incoming_slot(slot_id);
         let result = {
             let mut r = Ok(());
             let mut first = clear_deadline_after_first;
@@ -3981,12 +3985,11 @@ impl RpcSession {
         // A client's incoming (callback) slot never bumped `live_conns`,
         // so its exit must not decrement either; instead the session dies
         // once the **last** such slot is gone: the founding connection's
-        // `Live(1)` is what the CAS consumes. Its role is read before the
-        // slot is retired. Eager death by design, *not* AOSP (whose
+        // `Live(1)` is what the CAS consumes. Its role was read before the
+        // loop. Eager death by design, *not* AOSP (whose
         // client-side `onSessionAllIncomingThreadsEnded` is a no-op) —
         // the trade-off is on
         // [`RpcUnixClientConfig::incoming_connections`].
-        let client_incoming = self.inner.is_client_incoming_slot(slot_id);
         if !client_incoming && self.inner.shared.lifecycle.drop_connection() {
             self.inner.on_session_dead();
         }

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -2183,7 +2183,7 @@ impl RpcSessionInner {
             .collect();
         for t in transports {
             if let Err(e) = t.shutdown() {
-                log::debug!("RPC: transport shutdown failed (already closed?): {e:?}");
+                log::warn!("RPC: shutting a connection's transport down failed: {e}");
             }
         }
     }
@@ -2532,7 +2532,7 @@ impl RpcSessionInner {
                     // Only wakes a reader blocked in `recv`; the mark above
                     // is what stops already-buffered frames.
                     if let Err(e) = transport.shutdown() {
-                        log::debug!("RPC: shutting the desynced connection down failed: {e:?}");
+                        log::warn!("RPC: shutting the desynced connection down failed: {e}");
                     }
                 }
             }
@@ -3052,6 +3052,9 @@ impl RpcSessionInner {
             Err(RpcError::UncleanEndOfStream) => {
                 return ServeStep::Ended(EndReason::UncleanEndOfStream)
             }
+            Err(RpcError::DeadlineMidFrame) => {
+                return ServeStep::Ended(EndReason::DeadlineMidFrame)
+            }
             Err(e) => return ServeStep::Ended(EndReason::Frame(e.into())),
         };
         // This end ended the session while the frame was in flight (a
@@ -3488,7 +3491,9 @@ impl RpcSession {
                 // Retire now, not on the first send: a corpse slot still
                 // eats the callback budget and `find_conn` would draw it
                 // first (see this fn's rustdoc).
-                let _ = transport.shutdown();
+                if let Err(e) = transport.shutdown() {
+                    log::warn!("RPC: shutting a failed callback connection down failed: {e}");
+                }
                 self.inner.remove_slot(slot_id);
                 Err(StatusCode::from(e))
             }

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -855,6 +855,12 @@ struct ConnSlot {
     /// instead of being taken for unsolicited ones (see
     /// [`RpcSessionInner::note_stale_reply`]).
     stale_replies: u32,
+    /// Set by a nested (reentrant) frame that lost track of what the peer
+    /// sends next ([`Desync::ProtocolStateLost`]): whoever owns the slot
+    /// must not interpret another frame on it. Never cleared — the owner
+    /// retires the slot instead (see
+    /// [`RpcSessionInner::mark_slot_poisoned`]).
+    poisoned: bool,
 }
 
 /// The session's connection pool + its monotonic slot-id
@@ -896,6 +902,24 @@ impl ConnGuard<'_> {
     fn transport(&self) -> &dyn RpcTransport {
         &*self.transport
     }
+}
+
+/// What a failed step in `client_transact`'s reply wait left on the
+/// stream. Only a reentrant frame has to distinguish them: it cannot
+/// retire the slot, because the outer frame owns it.
+enum Desync {
+    /// Nothing came off the stream, so this call's `REPLY` may still be
+    /// on its way and the outer frame has to skip one.
+    ReplyStillInbound,
+    /// What the peer sends next is unknowable — the pending `REPLY` may
+    /// still arrive, or it may already be gone. Either a frame arrived
+    /// and did not decode, or a read failed without the guarantee that
+    /// it stopped at a frame boundary: only `PeerClosed` and `Timeout`
+    /// carry that guarantee, so every other read failure lands here,
+    /// including one that consumed nothing at all. AOSP ends the whole
+    /// session here (`RpcState::waitForReply`: "processCommand must
+    /// shutdown on failure").
+    ProtocolStateLost,
 }
 
 impl Drop for ConnGuard<'_> {
@@ -1691,6 +1715,7 @@ impl RpcSessionInner {
             role,
             allow_nested: false,
             stale_replies: 0,
+            poisoned: false,
         });
         drop(st);
         self.slot_cv.notify_all();
@@ -1732,6 +1757,7 @@ impl RpcSessionInner {
             role: SlotRole::Incoming,
             allow_nested: false,
             stale_replies: 0,
+            poisoned: false,
         });
         drop(st);
         self.slot_cv.notify_all();
@@ -1801,6 +1827,7 @@ impl RpcSessionInner {
             role: SlotRole::Outgoing,
             allow_nested: false,
             stale_replies: 0,
+            poisoned: false,
         });
         drop(st);
         self.slot_cv.notify_all();
@@ -1811,13 +1838,39 @@ impl RpcSessionInner {
     /// its reply. The slot stays in the pool — the outer frame owns it —
     /// so the reply is still inbound; count it so the stream re-syncs by
     /// skipping it rather than tearing the connection down as
-    /// "unsolicited". A reply that was already consumed (a malformed
-    /// frame, say) is not counted.
+    /// "unsolicited". Only for a wait that ended with the stream still at
+    /// a frame boundary (`PeerClosed`, `Timeout`, or a failure before or
+    /// after the read itself); a read that failed without that guarantee
+    /// marks the slot unreadable instead
+    /// ([`mark_slot_poisoned`](Self::mark_slot_poisoned)).
     fn note_stale_reply(&self, slot_id: u64) {
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
         if let Some(s) = st.slots.iter_mut().find(|s| s.id == slot_id) {
             s.stale_replies += 1;
         }
+    }
+
+    /// Mark `slot_id` unreadable: a nested (reentrant) call lost track of
+    /// what the peer sends next, and the slot's owner must not take the
+    /// next frame for its own. The flag — not
+    /// [`RpcTransport::shutdown`](crate::rpc::RpcTransport::shutdown) — is
+    /// what enforces that. What a `shutdown` does to bytes already
+    /// received is platform- and backend-dependent (a kernel may keep or
+    /// discard its receive queue, a transport may hold a buffered
+    /// leftover, the default impl does nothing), so nothing here assumes
+    /// it discards anything; the flag holds on every transport.
+    fn mark_slot_poisoned(&self, slot_id: u64) {
+        let mut st = self.conn_state.lock().expect("conn_state poisoned");
+        if let Some(s) = st.slots.iter_mut().find(|s| s.id == slot_id) {
+            s.poisoned = true;
+        }
+    }
+
+    /// Whether a nested call poisoned `slot_id`
+    /// ([`mark_slot_poisoned`](Self::mark_slot_poisoned)).
+    fn slot_poisoned(&self, slot_id: u64) -> bool {
+        let st = self.conn_state.lock().expect("conn_state poisoned");
+        st.slots.iter().any(|s| s.id == slot_id && s.poisoned)
     }
 
     /// Whether a `REPLY` just read on `slot_id` is one an abandoned nested
@@ -1833,17 +1886,21 @@ impl RpcSessionInner {
         }
     }
 
-    /// Remove a slot from the pool. Five legitimate callers: the slot's
-    /// *own* worker on its `serve_blocking_on` exit (self-remove),
-    /// `client_transact`'s two poison paths (a non-reentrant slot whose
-    /// send failed at the transport, or whose reply read desynced the
-    /// stream), and the two attach rollbacks — an incoming connection
-    /// whose serve thread failed to spawn, and a callback slot whose
-    /// `"cci"` never reached the peer. After a poison, the slot's worker
-    /// finds its slot gone and
-    /// gets `DeadObject` from `find_conn_pinned` — an expected exit
-    /// signal, not a structural bug. `notify_all` so any `find_conn`
+    /// Remove a slot from the pool — *retire* it. Six legitimate callers:
+    /// the slot's *own* worker on its `serve_blocking_on` exit
+    /// (self-remove); `client_transact`'s three retirements (a
+    /// non-reentrant slot whose send failed at the transport, whose reply
+    /// read lost the stream, or whose reply wait found the slot already
+    /// marked unreadable by a nested call); and the two attach rollbacks —
+    /// an incoming connection whose serve thread failed to spawn, and a
+    /// callback slot whose `"cci"` never reached the peer. After a
+    /// retirement, the slot's worker finds its slot gone and gets
+    /// `DeadObject` from `find_conn_pinned` — an expected exit signal,
+    /// not a structural bug. `notify_all` so any `find_conn`
     /// (any-available) waiter re-evaluates against the shrunk pool.
+    /// (Retiring is distinct from marking unreadable —
+    /// [`mark_slot_poisoned`](Self::mark_slot_poisoned) — which leaves
+    /// the slot in the pool for its owner to retire.)
     ///
     /// **Not a pure pool mutation:** emptying the pool — or, on an
     /// initiator, retiring its last `Outgoing` slot — runs the full
@@ -2417,23 +2474,30 @@ impl RpcSessionInner {
         // baseline `SO_RCVTIMEO` on every exit (return / `?` / panic) so
         // it never leaks onto the next call or a later recv here.
         let deadline = *self.shared.timeout.lock().expect("timeout poisoned");
-        // The request has already been sent, so any transport/decode error
-        // below (timeout, truncation, peer close, malformed frame) leaves the
-        // reply in-flight on a now-desynced stream. `WireReply` carries no
-        // transaction id (AOSP-faithful), so the next transact on this slot
-        // would misread the stale reply as its own. Retire the slot on such an
-        // error so the desynced stream is never reused — AOSP tears the whole
-        // session down here; retiring one connection is the multi-connection
-        // analogue. A clean, fully-consumed reply frame that carries a non-zero
-        // application `status` does NOT desync the stream and must not poison.
-        // A reentrant guard does not own the slot (the outer frame does), so it
-        // never retires it; while the reply is still inbound it marks the slot
-        // instead, so the outer frame skips that late `REPLY`.
-        let poison_slot = |reply_inbound: bool| {
+        // Post-send: a failed reply wait leaves this call's `REPLY` unaccounted
+        // for, and `WireReply` carries no id to match it by later.
+        let poison_slot = |desync: Desync| {
             if !conn.reentrant {
                 self.remove_slot(conn.slot_id);
-            } else if reply_inbound {
-                self.note_stale_reply(conn.slot_id);
+                return;
+            }
+            // A reentrant frame owns nothing: the outer frame holds this
+            // slot and will keep reading it.
+            match desync {
+                Desync::ReplyStillInbound => self.note_stale_reply(conn.slot_id),
+                Desync::ProtocolStateLost => {
+                    self.mark_slot_poisoned(conn.slot_id);
+                    log::error!(
+                        "RPC: a nested call lost track of the stream; what the peer sends next \
+                         is unknowable, so this connection is poisoned and shut down rather than \
+                         left for the outer call to read"
+                    );
+                    // Only wakes a reader blocked in `recv`; the poison flag
+                    // above is what stops already-buffered frames.
+                    if let Err(e) = transport.shutdown() {
+                        log::debug!("RPC: shutting the desynced connection down failed: {e:?}");
+                    }
+                }
             }
         };
         // Arming is itself post-send, so a failure here desyncs the stream
@@ -2442,22 +2506,37 @@ impl RpcSessionInner {
         let _deadline_guard = match ReplyDeadlineGuard::arm(transport, deadline, restore) {
             Ok(g) => g,
             Err(e) => {
-                poison_slot(true);
+                poison_slot(Desync::ReplyStillInbound);
                 return Err(e.into());
             }
         };
         loop {
+            // A nested call on this slot lost track of the stream, and
+            // `shutdown` does not drop what the peer already sent.
+            if self.slot_poisoned(conn.slot_id) {
+                if !conn.reentrant {
+                    self.remove_slot(conn.slot_id);
+                }
+                return Err(StatusCode::DeadObject);
+            }
             let (frame, in_fds) = match self.recv_msg(transport) {
                 Ok(v) => v,
                 Err(e) => {
-                    poison_slot(true);
+                    // Only a failure *at* a frame boundary leaves the reply
+                    // inbound; the rest may have consumed part of one.
+                    let desync = if matches!(e, RpcError::PeerClosed | RpcError::Timeout) {
+                        Desync::ReplyStillInbound
+                    } else {
+                        Desync::ProtocolStateLost
+                    };
+                    poison_slot(desync);
                     return Err(e.into());
                 }
             };
             let message = match self.profile.codec().decode_message(&frame) {
                 Ok(m) => m,
                 Err(e) => {
-                    poison_slot(false);
+                    poison_slot(Desync::ProtocolStateLost);
                     return Err(e.into());
                 }
             };
@@ -2518,13 +2597,13 @@ impl RpcSessionInner {
                     let _restore = match NestedDeadlineGuard::lift(transport, deadline) {
                         Ok(g) => g,
                         Err(e) => {
-                            poison_slot(true);
+                            poison_slot(Desync::ReplyStillInbound);
                             return Err(e.into());
                         }
                     };
                     let peer = transport.peer_identity();
                     if let Err(e) = self.dispatch_transact(t, in_fds, peer) {
-                        poison_slot(true);
+                        poison_slot(Desync::ReplyStillInbound);
                         return Err(e);
                     }
                 }
@@ -2918,13 +2997,18 @@ impl RpcSessionInner {
     /// worker drives a specific accepted connection's slot;
     /// nested outbound callbacks from the handler reuse this same slot
     /// via the `DRIVING` marker).
-    /// `Ok(false)` ⇒ peer closed (stop).
+    /// `Ok(false)` ⇒ end of stream (stop); a slot a nested call marked
+    /// unreadable ends the loop with `Err(StatusCode::DeadObject)`.
     fn serve_once_on_slot(&self, slot_id: u64) -> Result<bool> {
         // The worker drives its own slot. Pinning normally succeeds, but a
-        // concurrent `client_transact` may have poisoned (removed) the slot
-        // after a stale-reply desync — `find_conn_pinned` then returns
+        // concurrent `client_transact` may have retired the slot after a
+        // stale-reply desync — `find_conn_pinned` then returns
         // `DeadObject`, propagated so the worker exits cleanly.
         let conn = self.find_conn_pinned(slot_id)?;
+        // A nested call lost track of the stream: what is buffered is not ours.
+        if self.slot_poisoned(slot_id) {
+            return Err(StatusCode::DeadObject);
+        }
         let transport = conn.transport();
         let (frame, in_fds) = match self.recv_msg(transport) {
             Ok(f) => f,
@@ -3214,6 +3298,7 @@ impl RpcSession {
             role: founding_role,
             allow_nested: false,
             stale_replies: 0,
+            poisoned: false,
         };
         let (dec_strong_tx, dec_strong_rx) = mpsc::channel();
         let inner = Arc::new(RpcSessionInner {
@@ -3307,7 +3392,7 @@ impl RpcSession {
     /// callback transaction can overtake it on the wire.
     ///
     /// A failed init retires the slot immediately rather than leaving it
-    /// for the first send to poison: until something sends on it, a dead
+    /// for the first send to retire: until something sends on it, a dead
     /// slot still counts against the callback budget
     /// (`add_slot_inner_capped` counts `Outgoing` slots), and
     /// `find_conn` picks the *first* free `Outgoing` slot — so the next
@@ -3764,10 +3849,11 @@ impl RpcSession {
         reply.read::<SIBinder>()
     }
 
-    /// Server: process inbound messages until the peer closes.
+    /// Server: process inbound messages until this connection's read
+    /// reaches end of stream or the loop fails.
     ///
-    /// When the loop ends — peer closed (clean) **or** a fatal serve
-    /// error — every remote object reachable over this session is dead,
+    /// When the loop ends — for either reason — every remote object
+    /// reachable over this session is dead,
     /// so registered death recipients are fired here (AOSP
     /// `RpcState::sendObituaries` when a session's incoming threads
     /// end). This is the rsbinder death-detection point: a peer that
@@ -3775,17 +3861,51 @@ impl RpcSession {
     /// server died) must be running this serve loop — faithful to
     /// AOSP's `getMaxIncomingThreads() >= 1` requirement for an RPC
     /// `linkToDeath`.
+    ///
+    /// `Ok(())` is the clean end only: this connection's read reached
+    /// end of stream. Which side ended it is not part of that — the loop
+    /// returns `Ok(())` when the peer closed the connection or went
+    /// away, and equally when *this* side closed it, since
+    /// [`RpcSession::shutdown`](RpcSession::shutdown) — and every other
+    /// path that declares the session dead — shuts each slot's transport
+    /// down, and a serve loop woken out of `recv` that way ends here.
+    /// Every other end is an `Err`, including the case
+    /// where this loop's own read never failed — when a nested call made
+    /// from a handler on this same connection can no longer account for
+    /// what the peer sends next (a frame that arrived and did not decode,
+    /// or a read that failed without the guarantee that it stopped at a
+    /// frame boundary), the connection is marked unreadable and the loop
+    /// ends with [`StatusCode::DeadObject`] rather than interpreting
+    /// bytes whose meaning is unknowable. A caller (or a log line) can
+    /// therefore always tell the clean end from every other one — but not
+    /// a live peer from a dead one: that `Err` is reached both when the
+    /// peer is still up and only this end's view of the stream was lost,
+    /// and when the peer itself went away in the middle of a frame.
     pub fn serve_blocking(&self) -> Result<()> {
         self.serve_blocking_on(Self::FOUNDING_SLOT_ID)
     }
 
-    /// Serve a *specific* slot of the pool until peer
-    /// closes (the server worker's API — each accepted connection's
-    /// worker drives the slot it was added as via
-    /// `add_incoming_slot_capped`). The
-    /// default single-connection
+    /// Serve a *specific* slot of the pool until its read reaches end of
+    /// stream or the loop fails (the server worker's API — each accepted
+    /// connection's worker drives the slot it was added as via
+    /// `add_incoming_slot_capped`). The default single-connection
     /// [`serve_blocking`](RpcSession::serve_blocking) is exactly this
     /// on the founding slot (`FOUNDING_SLOT_ID`).
+    ///
+    /// The return contract is that of
+    /// [`serve_blocking`](RpcSession::serve_blocking), which delegates
+    /// here: `Ok(())` is the clean end only — end of stream on this
+    /// connection, whether the peer ended it or this side did — and
+    /// every other end is an `Err`.
+    /// This is also where that contract's one surprising end is actually
+    /// reached, since a handler runs on the slot it is served on: when a
+    /// nested call made from such a handler over this same connection can
+    /// no longer account for what the peer sends next (a frame that
+    /// arrived and did not decode, or a read that failed without the
+    /// guarantee that it stopped at a frame boundary), the slot is marked
+    /// unreadable and the loop ends with [`StatusCode::DeadObject`] —
+    /// which, as [`serve_blocking`](RpcSession::serve_blocking) states,
+    /// implies nothing about whether the peer is still up.
     pub fn serve_blocking_on(&self, slot_id: u64) -> Result<()> {
         self.serve_blocking_on_inner(slot_id, false)
     }
@@ -4772,6 +4892,197 @@ mod tests {
             .err(),
             Some(StatusCode::BadValue),
             "rejected before the connect — the path is never touched"
+        );
+    }
+
+    /// A **nested** call that cannot decode a frame must not leave the
+    /// connection readable for the frame that owns it.
+    ///
+    /// A reentrant frame borrows the outer frame's slot, so it cannot
+    /// retire it, and marking a stale reply does not help: once a frame
+    /// has come off the wire undecoded, whether this call's `REPLY` is
+    /// still coming is exactly what is unknown. If it is, the outer frame
+    /// reads it and — `WireReply` carrying no transaction id — takes it as
+    /// its own answer. So the slot is poisoned (and the connection shut
+    /// down), which is what the non-reentrant arm achieves by retiring the
+    /// slot.
+    ///
+    /// Two things are set up directly rather than driven through a peer:
+    /// the `DRIVING` marker (what an outer frame's `find_conn` leaves
+    /// behind), and the undecodable frame, which is queued in the socket
+    /// before the call so the test needs no second thread and no timing
+    /// assumption. Reaching this through a real nested dispatch would
+    /// need a peer that both calls back into this session and violates
+    /// the wire.
+    ///
+    /// **Mutant gate**: the flag *and* the refusal it exists for. Drop
+    /// the `mark_slot_poisoned` call and the flag assertion fails; drop
+    /// the poison check in `serve_once_on_slot` and the slot reads on as
+    /// if nothing happened — the state in which the frame that owns the
+    /// slot would go on to take the peer's next frame for its own.
+    /// `shutdown` alone gates neither: what it does to already-received
+    /// bytes is platform- and backend-dependent (Linux keeps the kernel
+    /// queue, a transport may hold a buffered leftover, the default impl
+    /// is a no-op). The reply wait's half of the refusal needs a live
+    /// connection, so it is gated by
+    /// `a_poisoned_slot_is_refused_by_the_reply_wait`.
+    #[test]
+    fn a_nested_call_that_loses_the_stream_makes_the_slot_unreadable() {
+        use crate::rpc::wire_android13::write_aosp_message;
+        use std::os::unix::net::UnixStream;
+
+        let (client_fd, peer_fd) = unix_socketpair_fd();
+        let mut peer = UnixStream::from(peer_fd);
+        let session = RpcSession::with_profile(
+            Box::new(
+                super::super::transport::UnixTransport::from_stream(UnixStream::from(client_fd))
+                    .expect("transport"),
+            ),
+            AddressSpace::Initiator,
+            WireProfile::Android13Plus(Android13PlusCodec::with_version(PROTOCOL_V2).expect("v2")),
+        )
+        .expect("session");
+
+        // Queued before the call: the reply wait reads it as soon as the
+        // request is out. Command 7 is not one of AOSP's three
+        // (`TRANSACT`/`REPLY`/`DEC_STRONG`), so the frame is well-formed
+        // to the framing reader and undecodable to the codec.
+        let mut undecodable = [0u8; 16];
+        undecodable[0..4].copy_from_slice(&7u32.to_le_bytes());
+        write_aosp_message(&mut peer, &undecodable).expect("queue the undecodable frame");
+
+        // Reentrant: this thread already drives the session's only slot,
+        // exactly as an outer `client_transact` would have left it.
+        let (slot_id, slot_transport) = {
+            let st = session.inner.conn_state.lock().expect("conn_state");
+            (st.slots[0].id, Arc::clone(&st.slots[0].transport))
+        };
+        let sess_ptr = &*session.inner as *const RpcSessionInner as usize;
+        // RAII: a failing assertion below must not leave a dead session's
+        // entry on this thread's `DRIVING` stack for the next test to
+        // inherit (libtest runs tests inline under `--test-threads=1`).
+        struct DrivingMark;
+        impl Drop for DrivingMark {
+            fn drop(&mut self) {
+                DRIVING.with(|d| {
+                    d.borrow_mut().pop();
+                });
+            }
+        }
+        DRIVING.with(|d| d.borrow_mut().push((sess_ptr, slot_id)));
+        let _mark = DrivingMark;
+
+        let err = session
+            .inner
+            .client_transact(
+                RpcAddress::zero(),
+                SpecialTransaction::GetSessionId.code(),
+                &Parcel::new(),
+                0,
+            )
+            .expect_err("an undecodable frame fails the nested call");
+        assert_eq!(err, StatusCode::RpcError, "protocol violation");
+
+        // The slot is still in the pool — a reentrant frame does not
+        // retire what the outer frame owns — but its connection is gone,
+        // so nothing more can be read from or written to it.
+        assert_eq!(
+            session
+                .inner
+                .conn_state
+                .lock()
+                .expect("conn_state")
+                .slots
+                .len(),
+            1,
+            "a reentrant frame must not retire the outer frame's slot"
+        );
+        assert!(
+            session.inner.slot_poisoned(slot_id),
+            "the borrowed slot must be marked unreadable for its owner"
+        );
+        assert!(
+            slot_transport.send_raw(b"x").is_err(),
+            "the borrowed connection must be shut down, not left usable"
+        );
+        // The flag is only worth having if a reader honors it: the serve
+        // loop must refuse the slot rather than read whatever comes next.
+        assert_eq!(
+            session
+                .inner
+                .serve_once_on_slot(slot_id)
+                .expect_err("a poisoned slot must not be served"),
+            StatusCode::DeadObject,
+            "the serve loop must refuse the slot, not read another frame on it"
+        );
+    }
+
+    /// The other reader of a poisoned slot — the reply wait inside
+    /// [`RpcSessionInner::client_transact`] — must refuse it too, and the
+    /// refusal must not rest on the connection being unusable.
+    ///
+    /// Here the connection is perfectly healthy and a well-formed `REPLY`
+    /// is already waiting on it: exactly the shape of the theft the poison
+    /// exists to stop, since `WireReply` carries no transaction id and the
+    /// waiting frame cannot tell the peer's answer to an abandoned nested
+    /// call from its own. The slot is poisoned directly rather than
+    /// through a nested call, because a nested call also shuts the
+    /// connection down and would hide which of the two mechanisms did the
+    /// work.
+    ///
+    /// **Mutant gate**: drop the poison check at the top of the reply
+    /// loop and this call returns `Ok(Some(_))` — the queued reply handed
+    /// back as this call's answer.
+    #[test]
+    fn a_poisoned_slot_is_refused_by_the_reply_wait() {
+        use crate::rpc::wire_android13::write_aosp_message;
+        use std::os::unix::net::UnixStream;
+
+        let (client_fd, peer_fd) = unix_socketpair_fd();
+        let mut peer = UnixStream::from(peer_fd);
+        let session = RpcSession::with_profile(
+            Box::new(
+                super::super::transport::UnixTransport::from_stream(UnixStream::from(client_fd))
+                    .expect("transport"),
+            ),
+            AddressSpace::Initiator,
+            WireProfile::Android13Plus(Android13PlusCodec::with_version(PROTOCOL_V2).expect("v2")),
+        )
+        .expect("session");
+
+        let slot_id = {
+            let st = session.inner.conn_state.lock().expect("conn_state");
+            st.slots[0].id
+        };
+
+        // Queued before the call, so the reply wait would find it the
+        // moment the request is out — no second thread, no timing.
+        let reply = session
+            .inner
+            .profile
+            .codec()
+            .encode_reply(&WireReply {
+                status: 0,
+                data: Vec::new(),
+                object_positions: Vec::new(),
+            })
+            .expect("encode a REPLY frame");
+        write_aosp_message(&mut peer, &reply).expect("queue the reply frame");
+
+        session.inner.mark_slot_poisoned(slot_id);
+
+        assert_eq!(
+            session
+                .inner
+                .client_transact(
+                    RpcAddress::zero(),
+                    SpecialTransaction::GetSessionId.code(),
+                    &Parcel::new(),
+                    0,
+                )
+                .expect_err("a poisoned slot must not be read again"),
+            StatusCode::DeadObject,
+            "the reply wait must refuse the slot, not decode the frame waiting on it"
         );
     }
 

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -477,18 +477,20 @@ impl Drop for ReplyDeadlineGuard<'_> {
     }
 }
 
-/// Read deadline for a connect/attach **handshake**, cleared when the
-/// handshake ends.
+/// Read **and write** deadlines for a connect/attach **handshake**,
+/// cleared when the handshake ends.
 ///
 /// The handshake runs before any session exists, so
 /// [`RpcSession::set_timeout`] cannot bound it — without this a peer that
-/// accepts the socket and then writes nothing blocks the caller forever.
+/// accepts the socket and then writes nothing, or stops reading, blocks the
+/// caller forever. Both directions are armed, as the server arms both for
+/// its half of the same phase.
 ///
 /// Clearing on drop is not optional. [`ReplyDeadlineGuard`] restores only a
 /// deadline it armed itself, and it arms nothing when the session deadline
 /// is `None` (the default), so a handshake deadline left on the socket
-/// would silently bound every later `recv` on that slot — and on a client's
-/// incoming (callback) slot it would break the serve loop outright.
+/// would silently bound every later `recv` or send on that slot — and on a
+/// client's incoming (callback) slot it would break the serve loop outright.
 struct HandshakeDeadline<'a> {
     transport: &'a dyn RpcTransport,
     armed: bool,
@@ -515,6 +517,7 @@ impl<'a> HandshakeDeadline<'a> {
         let armed = deadline.is_some();
         if armed {
             transport.set_read_timeout(deadline)?;
+            transport.set_write_timeout(deadline)?;
         }
         Ok(Self { transport, armed })
     }
@@ -541,6 +544,7 @@ impl Drop for HandshakeDeadline<'_> {
             // Best-effort: a failure cannot be surfaced from `Drop`, and
             // the slot's next reader arms or clears explicitly.
             let _ = self.transport.set_read_timeout(None);
+            let _ = self.transport.set_write_timeout(None);
         }
     }
 }
@@ -1195,7 +1199,7 @@ pub(crate) struct RpcSessionInner {
     incoming_live: AtomicUsize,
     /// How many of those threads [`RpcSession::close_session`] has actually
     /// `join()`ed. `incoming_live` cannot stand in for this: the serve
-    /// threads are woken by the transport shutdown that `shutdown`
+    /// threads are woken by the transport shutdown that `close_session`
     /// performs first, so they usually finish on their own while it is
     /// still tearing the session down, and the count would read zero
     /// even if every handle were dropped instead of joined.
@@ -1591,16 +1595,14 @@ impl RpcSessionInner {
     }
 
     /// Same as [`find_conn`] but pins to a **specific** slot id. Used
-    /// by the server worker's `serve_blocking_on(slot_id)` (each
-    /// worker drives only its own inbound slot) and by the oneway
-    /// path in [`find_conn`] (founding-slot FIFO).
+    /// by the server worker's `serve_blocking_on(slot_id)`: each worker
+    /// drives only its own inbound slot.
     ///
-    /// `Err(StatusCode::DeadObject)` when `want_slot_id` is not in
-    /// the pool — legitimately happens on the oneway path when the
-    /// founding slot's worker has exited (`remove_slot(FOUNDING_
-    /// SLOT_ID)`) while attached slots are still alive; the caller
-    /// falls back to any-available. Reentrant on the same slot via
-    /// DRIVING, like `find_conn`.
+    /// `Err(StatusCode::DeadObject)` when `want_slot_id` is not in the
+    /// pool — the slot was retired (by a transaction that failed on it,
+    /// or by the session ending) — and the serve loop that owns it ends
+    /// with [`EndReason::Retired`](crate::rpc::EndReason::Retired).
+    /// Reentrant on the same slot via DRIVING, like `find_conn`.
     fn find_conn_pinned(&self, want_slot_id: u64) -> Result<ConnGuard<'_>> {
         let tid = current_tid();
         let sess_ptr = self as *const RpcSessionInner as usize;
@@ -1914,10 +1916,13 @@ impl RpcSessionInner {
 
     /// Remove a slot from the pool — *retire* it. Six legitimate callers:
     /// the slot's *own* worker on its `serve_blocking_on` exit
-    /// (self-remove); `client_transact`'s three retirements (a
-    /// non-reentrant slot whose send failed at the transport, whose reply
-    /// read lost the stream, or whose reply wait found the slot already
-    /// marked unreadable by a nested call); and the two attach rollbacks —
+    /// (self-remove); the shared send-failure rule
+    /// ([`retire_after_failed_send`](Self::retire_after_failed_send)),
+    /// which every outbound frame of every kind funnels through;
+    /// `client_transact`'s two reply-wait retirements (a non-reentrant slot
+    /// whose reply read lost the stream, or whose reply wait found the slot
+    /// already marked unreadable by a nested call); and the two attach
+    /// rollbacks —
     /// an incoming connection whose serve thread failed to spawn, and a
     /// callback slot whose `"cci"` never reached the peer. After a
     /// retirement, the slot's worker finds its slot gone and gets
@@ -1952,6 +1957,60 @@ impl RpcSessionInner {
         // death only here.
         if (empty || no_outgoing) && self.shared.lifecycle.try_drop_sole_connection() {
             self.on_session_dead();
+        }
+    }
+
+    /// The single rule for a **send that failed on the transport**, applied
+    /// by every path that writes a frame to a pooled slot: a request, a
+    /// reply, and a `DEC_STRONG` from any of its three senders.
+    ///
+    /// A write that stopped part-way left the peer a frame header it will
+    /// complete out of whatever bytes arrive next, and no transport makes
+    /// such a failure sticky (each send is a fresh write), so a slot whose
+    /// send failed must never carry another frame.
+    ///
+    /// Two failures leave the slot healthy and are not retired: a codec or
+    /// protocol error, raised before any byte reaches the wire; and a send
+    /// deadline that expired *before the first byte*, which the socket
+    /// backends' raw senders report as [`RpcError::Timeout`]
+    /// (`write_all_reporting`). Nothing of that frame went out, so the
+    /// stream is still frame-synchronized and the connection keeps serving —
+    /// the caller is simply told the frame was not sent. A best-effort
+    /// sender that swallows the error therefore no longer takes a live
+    /// connection down with it.
+    ///
+    /// Every other transport failure ([`RpcError::EndOfStream`],
+    /// [`RpcError::Io`]) retires, including one that in fact sent nothing:
+    /// past the first byte a writer can no longer say how much went out. Two
+    /// senders never make the distinction, and are conservative rather than
+    /// wrong for it — `tls`, where a record its socket write dropped is gone
+    /// from the sequence however far it got, and the r34 length-prefixed
+    /// path, on whose pooled slots no send deadline is armed (the server
+    /// lifts the handshake one before it serves).
+    ///
+    /// A guard that owns the slot retires it. A reentrant guard owns
+    /// nothing — the outer frame holds this slot — so it marks the slot
+    /// unreadable instead, which is what stops the outer frame from writing
+    /// its own frame onto the desynced stream
+    /// ([`find_conn_impl`](Self::find_conn_impl) refuses an unreadable slot)
+    /// and from reading the next one as its own, and shuts the transport
+    /// down to wake anyone already blocked on it.
+    fn retire_after_failed_send(&self, conn: &ConnGuard<'_>, e: &RpcError) {
+        if !matches!(e, RpcError::EndOfStream | RpcError::Io(_)) {
+            return;
+        }
+        if conn.reentrant {
+            self.mark_slot_unreadable(conn.slot_id);
+            log::error!(
+                "RPC: a frame failed part-way through its send on a slot another frame owns; \
+                 what the peer reads next is unknowable, so this connection is marked \
+                 unreadable and shut down rather than left for that frame to write on"
+            );
+            if let Err(e) = conn.transport().shutdown() {
+                log::warn!("RPC: shutting the desynced connection down failed: {e}");
+            }
+        } else {
+            self.remove_slot(conn.slot_id);
         }
     }
 
@@ -2049,13 +2108,16 @@ impl RpcSessionInner {
                 let borrowed: Vec<_> = fds.iter().map(|f| f.as_fd()).collect();
                 return write_aosp_message_with_fds(transport, frame, &borrowed);
             }
+            // Through `send_raw_with_fds`, not `write_aosp_message` over
+            // `RawTransportIo`: that boundary folds a send that never started
+            // (`RpcError::Timeout`) into a generic `Io`, and the send-failure
+            // rule reads exactly that difference. Same bytes, no fds.
             debug_assert!(
                 fds.is_empty(),
                 "non-Unix android-13+ session must not carry fds"
             );
             let _ = fds; // release: `debug_assert!` is compiled out, so `fds` is otherwise unused
-            let mut io = RawTransportIo(transport);
-            return write_aosp_message(&mut io, frame);
+            return write_aosp_message_with_fds(transport, frame, &[]);
         }
         if self.fd_mode() == FileDescriptorTransportMode::Unix {
             let borrowed: Vec<_> = fds.iter().map(|f| f.as_fd()).collect();
@@ -2501,12 +2563,7 @@ impl RpcSessionInner {
         // (empty unless `Unix` fd-mode).
         if let Err(e) = self.send_msg(transport, &frame, data.rpc_out_fds()) {
             rollback();
-            // Transport-level send failure ⇒ this connection is done (peer
-            // gone, or shut down on this end); retire the slot like the
-            // reply path (encode errors are not).
-            if matches!(e, RpcError::EndOfStream | RpcError::Io(_)) && !conn.reentrant {
-                self.remove_slot(conn.slot_id);
-            }
+            self.retire_after_failed_send(&conn, &e);
             return Err(e.into());
         }
         if oneway {
@@ -2676,9 +2733,13 @@ impl RpcSessionInner {
     /// shape matches the *user-observable* behavior (sync when
     /// possible) without paying the hang risk in the contention case.
     ///
-    /// Send failures are silent — same as the original
-    /// `RpcProxy::drop` semantics (a dead session ⇒ peer
-    /// observationally gone, AOSP parity).
+    /// Send failures are not reported to the dropping user — same as the
+    /// original `RpcProxy::drop` semantics (a dead session ⇒ peer
+    /// observationally gone, AOSP parity) — but one that may have left a
+    /// partial frame on the wire still retires its slot
+    /// ([`retire_after_failed_send`](Self::retire_after_failed_send)). A
+    /// send that never started (a write deadline on a full socket buffer)
+    /// leaves the connection exactly as it was.
     pub(crate) fn queue_dec_strong(&self, addr: RpcAddress) {
         if self.shared.lifecycle.is_torn_down() {
             return;
@@ -2692,7 +2753,12 @@ impl RpcSessionInner {
         // cannot overtake it.
         if let Some(conn) = self.try_find_conn() {
             let frame = self.profile.codec().encode_dec_strong(&addr);
-            let _ = self.send_msg(conn.transport(), &frame, &[]);
+            // The send stays best-effort (the error is not reported to the
+            // dropping user), but a slot it half-wrote is still retired —
+            // see [`retire_after_failed_send`](Self::retire_after_failed_send).
+            if let Err(e) = self.send_msg(conn.transport(), &frame, &[]) {
+                self.retire_after_failed_send(&conn, &e);
+            }
             return;
         }
         // Slow path: pool is fully exclusive (every slot mid-transact
@@ -2720,7 +2786,10 @@ impl RpcSessionInner {
         // it via `DRIVING`, the documented "interleaved DEC_STRONG" path).
         let conn = self.find_conn_lenient()?;
         let frame = self.profile.codec().encode_dec_strong(&addr);
-        self.send_msg(conn.transport(), &frame, &[])?;
+        if let Err(e) = self.send_msg(conn.transport(), &frame, &[]) {
+            self.retire_after_failed_send(&conn, &e);
+            return Err(e.into());
+        }
         Ok(())
     }
 
@@ -2784,7 +2853,11 @@ impl RpcSessionInner {
         // role or nesting grant — the peer is waiting for this answer
         // on that socket and nowhere else.
         let conn = self.find_conn_impl(ConnUse::Reply)?;
-        Ok(self.send_msg(conn.transport(), &frame, fds)?)
+        if let Err(e) = self.send_msg(conn.transport(), &frame, fds) {
+            self.retire_after_failed_send(&conn, &e);
+            return Err(e.into());
+        }
+        Ok(())
     }
 
     /// Dispatch one inbound `TRANSACT` (server role, or a nested
@@ -3158,9 +3231,8 @@ impl RpcSessionInner {
                 // `Parcel::readByteVector` — a 32-byte (`kSessionIdBytes`)
                 // opaque id. rsbinder's `Vec<u8>`/`&[u8]` serializer is
                 // the AIDL `byte[]` path (`i32 len` + packed bytes +
-                // 4-pad) == libbinder `writeByteVector` byte-for-byte.
-                // (Was a bare `i32` ⇒ libbinder `BAD_VALUE` — found by
-                // the real-peer round-trip.)
+                // 4-pad) == libbinder `writeByteVector` byte-for-byte; a
+                // bare `i32` here is `BAD_VALUE` on a real libbinder peer.
                 let mut reply = Parcel::new();
                 reply.write(&self.shared.rpc_session_id.as_bytes()[..])?;
                 self.send_reply(0, reply.rpc_data_bytes(), &[], &[])
@@ -3955,32 +4027,56 @@ impl RpcSession {
     /// ends with [`EndReason::Unreadable`] and a lost stream — which says
     /// nothing about whether the peer is still up.
     pub fn serve_blocking_on(&self, slot_id: u64) -> SessionEnd {
-        self.serve_blocking_on_inner(slot_id, false)
+        self.serve_blocking_on_inner(slot_id, false, false)
     }
 
     /// Like [`serve_blocking`](RpcSession::serve_blocking), but the
     /// handshake/admission read deadline armed before the call is left in
     /// place for the **first** frame only and cleared once that frame is
-    /// read (or a clean EOF arrives). Used by the r34 server path, where
+    /// read. Used by the r34 server path, where
     /// there is no separate handshake: the first serve-loop frame *is* the
     /// first contact, so a connected-but-silent peer's worker must still be
     /// bounded by the deadline, while an established two-way session idles
     /// unbounded between requests after that first frame.
+    ///
+    /// Calling this **declares that such a deadline is armed**: the
+    /// returned [`SessionEnd`] reads a `TimedOut` over that first frame as
+    /// this end evicting an idle peer. With none armed the same code is
+    /// the kernel's `ETIMEDOUT` instead, and
+    /// [`serve_blocking`](RpcSession::serve_blocking) is the call that
+    /// reports it as the lost stream it is.
     pub fn serve_blocking_clearing_deadline_after_first(&self) -> SessionEnd {
-        self.serve_blocking_on_inner(Self::FOUNDING_SLOT_ID, true)
+        self.serve_blocking_on_inner(Self::FOUNDING_SLOT_ID, true, true)
+    }
+
+    /// The server's entry to the same loop, told whether it *actually*
+    /// armed the admission deadline this clears after the first frame:
+    /// [`RpcServer::set_handshake_timeout(None)`](super::RpcServer::set_handshake_timeout)
+    /// leaves an r34 worker serving with no deadline at all, and a
+    /// `TimedOut` between frames is then not this end's to claim.
+    pub(crate) fn serve_blocking_clearing_admission_deadline(&self, armed: bool) -> SessionEnd {
+        self.serve_blocking_on_inner(Self::FOUNDING_SLOT_ID, true, armed)
     }
 
     fn serve_blocking_on_inner(
         &self,
         slot_id: u64,
         clear_deadline_after_first: bool,
+        admission_deadline_armed: bool,
     ) -> SessionEnd {
         // Read the slot's role now: a `RpcSession::close_session` racing this
         // loop clears the pool, and a role read after the loop would come
         // back `false` for a slot that is simply gone.
         let client_incoming = self.inner.is_client_incoming_slot(slot_id);
-        let reason = {
+        // Whether a read deadline of ours is in force decides how a
+        // `TimedOut` at a frame boundary reads: ours (idle eviction) or the
+        // kernel's `ETIMEDOUT`. The baseline is the session's serve
+        // deadline; the r34 path additionally holds the admission deadline
+        // over the first frame and lifts it below.
+        let baseline_deadline = self.inner.slot_baseline_read_deadline(slot_id).is_some();
+        let (reason, deadline_armed) = {
             let mut first = clear_deadline_after_first;
+            let mut deadline_armed = baseline_deadline || admission_deadline_armed;
             loop {
                 match self.inner.serve_once_on_slot(slot_id) {
                     ServeStep::Continue => {
@@ -3990,9 +4086,10 @@ impl RpcSession {
                         if first {
                             self.inner.clear_slot_read_timeout(slot_id);
                             first = false;
+                            deadline_armed = false;
                         }
                     }
-                    ServeStep::Ended(reason) => break reason,
+                    ServeStep::Ended(reason) => break (reason, deadline_armed),
                 }
             }
         };
@@ -4001,6 +4098,7 @@ impl RpcSession {
         let end = SessionEnd::new(
             reason,
             self.inner.shared.ended_locally.load(Ordering::SeqCst),
+            deadline_armed,
         );
         // Typed lifecycle: this
         // connection is finished. Fire the session obituaries only on
@@ -4809,8 +4907,8 @@ impl RpcSession {
     }
 
     /// Test/diagnostic: incoming-connection threads whose `JoinHandle`
-    /// this session still holds. `shutdown` takes the whole set before
-    /// joining any of it, so this drops to zero the moment `shutdown`
+    /// this session still holds. `close_session` takes the whole set before
+    /// joining any of it, so this drops to zero the moment `close_session`
     /// starts — use [`__incoming_thread_live_count`](Self::__incoming_thread_live_count)
     /// to observe the join itself.
     #[doc(hidden)]
@@ -4828,7 +4926,7 @@ impl RpcSession {
         self.inner.incoming_live.load(Ordering::SeqCst)
     }
 
-    /// Test/diagnostic: incoming-connection threads `shutdown` has
+    /// Test/diagnostic: incoming-connection threads `close_session` has
     /// joined. Stays 0 if they are detached instead.
     #[doc(hidden)]
     pub fn __incoming_thread_joined_count(&self) -> usize {
@@ -4873,7 +4971,11 @@ fn reaper_loop(weak: Weak<RpcSessionInner>, rx: mpsc::Receiver<RpcAddress>) {
             continue;
         };
         let frame = inner.profile.codec().encode_dec_strong(&addr);
-        let _ = inner.send_msg(conn.transport(), &frame, &[]);
+        // Best-effort like the synchronous fast path: the failure is not
+        // reported anywhere, but a slot it half-wrote is still retired.
+        if let Err(e) = inner.send_msg(conn.transport(), &frame, &[]) {
+            inner.retire_after_failed_send(&conn, &e);
+        }
         drop(conn);
         drop(inner);
     }

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -164,7 +164,7 @@ impl<'a> RpcUnixClientConfig<'a> {
     /// session you do not own). Bounded on the server by twice its
     /// `RpcServer::set_max_threads` value. Default 0. The threads end
     /// when the server closes the session or on
-    /// [`RpcSession::shutdown`]; dropping the `RpcSession` handle alone
+    /// [`RpcSession::close_session`]; dropping the `RpcSession` handle alone
     /// does not stop them.
     pub fn incoming_connections(mut self, n: u32) -> Self {
         self.incoming_connections = n;
@@ -636,7 +636,7 @@ fn log_attach_refused(e: &RpcError) {
 fn client_handshake_err(e: RpcError, requesting_new_session: bool) -> StatusCode {
     if requesting_new_session {
         match &e {
-            RpcError::PeerClosed => log::error!(
+            RpcError::EndOfStream => log::error!(
                 "rsbinder RPC: the android-13+ handshake failed at the transport ({e}) after \
                  the peer accepted the connection — it may be speaking the r34 (default) \
                  profile. Connect without `?profile=android13plus`, or enable the android-13+ \
@@ -739,6 +739,11 @@ thread_local! {
     /// per-session in [`RpcState`]. It mirrors kernel binder's
     /// thread-local `IPCThreadState`. Documented exception in the
     /// `rpc_stack_has_no_globals` gate.
+    ///
+    /// Bound by the borrow-discipline invariant R1 (`thread_state`
+    /// module doc): every `DRIVING.with` copies its answer out of the
+    /// closure, and no guard is held across the user callback a nested
+    /// dispatch runs.
     static DRIVING: RefCell<Vec<(usize, u64)>> = const { RefCell::new(Vec::new()) };
 }
 
@@ -915,7 +920,7 @@ enum StreamPosition {
     /// What the peer sends next is unknowable — the pending `REPLY` may
     /// still arrive, or it may already be gone. Either a frame arrived
     /// and did not decode, or a read failed without the guarantee that
-    /// it stopped at a frame boundary: only `PeerClosed` and `Timeout`
+    /// it stopped at a frame boundary: only `EndOfStream` and `Timeout`
     /// carry that guarantee, so every other read failure lands here,
     /// including one that consumed nothing at all. AOSP ends the whole
     /// session here (`RpcState::waitForReply`: "processCommand must
@@ -1180,7 +1185,7 @@ pub(crate) struct RpcSessionInner {
     /// one place.
     shared: Arc<SharedSession>,
     /// Threads serving this client's incoming (callback) connections,
-    /// keyed by slot id. Joined by [`RpcSession::shutdown`].
+    /// keyed by slot id. Joined by [`RpcSession::close_session`].
     incoming_threads: Mutex<Vec<(u64, std::thread::JoinHandle<()>)>>,
     /// How many of those threads are still running. Bumped before the
     /// spawn and dropped by the thread itself as its very last act.
@@ -1188,7 +1193,7 @@ pub(crate) struct RpcSessionInner {
     /// `incoming_threads` is `mem::take`n before the first `join()`, so
     /// its length is zero either way.
     incoming_live: AtomicUsize,
-    /// How many of those threads [`RpcSession::shutdown`] has actually
+    /// How many of those threads [`RpcSession::close_session`] has actually
     /// `join()`ed. `incoming_live` cannot stand in for this: the serve
     /// threads are woken by the transport shutdown that `shutdown`
     /// performs first, so they usually finish on their own while it is
@@ -1860,7 +1865,7 @@ impl RpcSessionInner {
     /// so the reply is still inbound; count it so the stream re-syncs by
     /// skipping it rather than tearing the connection down as
     /// "unsolicited". Only for a wait that ended with the stream still at
-    /// a frame boundary (`PeerClosed`, `Timeout`, or a failure before or
+    /// a frame boundary (`EndOfStream`, `Timeout`, or a failure before or
     /// after the read itself); a read that failed without that guarantee
     /// marks the slot unreadable instead
     /// ([`mark_slot_unreadable`](Self::mark_slot_unreadable)).
@@ -1953,7 +1958,7 @@ impl RpcSessionInner {
     /// End this session now, whatever its connection count: declare
     /// death (`Live(n) → Dying`) and run the death sequence. Exactly one
     /// caller does the work; from `Dying`/`Dead` it is a no-op. Both
-    /// [`RpcSession::shutdown`] and the server's
+    /// [`RpcSession::close_session`] and the server's
     /// [`terminate`](super::RpcServer::terminate) land here, so a session
     /// several workers drive ends the same way a sole-connection one does.
     pub(crate) fn close(&self) {
@@ -1975,7 +1980,7 @@ impl RpcSessionInner {
     ///
     /// **Unblock before user code.** Every step that can wake a thread of
     /// this session runs ahead of the obituaries, because an obituary (or
-    /// a local `Drop`) may call [`RpcSession::shutdown`], which *joins*
+    /// a local `Drop`) may call [`RpcSession::close_session`], which *joins*
     /// those threads — one still parked would deadlock that join. Two
     /// steps are needed, not one: `shutdown_all_transports` wakes only
     /// threads blocked in `recv`/`send`, while a thread waiting on
@@ -2068,7 +2073,7 @@ impl RpcSessionInner {
         if self.profile.aosp_framing() {
             // android-13+: read `RpcWireHeader` then exactly `bodySize`
             // bytes (capped vs `MAX_FRAME_LEN`); a clean EOF before
-            // any byte surfaces as `PeerClosed` so the `serve_blocking`
+            // any byte surfaces as `EndOfStream` so the `serve_blocking`
             // loop terminates exactly like the R34 path. On a v1+ `Unix`
             // session the same connection always
             // uses `recvmsg` (never mixes with `Read`), accumulating the
@@ -2170,7 +2175,7 @@ impl RpcSessionInner {
 
     /// Shut every slot's transport down (best-effort) so a thread blocked
     /// in `recv` on this session — a client's incoming-connection thread,
-    /// a user `serve_blocking` — returns with `PeerClosed`. Transports are
+    /// a user `serve_blocking` — returns with `EndOfStream`. Transports are
     /// cloned out first: the lock is never held across the syscalls.
     fn shutdown_all_transports(&self) {
         let transports: Vec<Arc<dyn RpcTransport>> = self
@@ -2496,9 +2501,10 @@ impl RpcSessionInner {
         // (empty unless `Unix` fd-mode).
         if let Err(e) = self.send_msg(transport, &frame, data.rpc_out_fds()) {
             rollback();
-            // Transport-level send failure ⇒ peer gone on this connection;
-            // retire the slot like the reply path (encode errors are not).
-            if matches!(e, RpcError::PeerClosed | RpcError::Io(_)) && !conn.reentrant {
+            // Transport-level send failure ⇒ this connection is done (peer
+            // gone, or shut down on this end); retire the slot like the
+            // reply path (encode errors are not).
+            if matches!(e, RpcError::EndOfStream | RpcError::Io(_)) && !conn.reentrant {
                 self.remove_slot(conn.slot_id);
             }
             return Err(e.into());
@@ -3048,7 +3054,7 @@ impl RpcSessionInner {
         let transport = conn.transport();
         let (frame, in_fds) = match self.recv_msg(transport) {
             Ok(f) => f,
-            Err(RpcError::PeerClosed) => return ServeStep::Ended(EndReason::EndOfStream),
+            Err(RpcError::EndOfStream) => return ServeStep::Ended(EndReason::EndOfStream),
             Err(RpcError::UncleanEndOfStream) => {
                 return ServeStep::Ended(EndReason::UncleanEndOfStream)
             }
@@ -3235,13 +3241,13 @@ impl RpcSessionInner {
 /// That leaves one case the runtime cannot notice: a local object handed
 /// to the peer may itself hold a proxy back into this session, and if the
 /// session neither serves nor transacts again, nothing runs the release.
-/// [`RpcSession::shutdown`] is the explicit break for it.
+/// [`RpcSession::close_session`] is the explicit break for it.
 ///
 /// A client session with incoming (callback) connections
 /// ([`RpcUnixClientConfig::incoming_connections`]) owns the threads that
 /// serve them, and those threads keep the session alive: dropping every
 /// handle and proxy does not stop them. They end when the server closes
-/// the session or on [`RpcSession::shutdown`] — call it when you are done
+/// the session or on [`RpcSession::close_session`] — call it when you are done
 /// with such a session.
 #[derive(Clone)]
 pub struct RpcSession {
@@ -3926,7 +3932,7 @@ impl RpcSession {
     /// ([`reason`](SessionEnd::reason)). A caller that wants only
     /// "did it end well" calls [`into_result`](SessionEnd::into_result):
     /// `Ok(())` for an intact stream — a peer that closed, or this end's
-    /// own [`shutdown`](RpcSession::shutdown), read the same — and
+    /// own [`close_session`](RpcSession::close_session), read the same — and
     /// `Err(`[`StatusCode::DeadObject`]`)` for a lost one, whatever the
     /// cause; the cause is in the value, not in the code.
     pub fn serve_blocking(&self) -> SessionEnd {
@@ -3969,7 +3975,7 @@ impl RpcSession {
         slot_id: u64,
         clear_deadline_after_first: bool,
     ) -> SessionEnd {
-        // Read the slot's role now: a `RpcSession::shutdown` racing this
+        // Read the slot's role now: a `RpcSession::close_session` racing this
         // loop clears the pool, and a role read after the loop would come
         // back `false` for a slot that is simply gone.
         let client_incoming = self.inner.is_client_incoming_slot(slot_id);
@@ -4024,7 +4030,7 @@ impl RpcSession {
         // the lifecycle transition + obituary so a concurrent
         // `RpcProxy::drop`'s best-effort `send_dec_strong` sees either
         // (i) the slot still present (`find_conn` picks it, send returns
-        // `PeerClosed`, best-effort path Err — no deadlock) or (ii) the
+        // `EndOfStream`, best-effort path Err — no deadlock) or (ii) the
         // lifecycle in Dying/Dead (the `send_dec_strong` early-out
         // short-circuits, skipping `find_conn` entirely). Removing the
         // slot *before* the lifecycle transition opened a window where a
@@ -4079,22 +4085,22 @@ impl RpcSession {
     /// The threads serving this client's incoming (callback) connections
     /// (`RpcUnixClientConfig::incoming_connections`) are stopped and
     /// joined here — every slot's transport is shut down, which ends
-    /// their serve loops — except a thread that calls `shutdown` from
+    /// their serve loops — except a thread that calls `close_session` from
     /// inside its own callback handler, which is left to finish on its
     /// own (joining it would deadlock). Unlike AOSP
     /// `RpcSession::shutdownAndWait`, a user-driven `serve_blocking` on
     /// the founding slot is not joined; it exits on its own once the
     /// transport is shut down.
-    pub fn shutdown(&self) {
+    pub fn close_session(&self) {
         self.inner.close();
         let me = std::thread::current().id();
         for (slot_id, handle) in self.inner.take_incoming_threads() {
             if handle.thread().id() == me {
-                // `shutdown` from inside this connection's own dispatch:
+                // `close_session` from inside this connection's own dispatch:
                 // the loop ends when the handler returns; dropping the
                 // handle detaches it.
                 log::debug!(
-                    "RPC: shutdown from incoming connection {slot_id}'s own thread; not joined"
+                    "RPC: close_session from incoming connection {slot_id}'s own thread; not joined"
                 );
                 continue;
             }
@@ -4350,7 +4356,7 @@ impl RpcSession {
             // No degradation: the partial session is torn down here —
             // including any incoming threads already serving — since the
             // caller never gets a handle to do it.
-            session.shutdown();
+            session.close_session();
             return Err(e);
         }
         Ok(session)
@@ -5513,7 +5519,7 @@ mod tests {
         let codec = Android13PlusCodec::android14_15();
         let session = RpcSession::from_android13plus(Box::new(t0), codec, FD_MODE_NONE, false)
             .expect("build session");
-        session.shutdown();
+        session.close_session();
 
         let (t, _p) = MemTransport::pair();
         assert!(

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -857,11 +857,11 @@ struct ConnSlot {
     /// [`RpcSessionInner::note_stale_reply`]).
     stale_replies: u32,
     /// Set by a nested (reentrant) frame that lost track of what the peer
-    /// sends next ([`Desync::ProtocolStateLost`]): whoever owns the slot
+    /// sends next ([`StreamPosition::StreamPositionUnknown`]): whoever owns the slot
     /// must not interpret another frame on it. Never cleared — the owner
     /// retires the slot instead (see
-    /// [`RpcSessionInner::mark_slot_poisoned`]).
-    poisoned: bool,
+    /// [`RpcSessionInner::mark_slot_unreadable`]).
+    unreadable: bool,
 }
 
 /// The session's connection pool + its monotonic slot-id
@@ -908,10 +908,10 @@ impl ConnGuard<'_> {
 /// What a failed step in `client_transact`'s reply wait left on the
 /// stream. Only a reentrant frame has to distinguish them: it cannot
 /// retire the slot, because the outer frame owns it.
-enum Desync {
+enum StreamPosition {
     /// Nothing came off the stream, so this call's `REPLY` may still be
     /// on its way and the outer frame has to skip one.
-    ReplyStillInbound,
+    FrameBoundaryIntact,
     /// What the peer sends next is unknowable — the pending `REPLY` may
     /// still arrive, or it may already be gone. Either a frame arrived
     /// and did not decode, or a read failed without the guarantee that
@@ -920,7 +920,7 @@ enum Desync {
     /// including one that consumed nothing at all. AOSP ends the whole
     /// session here (`RpcState::waitForReply`: "processCommand must
     /// shutdown on failure").
-    ProtocolStateLost,
+    StreamPositionUnknown,
 }
 
 impl Drop for ConnGuard<'_> {
@@ -1241,7 +1241,7 @@ impl RpcSessionInner {
     ///     never claimed by a non-nested call: it is a serve loop's
     ///     socket, read by the peer only inside its own reply wait.
     /// - **No `Outgoing` slot at all** — fail **immediately** with
-    ///   `Err(StatusCode::FailedTransaction)` (AOSP `WOULD_BLOCK`:
+    ///   `Err(StatusCode::WouldBlock)` (AOSP `WOULD_BLOCK`:
     ///   "Session has no outgoing connections"). This is a server
     ///   calling a client proxy outside any handler while the client
     ///   opened no incoming connection; waiting would never end,
@@ -1333,6 +1333,9 @@ impl RpcSessionInner {
                     // push and this reentrant lookup. Surface a typed dead
                     // error rather than panicking on the driver loop.
                     None => return Err(StatusCode::DeadObject),
+                    // A nested call lost the stream on it: nothing more is
+                    // written there, not even by the frame that owns it.
+                    Some(s) if s.unreadable => return Err(StatusCode::DeadObject),
                     Some(s)
                         if s.role == SlotRole::Outgoing
                             || s.allow_nested
@@ -1367,7 +1370,7 @@ impl RpcSessionInner {
             let pick = st
                 .slots
                 .iter()
-                .position(|s| free(s) && s.role == SlotRole::Outgoing);
+                .position(|s| free(s) && s.role == SlotRole::Outgoing && !s.unreadable);
             if let Some(idx) = pick {
                 let s = &mut st.slots[idx];
                 s.exclusive_tid = Some(tid);
@@ -1383,7 +1386,11 @@ impl RpcSessionInner {
             }
             // (3b) Nothing to wait for: no `Outgoing` slot exists, and only a
             //      peer attach can create one. AOSP `WOULD_BLOCK`.
-            if !st.slots.iter().any(|s| s.role == SlotRole::Outgoing) {
+            if !st
+                .slots
+                .iter()
+                .any(|s| s.role == SlotRole::Outgoing && !s.unreadable)
+            {
                 if refcount {
                     // Best-effort by contract, so this is a skip, not an
                     // error: the peer's node is released at session end
@@ -1424,7 +1431,7 @@ impl RpcSessionInner {
                          ARpcSession_setMaxIncomingThreads); refusing instead of waiting forever"
                     );
                 }
-                return Err(StatusCode::FailedTransaction);
+                return Err(StatusCode::WouldBlock);
             }
             // (4) Pool exhausted — wait, bounded by the session deadline: a serve-pinned slot is released only by the peer.
             let deadline = *self.shared.timeout.lock().expect("timeout poisoned");
@@ -1441,9 +1448,9 @@ impl RpcSessionInner {
                             "RPC: no connection slot became available within {d:?} \
                              (every slot is driven by another thread — a session \
                              served on one thread and transacted on another needs \
-                             more than one connection)"
+                             more than one connection); nothing was sent"
                         );
-                        return Err(StatusCode::TimedOut);
+                        return Err(StatusCode::WouldBlock);
                     }
                     self.slot_cv
                         .wait_timeout(st, remaining)
@@ -1480,7 +1487,11 @@ impl RpcSessionInner {
                 .find_map(|&(sp, sid)| if sp == sess_ptr { Some(sid) } else { None })
         }) {
             let st = self.conn_state.lock().expect("conn_state poisoned");
-            let transport = Arc::clone(&st.slots.iter().find(|s| s.id == slot_id)?.transport);
+            let slot = st.slots.iter().find(|s| s.id == slot_id)?;
+            if slot.unreadable {
+                return None;
+            }
+            let transport = Arc::clone(&slot.transport);
             drop(st);
             return Some(ConnGuard {
                 inner: self,
@@ -1497,10 +1508,9 @@ impl RpcSessionInner {
         //     blocks and this slot's serve loop is locked out of it.
         //     `None` here just defers to the reaper, then to session end.
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
-        let idx = st
-            .slots
-            .iter()
-            .position(|s| s.exclusive_tid.is_none() && s.role == SlotRole::Outgoing)?;
+        let idx = st.slots.iter().position(|s| {
+            s.exclusive_tid.is_none() && s.role == SlotRole::Outgoing && !s.unreadable
+        })?;
         let s = &mut st.slots[idx];
         s.exclusive_tid = Some(tid);
         let slot_id = s.id;
@@ -1546,7 +1556,7 @@ impl RpcSessionInner {
             let pick = st
                 .slots
                 .iter()
-                .position(|s| free(s) && s.role == SlotRole::Outgoing);
+                .position(|s| free(s) && s.role == SlotRole::Outgoing && !s.unreadable);
             if let Some(idx) = pick {
                 let s = &mut st.slots[idx];
                 s.exclusive_tid = Some(tid);
@@ -1564,7 +1574,11 @@ impl RpcSessionInner {
             // `Outgoing` slot, and parking here would hold the session's
             // strong `Arc` (the leak this function's doc guards against).
             // Skipping is the documented best-effort contract.
-            if !st.slots.iter().any(|s| s.role == SlotRole::Outgoing) {
+            if !st
+                .slots
+                .iter()
+                .any(|s| s.role == SlotRole::Outgoing && !s.unreadable)
+            {
                 return None;
             }
             st = self.slot_cv.wait(st).expect("slot_cv poisoned");
@@ -1722,7 +1736,7 @@ impl RpcSessionInner {
             role,
             allow_nested: false,
             stale_replies: 0,
-            poisoned: false,
+            unreadable: false,
         });
         drop(st);
         self.slot_cv.notify_all();
@@ -1764,7 +1778,7 @@ impl RpcSessionInner {
             role: SlotRole::Incoming,
             allow_nested: false,
             stale_replies: 0,
-            poisoned: false,
+            unreadable: false,
         });
         drop(st);
         self.slot_cv.notify_all();
@@ -1834,7 +1848,7 @@ impl RpcSessionInner {
             role: SlotRole::Outgoing,
             allow_nested: false,
             stale_replies: 0,
-            poisoned: false,
+            unreadable: false,
         });
         drop(st);
         self.slot_cv.notify_all();
@@ -1849,7 +1863,7 @@ impl RpcSessionInner {
     /// a frame boundary (`PeerClosed`, `Timeout`, or a failure before or
     /// after the read itself); a read that failed without that guarantee
     /// marks the slot unreadable instead
-    /// ([`mark_slot_poisoned`](Self::mark_slot_poisoned)).
+    /// ([`mark_slot_unreadable`](Self::mark_slot_unreadable)).
     fn note_stale_reply(&self, slot_id: u64) {
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
         if let Some(s) = st.slots.iter_mut().find(|s| s.id == slot_id) {
@@ -1866,18 +1880,18 @@ impl RpcSessionInner {
     /// discard its receive queue, a transport may hold a buffered
     /// leftover, the default impl does nothing), so nothing here assumes
     /// it discards anything; the flag holds on every transport.
-    fn mark_slot_poisoned(&self, slot_id: u64) {
+    fn mark_slot_unreadable(&self, slot_id: u64) {
         let mut st = self.conn_state.lock().expect("conn_state poisoned");
         if let Some(s) = st.slots.iter_mut().find(|s| s.id == slot_id) {
-            s.poisoned = true;
+            s.unreadable = true;
         }
     }
 
-    /// Whether a nested call poisoned `slot_id`
-    /// ([`mark_slot_poisoned`](Self::mark_slot_poisoned)).
-    fn slot_poisoned(&self, slot_id: u64) -> bool {
+    /// Whether a nested call marked `slot_id` unreadable
+    /// ([`mark_slot_unreadable`](Self::mark_slot_unreadable)).
+    fn slot_unreadable(&self, slot_id: u64) -> bool {
         let st = self.conn_state.lock().expect("conn_state poisoned");
-        st.slots.iter().any(|s| s.id == slot_id && s.poisoned)
+        st.slots.iter().any(|s| s.id == slot_id && s.unreadable)
     }
 
     /// Whether a `REPLY` just read on `slot_id` is one an abandoned nested
@@ -1906,7 +1920,7 @@ impl RpcSessionInner {
     /// not a structural bug. `notify_all` so any `find_conn`
     /// (any-available) waiter re-evaluates against the shrunk pool.
     /// (Retiring is distinct from marking unreadable —
-    /// [`mark_slot_poisoned`](Self::mark_slot_poisoned) — which leaves
+    /// [`mark_slot_unreadable`](Self::mark_slot_unreadable) — which leaves
     /// the slot in the pool for its owner to retire.)
     ///
     /// **Not a pure pool mutation:** emptying the pool — or, on an
@@ -2499,7 +2513,7 @@ impl RpcSessionInner {
         let deadline = *self.shared.timeout.lock().expect("timeout poisoned");
         // Post-send: a failed reply wait leaves this call's `REPLY` unaccounted
         // for, and `WireReply` carries no id to match it by later.
-        let poison_slot = |desync: Desync| {
+        let record_stream_position = |desync: StreamPosition| {
             if !conn.reentrant {
                 self.remove_slot(conn.slot_id);
                 return;
@@ -2507,16 +2521,16 @@ impl RpcSessionInner {
             // A reentrant frame owns nothing: the outer frame holds this
             // slot and will keep reading it.
             match desync {
-                Desync::ReplyStillInbound => self.note_stale_reply(conn.slot_id),
-                Desync::ProtocolStateLost => {
-                    self.mark_slot_poisoned(conn.slot_id);
+                StreamPosition::FrameBoundaryIntact => self.note_stale_reply(conn.slot_id),
+                StreamPosition::StreamPositionUnknown => {
+                    self.mark_slot_unreadable(conn.slot_id);
                     log::error!(
                         "RPC: a nested call lost track of the stream; what the peer sends next \
-                         is unknowable, so this connection is poisoned and shut down rather than \
-                         left for the outer call to read"
+                         is unknowable, so this connection is marked unreadable and shut down \
+                         rather than left for the outer call to read"
                     );
-                    // Only wakes a reader blocked in `recv`; the poison flag
-                    // above is what stops already-buffered frames.
+                    // Only wakes a reader blocked in `recv`; the mark above
+                    // is what stops already-buffered frames.
                     if let Err(e) = transport.shutdown() {
                         log::debug!("RPC: shutting the desynced connection down failed: {e:?}");
                     }
@@ -2524,19 +2538,19 @@ impl RpcSessionInner {
             }
         };
         // Arming is itself post-send, so a failure here desyncs the stream
-        // exactly like a failed recv: poison before propagating.
+        // exactly like a failed recv: record it before propagating.
         let restore = self.slot_baseline_read_deadline(conn.slot_id);
         let _deadline_guard = match ReplyDeadlineGuard::arm(transport, deadline, restore) {
             Ok(g) => g,
             Err(e) => {
-                poison_slot(Desync::ReplyStillInbound);
+                record_stream_position(StreamPosition::FrameBoundaryIntact);
                 return Err(e.into());
             }
         };
         loop {
             // A nested call on this slot lost track of the stream, and
             // `shutdown` does not drop what the peer already sent.
-            if self.slot_poisoned(conn.slot_id) {
+            if self.slot_unreadable(conn.slot_id) {
                 if !conn.reentrant {
                     self.remove_slot(conn.slot_id);
                 }
@@ -2548,18 +2562,18 @@ impl RpcSessionInner {
                     // Only a failure *at* a frame boundary leaves the reply
                     // inbound; the rest may have consumed part of one.
                     let desync = if e.leaves_frame_boundary_intact() {
-                        Desync::ReplyStillInbound
+                        StreamPosition::FrameBoundaryIntact
                     } else {
-                        Desync::ProtocolStateLost
+                        StreamPosition::StreamPositionUnknown
                     };
-                    poison_slot(desync);
+                    record_stream_position(desync);
                     return Err(e.into());
                 }
             };
             let message = match self.profile.codec().decode_message(&frame) {
                 Ok(m) => m,
                 Err(e) => {
-                    poison_slot(Desync::ProtocolStateLost);
+                    record_stream_position(StreamPosition::StreamPositionUnknown);
                     return Err(e.into());
                 }
             };
@@ -2620,13 +2634,13 @@ impl RpcSessionInner {
                     let _restore = match NestedDeadlineGuard::lift(transport, deadline) {
                         Ok(g) => g,
                         Err(e) => {
-                            poison_slot(Desync::ReplyStillInbound);
+                            record_stream_position(StreamPosition::FrameBoundaryIntact);
                             return Err(e.into());
                         }
                     };
                     let peer = transport.peer_identity();
                     if let Err(e) = self.dispatch_transact(t, in_fds, peer) {
-                        poison_slot(Desync::ReplyStillInbound);
+                        record_stream_position(StreamPosition::FrameBoundaryIntact);
                         return Err(e);
                     }
                 }
@@ -3028,7 +3042,7 @@ impl RpcSessionInner {
             return ServeStep::Ended(EndReason::Retired);
         };
         // A nested call lost track of the stream: what is buffered is not ours.
-        if self.slot_poisoned(slot_id) {
+        if self.slot_unreadable(slot_id) {
             return ServeStep::Ended(EndReason::Unreadable);
         }
         let transport = conn.transport();
@@ -3250,7 +3264,7 @@ impl RpcSession {
     /// session therefore **cannot open a transaction of its own** —
     /// `get_root`, `RpcProxy::transact` and `ping_binder` called on it
     /// from outside a dispatch fail with
-    /// [`StatusCode::FailedTransaction`], because writing a request into
+    /// [`StatusCode::WouldBlock`], because writing a request into
     /// a connection the peer only reads inside its own reply wait would
     /// sit unread. Callbacks *from inside a twoway handler* are
     /// unaffected (they re-enter the dispatching connection). To call
@@ -3336,7 +3350,7 @@ impl RpcSession {
             role: founding_role,
             allow_nested: false,
             stale_replies: 0,
-            poisoned: false,
+            unreadable: false,
         };
         let (dec_strong_tx, dec_strong_rx) = mpsc::channel();
         let inner = Arc::new(RpcSessionInner {
@@ -4092,8 +4106,11 @@ impl RpcSession {
     /// The same deadline bounds how long a call waits for a free
     /// connection slot when every slot is driven by another thread — a
     /// session served on one thread and transacted on another needs more
-    /// than one connection, or its calls time out here without ever
-    /// reaching the peer.
+    /// than one connection. The two expiries are told apart by their
+    /// code: the slot wait fails with [`StatusCode::WouldBlock`] — the
+    /// request was never sent, so the call is safe to retry — where the
+    /// reply wait fails with [`StatusCode::TimedOut`], after the peer may
+    /// already have executed it.
     ///
     /// `Some(Duration::ZERO)` is **not** a valid deadline — the reply wait
     /// arms it as `SO_RCVTIMEO`, which rejects a zero duration — so it is
@@ -4921,9 +4938,9 @@ mod tests {
     /// has come off the wire undecoded, whether this call's `REPLY` is
     /// still coming is exactly what is unknown. If it is, the outer frame
     /// reads it and — `WireReply` carrying no transaction id — takes it as
-    /// its own answer. So the slot is poisoned (and the connection shut
-    /// down), which is what the non-reentrant arm achieves by retiring the
-    /// slot.
+    /// its own answer. So the slot is marked unreadable (and the
+    /// connection shut down), which is what the non-reentrant arm achieves
+    /// by retiring the slot.
     ///
     /// Two things are set up directly rather than driven through a peer:
     /// the `DRIVING` marker (what an outer frame's `find_conn` leaves
@@ -4934,8 +4951,8 @@ mod tests {
     /// the wire.
     ///
     /// **Mutant gate**: the flag *and* the refusal it exists for. Drop
-    /// the `mark_slot_poisoned` call and the flag assertion fails; drop
-    /// the poison check in `serve_once_on_slot` and the slot reads on as
+    /// the `mark_slot_unreadable` call and the flag assertion fails; drop
+    /// the unreadable check in `serve_once_on_slot` and the slot reads on as
     /// if nothing happened — the state in which the frame that owns the
     /// slot would go on to take the peer's next frame for its own.
     /// `shutdown` alone gates neither: what it does to already-received
@@ -4943,7 +4960,7 @@ mod tests {
     /// queue, a transport may hold a buffered leftover, the default impl
     /// is a no-op). The reply wait's half of the refusal needs a live
     /// connection, so it is gated by
-    /// `a_poisoned_slot_is_refused_by_the_reply_wait`.
+    /// `an_unreadable_slot_is_refused_before_a_request_is_sent`.
     #[test]
     fn a_nested_call_that_loses_the_stream_makes_the_slot_unreadable() {
         use crate::rpc::wire_android13::write_aosp_message;
@@ -5016,7 +5033,7 @@ mod tests {
             "a reentrant frame must not retire the outer frame's slot"
         );
         assert!(
-            session.inner.slot_poisoned(slot_id),
+            session.inner.slot_unreadable(slot_id),
             "the borrowed slot must be marked unreadable for its owner"
         );
         assert!(
@@ -5092,25 +5109,67 @@ mod tests {
         );
     }
 
-    /// The other reader of a poisoned slot — the reply wait inside
-    /// [`RpcSessionInner::client_transact`] — must refuse it too, and the
-    /// refusal must not rest on the connection being unusable.
+    /// Plan 2-21 B-7 — an unreadable slot is refused at *selection*, not
+    /// only at the two reads: the frame that owns it gets `DeadObject`
+    /// before writing anything, a scan for a free outgoing slot skips it
+    /// (and, this being the only one, fails fast with `WouldBlock`), and
+    /// the non-blocking selector declines it. Nothing is written on a
+    /// stream a nested call has already lost.
+    #[test]
+    fn an_unreadable_slot_is_never_selected_for_writing() {
+        let (a, _b) = super::super::transport::UnixTransport::pair().expect("socketpair");
+        let session = RpcSession::new(Box::new(a), AddressSpace::Initiator).expect("session");
+        let slot_id = session.inner.conn_state.lock().expect("conn_state").slots[0].id;
+        session.inner.mark_slot_unreadable(slot_id);
+
+        assert!(
+            matches!(session.inner.find_conn(), Err(StatusCode::WouldBlock)),
+            "the scan must not hand out the only outgoing slot once it is unreadable"
+        );
+        assert!(
+            session.inner.try_find_conn().is_none(),
+            "the non-blocking selector must decline it too"
+        );
+
+        // Reentrant: the frame that owns the slot asks for it again.
+        let sess_ptr = &*session.inner as *const RpcSessionInner as usize;
+        struct DrivingMark;
+        impl Drop for DrivingMark {
+            fn drop(&mut self) {
+                DRIVING.with(|d| {
+                    d.borrow_mut().pop();
+                });
+            }
+        }
+        DRIVING.with(|d| d.borrow_mut().push((sess_ptr, slot_id)));
+        let _mark = DrivingMark;
+        assert!(
+            matches!(session.inner.find_conn(), Err(StatusCode::DeadObject)),
+            "the owning frame must be refused before it writes"
+        );
+        assert!(session.inner.try_find_conn().is_none());
+    }
+
+    /// An unreadable slot is refused before a request is written on it,
+    /// and the refusal does not rest on the connection being unusable.
     ///
     /// Here the connection is perfectly healthy and a well-formed `REPLY`
-    /// is already waiting on it: exactly the shape of the theft the poison
-    /// exists to stop, since `WireReply` carries no transaction id and the
+    /// is already waiting on it: exactly the shape of the theft the mark
+    /// exists to stop, since `WireReply` carries no transaction id and a
     /// waiting frame cannot tell the peer's answer to an abandoned nested
-    /// call from its own. The slot is poisoned directly rather than
-    /// through a nested call, because a nested call also shuts the
-    /// connection down and would hide which of the two mechanisms did the
-    /// work.
+    /// call from its own. The slot is marked directly rather than through
+    /// a nested call, because a nested call also shuts the connection down
+    /// and would hide which mechanism did the work. The call fails at slot
+    /// selection (Plan 2-21 B-7), and the peer sees nothing sent.
     ///
-    /// **Mutant gate**: drop the poison check at the top of the reply
-    /// loop and this call returns `Ok(Some(_))` — the queued reply handed
-    /// back as this call's answer.
+    /// The reply wait keeps its own check for the one path that reaches
+    /// it: a nested call made from inside this frame's dispatch marks the
+    /// slot *after* selection, and the outer frame's next loop pass must
+    /// refuse it rather than read the frame waiting there.
     #[test]
-    fn a_poisoned_slot_is_refused_by_the_reply_wait() {
+    fn an_unreadable_slot_is_refused_before_a_request_is_sent() {
         use crate::rpc::wire_android13::write_aosp_message;
+        use std::io::Read;
         use std::os::unix::net::UnixStream;
 
         let (client_fd, peer_fd) = unix_socketpair_fd();
@@ -5144,7 +5203,7 @@ mod tests {
             .expect("encode a REPLY frame");
         write_aosp_message(&mut peer, &reply).expect("queue the reply frame");
 
-        session.inner.mark_slot_poisoned(slot_id);
+        session.inner.mark_slot_unreadable(slot_id);
 
         assert_eq!(
             session
@@ -5155,9 +5214,17 @@ mod tests {
                     &Parcel::new(),
                     0,
                 )
-                .expect_err("a poisoned slot must not be read again"),
-            StatusCode::DeadObject,
-            "the reply wait must refuse the slot, not decode the frame waiting on it"
+                .expect_err("an unreadable slot must not be used again"),
+            StatusCode::WouldBlock,
+            "the session's only outgoing slot is unreadable: refused at selection"
+        );
+        // Nothing went out: the peer's read finds no request.
+        peer.set_read_timeout(Some(Duration::from_millis(100)))
+            .expect("read timeout");
+        let mut buf = [0u8; 16];
+        assert!(
+            matches!(peer.read(&mut buf), Err(e) if super::super::transport::is_timeout(&e)),
+            "no request may be written on an unreadable slot"
         );
     }
 
@@ -5314,7 +5381,7 @@ mod tests {
         assert!(
             matches!(
                 session.inner.find_conn_lenient(),
-                Err(StatusCode::FailedTransaction)
+                Err(StatusCode::WouldBlock)
             ),
             "a DEC_STRONG must not claim the free serve-driven slot"
         );

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -21,6 +21,7 @@ use std::sync::mpsc;
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
+use super::end::{EndReason, ServeStep, SessionEnd};
 use super::fd_mode::FileDescriptorTransportMode;
 use super::lifecycle::SessionLifecycle;
 use crate::binder::{SIBinder, FLAG_ONEWAY, INTERFACE_TRANSACTION, PING_TRANSACTION};
@@ -1084,6 +1085,12 @@ pub(crate) struct SharedSession {
     /// empty slot pool — unlike an `obituary_sent`-style flag, which
     /// would only flip after the callback returned.
     lifecycle: SessionLifecycle,
+    /// Set by [`RpcSessionInner::close`] — this end decided to end the
+    /// session — before the transports are shut down, so every serve
+    /// loop that ends after that reports [`EndedBy::Local`], whether it
+    /// was woken out of `recv`, found its slot gone, or was holding a
+    /// frame it had just read. Never cleared.
+    ended_locally: AtomicBool,
     /// Which side of the connection this session is: decides the
     /// founding slot's [`SlotRole`] and the client-vs-server teardown
     /// rules for serve-driven slots.
@@ -1937,6 +1944,10 @@ impl RpcSessionInner {
     /// several workers drive ends the same way a sole-connection one does.
     pub(crate) fn close(&self) {
         if self.shared.lifecycle.force_dying() {
+            // Only the winner of the death CAS ended the session; set the
+            // flag before the transports go down so a worker woken by
+            // them — or holding a frame it read just before — sees it.
+            self.shared.ended_locally.store(true, Ordering::SeqCst);
             self.on_session_dead();
         }
     }
@@ -2536,7 +2547,7 @@ impl RpcSessionInner {
                 Err(e) => {
                     // Only a failure *at* a frame boundary leaves the reply
                     // inbound; the rest may have consumed part of one.
-                    let desync = if matches!(e, RpcError::PeerClosed | RpcError::Timeout) {
+                    let desync = if e.leaves_frame_boundary_intact() {
                         Desync::ReplyStillInbound
                     } else {
                         Desync::ProtocolStateLost
@@ -3008,32 +3019,46 @@ impl RpcSessionInner {
     /// Handle one inbound message on the pinned **slot** (a server
     /// worker drives a specific accepted connection's slot;
     /// nested outbound callbacks from the handler reuse this same slot
-    /// via the `DRIVING` marker).
-    /// `Ok(false)` ⇒ end of stream (stop); a slot a nested call marked
-    /// unreadable ends the loop with `Err(StatusCode::DeadObject)`.
-    fn serve_once_on_slot(&self, slot_id: u64) -> Result<bool> {
-        // The worker drives its own slot. Pinning normally succeeds, but a
-        // concurrent `client_transact` may have retired the slot after a
-        // stale-reply desync — `find_conn_pinned` then returns
-        // `DeadObject`, propagated so the worker exits cleanly.
-        let conn = self.find_conn_pinned(slot_id)?;
+    /// via the `DRIVING` marker). Every way the loop can end is named
+    /// here as an [`EndReason`]; the loop turns it into a [`SessionEnd`].
+    fn serve_once_on_slot(&self, slot_id: u64) -> ServeStep {
+        // A concurrent `client_transact` may have retired the slot, or the
+        // session may have ended: the loop is over either way.
+        let Ok(conn) = self.find_conn_pinned(slot_id) else {
+            return ServeStep::Ended(EndReason::Retired);
+        };
         // A nested call lost track of the stream: what is buffered is not ours.
         if self.slot_poisoned(slot_id) {
-            return Err(StatusCode::DeadObject);
+            return ServeStep::Ended(EndReason::Unreadable);
         }
         let transport = conn.transport();
         let (frame, in_fds) = match self.recv_msg(transport) {
             Ok(f) => f,
-            Err(RpcError::PeerClosed) => return Ok(false),
-            Err(e) => return Err(e.into()),
+            Err(RpcError::PeerClosed) => return ServeStep::Ended(EndReason::EndOfStream),
+            Err(RpcError::UncleanEndOfStream) => {
+                return ServeStep::Ended(EndReason::UncleanEndOfStream)
+            }
+            Err(e) => return ServeStep::Ended(EndReason::Frame(e.into())),
         };
-        match self.profile.codec().decode_message(&frame)? {
+        // This end ended the session while the frame was in flight (a
+        // kernel that keeps its queue hands it over even after the
+        // shutdown): it belongs to a session that is over.
+        if self.shared.ended_locally.load(Ordering::SeqCst) {
+            return ServeStep::Ended(EndReason::Interrupted);
+        }
+        let msg = match self.profile.codec().decode_message(&frame) {
+            Ok(m) => m,
+            Err(e) => return ServeStep::Ended(EndReason::Frame(e.into())),
+        };
+        match msg {
             WireMessage::Transact(t) => {
                 // Resolve the connecting peer's identity (Plan 2-16
                 // Phase B) so the dispatch can stamp the calling uid/pid.
                 let peer = transport.peer_identity();
-                self.dispatch_transact(t, in_fds, peer)?;
-                Ok(true)
+                match self.dispatch_transact(t, in_fds, peer) {
+                    Ok(()) => ServeStep::Continue,
+                    Err(e) => ServeStep::Ended(EndReason::Dispatch(e)),
+                }
             }
             WireMessage::DecStrong(a, amount) => {
                 // Bind the removed ref so it drops after the guard (a
@@ -3046,18 +3071,18 @@ impl RpcSessionInner {
                     .expect("rpc state poisoned")
                     .dec_strong_local(&a, amount);
                 drop(released);
-                Ok(true)
+                ServeStep::Continue
             }
             WireMessage::Reply(_) => {
                 if self.take_stale_reply(slot_id) {
                     log::debug!("RPC: skipped the late reply of an abandoned nested call");
-                    return Ok(true);
+                    return ServeStep::Continue;
                 }
                 // AOSP `RpcState::processCommand` ends the session for an
                 // unsolicited command ("misbehaving client"); ignoring it
                 // would let a peer flood the log at wire speed.
                 log::warn!("RPC server received an unexpected REPLY; ending the session");
-                Err(StatusCode::BadType)
+                ServeStep::Ended(EndReason::Frame(StatusCode::BadType))
             }
         }
     }
@@ -3271,6 +3296,7 @@ impl RpcSession {
             fd_unix_supported: AtomicBool::new(false),
             rpc_session_id: gen_rpc_session_id()?,
             lifecycle: SessionLifecycle::new(),
+            ended_locally: AtomicBool::new(false),
             space,
         }))
     }
@@ -3874,26 +3900,17 @@ impl RpcSession {
     /// AOSP's `getMaxIncomingThreads() >= 1` requirement for an RPC
     /// `linkToDeath`.
     ///
-    /// `Ok(())` is the clean end only: this connection's read reached
-    /// end of stream. Which side ended it is not part of that — the loop
-    /// returns `Ok(())` when the peer closed the connection or went
-    /// away, and equally when *this* side closed it, since
-    /// [`RpcSession::shutdown`](RpcSession::shutdown) — and every other
-    /// path that declares the session dead — shuts each slot's transport
-    /// down, and a serve loop woken out of `recv` that way ends here.
-    /// Every other end is an `Err`, including the case
-    /// where this loop's own read never failed — when a nested call made
-    /// from a handler on this same connection can no longer account for
-    /// what the peer sends next (a frame that arrived and did not decode,
-    /// or a read that failed without the guarantee that it stopped at a
-    /// frame boundary), the connection is marked unreadable and the loop
-    /// ends with [`StatusCode::DeadObject`] rather than interpreting
-    /// bytes whose meaning is unknowable. A caller (or a log line) can
-    /// therefore always tell the clean end from every other one — but not
-    /// a live peer from a dead one: that `Err` is reached both when the
-    /// peer is still up and only this end's view of the stream was lost,
-    /// and when the peer itself went away in the middle of a frame.
-    pub fn serve_blocking(&self) -> Result<()> {
+    /// The returned [`SessionEnd`] says how the loop ended, on three
+    /// axes: whether the stream was still intact
+    /// ([`stream`](SessionEnd::stream)), whether this end decided to end
+    /// it ([`by`](SessionEnd::by)), and what happened
+    /// ([`reason`](SessionEnd::reason)). A caller that wants only
+    /// "did it end well" calls [`into_result`](SessionEnd::into_result):
+    /// `Ok(())` for an intact stream — a peer that closed, or this end's
+    /// own [`shutdown`](RpcSession::shutdown), read the same — and
+    /// `Err(`[`StatusCode::DeadObject`]`)` for a lost one, whatever the
+    /// cause; the cause is in the value, not in the code.
+    pub fn serve_blocking(&self) -> SessionEnd {
         self.serve_blocking_on(Self::FOUNDING_SLOT_ID)
     }
 
@@ -3904,21 +3921,15 @@ impl RpcSession {
     /// [`serve_blocking`](RpcSession::serve_blocking) is exactly this
     /// on the founding slot (`FOUNDING_SLOT_ID`).
     ///
-    /// The return contract is that of
+    /// Returns the same [`SessionEnd`] as
     /// [`serve_blocking`](RpcSession::serve_blocking), which delegates
-    /// here: `Ok(())` is the clean end only — end of stream on this
-    /// connection, whether the peer ended it or this side did — and
-    /// every other end is an `Err`.
-    /// This is also where that contract's one surprising end is actually
-    /// reached, since a handler runs on the slot it is served on: when a
-    /// nested call made from such a handler over this same connection can
-    /// no longer account for what the peer sends next (a frame that
-    /// arrived and did not decode, or a read that failed without the
-    /// guarantee that it stopped at a frame boundary), the slot is marked
-    /// unreadable and the loop ends with [`StatusCode::DeadObject`] —
-    /// which, as [`serve_blocking`](RpcSession::serve_blocking) states,
-    /// implies nothing about whether the peer is still up.
-    pub fn serve_blocking_on(&self, slot_id: u64) -> Result<()> {
+    /// here. One end is reached mostly on this path, since a handler runs
+    /// on the slot it is served on: a nested call made from such a
+    /// handler over this same connection that can no longer account for
+    /// what the peer sends next marks the slot unreadable, and the loop
+    /// ends with [`EndReason::Unreadable`] and a lost stream — which says
+    /// nothing about whether the peer is still up.
+    pub fn serve_blocking_on(&self, slot_id: u64) -> SessionEnd {
         self.serve_blocking_on_inner(slot_id, false)
     }
 
@@ -3930,7 +3941,7 @@ impl RpcSession {
     /// first contact, so a connected-but-silent peer's worker must still be
     /// bounded by the deadline, while an established two-way session idles
     /// unbounded between requests after that first frame.
-    pub fn serve_blocking_clearing_deadline_after_first(&self) -> Result<()> {
+    pub fn serve_blocking_clearing_deadline_after_first(&self) -> SessionEnd {
         self.serve_blocking_on_inner(Self::FOUNDING_SLOT_ID, true)
     }
 
@@ -3938,37 +3949,34 @@ impl RpcSession {
         &self,
         slot_id: u64,
         clear_deadline_after_first: bool,
-    ) -> Result<()> {
+    ) -> SessionEnd {
         // Read the slot's role now: a `RpcSession::shutdown` racing this
         // loop clears the pool, and a role read after the loop would come
         // back `false` for a slot that is simply gone.
         let client_incoming = self.inner.is_client_incoming_slot(slot_id);
-        let result = {
-            let mut r = Ok(());
+        let reason = {
             let mut first = clear_deadline_after_first;
             loop {
                 match self.inner.serve_once_on_slot(slot_id) {
-                    Ok(cont) => {
+                    ServeStep::Continue => {
                         // First-frame-only deadline: once the first frame is
-                        // read (or a clean EOF arrives), lift the admission
-                        // deadline so subsequent idle waits are unbounded.
+                        // read, lift the admission deadline so subsequent
+                        // idle waits are unbounded.
                         if first {
                             self.inner.clear_slot_read_timeout(slot_id);
                             first = false;
                         }
-                        if cont {
-                            continue;
-                        }
-                        break;
                     }
-                    Err(e) => {
-                        r = Err(e);
-                        break;
-                    }
+                    ServeStep::Ended(reason) => break reason,
                 }
             }
-            r
         };
+        // Attribution is read at the loop's exit, before this worker's own
+        // teardown below — which is never a local decision.
+        let end = SessionEnd::new(
+            reason,
+            self.inner.shared.ended_locally.load(Ordering::SeqCst),
+        );
         // Typed lifecycle: this
         // connection is finished. Fire the session obituaries only on
         // the **last** connection's teardown (full session death) —
@@ -4011,7 +4019,7 @@ impl RpcSession {
         {
             self.inner.on_session_dead();
         }
-        result
+        end
     }
 
     /// Internal: set this session's advertised max-threads value
@@ -4565,9 +4573,9 @@ impl RpcSession {
             .name(format!("rsbinder-rpc-in-{slot_id}"))
             .spawn(move || {
                 let session = RpcSession::wrap_inner(inner);
-                if let Err(e) = session.serve_blocking_on(slot_id) {
-                    log::debug!("RPC: incoming connection {slot_id} ended: {e:?}");
-                }
+                session
+                    .serve_blocking_on(slot_id)
+                    .log(&format!("RPC: incoming connection {slot_id} ended"));
                 // Last act of the thread — see `incoming_live`.
                 session.inner.incoming_live.fetch_sub(1, Ordering::SeqCst);
             });
@@ -5017,13 +5025,70 @@ mod tests {
         );
         // The flag is only worth having if a reader honors it: the serve
         // loop must refuse the slot rather than read whatever comes next.
-        assert_eq!(
-            session
-                .inner
-                .serve_once_on_slot(slot_id)
-                .expect_err("a poisoned slot must not be served"),
-            StatusCode::DeadObject,
+        assert!(
+            matches!(
+                session.inner.serve_once_on_slot(slot_id),
+                ServeStep::Ended(EndReason::Unreadable)
+            ),
             "the serve loop must refuse the slot, not read another frame on it"
+        );
+    }
+
+    /// Plan 2-21 C-0 — a frame the serve loop reads after this end has
+    /// ended the session is not dispatched. A kernel that keeps its
+    /// receive queue across a local shutdown (Linux) can hand one over;
+    /// the loop then ends with `Interrupted` before the decoder sees it.
+    /// The same frame on a session that was not ended reaches the
+    /// decoder — here it is undecodable, so the contrast is a `Frame`
+    /// end — which pins the gate, not the frame, as what decides.
+    #[test]
+    fn a_frame_read_after_a_local_end_is_not_dispatched() {
+        use crate::rpc::wire_android13::write_aosp_message;
+        use std::os::unix::net::UnixStream;
+
+        let build = || {
+            let (client_fd, peer_fd) = unix_socketpair_fd();
+            let mut peer = UnixStream::from(peer_fd);
+            let session = RpcSession::with_profile(
+                Box::new(
+                    super::super::transport::UnixTransport::from_stream(UnixStream::from(
+                        client_fd,
+                    ))
+                    .expect("transport"),
+                ),
+                AddressSpace::Acceptor,
+                WireProfile::Android13Plus(
+                    Android13PlusCodec::with_version(PROTOCOL_V2).expect("v2"),
+                ),
+            )
+            .expect("session");
+            let mut undecodable = [0u8; 16];
+            undecodable[0..4].copy_from_slice(&7u32.to_le_bytes());
+            write_aosp_message(&mut peer, &undecodable).expect("queue a frame");
+            (session, peer)
+        };
+
+        let (ended, _peer) = build();
+        ended
+            .inner
+            .shared
+            .ended_locally
+            .store(true, Ordering::SeqCst);
+        assert!(
+            matches!(
+                ended.inner.serve_once_on_slot(RpcSession::FOUNDING_SLOT_ID),
+                ServeStep::Ended(EndReason::Interrupted)
+            ),
+            "a frame read after a local end must end the loop, not be dispatched"
+        );
+
+        let (live, _peer) = build();
+        assert!(
+            matches!(
+                live.inner.serve_once_on_slot(RpcSession::FOUNDING_SLOT_ID),
+                ServeStep::Ended(EndReason::Frame(_))
+            ),
+            "the same frame on a live session reaches the decoder"
         );
     }
 

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -1929,6 +1929,18 @@ impl RpcSessionInner {
         }
     }
 
+    /// End this session now, whatever its connection count: declare
+    /// death (`Live(n) → Dying`) and run the death sequence. Exactly one
+    /// caller does the work; from `Dying`/`Dead` it is a no-op. Both
+    /// [`RpcSession::shutdown`] and the server's
+    /// [`terminate`](super::RpcServer::terminate) land here, so a session
+    /// several workers drive ends the same way a sole-connection one does.
+    pub(crate) fn close(&self) {
+        if self.shared.lifecycle.force_dying() {
+            self.on_session_dead();
+        }
+    }
+
     /// Full session death (the `Dying` state has just been entered):
     /// fire the obituaries, settle to `Dead`, then release every local
     /// object the peer held (AOSP `RpcState::clear`) — the step that
@@ -4019,7 +4031,10 @@ impl RpcSession {
     /// Declare this session dead now: fire every cached proxy's
     /// `binder_died` and release every local object the peer held (AOSP
     /// `RpcState::clear`). Idempotent; subsequent transactions on proxies
-    /// of this session fail with [`StatusCode::DeadObject`].
+    /// of this session fail with [`StatusCode::DeadObject`]. The
+    /// connection count does not matter: a session several workers drive
+    /// (a server session with attached connections) is ended the same
+    /// way — every slot's transport is shut down and its workers exit.
     ///
     /// Normally death is detected on its own — a serve loop ending, or a
     /// transaction failing on a lost connection. This is the explicit
@@ -4041,15 +4056,7 @@ impl RpcSession {
     /// the founding slot is not joined; it exits on its own once the
     /// transport is shut down.
     pub fn shutdown(&self) {
-        let lifecycle = &self.inner.shared.lifecycle;
-        if lifecycle.try_drop_sole_connection() {
-            self.inner.on_session_dead();
-        } else if !lifecycle.is_torn_down() {
-            log::warn!(
-                "RpcSession::shutdown: {} connections still live; nothing torn down",
-                lifecycle.live_count()
-            );
-        }
+        self.inner.close();
         let me = std::thread::current().id();
         for (slot_id, handle) in self.inner.take_incoming_threads() {
             if handle.thread().id() == me {

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -5120,6 +5120,211 @@ mod tests {
         );
     }
 
+    /// AC-21.24 — a **real** nested dispatch whose nested call loses the
+    /// stream: the outer call must fail, and the frames the peer already
+    /// queued must not be taken as its reply.
+    ///
+    /// This thread is the client and makes the outer call; a scripted
+    /// peer thread reads the outer `TRANSACT` and answers with four frames
+    /// in one write — a nested `TRANSACT` into a local object of this
+    /// session, an undecodable frame (command 7), and two `REPLY`s. The
+    /// outer's reply wait dispatches the nested `TRANSACT` inline; the
+    /// handler makes a nested call on the same slot (reentrant), whose
+    /// reply wait reads the undecodable frame and marks the slot
+    /// unreadable; the handler swallows that error and returns `Ok` — the
+    /// worst case for the frame that owns the slot.
+    ///
+    /// What the outer sees: `DeadObject`, its slot retired, the session
+    /// dead. Which check fires: the reply to the nested `TRANSACT` is
+    /// refused at slot selection (`find_conn_impl` for `ConnUse::Reply`
+    /// declines an unreadable slot), so the dispatch fails and the outer
+    /// returns through its dispatch-error arm. The check at the top of the
+    /// reply-wait loop is not reached this way — the selector refuses the
+    /// slot before a send is attempted, and every in-tree transport fails
+    /// this end's sends after `shutdown` anyway — so it is defensive.
+    ///
+    /// **Mutant gate**: treat the nested loss as `FrameBoundaryIntact`
+    /// (`note_stale_reply` instead of `mark_slot_unreadable` + shutdown)
+    /// and the outer skips the first `REPLY` as its nested call's late
+    /// answer and takes the second as its own — `Ok(Some(_))`, the wire
+    /// now one reply out of step. Two `REPLY`s are queued for exactly
+    /// that: with one, that mutant would run into end of stream and fail
+    /// for the wrong reason. Platform-independent, because that mutant
+    /// never shuts the socket down and so the queue is intact on both;
+    /// the platform split (macOS discards the queue on shutdown, Linux
+    /// keeps it) is on the *correct* path, which is why no end-of-stream
+    /// reason is asserted here.
+    #[test]
+    fn a_real_nested_call_that_loses_the_stream_fails_the_outer_call() {
+        use crate::rpc::wire_android13::read_aosp_message;
+        use crate::{Binder, Interface, Remotable, TransactionCode};
+        use std::io::{Read, Write};
+        use std::os::unix::net::UnixStream;
+
+        const DESC: &str = "rsbinder.test.INestedLoser";
+        const TX_OUTER: TransactionCode = crate::FIRST_CALL_TRANSACTION;
+        const TX_CALLBACK: TransactionCode = crate::FIRST_CALL_TRANSACTION + 1;
+        const TX_NESTED: TransactionCode = crate::FIRST_CALL_TRANSACTION + 2;
+
+        /// The local object the peer calls back into: its handler makes
+        /// the nested call and swallows its failure.
+        struct Loser {
+            session: Arc<Mutex<Option<Arc<RpcSessionInner>>>>,
+            nested: Arc<Mutex<Option<Result<()>>>>,
+        }
+        impl Interface for Loser {}
+        impl Remotable for Loser {
+            fn descriptor() -> &'static str {
+                DESC
+            }
+            fn on_transact(
+                &self,
+                code: TransactionCode,
+                _reader: &mut Parcel,
+                _reply: &mut Parcel,
+            ) -> Result<()> {
+                assert_eq!(code, TX_CALLBACK, "the peer's nested TRANSACT");
+                let session = self
+                    .session
+                    .lock()
+                    .expect("session cell")
+                    .clone()
+                    .expect("session installed before the outer call");
+                let r = session
+                    .client_transact(RpcAddress::zero(), TX_NESTED, &Parcel::new(), 0)
+                    .map(|_| ());
+                *self.nested.lock().expect("nested cell") = Some(r);
+                Ok(())
+            }
+            fn on_dump(&self, _w: &mut dyn std::io::Write, _a: &[String]) -> Result<()> {
+                Ok(())
+            }
+        }
+
+        let (client_fd, peer_fd) = unix_socketpair_fd();
+        let mut peer = UnixStream::from(peer_fd);
+        peer.set_read_timeout(Some(Duration::from_secs(10)))
+            .expect("peer read timeout");
+        // Ends the peer thread's final read from here: whether this end's
+        // `shutdown` reaches a peer parked in `read` is the platform's
+        // business (pinned by the transport conformance suite), not this
+        // test's.
+        let peer_dup = peer.try_clone().expect("dup the peer socket");
+        let session = RpcSession::with_profile(
+            Box::new(
+                super::super::transport::UnixTransport::from_stream(UnixStream::from(client_fd))
+                    .expect("transport"),
+            ),
+            AddressSpace::Initiator,
+            WireProfile::Android13Plus(Android13PlusCodec::with_version(PROTOCOL_V2).expect("v2")),
+        )
+        .expect("session");
+        // A hang is a failure, not a wait: bound every reply wait.
+        session.set_timeout(Some(Duration::from_secs(10)));
+
+        let session_cell = Arc::new(Mutex::new(Some(Arc::clone(&session.inner))));
+        let nested_cell: Arc<Mutex<Option<Result<()>>>> = Arc::new(Mutex::new(None));
+        let cb: SIBinder = Interface::as_binder(&Binder::new(Loser {
+            session: Arc::clone(&session_cell),
+            nested: Arc::clone(&nested_cell),
+        }));
+        // Hand the peer an address for `cb` as sending it in a parcel
+        // would; the peer scripts its callback against that address.
+        let cb_addr = session
+            .inner
+            .shared
+            .state
+            .lock()
+            .expect("rpc state")
+            .on_binder_leaving(&cb)
+            .expect("address for the callback");
+        let (slot_id, slot_transport) = {
+            let st = session.inner.conn_state.lock().expect("conn_state");
+            (st.slots[0].id, Arc::clone(&st.slots[0].transport))
+        };
+
+        let peer_thread = std::thread::spawn(move || {
+            let codec = Android13PlusCodec::with_version(PROTOCOL_V2).expect("v2");
+            let frame = read_aosp_message(&mut peer).expect("the outer TRANSACT");
+            match codec
+                .decode_message(&frame)
+                .expect("decode the outer TRANSACT")
+            {
+                WireMessage::Transact(t) => assert_eq!(t.code, TX_OUTER),
+                other => panic!("expected the outer TRANSACT, got {other:?}"),
+            }
+            let mut token = Parcel::new();
+            write_rpc_interface_token(&mut token, DESC).expect("interface token");
+            let nested = codec
+                .encode_transact(&WireTransaction {
+                    address: cb_addr,
+                    code: TX_CALLBACK,
+                    flags: 0,
+                    async_number: 0,
+                    data: token.rpc_data_bytes().to_vec(),
+                    object_positions: Vec::new(),
+                })
+                .expect("encode the nested TRANSACT");
+            // Command 7 is none of AOSP's three, so the frame is
+            // well-formed to the framing reader and undecodable to the
+            // codec — what the nested call's reply wait will read.
+            let mut undecodable = [0u8; 16];
+            undecodable[0..4].copy_from_slice(&7u32.to_le_bytes());
+            let reply = codec
+                .encode_reply(&WireReply::default())
+                .expect("encode a REPLY");
+            let mut burst = nested;
+            burst.extend_from_slice(&undecodable);
+            burst.extend_from_slice(&reply);
+            burst.extend_from_slice(&reply);
+            peer.write_all(&burst).expect("queue the burst");
+            peer.flush().expect("flush the burst");
+            // Stay connected until the client ends the connection, so
+            // nothing here decides when the stream ends. What the client
+            // sent (the nested request) is drained and ignored.
+            let mut sink = Vec::new();
+            let _ = peer.read_to_end(&mut sink);
+        });
+
+        let outer = session
+            .inner
+            .client_transact(RpcAddress::zero(), TX_OUTER, &Parcel::new(), 0);
+        assert!(
+            matches!(outer, Err(StatusCode::DeadObject)),
+            "the outer call must fail as DeadObject, got {outer:?}"
+        );
+        assert!(
+            matches!(
+                *nested_cell.lock().expect("nested cell"),
+                Some(Err(StatusCode::RpcError))
+            ),
+            "the nested call must have run and failed on the undecodable frame"
+        );
+        assert!(
+            session
+                .inner
+                .conn_state
+                .lock()
+                .expect("conn_state")
+                .slots
+                .is_empty(),
+            "the outer frame owns slot {slot_id} and must retire it on the way out"
+        );
+        assert!(
+            session.inner.shared.lifecycle.is_torn_down(),
+            "the only connection is gone, so the session is dead"
+        );
+        assert!(
+            slot_transport.send_raw(b"x").is_err(),
+            "the lost connection must be shut down, not left usable"
+        );
+
+        session.close_session();
+        drop(slot_transport);
+        let _ = peer_dup.shutdown(std::net::Shutdown::Both);
+        peer_thread.join().expect("peer thread");
+    }
+
     /// Plan 2-21 B-7 — an unreadable slot is refused at *selection*, not
     /// only at the two reads: the frame that owns it gets `DeadObject`
     /// before writing anything, a scan for a free outgoing slot skips it

--- a/rsbinder/src/rpc/strong_session_tests.rs
+++ b/rsbinder/src/rpc/strong_session_tests.rs
@@ -154,7 +154,7 @@ fn proxy_outlives_session_handle() {
     );
     drop(root);
     // Last proxy gone ⇒ client transport closed ⇒ server serve loop ends.
-    jh.join().expect("serve thread").ok();
+    let _ = jh.join().expect("serve thread");
     drop(server);
 }
 
@@ -179,7 +179,7 @@ fn server_side_callback_cycle_reclaimed_on_client_disconnect() {
     drop(client);
     drop(cb);
 
-    jh.join().expect("serve thread").ok();
+    let _ = jh.join().expect("serve thread");
     assert!(
         wait_gone(&probe),
         "server session leaked through root → Holder → callback proxy"
@@ -220,7 +220,7 @@ fn explicit_shutdown_breaks_cycle_without_any_transaction() {
         wait_gone(&probe),
         "shutdown() must release the peer's local objects and break the cycle"
     );
-    jh.join().expect("serve thread").ok();
+    let _ = jh.join().expect("serve thread");
 }
 
 /// A.1b / test 2b: the **client** has no serve thread and stores the
@@ -251,7 +251,7 @@ fn client_side_callback_cycle_reclaimed_on_server_death() {
     server_dup
         .shutdown(Shutdown::Both)
         .expect("kill server socket");
-    jh.join().expect("serve thread").ok();
+    let _ = jh.join().expect("serve thread");
     drop(server);
 
     drop(cb);

--- a/rsbinder/src/rpc/strong_session_tests.rs
+++ b/rsbinder/src/rpc/strong_session_tests.rs
@@ -187,7 +187,7 @@ fn server_side_callback_cycle_reclaimed_on_client_disconnect() {
 }
 
 /// The cycle case the runtime cannot detect on its own: a client that
-/// neither serves nor transacts again. `RpcSession::shutdown` is the
+/// neither serves nor transacts again. `RpcSession::close_session` is the
 /// explicit break — without it the graph would stay alive for the
 /// process lifetime.
 #[test]
@@ -209,7 +209,7 @@ fn explicit_shutdown_breaks_cycle_without_any_transaction() {
 
     // Abandon the session: no serve loop here, no further transactions.
     drop(root);
-    client.shutdown();
+    client.close_session();
     drop(client);
     drop(server);
 
@@ -336,7 +336,7 @@ fn argument_proxy_dec_strong_follows_the_reply_on_the_serving_connection() {
 
     drop(root);
     drop(client);
-    server.shutdown();
+    server.stop_accepting();
     let _ = bg.join();
     let _ = std::fs::remove_file(&path);
 }

--- a/rsbinder/src/rpc/strong_session_tests.rs
+++ b/rsbinder/src/rpc/strong_session_tests.rs
@@ -218,7 +218,7 @@ fn explicit_shutdown_breaks_cycle_without_any_transaction() {
     // hang instead of failing.
     assert!(
         wait_gone(&probe),
-        "shutdown() must release the peer's local objects and break the cycle"
+        "close_session() must release the peer's local objects and break the cycle"
     );
     let _ = jh.join().expect("serve thread");
 }

--- a/rsbinder/src/rpc/transport/mem.rs
+++ b/rsbinder/src/rpc/transport/mem.rs
@@ -8,11 +8,20 @@
 //! entirely. Two `MemTransport`s from [`MemTransport::pair`] are wired
 //! cross-over so a write on one is a read on the other.
 //!
+//! `shutdown` models a **Linux** socket, deliberately: frames already
+//! queued on either side are still delivered, then the end of stream;
+//! later sends on either side fail. Linux is the deployment target, and
+//! it is the platform where a caller that assumes a shutdown discards
+//! what was queued is wrong — a hermetic backend that modelled the other
+//! platform (macOS drops its queue) would certify that assumption on the
+//! developer's machine and let it break on the device.
+//!
 //! There is no global state — every test makes its own independent
 //! pair, so the RPC test suite is parallel-safe by construction.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Sender};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use super::{PeerIdentity, RpcTransport};
 use crate::rpc::{RpcError, RpcResult};
@@ -29,12 +38,18 @@ pub struct MemTransport {
     peer: PeerIdentity,
     desc: &'static str,
     timeout: Mutex<Option<std::time::Duration>>,
-    /// Set by [`shutdown`](RpcTransport::shutdown); `recv_frame` then
-    /// reports `PeerClosed` even if frames are queued. A blocked
-    /// `recv_frame` notices within one poll tick — a sender into our own
-    /// `rx` would have been a cleaner wake-up, but it would also keep the
-    /// channel alive past the peer's drop and hide `PeerClosed`.
-    closed: std::sync::atomic::AtomicBool,
+    /// Set by this end's [`shutdown`](RpcTransport::shutdown); shared with
+    /// the peer as its `peer_closed`. Frames already queued are still
+    /// delivered (the Linux model — see the module doc); once the queue is
+    /// empty `recv_frame` reports `PeerClosed`, and sends on either side
+    /// fail. A blocked `recv_frame` notices within one poll tick — a
+    /// sender into our own `rx` would have been a cleaner wake-up, but it
+    /// would also keep the channel alive past the peer's drop and hide
+    /// `PeerClosed`.
+    closed: Arc<AtomicBool>,
+    /// The peer's `closed`: its shutdown is our end of stream and our
+    /// `EPIPE`, as a socket peer's `shutdown(Both)` would be.
+    peer_closed: Arc<AtomicBool>,
 }
 
 impl MemTransport {
@@ -45,6 +60,8 @@ impl MemTransport {
         let (a_tx, a_rx) = std::sync::mpsc::channel();
         let (b_tx, b_rx) = std::sync::mpsc::channel();
         let peer = self_identity();
+        let a_closed = Arc::new(AtomicBool::new(false));
+        let b_closed = Arc::new(AtomicBool::new(false));
         (
             MemTransport {
                 tx: a_tx,
@@ -52,7 +69,8 @@ impl MemTransport {
                 peer: peer.clone(),
                 desc: "mem",
                 timeout: Mutex::new(None),
-                closed: std::sync::atomic::AtomicBool::new(false),
+                closed: Arc::clone(&a_closed),
+                peer_closed: Arc::clone(&b_closed),
             },
             MemTransport {
                 tx: b_tx,
@@ -60,9 +78,14 @@ impl MemTransport {
                 peer,
                 desc: "mem",
                 timeout: Mutex::new(None),
-                closed: std::sync::atomic::AtomicBool::new(false),
+                closed: b_closed,
+                peer_closed: a_closed,
             },
         )
+    }
+
+    fn either_end_shut(&self) -> bool {
+        self.closed.load(Ordering::SeqCst) || self.peer_closed.load(Ordering::SeqCst)
     }
 }
 
@@ -87,12 +110,11 @@ impl RpcTransport for MemTransport {
                 max: super::MAX_FRAME_LEN,
             });
         }
-        // `shutdown` closed this end in both directions, so a later send
-        // must fail as the socket backends' `shutdown(Both)` makes it
-        // fail (EPIPE) — callers rely on that to retire a slot whose
-        // handshake failed. Without it the frame would queue on an
-        // unbounded channel nobody reads.
-        if self.closed.load(std::sync::atomic::Ordering::SeqCst) {
+        // A shutdown on either end makes a later send fail, as the socket
+        // backends' `shutdown(Both)` does on both sides (EPIPE) — callers
+        // rely on that to retire a slot whose handshake failed. Without it
+        // the frame would queue on an unbounded channel nobody reads.
+        if self.either_end_shut() {
             return Err(RpcError::PeerClosed);
         }
         // A channel send only fails once the peer's receiver is
@@ -101,10 +123,6 @@ impl RpcTransport for MemTransport {
     }
 
     fn recv_frame(&self) -> RpcResult<Vec<u8>> {
-        use std::sync::atomic::Ordering;
-        if self.closed.load(Ordering::SeqCst) {
-            return Err(RpcError::PeerClosed);
-        }
         let timeout = *self.timeout.lock().expect("mem timeout poisoned");
         let rx = self.rx.lock().expect("mem rx poisoned");
         // Block in short `recv_timeout` ticks so a local `shutdown` is
@@ -128,17 +146,14 @@ impl RpcTransport for MemTransport {
                 None => TICK,
             };
             match rx.recv_timeout(wait) {
-                Ok(frame) => {
-                    if self.closed.load(Ordering::SeqCst) {
-                        return Err(RpcError::PeerClosed);
-                    }
-                    return Ok(frame);
-                }
+                // Queued before a shutdown on either end: still delivered,
+                // as a Linux socket delivers what it has queued.
+                Ok(frame) => return Ok(frame),
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                     return Err(RpcError::PeerClosed);
                 }
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                    if self.closed.load(Ordering::SeqCst) {
+                    if self.either_end_shut() {
                         return Err(RpcError::PeerClosed);
                     }
                 }
@@ -155,7 +170,7 @@ impl RpcTransport for MemTransport {
     }
 
     fn shutdown(&self) -> RpcResult<()> {
-        self.closed.store(true, std::sync::atomic::Ordering::SeqCst);
+        self.closed.store(true, Ordering::SeqCst);
         Ok(())
     }
 
@@ -180,23 +195,33 @@ mod tests {
         }
     }
 
-    /// `RpcTransport::shutdown` promises both directions: a blocked
-    /// `recv_frame` returns **and** later sends fail. The socket backends
-    /// get the second half from `shutdown(Both)`; `mem` has to model it,
-    /// or a teardown bug that a real transport would surface stays
-    /// invisible to every hermetic test.
+    /// `RpcTransport::shutdown` on a Linux socket: what either side had
+    /// queued is still delivered, then the end of stream; later sends on
+    /// either side fail. `mem` models exactly that (module doc), so a
+    /// teardown bug that a real transport would surface on the device is
+    /// visible to every hermetic test.
     #[test]
-    fn mem_shutdown_fails_later_sends() {
+    fn mem_shutdown_models_a_linux_socket() {
         let (a, b) = MemTransport::pair();
-        a.send_frame(b"before").expect("send before shutdown");
+        a.send_frame(b"a->b before").expect("send before shutdown");
+        b.send_frame(b"b->a before").expect("send before shutdown");
         a.shutdown().expect("shutdown");
+        a.shutdown().expect("a second shutdown is Ok");
+        // Our side: the queued frame first, then the end of stream; sends fail.
+        assert_eq!(
+            a.recv_frame().expect("queued frame survives"),
+            b"b->a before"
+        );
+        assert!(matches!(a.recv_frame(), Err(RpcError::PeerClosed)));
         assert!(
             matches!(a.send_frame(b"after"), Err(RpcError::PeerClosed)),
             "a send after shutdown must fail, not queue"
         );
-        assert!(matches!(a.recv_frame(), Err(RpcError::PeerClosed)));
-        // The peer end is untouched — only this side was shut down.
-        assert_eq!(b.recv_frame().expect("peer still reads"), b"before");
+        // The peer: drains what we sent, then sees our shutdown as its
+        // end of stream, and its sends fail (EPIPE on a socket).
+        assert_eq!(b.recv_frame().expect("peer drains"), b"a->b before");
+        assert!(matches!(b.recv_frame(), Err(RpcError::PeerClosed)));
+        assert!(matches!(b.send_frame(b"x"), Err(RpcError::PeerClosed)));
     }
 
     #[test]

--- a/rsbinder/src/rpc/transport/mem.rs
+++ b/rsbinder/src/rpc/transport/mem.rs
@@ -41,11 +41,11 @@ pub struct MemTransport {
     /// Set by this end's [`shutdown`](RpcTransport::shutdown); shared with
     /// the peer as its `peer_closed`. Frames already queued are still
     /// delivered (the Linux model — see the module doc); once the queue is
-    /// empty `recv_frame` reports `PeerClosed`, and sends on either side
+    /// empty `recv_frame` reports `EndOfStream`, and sends on either side
     /// fail. A blocked `recv_frame` notices within one poll tick — a
     /// sender into our own `rx` would have been a cleaner wake-up, but it
     /// would also keep the channel alive past the peer's drop and hide
-    /// `PeerClosed`.
+    /// `EndOfStream`.
     closed: Arc<AtomicBool>,
     /// The peer's `closed`: its shutdown is our end of stream and our
     /// `EPIPE`, as a socket peer's `shutdown(Both)` would be.
@@ -115,11 +115,13 @@ impl RpcTransport for MemTransport {
         // rely on that to retire a slot whose handshake failed. Without it
         // the frame would queue on an unbounded channel nobody reads.
         if self.either_end_shut() {
-            return Err(RpcError::PeerClosed);
+            return Err(RpcError::EndOfStream);
         }
         // A channel send only fails once the peer's receiver is
         // dropped — i.e. the peer is gone. Lock-free (`Sender: Sync`).
-        self.tx.send(buf.to_vec()).map_err(|_| RpcError::PeerClosed)
+        self.tx
+            .send(buf.to_vec())
+            .map_err(|_| RpcError::EndOfStream)
     }
 
     fn recv_frame(&self) -> RpcResult<Vec<u8>> {
@@ -150,11 +152,11 @@ impl RpcTransport for MemTransport {
                 // as a Linux socket delivers what it has queued.
                 Ok(frame) => return Ok(frame),
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                    return Err(RpcError::PeerClosed);
+                    return Err(RpcError::EndOfStream);
                 }
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                     if self.either_end_shut() {
-                        return Err(RpcError::PeerClosed);
+                        return Err(RpcError::EndOfStream);
                     }
                 }
             }
@@ -212,16 +214,16 @@ mod tests {
             a.recv_frame().expect("queued frame survives"),
             b"b->a before"
         );
-        assert!(matches!(a.recv_frame(), Err(RpcError::PeerClosed)));
+        assert!(matches!(a.recv_frame(), Err(RpcError::EndOfStream)));
         assert!(
-            matches!(a.send_frame(b"after"), Err(RpcError::PeerClosed)),
+            matches!(a.send_frame(b"after"), Err(RpcError::EndOfStream)),
             "a send after shutdown must fail, not queue"
         );
         // The peer: drains what we sent, then sees our shutdown as its
         // end of stream, and its sends fail (EPIPE on a socket).
         assert_eq!(b.recv_frame().expect("peer drains"), b"a->b before");
-        assert!(matches!(b.recv_frame(), Err(RpcError::PeerClosed)));
-        assert!(matches!(b.send_frame(b"x"), Err(RpcError::PeerClosed)));
+        assert!(matches!(b.recv_frame(), Err(RpcError::EndOfStream)));
+        assert!(matches!(b.send_frame(b"x"), Err(RpcError::EndOfStream)));
     }
 
     #[test]
@@ -241,8 +243,8 @@ mod tests {
     fn mem_peer_closed_on_drop() {
         let (a, b) = MemTransport::pair();
         drop(b);
-        assert!(matches!(a.recv_frame(), Err(RpcError::PeerClosed)));
-        assert!(matches!(a.send_frame(b"x"), Err(RpcError::PeerClosed)));
+        assert!(matches!(a.recv_frame(), Err(RpcError::EndOfStream)));
+        assert!(matches!(a.send_frame(b"x"), Err(RpcError::EndOfStream)));
     }
 
     /// Bidirectional simultaneous traffic must not deadlock or

--- a/rsbinder/src/rpc/transport/mod.rs
+++ b/rsbinder/src/rpc/transport/mod.rs
@@ -365,7 +365,10 @@ pub(crate) fn write_frame<W: Write>(w: &mut W, buf: &[u8]) -> RpcResult<()> {
 
 /// Read exactly `buf.len()` bytes for a *frame header*. Zero bytes
 /// before any progress is a clean [`RpcError::PeerClosed`]; a partial
-/// header then EOF is [`RpcError::Truncated`].
+/// header then EOF is [`RpcError::Truncated`]. A transport that can tell
+/// an unclean end apart ([`RpcError::UncleanEndOfStream`], TLS with no
+/// `close_notify`) reports it as itself before any progress and as
+/// `Truncated` after — mid-frame, the stream position is what is lost.
 fn read_header<R: Read>(r: &mut R, buf: &mut [u8]) -> RpcResult<()> {
     let mut filled = 0;
     while filled < buf.len() {
@@ -389,6 +392,9 @@ fn read_header<R: Read>(r: &mut R, buf: &mut [u8]) -> RpcResult<()> {
                     RpcError::Truncated
                 });
             }
+            Err(e) if e.kind() == ErrorKind::UnexpectedEof && filled > 0 => {
+                return Err(RpcError::Truncated);
+            }
             Err(e) => return Err(e.into()),
         }
     }
@@ -411,6 +417,7 @@ fn read_body<R: Read>(r: &mut R, buf: &mut [u8]) -> RpcResult<()> {
             Err(e) if e.kind() == ErrorKind::Interrupted => continue,
             // Mid-frame deadline = desync, not a clean timeout.
             Err(e) if is_timeout(&e) => return Err(RpcError::Truncated),
+            Err(e) if e.kind() == ErrorKind::UnexpectedEof => return Err(RpcError::Truncated),
             Err(e) => return Err(e.into()),
         }
     }

--- a/rsbinder/src/rpc/transport/mod.rs
+++ b/rsbinder/src/rpc/transport/mod.rs
@@ -149,8 +149,11 @@ pub trait RpcTransport: Send + Sync {
     /// - **This is not `close`.** The kernel's queue is certainly gone only
     ///   when the last `Arc<dyn RpcTransport>` drops.
     ///
-    /// The measured behaviour of every in-tree backend on both platforms
-    /// is pinned by `tests/rpc_transport_conformance.rs`.
+    /// The measured behaviour of `unix` (both modes), `mem`, `tcp_debug`
+    /// and `tls` on both platforms is pinned by
+    /// `tests/rpc_transport_conformance.rs`. `vsock` is not measured: it
+    /// needs a VM peer, so its behaviour here is inferred from `vsock(7)`
+    /// and covered only by its own `#[ignore]`d tests.
     fn shutdown(&self) -> RpcResult<()>;
 
     /// Send one frame plus passed file descriptors out-of-band (opt-in
@@ -394,6 +397,38 @@ pub(crate) fn write_frame<W: Write>(w: &mut W, buf: &[u8]) -> RpcResult<()> {
     Ok(())
 }
 
+/// `write_all`, but telling a failure that put **nothing** on the wire
+/// apart from one that stopped part-way.
+///
+/// `write_all` reports the same error either way, and the session's
+/// send-failure rule needs the difference: a frame that stopped part-way
+/// left the peer a header it will complete out of whatever arrives next,
+/// so its connection must be retired, while a frame that never started
+/// left the stream frame-synchronized and its connection healthy. A send
+/// deadline (`SO_SNDTIMEO`) that expires before the first byte is
+/// therefore [`RpcError::Timeout`] — the value a read deadline that
+/// consumed nothing already yields — and every other failure, at any
+/// position, stays the transport error.
+///
+/// `w` must report partial progress honestly, as a socket does. An
+/// adapter that hands the whole buffer to another all-or-nothing send does
+/// not, and classifies at its own level instead: `tls` never reports this,
+/// because a record its socket write dropped is gone from the sequence
+/// whether or not a byte of it went out.
+pub(crate) fn write_all_reporting<W: Write>(w: &mut W, buf: &[u8]) -> RpcResult<()> {
+    let mut sent = 0;
+    while sent < buf.len() {
+        match w.write(&buf[sent..]) {
+            Ok(0) => return Err(std::io::Error::from(ErrorKind::WriteZero).into()),
+            Ok(n) => sent += n,
+            Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+            Err(e) if sent == 0 && is_timeout(&e) => return Err(RpcError::Timeout),
+            Err(e) => return Err(RpcError::from(e)),
+        }
+    }
+    Ok(())
+}
+
 /// Read exactly `buf.len()` bytes for a *frame header*. Zero bytes
 /// before any progress is a clean [`RpcError::EndOfStream`]; a partial
 /// header then EOF is [`RpcError::Truncated`]. A transport that can tell
@@ -426,13 +461,33 @@ fn read_header<R: Read>(r: &mut R, buf: &mut [u8]) -> RpcResult<()> {
             Err(e) if e.kind() == ErrorKind::UnexpectedEof && filled > 0 => {
                 return Err(RpcError::Truncated);
             }
-            Err(e) => return Err(e.into()),
+            // Past the first byte the header is committed, so a disconnect
+            // has lost the position whichever kind it arrived as: the ones
+            // `From<io::Error>` folds into `EndOfStream` (a reset among
+            // them) do not mean "nothing was pending" here.
+            Err(e) => {
+                return Err(match RpcError::from(e) {
+                    RpcError::EndOfStream if filled > 0 => RpcError::Truncated,
+                    other => other,
+                })
+            }
         }
     }
     Ok(())
 }
 
-/// `WouldBlock`/`TimedOut` is how a socket read deadline surfaces.
+/// Whether an I/O operation failed on a deadline this end armed:
+/// `SO_RCVTIMEO` for the framing readers, `SO_SNDTIMEO` for
+/// [`write_all_reporting`] and for `tls`'s teardown control flush. On the
+/// supported platforms both surface as `WouldBlock`; `TimedOut` is here
+/// because the `Read`
+/// adapters carry [`RpcError::Timeout`] across the `RpcError` ⇄
+/// `io::Error` boundary with exactly that kind, and the framing readers
+/// sit on top of both. The cost is that a raw socket's own `ETIMEDOUT` —
+/// a peer whose host stopped answering, not a deadline of ours — is
+/// `TimedOut` too and cannot be told apart here; what is decided on that
+/// distinction (see [`SessionEnd::new`](super::SessionEnd)) is decided
+/// from whether a deadline was armed at all.
 pub(crate) fn is_timeout(e: &std::io::Error) -> bool {
     matches!(e.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut)
 }
@@ -451,7 +506,7 @@ pub(crate) fn absorb_already_shut(r: std::io::Result<()>) -> RpcResult<()> {
 /// Read exactly `buf.len()` body bytes. The header was already
 /// committed, so any short read has lost the stream position:
 /// [`RpcError::Truncated`] if the stream ended, [`RpcError::DeadlineMidFrame`]
-/// if our own deadline cut it.
+/// if a read deadline cut it ([`is_timeout`] cannot say whose — see its doc).
 fn read_body<R: Read>(r: &mut R, buf: &mut [u8]) -> RpcResult<()> {
     let mut filled = 0;
     while filled < buf.len() {
@@ -461,7 +516,15 @@ fn read_body<R: Read>(r: &mut R, buf: &mut [u8]) -> RpcResult<()> {
             Err(e) if e.kind() == ErrorKind::Interrupted => continue,
             Err(e) if is_timeout(&e) => return Err(RpcError::DeadlineMidFrame),
             Err(e) if e.kind() == ErrorKind::UnexpectedEof => return Err(RpcError::Truncated),
-            Err(e) => return Err(e.into()),
+            // The header is already consumed, so every disconnect here is a
+            // cut frame — including the kinds `From<io::Error>` folds into
+            // `EndOfStream` (`ConnectionReset` from a peer killed mid-frame).
+            Err(e) => {
+                return Err(match RpcError::from(e) {
+                    RpcError::EndOfStream => RpcError::Truncated,
+                    other => other,
+                })
+            }
         }
     }
     Ok(())
@@ -587,6 +650,45 @@ mod tests {
             write_frame(&mut Trap, &big),
             Err(RpcError::FrameTooLarge { .. })
         ));
+    }
+
+    /// A send deadline is only frame-synchronized while nothing has gone
+    /// out, and that is the whole difference the session's send-failure
+    /// rule acts on: `Timeout` keeps the connection, a transport error
+    /// retires it.
+    ///
+    /// **Mutant gate**: dropping the `sent == 0` guard makes the second
+    /// case report `Timeout` as well, and a peer left half a frame keeps
+    /// its slot.
+    #[test]
+    fn a_send_deadline_is_a_timeout_only_before_the_first_byte() {
+        struct Stall(usize);
+        impl Write for Stall {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                if self.0 == 0 {
+                    return Err(std::io::Error::from(ErrorKind::WouldBlock));
+                }
+                let n = self.0.min(buf.len());
+                self.0 -= n;
+                Ok(n)
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        assert!(matches!(
+            write_all_reporting(&mut Stall(0), b"frame"),
+            Err(RpcError::Timeout)
+        ));
+        assert!(
+            matches!(
+                write_all_reporting(&mut Stall(2), b"frame"),
+                Err(RpcError::Io(ref e)) if e.kind() == ErrorKind::WouldBlock
+            ),
+            "a deadline past the first byte left a partial frame on the wire"
+        );
+        assert!(write_all_reporting(&mut Stall(5), b"frame").is_ok());
     }
 
     #[test]

--- a/rsbinder/src/rpc/transport/mod.rs
+++ b/rsbinder/src/rpc/transport/mod.rs
@@ -157,10 +157,13 @@ pub trait RpcTransport: Send + Sync {
     /// has no length prefix (`RpcState::rpcSend` writes the
     /// `RpcWireHeader` + body directly) — the android-13+ profile drives
     /// framing itself via `wire_android13`. The default is
-    /// **unsupported**, so a backend that does not override it stays
-    /// frame-only *by type* (currently `mem`); `unix`, `tls` and `vsock`
-    /// override it. The existing R34 path never calls this —
-    /// `send_frame`/`recv_frame` are byte-unchanged.
+    /// **unsupported**: right for a frame-only backend (`mem`), and a
+    /// silent trap for a byte-stream one — an android-13+ session over a
+    /// backend that forgot it fails at its first handshake byte (it
+    /// happened to `vsock`, then to `tcp_debug`). Every stream backend
+    /// (`unix`, `tcp_debug`, `vsock`, `tls`) must override both this and
+    /// [`recv_raw`](Self::recv_raw). The existing R34 path never calls
+    /// this — `send_frame`/`recv_frame` are byte-unchanged.
     fn send_raw(&self, _buf: &[u8]) -> RpcResult<()> {
         Err(RpcError::Protocol("this transport has no raw byte access"))
     }

--- a/rsbinder/src/rpc/transport/mod.rs
+++ b/rsbinder/src/rpc/transport/mod.rs
@@ -90,7 +90,7 @@ pub trait RpcTransport: Send + Sync {
     /// `unix` / `mem` / `tcp_debug` / `vsock` / `tls` override it. A deadline that
     /// elapses with **nothing consumed** surfaces as
     /// [`RpcError::Timeout`] (the stream stays frame-synchronized); a
-    /// deadline that elapses mid-frame is [`RpcError::Truncated`].
+    /// deadline that elapses mid-frame is [`RpcError::DeadlineMidFrame`].
     fn set_read_timeout(&self, _timeout: Option<std::time::Duration>) -> RpcResult<()> {
         Ok(())
     }
@@ -108,22 +108,45 @@ pub trait RpcTransport: Send + Sync {
         Ok(())
     }
 
-    /// Shut the connection down in both directions so a thread blocked in
-    /// [`recv_frame`](Self::recv_frame) returns (`PeerClosed`) and later
-    /// sends fail. Used to end a client's incoming-connection threads on
-    /// session death / `RpcSession::shutdown`. Best-effort; the default
-    /// does nothing, for a transport that cannot be interrupted.
+    /// Shut the connection down in both directions: wake a reader blocked
+    /// in [`recv_frame`](Self::recv_frame) / [`recv_raw`](Self::recv_raw)
+    /// and make later sends fail. This is how a session ends its
+    /// connections — `RpcSession::shutdown`, `RpcServer::terminate`, a
+    /// slot retired after a lost stream. Required, with no default on
+    /// purpose: a transport that silently did nothing here would leave a
+    /// serve loop or an incoming-connection thread parked in `recv`
+    /// forever, and `RpcSession::shutdown` would hang on the join. The
+    /// same reasoning already made [`TlsStream::shutdown`] required.
     ///
-    /// **Override it if your transport can be interrupted at all.** With
-    /// the no-op default, `RpcSession::shutdown` has nothing to wake a
-    /// thread parked in `recv_frame` on this transport, so a
-    /// `serve_blocking` or incoming-connection thread on it never exits
-    /// and the documented teardown ("it exits on its own once the
-    /// transport is shut down") does not hold. Every in-tree
-    /// socket-backed transport overrides it.
-    fn shutdown(&self) -> RpcResult<()> {
-        Ok(())
-    }
+    /// The contract is narrower than the name suggests, and every caller
+    /// in rsbinder is written to it (plan 2-21 §3.4):
+    ///
+    /// - **What happens to bytes already received is platform- and
+    ///   backend-dependent, and nothing may assume it.** A kernel may keep
+    ///   its receive queue across a local shutdown — Linux: a reader gets
+    ///   the queued bytes, then end of stream — or drop it (macOS). A
+    ///   transport's own buffer may survive (`tls`'s decrypted plaintext)
+    ///   or be cleared (`unix` fd-mode clears its leftover here). A caller
+    ///   that must not read what is buffered keeps that decision in
+    ///   session state — the slot's `unreadable` mark — not here. `mem`
+    ///   models the Linux behaviour, so a hermetic test exercises the case
+    ///   that hides bugs.
+    /// - **A reader woken by this returns the end of stream** —
+    ///   [`RpcError::PeerClosed`] at a frame boundary, [`RpcError::Truncated`]
+    ///   mid-frame — never a distinct "shut down locally" error. Who ended
+    ///   the connection is session knowledge (`SessionEnd::by`), not
+    ///   transport knowledge; a TLS transport does not report its own
+    ///   shutdown as an unclean end.
+    /// - **Idempotent.** A second call returns `Ok(())`; the socket
+    ///   backends absorb the `ENOTCONN` a second shutdown raises on macOS.
+    /// - **The `Err` is diagnostic.** The connection is being ended
+    ///   whatever it says; callers log it and never branch on it.
+    /// - **This is not `close`.** The kernel's queue is certainly gone only
+    ///   when the last `Arc<dyn RpcTransport>` drops.
+    ///
+    /// The measured behaviour of every in-tree backend on both platforms
+    /// is pinned by `tests/rpc_transport_conformance.rs`.
+    fn shutdown(&self) -> RpcResult<()>;
 
     /// Send one frame plus passed file descriptors out-of-band (opt-in
     /// `FileDescriptorTransportMode::Unix`).
@@ -392,7 +415,7 @@ fn read_header<R: Read>(r: &mut R, buf: &mut [u8]) -> RpcResult<()> {
                 return Err(if filled == 0 {
                     RpcError::Timeout
                 } else {
-                    RpcError::Truncated
+                    RpcError::DeadlineMidFrame
                 });
             }
             Err(e) if e.kind() == ErrorKind::UnexpectedEof && filled > 0 => {
@@ -409,8 +432,21 @@ pub(crate) fn is_timeout(e: &std::io::Error) -> bool {
     matches!(e.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut)
 }
 
+/// The socket backends' `shutdown`: a second call raises `ENOTCONN` on
+/// macOS (Linux returns `Ok`), and the trait promises idempotence, so that
+/// one is absorbed. Anything else is the diagnostic the trait documents.
+pub(crate) fn absorb_already_shut(r: std::io::Result<()>) -> RpcResult<()> {
+    match r {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == ErrorKind::NotConnected => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
 /// Read exactly `buf.len()` body bytes. The header was already
-/// committed, so *any* short read is [`RpcError::Truncated`].
+/// committed, so any short read has lost the stream position:
+/// [`RpcError::Truncated`] if the stream ended, [`RpcError::DeadlineMidFrame`]
+/// if our own deadline cut it.
 fn read_body<R: Read>(r: &mut R, buf: &mut [u8]) -> RpcResult<()> {
     let mut filled = 0;
     while filled < buf.len() {
@@ -418,8 +454,7 @@ fn read_body<R: Read>(r: &mut R, buf: &mut [u8]) -> RpcResult<()> {
             Ok(0) => return Err(RpcError::Truncated),
             Ok(n) => filled += n,
             Err(e) if e.kind() == ErrorKind::Interrupted => continue,
-            // Mid-frame deadline = desync, not a clean timeout.
-            Err(e) if is_timeout(&e) => return Err(RpcError::Truncated),
+            Err(e) if is_timeout(&e) => return Err(RpcError::DeadlineMidFrame),
             Err(e) if e.kind() == ErrorKind::UnexpectedEof => return Err(RpcError::Truncated),
             Err(e) => return Err(e.into()),
         }

--- a/rsbinder/src/rpc/transport/mod.rs
+++ b/rsbinder/src/rpc/transport/mod.rs
@@ -110,7 +110,12 @@ pub trait RpcTransport: Send + Sync {
 
     /// Shut the connection down in both directions: wake a reader blocked
     /// in [`recv_frame`](Self::recv_frame) / [`recv_raw`](Self::recv_raw)
-    /// and make later sends fail. This is how a session ends its
+    /// and make this end's later sends fail. (The *peer's* sends are the
+    /// platform's business — a Linux `AF_UNIX` peer gets `EPIPE` at once,
+    /// a macOS one has its writes accepted and discarded, a TCP peer on
+    /// either sees the reset on a later write; it reads the end of stream
+    /// either way.)
+    /// This is how a session ends its
     /// connections — `RpcSession::shutdown`, `RpcServer::terminate`, a
     /// slot retired after a lost stream. Required, with no default on
     /// purpose: a transport that silently did nothing here would leave a

--- a/rsbinder/src/rpc/transport/mod.rs
+++ b/rsbinder/src/rpc/transport/mod.rs
@@ -66,7 +66,7 @@ pub trait RpcTransport: Send + Sync {
     /// Receive exactly one logical frame.
     ///
     /// A clean peer close with nothing pending is
-    /// [`RpcError::PeerClosed`]; a header received but body short is
+    /// [`RpcError::EndOfStream`]; a header received but body short is
     /// [`RpcError::Truncated`]. Never panics or loops forever on a
     /// hostile peer.
     fn recv_frame(&self) -> RpcResult<Vec<u8>>;
@@ -116,12 +116,12 @@ pub trait RpcTransport: Send + Sync {
     /// either sees the reset on a later write; it reads the end of stream
     /// either way.)
     /// This is how a session ends its
-    /// connections — `RpcSession::shutdown`, `RpcServer::terminate`, a
+    /// connections — `RpcSession::close_session`, `RpcServer::terminate`, a
     /// slot retired after a lost stream. Required, with no default on
     /// purpose: a transport that silently did nothing here would leave a
     /// serve loop or an incoming-connection thread parked in `recv`
-    /// forever, and `RpcSession::shutdown` would hang on the join. The
-    /// same reasoning already made [`TlsStream::shutdown`] required.
+    /// forever, and `RpcSession::close_session` would hang on the join. The
+    /// same reasoning already made [`TlsStream::shutdown_stream`] required.
     ///
     /// The contract is narrower than the name suggests, and every caller
     /// in rsbinder is written to it (plan 2-21 §3.4):
@@ -137,7 +137,7 @@ pub trait RpcTransport: Send + Sync {
     ///   models the Linux behaviour, so a hermetic test exercises the case
     ///   that hides bugs.
     /// - **A reader woken by this returns the end of stream** —
-    ///   [`RpcError::PeerClosed`] at a frame boundary, [`RpcError::Truncated`]
+    ///   [`RpcError::EndOfStream`] at a frame boundary, [`RpcError::Truncated`]
     ///   mid-frame — never a distinct "shut down locally" error. Who ended
     ///   the connection is session knowledge (`SessionEnd::by`), not
     ///   transport knowledge; a TLS transport does not report its own
@@ -395,7 +395,7 @@ pub(crate) fn write_frame<W: Write>(w: &mut W, buf: &[u8]) -> RpcResult<()> {
 }
 
 /// Read exactly `buf.len()` bytes for a *frame header*. Zero bytes
-/// before any progress is a clean [`RpcError::PeerClosed`]; a partial
+/// before any progress is a clean [`RpcError::EndOfStream`]; a partial
 /// header then EOF is [`RpcError::Truncated`]. A transport that can tell
 /// an unclean end apart ([`RpcError::UncleanEndOfStream`], TLS with no
 /// `close_notify`) reports it as itself before any progress and as
@@ -406,7 +406,7 @@ fn read_header<R: Read>(r: &mut R, buf: &mut [u8]) -> RpcResult<()> {
         match r.read(&mut buf[filled..]) {
             Ok(0) => {
                 return Err(if filled == 0 {
-                    RpcError::PeerClosed
+                    RpcError::EndOfStream
                 } else {
                     RpcError::Truncated
                 });
@@ -540,7 +540,7 @@ mod tests {
         // Empty input: clean peer-closed, no header at all.
         assert!(matches!(
             __fuzz_decode_frame(&[]),
-            Err(RpcError::PeerClosed)
+            Err(RpcError::EndOfStream)
         ));
 
         // Partial header (2 of 4 bytes): truncated, not a panic.

--- a/rsbinder/src/rpc/transport/tcp_debug.rs
+++ b/rsbinder/src/rpc/transport/tcp_debug.rs
@@ -130,6 +130,36 @@ impl RpcTransport for TcpDebugTransport {
         read_frame(&mut r)
     }
 
+    /// Raw, unframed write for the android-13+ profile (the real android
+    /// RPC wire has no length prefix). Same shape as `VsockTransport`'s;
+    /// the trait default refuses raw access, which is right for a
+    /// frame-only backend and wrong here — `RpcSession::from_preconnected_fd`
+    /// wraps an `AF_INET` fd in this transport and goes straight into the
+    /// android-13+ handshake, whose first byte is a raw write.
+    fn send_raw(&self, buf: &[u8]) -> RpcResult<()> {
+        use std::io::Write;
+        let mut w = &self.stream;
+        w.write_all(buf)?;
+        w.flush()?;
+        Ok(())
+    }
+
+    /// Raw, unframed read (one `read`; `Ok(0)` = end of stream), with the
+    /// `Interrupted` retry and the deadline → `Timeout` mapping the other
+    /// stream backends share.
+    fn recv_raw(&self, buf: &mut [u8]) -> RpcResult<usize> {
+        use std::io::Read;
+        let mut r = &self.stream;
+        loop {
+            return match r.read(buf) {
+                Ok(n) => Ok(n),
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) if super::is_timeout(&e) => Err(crate::rpc::RpcError::Timeout),
+                Err(e) => Err(e.into()),
+            };
+        }
+    }
+
     /// **Always** [`PeerIdentity::Anonymous`]. There is deliberately no
     /// other return path: plaintext TCP carries no trustworthy peer
     /// identity, so ACL against it is impossible *by type*.
@@ -213,6 +243,18 @@ mod tests {
         };
         assert_eq!(server.recv_frame().expect("recv"), payload);
         sender.join().unwrap();
+    }
+
+    /// Plan 2-21 B-4 — the raw (unframed) path the android-13+ profile
+    /// needs. The trait default refuses it; `from_preconnected_fd` wraps
+    /// an `AF_INET` fd here and goes straight into that handshake.
+    #[test]
+    fn tcp_debug_raw_bytes_roundtrip() {
+        let (client, server) = TcpDebugTransport::pair_loopback().expect("loopback pair");
+        client.send_raw(b"\x01\x02\x03").expect("send_raw");
+        let mut buf = [0u8; 8];
+        let n = server.recv_raw(&mut buf).expect("recv_raw");
+        assert_eq!(&buf[..n], b"\x01\x02\x03");
     }
 
     #[test]

--- a/rsbinder/src/rpc/transport/tcp_debug.rs
+++ b/rsbinder/src/rpc/transport/tcp_debug.rs
@@ -182,8 +182,7 @@ impl RpcTransport for TcpDebugTransport {
     }
 
     fn shutdown(&self) -> RpcResult<()> {
-        self.stream.shutdown(std::net::Shutdown::Both)?;
-        Ok(())
+        super::absorb_already_shut(self.stream.shutdown(std::net::Shutdown::Both))
     }
 }
 

--- a/rsbinder/src/rpc/transport/tcp_debug.rs
+++ b/rsbinder/src/rpc/transport/tcp_debug.rs
@@ -139,7 +139,7 @@ impl RpcTransport for TcpDebugTransport {
     fn send_raw(&self, buf: &[u8]) -> RpcResult<()> {
         use std::io::Write;
         let mut w = &self.stream;
-        w.write_all(buf)?;
+        super::write_all_reporting(&mut w, buf)?;
         w.flush()?;
         Ok(())
     }

--- a/rsbinder/src/rpc/transport/tls.rs
+++ b/rsbinder/src/rpc/transport/tls.rs
@@ -64,19 +64,86 @@ const TLS_READ_CHUNK: usize = 16 * 1024;
 /// transport queued behind it in `shutdown_all_transports` — forever.
 const CLOSE_NOTIFY_TIMEOUT: Duration = Duration::from_millis(500);
 
-/// How long [`TlsTransport::shutdown`] may wait for the write lock before
-/// transmitting `close_notify`. A send in flight holds `wlock`, and only
-/// the thread holding it may put records on the wire, so a shutdown that
-/// took the lock-free path would cut the socket with the alert still
-/// queued and hand the peer an unclean end.
+/// How long [`TlsTransport::shutdown`] waits for the send in flight before
+/// giving up on `close_notify` and cutting the socket anyway.
 ///
-/// Short on purpose. What this covers is a send about to release the lock
-/// — microseconds — not a peer that has stopped reading: that peer holds
-/// the sender for as long as its window stays shut, and is getting the
-/// unclean end either way. The wait is therefore what teardown latency
-/// this adds per stalled connection, and `shutdown_all_transports` walks
-/// its slots one at a time, so it is additive.
+/// Only the thread holding `wlock` may put records on the wire, and
+/// `shutdown` refuses every send that starts after it, so there is at
+/// most one such send and it ends in one of two ways. It completes — the
+/// lock's release wakes `shutdown` at once, and this bound is never felt.
+/// Or it is parked in a socket write to a peer that has stopped reading —
+/// then nothing short of the cut unparks it, the alert could not reach
+/// that peer regardless, and this is how long teardown spends finding
+/// that out. `shutdown_all_transports` walks slots one at a time, so it is
+/// paid once per stalled connection.
 const CLOSE_NOTIFY_WLOCK_WAIT: Duration = Duration::from_millis(50);
+
+/// The write-path lock. A mutex with a bounded acquire, which `std`'s
+/// lacks: [`TlsTransport::shutdown`] must wait for the send in flight, but
+/// not for a sender parked on a peer that has stopped reading.
+///
+/// Every release signals `freed`, so a waiter wakes the moment the send
+/// ends rather than on a poll tick.
+struct WriteLock {
+    busy: Mutex<bool>,
+    freed: std::sync::Condvar,
+}
+
+/// Holding this is holding `wlock`; dropping it releases and signals.
+struct WriteGuard<'a>(&'a WriteLock);
+
+impl WriteLock {
+    fn new() -> Self {
+        Self {
+            busy: Mutex::new(false),
+            freed: std::sync::Condvar::new(),
+        }
+    }
+
+    fn lock(&self) -> WriteGuard<'_> {
+        let mut busy = self.busy.lock().expect("tls wlock poisoned");
+        while *busy {
+            busy = self.freed.wait(busy).expect("tls wlock poisoned");
+        }
+        *busy = true;
+        WriteGuard(self)
+    }
+
+    fn try_lock(&self) -> Option<WriteGuard<'_>> {
+        let mut busy = self.busy.lock().expect("tls wlock poisoned");
+        if *busy {
+            return None;
+        }
+        *busy = true;
+        Some(WriteGuard(self))
+    }
+
+    /// `None` once `wait` has passed with the lock still held.
+    fn lock_timeout(&self, wait: Duration) -> Option<WriteGuard<'_>> {
+        let deadline = std::time::Instant::now() + wait;
+        let mut busy = self.busy.lock().expect("tls wlock poisoned");
+        while *busy {
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                return None;
+            }
+            let (guard, _) = self
+                .freed
+                .wait_timeout(busy, deadline - now)
+                .expect("tls wlock poisoned");
+            busy = guard;
+        }
+        *busy = true;
+        Some(WriteGuard(self))
+    }
+}
+
+impl Drop for WriteGuard<'_> {
+    fn drop(&mut self) {
+        *self.0.busy.lock().expect("tls wlock poisoned") = false;
+        self.0.freed.notify_all();
+    }
+}
 
 /// A connected, byte-oriented stream that TLS can run over.
 ///
@@ -195,8 +262,10 @@ pub struct TlsTransport {
     /// every writer (data send and control flush) so the on-wire TLS
     /// record order always equals rustls's sequence-number order. The
     /// reader takes it with `try_lock` for an opportunistic control
-    /// flush and never blocks on it (see `flush_control`).
-    wlock: Mutex<()>,
+    /// flush and never blocks on it (see `flush_control`); `shutdown`
+    /// takes it with a bound, after the send in flight (see
+    /// `CLOSE_NOTIFY_WLOCK_WAIT`).
+    wlock: WriteLock,
     /// The byte stream; reads are lock-free, writes go under `wlock`.
     stream: Box<dyn TlsStream>,
     peer: PeerIdentity,
@@ -259,7 +328,7 @@ impl TlsTransport {
         let peer = PeerIdentity::Certificate(cert_identity(conn.peer_certificates(), server_name)?);
         Ok(TlsTransport {
             conn: Mutex::new(conn),
-            wlock: Mutex::new(()),
+            wlock: WriteLock::new(),
             stream,
             peer,
             desc: format!("tls:{server_name}"),
@@ -291,7 +360,7 @@ impl TlsTransport {
         };
         Ok(TlsTransport {
             conn: Mutex::new(conn),
-            wlock: Mutex::new(()),
+            wlock: WriteLock::new(),
             stream,
             peer,
             desc: "tls:server".to_string(),
@@ -354,7 +423,7 @@ impl TlsTransport {
     /// socket write — preserving the lock-free-duplex liveness, while
     /// still ordering every write_tls → transmit under `wlock`.
     fn flush_control(&self) -> RpcResult<()> {
-        let Ok(_g) = self.wlock.try_lock() else {
+        let Some(_g) = self.wlock.try_lock() else {
             return Ok(());
         };
         let cipher = {
@@ -367,35 +436,6 @@ impl TlsTransport {
             v
         };
         self.write_socket_locked(&cipher)
-    }
-
-    /// Take `wlock` for [`shutdown`](RpcTransport::shutdown), waiting up to
-    /// [`CLOSE_NOTIFY_WLOCK_WAIT`]. `None` ⇒ a sender still holds it and the
-    /// caller must cut the socket without transmitting.
-    ///
-    /// Spins first, then sleeps: the case worth catching is a send one
-    /// instruction from releasing the lock, and yielding catches that
-    /// without a millisecond of latency. A poisoned lock returns `None`
-    /// at once rather than waiting out a deadline nothing can meet.
-    fn wlock_for_close(&self) -> Option<std::sync::MutexGuard<'_, ()>> {
-        let deadline = std::time::Instant::now() + CLOSE_NOTIFY_WLOCK_WAIT;
-        let mut spins = 0u32;
-        loop {
-            match self.wlock.try_lock() {
-                Ok(g) => return Some(g),
-                Err(std::sync::TryLockError::Poisoned(_)) => return None,
-                Err(std::sync::TryLockError::WouldBlock) => {}
-            }
-            if std::time::Instant::now() >= deadline {
-                return None;
-            }
-            if spins < 64 {
-                spins += 1;
-                std::thread::yield_now();
-            } else {
-                std::thread::sleep(Duration::from_millis(1));
-            }
-        }
     }
 
     /// Pull one chunk of ciphertext off the socket (lock-free) and feed
@@ -455,13 +495,25 @@ impl RpcTransport for TlsTransport {
     }
 
     fn send_raw(&self, buf: &[u8]) -> RpcResult<()> {
+        // After our own `shutdown` a send fails here, before touching
+        // rustls or the lock. It is what the trait promises ("later sends
+        // fail"), and it is what makes `shutdown`'s wait a handoff: with
+        // new senders refused, the one already holding `wlock` is the only
+        // one there is, and its release is the only event to wait for.
+        // Without this a busy sender re-takes the lock the moment it lets
+        // go and can starve `shutdown` past its bound — and every frame it
+        // sent meanwhile, queued behind an alert the peer discards it
+        // after (RFC 8446 §6.1), was reported `Ok`.
+        if self.shut.load(std::sync::atomic::Ordering::SeqCst) {
+            return Err(RpcError::EndOfStream);
+        }
         // `wlock` spans BOTH the rustls encrypt-drain and the socket
         // transmit so the on-wire record order equals the sequence-number
         // order even under a concurrent recv-side control flush (the
         // `conn` lock is released before the blocking transmit, so the
         // reader's `pump_incoming` can still drain — no flow-control
         // deadlock).
-        let _g = self.wlock.lock().expect("tls wlock poisoned");
+        let _g = self.wlock.lock();
         // rustls bounds its plaintext sendable buffer (`DEFAULT_BUFFER_LIMIT`,
         // ~64 KiB); feeding a larger frame in a single `write_all` fails with
         // `WriteZero`. Chunk the plaintext and interleave encrypt
@@ -571,39 +623,42 @@ impl RpcTransport for TlsTransport {
     }
 
     fn shutdown(&self) -> RpcResult<()> {
-        // close_notify first, so a deliberate close on this end is the clean
-        // end on the peer rather than the cut `recv_raw` reports.
+        // Refuse every send from here on (`send_raw` checks this first). At
+        // most one send is then still running — the one already holding
+        // `wlock` — and it is the only thing the wait below is for.
         self.shut.store(true, std::sync::atomic::Ordering::SeqCst);
-        // Bound that write: `write_socket_locked` blocks until the whole
+        // Bound the socket writes from here: that send's remaining chunks
+        // and our own alert. `write_socket_locked` blocks until the whole
         // buffer is on the wire, and this is a teardown path whose caller
         // (`shutdown_all_transports`, then `terminate`'s join) has no other
         // way out. A peer that stalled sees a partial record — an unclean
         // end, which is what a stalled peer is getting anyway.
         let _ = self.stream.set_write_timeout(Some(CLOSE_NOTIFY_TIMEOUT));
-        // Queue it whatever `wlock` says — that lock guards the socket, not
-        // the crypto state, and a concurrent sender's next `write_tls`
-        // drains the shared output buffer in sequence order, so a sender
-        // that still has records to write carries this one out for us.
-        {
-            let mut c = self.conn.lock().expect("tls conn poisoned");
-            c.send_close_notify(); // idempotent in rustls
-        }
-        // Transmitting is this call's own job for every send that is not
-        // still running: only the `wlock` holder may put records on the
-        // wire, so cutting the socket while a sender holds it would strand
-        // the queued alert and leave the peer an unclean end. Wait for the
-        // lock, but briefly — see `CLOSE_NOTIFY_WLOCK_WAIT`.
-        if let Some(_g) = self.wlock_for_close() {
+        // Only the `wlock` holder may put records on the wire, so take it —
+        // after the send in flight, if there is one — and only then queue
+        // and transmit `close_notify`: the alert follows a complete frame
+        // rather than cutting into one, and the peer reads that frame,
+        // then a clean end. Keep holding it across the socket cut: released
+        // before, a sender could slip a frame in between, be told `Ok`, and
+        // the peer would discard it (RFC 8446 §6.1).
+        let held = self.wlock.lock_timeout(CLOSE_NOTIFY_WLOCK_WAIT);
+        if held.is_some() {
             let mut cipher = Vec::new();
             {
                 let mut c = self.conn.lock().expect("tls conn poisoned");
+                c.send_close_notify(); // idempotent in rustls
                 let _ = c.write_tls(&mut cipher);
             }
             if !cipher.is_empty() {
                 let _ = self.write_socket_locked(&cipher);
             }
         }
-        super::absorb_already_shut(self.stream.shutdown_stream())
+        // `None`: the sender is parked in a socket write to a peer that has
+        // stopped reading. No alert could reach that peer; the cut is what
+        // unparks the sender (`EPIPE`), and it reports its frame as failed.
+        let cut = super::absorb_already_shut(self.stream.shutdown_stream());
+        drop(held);
+        cut
     }
 }
 

--- a/rsbinder/src/rpc/transport/tls.rs
+++ b/rsbinder/src/rpc/transport/tls.rs
@@ -181,6 +181,10 @@ pub struct TlsTransport {
     stream: Box<dyn TlsStream>,
     peer: PeerIdentity,
     desc: String,
+    /// Set by [`shutdown`](RpcTransport::shutdown): the end of stream our
+    /// own reader then sees carries no `close_notify` from the peer, and
+    /// must not be reported as a cut — it is ours.
+    shut: std::sync::atomic::AtomicBool,
 }
 
 /// SHA-256 of the peer's leaf certificate, as a [`CertId`]. `subject`
@@ -239,6 +243,7 @@ impl TlsTransport {
             stream,
             peer,
             desc: format!("tls:{server_name}"),
+            shut: std::sync::atomic::AtomicBool::new(false),
         })
     }
 
@@ -270,6 +275,7 @@ impl TlsTransport {
             stream,
             peer,
             desc: "tls:server".to_string(),
+            shut: std::sync::atomic::AtomicBool::new(false),
         })
     }
 
@@ -450,6 +456,12 @@ impl RpcTransport for TlsTransport {
                     // TCP EOF with no close_notify: on this backend that is
                     // what a cut stream looks like, so it is not a close.
                     Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                        // Our own shutdown produces exactly this on our
+                        // side: an end of stream, no close_notify from the
+                        // peer. That is a close, not a cut.
+                        if self.shut.load(std::sync::atomic::Ordering::SeqCst) {
+                            return Ok(0);
+                        }
                         log::warn!("TLS stream ended without close_notify ({})", self.desc);
                         return Err(RpcError::UncleanEndOfStream);
                     }
@@ -488,19 +500,19 @@ impl RpcTransport for TlsTransport {
         // end on the peer rather than the cut `recv_raw` reports. Best
         // effort: a sender blocked on the socket holds `wlock`, and waking
         // our own reader must not wait on it.
+        self.shut.store(true, std::sync::atomic::Ordering::SeqCst);
         if let Ok(_g) = self.wlock.try_lock() {
             let mut cipher = Vec::new();
             {
                 let mut c = self.conn.lock().expect("tls conn poisoned");
-                c.send_close_notify();
+                c.send_close_notify(); // idempotent in rustls
                 let _ = c.write_tls(&mut cipher);
             }
             if !cipher.is_empty() {
                 let _ = self.write_socket_locked(&cipher);
             }
         }
-        self.stream.shutdown()?;
-        Ok(())
+        super::absorb_already_shut(self.stream.shutdown())
     }
 }
 

--- a/rsbinder/src/rpc/transport/tls.rs
+++ b/rsbinder/src/rpc/transport/tls.rs
@@ -344,7 +344,9 @@ impl TlsTransport {
     }
 
     /// Pull one chunk of ciphertext off the socket (lock-free) and feed
-    /// it into the crypto state. Returns `false` on a clean TCP EOF.
+    /// it into the crypto state. Returns `false` on TCP EOF — after
+    /// handing that EOF to rustls, so its reader can then tell a
+    /// `close_notify` (clean) from a cut stream (`UnexpectedEof`).
     fn pump_incoming(&self) -> RpcResult<bool> {
         let mut tmp = [0u8; TLS_READ_CHUNK];
         let k = loop {
@@ -360,10 +362,12 @@ impl TlsTransport {
                 Err(e) => return Err(e.into()),
             }
         };
-        if k == 0 {
-            return Ok(false); // peer closed the socket
-        }
         let mut c = self.conn.lock().expect("tls conn poisoned");
+        if k == 0 {
+            let mut eof: &[u8] = &[];
+            let _ = c.read_tls(&mut eof);
+            return Ok(false);
+        }
         let mut src: &[u8] = &tmp[..k];
         while !src.is_empty() {
             let n = c.read_tls(&mut src)?;
@@ -441,20 +445,23 @@ impl RpcTransport for TlsTransport {
                 let mut c = self.conn.lock().expect("tls conn poisoned");
                 match c.reader().read(out) {
                     Ok(n) if n > 0 => return Ok(n),
-                    Ok(_) => return Ok(0), // clean close_notify, all drained
+                    Ok(_) => return Ok(0), // close_notify received, all drained
                     Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
-                    // Unclean TCP EOF after rustls drained: treat as close.
-                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(0),
+                    // TCP EOF with no close_notify: on this backend that is
+                    // what a cut stream looks like, so it is not a close.
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                        log::warn!("TLS stream ended without close_notify ({})", self.desc);
+                        return Err(RpcError::UncleanEndOfStream);
+                    }
                     Err(e) => return Err(e.into()),
                 }
             }
             // 2. Opportunistically flush any control-plane output rustls
             //    queued (non-blocking on `wlock`; see `flush_control`).
             self.flush_control()?;
-            // 3. Block on the socket (lock-free) for more ciphertext.
-            if !self.pump_incoming()? {
-                return Ok(0);
-            }
+            // 3. Block on the socket (lock-free) for more ciphertext. On EOF
+            //    rustls now knows, and the next pass of step 1 decides.
+            self.pump_incoming()?;
         }
     }
 
@@ -477,8 +484,21 @@ impl RpcTransport for TlsTransport {
     }
 
     fn shutdown(&self) -> RpcResult<()> {
-        // TCP-level shutdown, not a TLS close_notify: the goal is to wake
-        // the reader, and the peer sees a truncated stream either way.
+        // close_notify first, so a deliberate close on this end is the clean
+        // end on the peer rather than the cut `recv_raw` reports. Best
+        // effort: a sender blocked on the socket holds `wlock`, and waking
+        // our own reader must not wait on it.
+        if let Ok(_g) = self.wlock.try_lock() {
+            let mut cipher = Vec::new();
+            {
+                let mut c = self.conn.lock().expect("tls conn poisoned");
+                c.send_close_notify();
+                let _ = c.write_tls(&mut cipher);
+            }
+            if !cipher.is_empty() {
+                let _ = self.write_socket_locked(&cipher);
+            }
+        }
         self.stream.shutdown()?;
         Ok(())
     }
@@ -501,6 +521,9 @@ impl Read for RawIo<'_> {
             // loses the Timeout/Truncated contract.
             Err(RpcError::Timeout) => Err(std::io::ErrorKind::TimedOut.into()),
             Err(RpcError::PeerClosed) => Ok(0),
+            // Carried as the payload so `From<io::Error>` hands it back as
+            // itself on the far side of `read_header`.
+            Err(e @ RpcError::UncleanEndOfStream) => Err(std::io::Error::from(e)),
             Err(e) => Err(std::io::Error::other(e.to_string())),
         }
     }

--- a/rsbinder/src/rpc/transport/tls.rs
+++ b/rsbinder/src/rpc/transport/tls.rs
@@ -58,6 +58,26 @@ use crate::rpc::{RpcError, RpcResult};
 /// most a record-or-so worth of bytes per blocking socket `read`.
 const TLS_READ_CHUNK: usize = 16 * 1024;
 
+/// How long [`TlsTransport::shutdown`] may spend putting `close_notify` on
+/// the wire. Teardown must stay finite: without a bound, a peer that
+/// stopped reading (its send buffer full) holds `shutdown` — and every
+/// transport queued behind it in `shutdown_all_transports` — forever.
+const CLOSE_NOTIFY_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// How long [`TlsTransport::shutdown`] may wait for the write lock before
+/// transmitting `close_notify`. A send in flight holds `wlock`, and only
+/// the thread holding it may put records on the wire, so a shutdown that
+/// took the lock-free path would cut the socket with the alert still
+/// queued and hand the peer an unclean end.
+///
+/// Short on purpose. What this covers is a send about to release the lock
+/// — microseconds — not a peer that has stopped reading: that peer holds
+/// the sender for as long as its window stays shut, and is getting the
+/// unclean end either way. The wait is therefore what teardown latency
+/// this adds per stalled connection, and `shutdown_all_transports` walks
+/// its slots one at a time, so it is additive.
+const CLOSE_NOTIFY_WLOCK_WAIT: Duration = Duration::from_millis(50);
+
 /// A connected, byte-oriented stream that TLS can run over.
 ///
 /// Methods take `&self` (not the `&mut self` of `Read`/`Write`) so a
@@ -349,6 +369,35 @@ impl TlsTransport {
         self.write_socket_locked(&cipher)
     }
 
+    /// Take `wlock` for [`shutdown`](RpcTransport::shutdown), waiting up to
+    /// [`CLOSE_NOTIFY_WLOCK_WAIT`]. `None` ⇒ a sender still holds it and the
+    /// caller must cut the socket without transmitting.
+    ///
+    /// Spins first, then sleeps: the case worth catching is a send one
+    /// instruction from releasing the lock, and yielding catches that
+    /// without a millisecond of latency. A poisoned lock returns `None`
+    /// at once rather than waiting out a deadline nothing can meet.
+    fn wlock_for_close(&self) -> Option<std::sync::MutexGuard<'_, ()>> {
+        let deadline = std::time::Instant::now() + CLOSE_NOTIFY_WLOCK_WAIT;
+        let mut spins = 0u32;
+        loop {
+            match self.wlock.try_lock() {
+                Ok(g) => return Some(g),
+                Err(std::sync::TryLockError::Poisoned(_)) => return None,
+                Err(std::sync::TryLockError::WouldBlock) => {}
+            }
+            if std::time::Instant::now() >= deadline {
+                return None;
+            }
+            if spins < 64 {
+                spins += 1;
+                std::thread::yield_now();
+            } else {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        }
+    }
+
     /// Pull one chunk of ciphertext off the socket (lock-free) and feed
     /// it into the crypto state. Returns `false` on TCP EOF — after
     /// handing that EOF to rustls, so its reader can then tell a
@@ -470,7 +519,33 @@ impl RpcTransport for TlsTransport {
             }
             // 2. Opportunistically flush any control-plane output rustls
             //    queued (non-blocking on `wlock`; see `flush_control`).
-            self.flush_control()?;
+            if let Err(e) = self.flush_control() {
+                if self.shut.load(std::sync::atomic::Ordering::SeqCst) {
+                    // Our own `shutdown` breaks the write half on purpose,
+                    // and the trait promises a reader it wakes sees the end
+                    // of the stream, never a distinct "shut down locally"
+                    // error. `shutdown` bounds its own close_notify write, so
+                    // between setting the flag and breaking the stream that
+                    // write can expire rather than fail outright; report that
+                    // deadline as the end too, since with no deadline of ours
+                    // armed a timeout reads as the kernel's and the session
+                    // would end saying the stream was lost.
+                    let deadline = matches!(&e, RpcError::Io(io) if super::is_timeout(io));
+                    return Err(if deadline { RpcError::EndOfStream } else { e });
+                }
+                // Otherwise the outbound half is lost: those records left
+                // rustls before the write, so the peer never sees them —
+                // and a write that stopped part-way (a send deadline on a
+                // full socket buffer) left it a truncated record it can
+                // decrypt nothing after. That must not surface on the read
+                // side as a boundary-preserving error, which would keep the
+                // connection in the pool as if the stream were still good.
+                log::warn!(
+                    "TLS control flush failed, outbound half lost: {e} ({})",
+                    self.desc
+                );
+                return Err(RpcError::UncleanEndOfStream);
+            }
             // 3. Block on the socket (lock-free) for more ciphertext. On EOF
             //    rustls now knows, and the next pass of step 1 decides.
             self.pump_incoming()?;
@@ -497,15 +572,31 @@ impl RpcTransport for TlsTransport {
 
     fn shutdown(&self) -> RpcResult<()> {
         // close_notify first, so a deliberate close on this end is the clean
-        // end on the peer rather than the cut `recv_raw` reports. Best
-        // effort: a sender blocked on the socket holds `wlock`, and waking
-        // our own reader must not wait on it.
+        // end on the peer rather than the cut `recv_raw` reports.
         self.shut.store(true, std::sync::atomic::Ordering::SeqCst);
-        if let Ok(_g) = self.wlock.try_lock() {
+        // Bound that write: `write_socket_locked` blocks until the whole
+        // buffer is on the wire, and this is a teardown path whose caller
+        // (`shutdown_all_transports`, then `terminate`'s join) has no other
+        // way out. A peer that stalled sees a partial record — an unclean
+        // end, which is what a stalled peer is getting anyway.
+        let _ = self.stream.set_write_timeout(Some(CLOSE_NOTIFY_TIMEOUT));
+        // Queue it whatever `wlock` says — that lock guards the socket, not
+        // the crypto state, and a concurrent sender's next `write_tls`
+        // drains the shared output buffer in sequence order, so a sender
+        // that still has records to write carries this one out for us.
+        {
+            let mut c = self.conn.lock().expect("tls conn poisoned");
+            c.send_close_notify(); // idempotent in rustls
+        }
+        // Transmitting is this call's own job for every send that is not
+        // still running: only the `wlock` holder may put records on the
+        // wire, so cutting the socket while a sender holds it would strand
+        // the queued alert and leave the peer an unclean end. Wait for the
+        // lock, but briefly — see `CLOSE_NOTIFY_WLOCK_WAIT`.
+        if let Some(_g) = self.wlock_for_close() {
             let mut cipher = Vec::new();
             {
                 let mut c = self.conn.lock().expect("tls conn poisoned");
-                c.send_close_notify(); // idempotent in rustls
                 let _ = c.write_tls(&mut cipher);
             }
             if !cipher.is_empty() {

--- a/rsbinder/src/rpc/transport/tls.rs
+++ b/rsbinder/src/rpc/transport/tls.rs
@@ -79,7 +79,7 @@ pub trait TlsStream: Send + Sync {
     fn set_write_timeout(&self, t: Option<Duration>) -> std::io::Result<()>;
     /// Shut the underlying stream down in both directions (wakes a
     /// blocked `read`).
-    fn shutdown(&self) -> std::io::Result<()>;
+    fn shutdown_stream(&self) -> std::io::Result<()>;
 }
 
 // All std stream types implement `Read`/`Write` for `&Stream`, so the
@@ -100,7 +100,7 @@ impl TlsStream for TcpStream {
     fn set_write_timeout(&self, t: Option<Duration>) -> std::io::Result<()> {
         TcpStream::set_write_timeout(self, t)
     }
-    fn shutdown(&self) -> std::io::Result<()> {
+    fn shutdown_stream(&self) -> std::io::Result<()> {
         TcpStream::shutdown(self, std::net::Shutdown::Both)
     }
 }
@@ -121,7 +121,7 @@ impl TlsStream for UnixStream {
     fn set_write_timeout(&self, t: Option<Duration>) -> std::io::Result<()> {
         UnixStream::set_write_timeout(self, t)
     }
-    fn shutdown(&self) -> std::io::Result<()> {
+    fn shutdown_stream(&self) -> std::io::Result<()> {
         UnixStream::shutdown(self, std::net::Shutdown::Both)
     }
 }
@@ -143,7 +143,7 @@ impl TlsStream for vsock::VsockStream {
     fn set_write_timeout(&self, t: Option<Duration>) -> std::io::Result<()> {
         vsock::VsockStream::set_write_timeout(self, t)
     }
-    fn shutdown(&self) -> std::io::Result<()> {
+    fn shutdown_stream(&self) -> std::io::Result<()> {
         vsock::VsockStream::shutdown(self, std::net::Shutdown::Both)
     }
 }
@@ -312,7 +312,7 @@ impl TlsTransport {
         let mut off = 0;
         while off < cipher.len() {
             match self.stream.write(&cipher[off..]) {
-                Ok(0) => return Err(RpcError::PeerClosed),
+                Ok(0) => return Err(RpcError::EndOfStream),
                 Ok(n) => off += n,
                 // EINTR: a signal interrupted the write — retry (matches the
                 // plain-socket backends).
@@ -512,7 +512,7 @@ impl RpcTransport for TlsTransport {
                 let _ = self.write_socket_locked(&cipher);
             }
         }
-        super::absorb_already_shut(self.stream.shutdown())
+        super::absorb_already_shut(self.stream.shutdown_stream())
     }
 }
 
@@ -532,7 +532,7 @@ impl Read for RawIo<'_> {
             // otherwise it degrades to a generic `Other` and the frame path
             // loses the Timeout/Truncated contract.
             Err(RpcError::Timeout) => Err(std::io::ErrorKind::TimedOut.into()),
-            Err(RpcError::PeerClosed) => Ok(0),
+            Err(RpcError::EndOfStream) => Ok(0),
             // Carried as the payload so `From<io::Error>` hands it back as
             // itself on the far side of `read_header`.
             Err(e @ RpcError::UncleanEndOfStream) => Err(std::io::Error::from(e)),
@@ -547,7 +547,7 @@ impl Write for RawIo<'_> {
     }
     fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
         // Kind-preserving like `RawTransportIo`: a write to a peer that
-        // already closed must reach `write_frame`'s `?` as `PeerClosed`
+        // already closed must reach `write_frame`'s `?` as `EndOfStream`
         // (`DeadObject`), not an unclassified `Io(Other)`.
         self.0.send_raw(buf).map_err(std::io::Error::from)
     }

--- a/rsbinder/src/rpc/transport/unix.rs
+++ b/rsbinder/src/rpc/transport/unix.rs
@@ -288,7 +288,7 @@ impl RpcTransport for UnixTransport {
     /// `&self` stays full-duplex (same as `send_frame`).
     fn send_raw(&self, buf: &[u8]) -> RpcResult<()> {
         let mut w = &self.stream;
-        w.write_all(buf).map_err(RpcError::from)?;
+        super::write_all_reporting(&mut w, buf)?;
         w.flush().map_err(RpcError::from)?;
         Ok(())
     }
@@ -374,7 +374,17 @@ impl RpcTransport for UnixTransport {
                 Ok(n) => n,
                 // EINTR is benign — retry the syscall.
                 Err(rustix::io::Errno::INTR) => continue,
-                Err(e) => return Err(std::io::Error::from(e).into()),
+                // Same split `write_all_reporting` makes: a send deadline
+                // that expired before the first byte started no frame, so
+                // the stream is still frame-synchronized.
+                Err(e) => {
+                    let e = std::io::Error::from(e);
+                    return Err(if sent == 0 && super::is_timeout(&e) {
+                        RpcError::Timeout
+                    } else {
+                        e.into()
+                    });
+                }
             };
             if n == 0 {
                 return Err(RpcError::EndOfStream);
@@ -475,8 +485,9 @@ impl RpcTransport for UnixTransport {
         // for the whole call and releases it only once it wakes, so taking
         // the lock first deadlocks against it. What it appends on waking was
         // queued in the kernel before this call (the platform's business);
-        // what is left in this buffer after it returns is ours, and a later
-        // reader must not be handed a frame of the connection just ended.
+        // what is left in this buffer after it returns is ours — the prefix
+        // of a frame some error cut short — and a later reader must not
+        // decode the connection just ended out of it.
         let shut = self.stream.shutdown(std::net::Shutdown::Both);
         if let Ok(mut leftover) = self.fd_recv_buf.lock() {
             leftover.clear();
@@ -561,6 +572,10 @@ impl RpcTransport for UnixTransport {
 
         let mut leftover = self.fd_recv_buf.lock().expect("fd recv buf poisoned");
         let mut fds: Vec<std::os::fd::OwnedFd> = Vec::new();
+        // Reused across iterations — a frame costs at least two `recvmsg`s
+        // (header, then body), and `RecvAncillaryBuffer::new` resets it.
+        let mut space =
+            vec![MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(MAX_FDS_PER_FRAME))];
         loop {
             if leftover.len() >= 4 {
                 let len = u32::from_le_bytes(leftover[0..4].try_into().unwrap()) as usize;
@@ -577,8 +592,22 @@ impl RpcTransport for UnixTransport {
                 }
             }
             let mut tmp = [0u8; 8192];
-            let mut space =
-                vec![MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(MAX_FDS_PER_FRAME))];
+            // Never read past this frame's last byte. `AF_UNIX` glues
+            // stream data across skbs and only stops *after* consuming the
+            // one that carried fds, so a `recvmsg` spilling into the next
+            // frame would hand that frame's `SCM_RIGHTS` fds back attached
+            // to this one — and leave the next frame with none. The
+            // android-13+ reader (`read_aosp_message_with_fds`) is exact
+            // for the same reason.
+            let want = if leftover.len() < 4 {
+                4 - leftover.len()
+            } else {
+                // Bounded by `MAX_FRAME_LEN` above, and short of `4 + len`
+                // (a complete frame returned already).
+                let len = u32::from_le_bytes(leftover[0..4].try_into().unwrap()) as usize;
+                4 + len - leftover.len()
+            };
+            let want = want.min(tmp.len());
             let mut anc = RecvAncillaryBuffer::new(&mut space);
             // `RecvFlags::CMSG_CLOEXEC` (`MSG_CMSG_CLOEXEC`) is
             // Linux-only; for portability set `FD_CLOEXEC` explicitly
@@ -586,7 +615,7 @@ impl RpcTransport for UnixTransport {
             let r = loop {
                 match rustix::net::recvmsg(
                     &self.stream,
-                    &mut [IoSliceMut::new(&mut tmp)],
+                    &mut [IoSliceMut::new(&mut tmp[..want])],
                     &mut anc,
                     RecvFlags::empty(),
                 ) {
@@ -605,7 +634,15 @@ impl RpcTransport for UnixTransport {
                                 RpcError::DeadlineMidFrame
                             });
                         }
-                        return Err(io_err.into());
+                        // Likewise for a disconnect: past the first byte or
+                        // fd of a message the position is lost, so the kinds
+                        // folded into `EndOfStream` are a cut, not a boundary.
+                        return Err(match RpcError::from(io_err) {
+                            RpcError::EndOfStream if !leftover.is_empty() || !fds.is_empty() => {
+                                RpcError::Truncated
+                            }
+                            other => other,
+                        });
                     }
                 }
             };
@@ -695,26 +732,36 @@ mod tests {
         assert!(matches!(a.recv_frame(), Err(RpcError::EndOfStream)));
     }
 
-    /// Plan 2-21 B-3 — `shutdown` drops the fd-mode leftover. Two frames
-    /// arrive in one `recvmsg`; the first is returned and the second stays
-    /// buffered. A reader woken by `shutdown` must not be handed that
-    /// second frame — it belongs to a connection that has ended. What the
-    /// *kernel* still holds is the platform's business (macOS drops its
-    /// queue, Linux keeps it); this buffer is ours to clear.
+    /// Plan 2-21 B-3 — `shutdown` drops the fd-mode leftover. The reader
+    /// never reads past the frame in progress, so what this buffer can
+    /// hold is the prefix an error left behind; a deadline part-way
+    /// through a frame is the cheapest way to put one there. That prefix
+    /// belongs to a connection that has ended and must not be the head of
+    /// what a later reader decodes. What the *kernel* still holds is the
+    /// platform's business and is pinned by `rpc_transport_conformance`,
+    /// not here.
     #[test]
     fn unix_shutdown_drops_the_fd_mode_leftover() {
+        use std::io::Write;
         let (a, b) = UnixTransport::pair().expect("socketpair");
-        // Both frames sit in b's socket buffer before b reads once.
-        a.send_frame(b"first").unwrap();
-        a.send_frame(b"second").unwrap();
-        let (first, fds) = b.recv_frame_with_fds().expect("first frame");
-        assert_eq!(first, b"first");
-        assert!(fds.is_empty());
-        b.shutdown().expect("shutdown");
-        let second = b.recv_frame_with_fds();
+        b.set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .expect("deadline");
+        // A header promising 8 bytes, then only 3 of them.
+        let mut partial = 8u32.to_le_bytes().to_vec();
+        partial.extend_from_slice(&[1, 2, 3]);
+        (&a.stream).write_all(&partial).expect("partial frame");
+        assert!(matches!(
+            b.recv_frame_with_fds(),
+            Err(RpcError::DeadlineMidFrame)
+        ));
         assert!(
-            !matches!(&second, Ok((f, _)) if f == b"second"),
-            "a frame of the ended connection was handed out after shutdown: {second:?}"
+            !b.fd_recv_buf.lock().unwrap().is_empty(),
+            "the prefix of the cut frame is buffered"
+        );
+        b.shutdown().expect("shutdown");
+        assert!(
+            b.fd_recv_buf.lock().unwrap().is_empty(),
+            "shutdown must drop what this end had buffered"
         );
         b.shutdown().expect("a second shutdown is Ok (idempotent)");
     }

--- a/rsbinder/src/rpc/transport/unix.rs
+++ b/rsbinder/src/rpc/transport/unix.rs
@@ -471,6 +471,12 @@ impl RpcTransport for UnixTransport {
     }
 
     fn shutdown(&self) -> RpcResult<()> {
+        // What the kernel does with its receive queue is the platform's
+        // business; this buffer is ours, and a reader woken by this call
+        // must not be handed a frame of the connection just ended.
+        if let Ok(mut leftover) = self.fd_recv_buf.lock() {
+            leftover.clear();
+        }
         self.stream.shutdown(std::net::Shutdown::Both)?;
         Ok(())
     }
@@ -685,6 +691,29 @@ mod tests {
         drop(b);
         // First recv sees EOF -> clean PeerClosed.
         assert!(matches!(a.recv_frame(), Err(RpcError::PeerClosed)));
+    }
+
+    /// Plan 2-21 B-3 — `shutdown` drops the fd-mode leftover. Two frames
+    /// arrive in one `recvmsg`; the first is returned and the second stays
+    /// buffered. A reader woken by `shutdown` must not be handed that
+    /// second frame — it belongs to a connection that has ended. What the
+    /// *kernel* still holds is the platform's business (macOS drops its
+    /// queue, Linux keeps it); this buffer is ours to clear.
+    #[test]
+    fn unix_shutdown_drops_the_fd_mode_leftover() {
+        let (a, b) = UnixTransport::pair().expect("socketpair");
+        // Both frames sit in b's socket buffer before b reads once.
+        a.send_frame(b"first").unwrap();
+        a.send_frame(b"second").unwrap();
+        let (first, fds) = b.recv_frame_with_fds().expect("first frame");
+        assert_eq!(first, b"first");
+        assert!(fds.is_empty());
+        b.shutdown().expect("shutdown");
+        let second = b.recv_frame_with_fds();
+        assert!(
+            !matches!(&second, Ok((f, _)) if f == b"second"),
+            "a frame of the ended connection was handed out after shutdown: {second:?}"
+        );
     }
 
     /// Adopt one half of a `socketpair` via `from_owned_fd` and verify

--- a/rsbinder/src/rpc/transport/unix.rs
+++ b/rsbinder/src/rpc/transport/unix.rs
@@ -377,7 +377,7 @@ impl RpcTransport for UnixTransport {
                 Err(e) => return Err(std::io::Error::from(e).into()),
             };
             if n == 0 {
-                return Err(RpcError::PeerClosed);
+                return Err(RpcError::EndOfStream);
             }
             sent += n;
         }
@@ -540,7 +540,7 @@ impl RpcTransport for UnixTransport {
                 Err(e) => return Err(std::io::Error::from(e).into()),
             };
             if n == 0 {
-                return Err(RpcError::PeerClosed);
+                return Err(RpcError::EndOfStream);
             }
             sent += n;
         }
@@ -633,7 +633,7 @@ impl RpcTransport for UnixTransport {
             }
             if r.bytes == 0 {
                 return Err(if leftover.is_empty() && fds.is_empty() {
-                    RpcError::PeerClosed
+                    RpcError::EndOfStream
                 } else {
                     RpcError::Truncated
                 });
@@ -691,8 +691,8 @@ mod tests {
     fn unix_peer_closed_on_drop() {
         let (a, b) = UnixTransport::pair().expect("socketpair");
         drop(b);
-        // First recv sees EOF -> clean PeerClosed.
-        assert!(matches!(a.recv_frame(), Err(RpcError::PeerClosed)));
+        // First recv sees EOF -> clean EndOfStream.
+        assert!(matches!(a.recv_frame(), Err(RpcError::EndOfStream)));
     }
 
     /// Plan 2-21 B-3 — `shutdown` drops the fd-mode leftover. Two frames
@@ -785,7 +785,7 @@ mod tests {
     fn unix_partial_header_then_close_is_truncated() {
         // The spec is deterministic — 2-of-4 header bytes consumed
         // *then* EOF MUST surface as `Truncated` (see `read_header` in
-        // transport/mod.rs: `filled == 0` ⇒ `PeerClosed`, `filled > 0`
+        // transport/mod.rs: `filled == 0` ⇒ `EndOfStream`, `filled > 0`
         // ⇒ `Truncated`). The kernel does not coalesce these into an
         // immediate EOF.
         let (a, b) = UnixTransport::pair().expect("socketpair");

--- a/rsbinder/src/rpc/transport/unix.rs
+++ b/rsbinder/src/rpc/transport/unix.rs
@@ -471,13 +471,17 @@ impl RpcTransport for UnixTransport {
     }
 
     fn shutdown(&self) -> RpcResult<()> {
-        // What the kernel does with its receive queue is the platform's
-        // business; this buffer is ours, and a reader woken by this call
-        // must not be handed a frame of the connection just ended.
+        // Socket first: a reader parked in `recvmsg` holds `fd_recv_buf`
+        // for the whole call and releases it only once it wakes, so taking
+        // the lock first deadlocks against it. What it appends on waking was
+        // queued in the kernel before this call (the platform's business);
+        // what is left in this buffer after it returns is ours, and a later
+        // reader must not be handed a frame of the connection just ended.
+        let shut = self.stream.shutdown(std::net::Shutdown::Both);
         if let Ok(mut leftover) = self.fd_recv_buf.lock() {
             leftover.clear();
         }
-        super::absorb_already_shut(self.stream.shutdown(std::net::Shutdown::Both))
+        super::absorb_already_shut(shut)
     }
 
     /// Send `buf` as a length-prefixed frame, passing `fds` out-of-band

--- a/rsbinder/src/rpc/transport/unix.rs
+++ b/rsbinder/src/rpc/transport/unix.rs
@@ -477,8 +477,7 @@ impl RpcTransport for UnixTransport {
         if let Ok(mut leftover) = self.fd_recv_buf.lock() {
             leftover.clear();
         }
-        self.stream.shutdown(std::net::Shutdown::Both)?;
-        Ok(())
+        super::absorb_already_shut(self.stream.shutdown(std::net::Shutdown::Both))
     }
 
     /// Send `buf` as a length-prefixed frame, passing `fds` out-of-band
@@ -591,16 +590,15 @@ impl RpcTransport for UnixTransport {
                     // EINTR retry.
                     Err(rustix::io::Errno::INTR) => continue,
                     Err(e) => {
-                        // Map a read deadline to `Timeout` (frame-
-                        // synchronized, nothing consumed) or `Truncated`
-                        // (mid-frame desync) so callers can distinguish
-                        // — same contract as `read_header`/`read_body`.
+                        // Same contract as `read_header`/`read_body`: a
+                        // deadline with nothing consumed is a boundary
+                        // `Timeout`; mid-frame it is our own cut.
                         let io_err = std::io::Error::from(e);
                         if super::is_timeout(&io_err) {
                             return Err(if leftover.is_empty() && fds.is_empty() {
                                 RpcError::Timeout
                             } else {
-                                RpcError::Truncated
+                                RpcError::DeadlineMidFrame
                             });
                         }
                         return Err(io_err.into());
@@ -713,6 +711,38 @@ mod tests {
         assert!(
             !matches!(&second, Ok((f, _)) if f == b"second"),
             "a frame of the ended connection was handed out after shutdown: {second:?}"
+        );
+        b.shutdown().expect("a second shutdown is Ok (idempotent)");
+    }
+
+    /// Plan 2-21 D-6 — a read deadline that elapses part-way through a
+    /// frame is this end's own cut (`DeadlineMidFrame`), told apart from
+    /// a stream that ended mid-frame (`Truncated`); with nothing consumed
+    /// it stays the boundary `Timeout`. Both the framed reader and the
+    /// fd-mode reader classify the same way.
+    #[test]
+    fn unix_mid_frame_deadline_is_our_own_cut() {
+        use std::io::Write;
+        let (a, b) = UnixTransport::pair().expect("socketpair");
+        b.set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .expect("deadline");
+        assert!(matches!(b.recv_frame(), Err(RpcError::Timeout)));
+        assert!(matches!(b.recv_frame_with_fds(), Err(RpcError::Timeout)));
+
+        // A header promising 8 bytes, then only 3 of them.
+        let mut partial = 8u32.to_le_bytes().to_vec();
+        partial.extend_from_slice(&[1, 2, 3]);
+        let mut w = &a.stream;
+        w.write_all(&partial).expect("partial frame");
+        assert!(
+            matches!(b.recv_frame(), Err(RpcError::DeadlineMidFrame)),
+            "the framed reader must name our own deadline, not a truncation"
+        );
+
+        w.write_all(&partial).expect("partial frame");
+        assert!(
+            matches!(b.recv_frame_with_fds(), Err(RpcError::DeadlineMidFrame)),
+            "the fd-mode reader must classify the same way"
         );
     }
 

--- a/rsbinder/src/rpc/transport/vsock.rs
+++ b/rsbinder/src/rpc/transport/vsock.rs
@@ -133,7 +133,6 @@ impl RpcTransport for VsockTransport {
     }
 
     fn shutdown(&self) -> RpcResult<()> {
-        self.stream.shutdown(std::net::Shutdown::Both)?;
-        Ok(())
+        super::absorb_already_shut(self.stream.shutdown(std::net::Shutdown::Both))
     }
 }

--- a/rsbinder/src/rpc/transport/vsock.rs
+++ b/rsbinder/src/rpc/transport/vsock.rs
@@ -93,7 +93,7 @@ impl RpcTransport for VsockTransport {
     fn send_raw(&self, buf: &[u8]) -> RpcResult<()> {
         use std::io::Write;
         let mut w = &self.stream;
-        w.write_all(buf)?;
+        super::write_all_reporting(&mut w, buf)?;
         w.flush()?;
         Ok(())
     }

--- a/rsbinder/src/rpc/wire_android13.rs
+++ b/rsbinder/src/rpc/wire_android13.rs
@@ -778,9 +778,10 @@ fn map_io(e: std::io::Error) -> RpcError {
 /// either one leaves the stream desynchronized ⇒
 /// [`RpcError::Truncated`].
 fn classify_short_read(e: RpcError, progress: usize) -> RpcError {
-    match e {
-        RpcError::PeerClosed | RpcError::Timeout if progress > 0 => RpcError::Truncated,
-        other => other,
+    if progress > 0 && e.leaves_frame_boundary_intact() {
+        RpcError::Truncated
+    } else {
+        e
     }
 }
 

--- a/rsbinder/src/rpc/wire_android13.rs
+++ b/rsbinder/src/rpc/wire_android13.rs
@@ -790,7 +790,7 @@ fn classify_short_read(e: RpcError, progress: usize) -> RpcError {
 }
 
 /// Read exactly `n` bytes. Zero bytes before any progress ⇒ a clean
-/// [`RpcError::PeerClosed`]; a short read after partial progress ⇒
+/// [`RpcError::EndOfStream`]; a short read after partial progress ⇒
 /// [`RpcError::Truncated`].
 fn read_exact_raw<R: Read>(r: &mut R, n: usize) -> RpcResult<Vec<u8>> {
     let mut buf = vec![0u8; n];
@@ -806,7 +806,7 @@ fn read_exact_into<R: Read>(r: &mut R, buf: &mut [u8]) -> RpcResult<()> {
     let mut got = 0;
     while got < n {
         match r.read(&mut buf[got..]) {
-            Ok(0) => return Err(classify_short_read(RpcError::PeerClosed, got)),
+            Ok(0) => return Err(classify_short_read(RpcError::EndOfStream, got)),
             Ok(k) => got += k,
             // A signal interrupted the read; retry like every other reader.
             Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
@@ -904,7 +904,7 @@ pub fn write_aosp_message_with_fds(
 /// `recvmsg`** that read the message (AOSP
 /// `RpcTransportRaw::interruptableReadFully`: the kernel delivers
 /// `SCM_RIGHTS` with the first byte of the sender's `sendmsg`, i.e. on
-/// the header read). Clean EOF before any byte ⇒ [`RpcError::PeerClosed`];
+/// the header read). Clean EOF before any byte ⇒ [`RpcError::EndOfStream`];
 /// a short read after partial progress ⇒ [`RpcError::Truncated`]
 /// (mirrors [`read_aosp_message`]).
 pub fn read_aosp_message_with_fds(
@@ -914,7 +914,7 @@ pub fn read_aosp_message_with_fds(
     let mut total_read = 0usize;
     // Fill `dst` via `recvmsg`, accumulating any fds into `fds`.
     // `total_read` tracks progress across header+body so a 0-byte recv
-    // distinguishes a clean pre-message close (PeerClosed) from a
+    // distinguishes a clean pre-message close (EndOfStream) from a
     // mid-message truncation (Truncated) — same contract as
     // `read_exact_raw`, through the same `classify_short_read`.
     let mut fill = |dst: &mut [u8]| -> RpcResult<()> {
@@ -939,7 +939,7 @@ pub fn read_aosp_message_with_fds(
                 ));
             }
             if n == 0 {
-                return Err(classify_short_read(RpcError::PeerClosed, total_read));
+                return Err(classify_short_read(RpcError::EndOfStream, total_read));
             }
             got += n;
             total_read += n;
@@ -1199,7 +1199,7 @@ fn write_all_raw<W: Write>(w: &mut W, buf: &[u8]) -> RpcResult<()> {
 /// helpers above run over any transport with raw byte access
 /// (currently `unix`). EOF (`recv_raw` ⇒ `Ok(0)`) is preserved as
 /// `Read` returning `Ok(0)`, so `read_exact_raw` still yields the
-/// correct `PeerClosed`/`Truncated`. This is the bridge the opt-in
+/// correct `EndOfStream`/`Truncated`. This is the bridge the opt-in
 /// android-13+ `RpcSession` profile uses; the R34 path never touches
 /// it.
 pub struct RawTransportIo<'a>(pub &'a dyn super::transport::RpcTransport);
@@ -1207,8 +1207,8 @@ pub struct RawTransportIo<'a>(pub &'a dyn super::transport::RpcTransport);
 impl Read for RawTransportIo<'_> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         // `From<RpcError>` is kind-preserving (`Timeout` -> `TimedOut`,
-        // `PeerClosed` -> `BrokenPipe`), so on the other side of this
-        // boundary `map_io` recovers `PeerClosed` and the `is_timeout`
+        // `EndOfStream` -> `BrokenPipe`), so on the other side of this
+        // boundary `map_io` recovers `EndOfStream` and the `is_timeout`
         // arm recovers `Timeout`, instead of a stringified `Io(Other)`.
         self.0.recv_raw(buf).map_err(std::io::Error::from)
     }
@@ -1221,7 +1221,7 @@ impl Write for RawTransportIo<'_> {
     }
     fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
         // Kind-preserving, as on the read side: a peer that closed
-        // before our write must surface as `PeerClosed` (`DeadObject`),
+        // before our write must surface as `EndOfStream` (`DeadObject`),
         // not as an unclassified `Io(Other)`.
         self.0.send_raw(buf).map_err(std::io::Error::from)
     }

--- a/rsbinder/src/rpc/wire_android13.rs
+++ b/rsbinder/src/rpc/wire_android13.rs
@@ -774,12 +774,16 @@ fn map_io(e: std::io::Error) -> RpcError {
 /// Classify a failed read by `progress`, the amount the **caller**
 /// counts as already arrived (this call's bytes for
 /// [`read_exact_into`], the whole message for the FD reader): at zero a
-/// clean close or an elapsed deadline stands as itself; above zero
-/// either one leaves the stream desynchronized ⇒
-/// [`RpcError::Truncated`].
+/// clean close or an elapsed deadline stands as itself; above zero the
+/// stream position is lost — [`RpcError::Truncated`] if the stream ended,
+/// [`RpcError::DeadlineMidFrame`] if our own deadline cut it.
 fn classify_short_read(e: RpcError, progress: usize) -> RpcError {
     if progress > 0 && e.leaves_frame_boundary_intact() {
-        RpcError::Truncated
+        if matches!(e, RpcError::Timeout) {
+            RpcError::DeadlineMidFrame
+        } else {
+            RpcError::Truncated
+        }
     } else {
         e
     }

--- a/rsbinder/src/rpc/wire_android13.rs
+++ b/rsbinder/src/rpc/wire_android13.rs
@@ -776,7 +776,8 @@ fn map_io(e: std::io::Error) -> RpcError {
 /// [`read_exact_into`], the whole message for the FD reader): at zero a
 /// clean close or an elapsed deadline stands as itself; above zero the
 /// stream position is lost — [`RpcError::Truncated`] if the stream ended,
-/// [`RpcError::DeadlineMidFrame`] if our own deadline cut it.
+/// [`RpcError::DeadlineMidFrame`] if a read deadline cut it (whose it was
+/// is not knowable here; see `transport::is_timeout`).
 fn classify_short_read(e: RpcError, progress: usize) -> RpcError {
     if progress > 0 && e.leaves_frame_boundary_intact() {
         if matches!(e, RpcError::Timeout) {
@@ -865,7 +866,8 @@ pub fn read_aosp_message<R: Read>(r: &mut R) -> RpcResult<Vec<u8>> {
     if body_size > 0 {
         // The header is already consumed, so a deadline or a clean EOF at the
         // start of the body is mid-message, not frame-synchronized: pass the
-        // header as progress so both become `Truncated`, the same value the FD
+        // header as progress so a stream that ended becomes `Truncated` and
+        // a read deadline becomes `DeadlineMidFrame`, the same values the FD
         // reader's `total_read` yields there.
         read_exact_into(r, &mut out[WIRE_HEADER_LEN..])
             .map_err(|e| classify_short_read(e, WIRE_HEADER_LEN))?;

--- a/rsbinder/src/thread_state.rs
+++ b/rsbinder/src/thread_state.rs
@@ -42,6 +42,12 @@
 //! callbacks routinely make outgoing binder calls from inside an incoming
 //! `BR_TRANSACTION`, so this is not a theoretical concern.
 //!
+//! The RPC stack's thread-locals are bound by the same rule:
+//! `rpc::session::DRIVING` (the nested-call recursion marker) and
+//! `RPC_CALLING` (below) both live across user callbacks — `rpc_transact`,
+//! `binder_died` — and every access copies its value out inside `with`,
+//! holding no guard across the callout.
+//!
 //! ## Patterns to satisfy R1
 //!
 //! - **P2 — Minimal scope**: scope each borrow as tightly as "read value →
@@ -130,10 +136,10 @@ fn ensure_thread_exit_guard(driver: &Arc<File>) {
 //
 // The store holds an `Arc<PeerIdentity>` (the full peer, so handler-side
 // authorization can see uid *and* the cert/vsock identity), borrowed only
-// momentarily (clone-out) and never across the user handler, so the R1
-// borrow discipline that governs `THREAD_STATE`/`BINDER_DEREFS` does not
-// apply here (set → run handler → restore, no live borrow during the
-// callout). `Arc` keeps the per-dispatch and oneway-drain installs cheap.
+// momentarily (clone-out) and never across the user handler — the R1
+// borrow discipline (module doc) satisfied by construction: set → run
+// handler → restore, no live borrow during the callout. `Arc` keeps the
+// per-dispatch and oneway-drain installs cheap.
 #[cfg(feature = "rpc")]
 thread_local! {
     static RPC_CALLING: std::cell::RefCell<Option<std::sync::Arc<crate::rpc::transport::PeerIdentity>>> =

--- a/rsbinder/tests/rpc_accessor.rs
+++ b/rsbinder/tests/rpc_accessor.rs
@@ -212,7 +212,7 @@ impl EchoServerGuard {
 
 impl Drop for EchoServerGuard {
     fn drop(&mut self) {
-        self.server.shutdown();
+        self.server.stop_accepting();
         if let Some(bg) = self.bg.take() {
             let _ = bg.join();
         }
@@ -273,7 +273,7 @@ fn accessor_arm_resolves_root_and_echoes() {
 
     // Drop the user-visible root: the wrapper's `Drop` must release the
     // inner proxy first (best-effort DEC_STRONG), then the session
-    // (peer-side serve loop exits on PeerClosed). No leak / no panic.
+    // (peer-side serve loop exits on EndOfStream). No leak / no panic.
     drop(root);
 }
 

--- a/rsbinder/tests/rpc_fd.rs
+++ b/rsbinder/tests/rpc_fd.rs
@@ -214,7 +214,7 @@ fn fd_roundtrip_when_both_opt_in_over_uds() {
 
     drop(root);
     drop(client);
-    server.shutdown();
+    server.stop_accepting();
     let _ = bg.join();
     let _ = std::fs::remove_file(&path);
 }
@@ -249,7 +249,7 @@ fn fd_rejected_without_mutual_opt_in() {
 
     drop(root);
     drop(client);
-    server.shutdown();
+    server.stop_accepting();
     let _ = bg.join();
     let _ = std::fs::remove_file(&path);
 }
@@ -358,7 +358,7 @@ fn fd_v1plus_aosp_roundtrip_both_directions() {
 
         drop(root);
         drop(client);
-        server.shutdown();
+        server.stop_accepting();
         let _ = bg.join();
         let _ = std::fs::remove_file(&path);
     }
@@ -397,6 +397,6 @@ fn fd_v1_abstract_unix_roundtrip_arg() {
 
     drop(root);
     drop(client);
-    server.shutdown();
+    server.stop_accepting();
     let _ = bg.join();
 }

--- a/rsbinder/tests/rpc_scenarios.rs
+++ b/rsbinder/tests/rpc_scenarios.rs
@@ -350,7 +350,7 @@ struct ServeCleanup {
 }
 impl Drop for ServeCleanup {
     fn drop(&mut self) {
-        self.server.shutdown();
+        self.server.stop_accepting();
         if let Some(h) = self.bg.take() {
             let _ = h.join();
         }

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -3621,6 +3621,41 @@ fn c_server_death_is_eager_with_incoming() {
     let _ = std::fs::remove_file(&path);
 }
 
+/// Plan 2-21 B-4 — an `AF_INET` fd handed to `from_preconnected_fd` is
+/// wrapped in `TcpDebugTransport` and goes straight into the android-13+
+/// handshake, whose first byte is a raw write. Without that transport's
+/// `send_raw`/`recv_raw` the write hit the trait default's `Protocol`
+/// refusal — the omission that had already broken `vsock` once.
+#[cfg(feature = "rpc-tcp-debug")]
+#[test]
+fn preconnected_inet_fd_handshakes_over_tcp_debug() {
+    use rsbinder::rpc::transport::TcpDebugTransport;
+    use std::os::fd::OwnedFd;
+
+    let listener = TcpDebugTransport::bind_loopback().expect("bind loopback");
+    let addr = listener.local_addr().expect("addr");
+    let client_stream = std::net::TcpStream::connect(addr).expect("connect");
+    let (server_stream, _) = listener.accept().expect("accept");
+    let server_t = TcpDebugTransport::from_stream(server_stream).expect("server transport");
+
+    // The server object needs a listener to exist; it is never run.
+    let path = tmp_sock("pcfd");
+    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    server.set_android13plus(2);
+    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server.serve_connection(Box::new(server_t));
+
+    let client = RpcSession::from_preconnected_fd(OwnedFd::from(client_stream), 2)
+        .expect("android-13+ handshake over a preconnected AF_INET fd");
+    assert_eq!(client.wire_protocol_version(), Some(2));
+    let root = EchoProxy(client.get_root().expect("root"));
+    assert_eq!(root.echo("inet").unwrap(), "inet");
+    drop(root);
+    drop(client);
+    server.terminate();
+    let _ = std::fs::remove_file(&path);
+}
+
 /// Plan 2-21 B-2 — `terminate` ends what `shutdown` only lets drain. An
 /// r34 client and an android-13+ client (the two minting paths — only
 /// the latter has a session id, so only it was ever in the id registry)

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -3621,6 +3621,165 @@ fn c_server_death_is_eager_with_incoming() {
     let _ = std::fs::remove_file(&path);
 }
 
+/// Plan 2-21 B-2 — `terminate` ends what `shutdown` only lets drain. An
+/// r34 client and an android-13+ client (the two minting paths — only
+/// the latter has a session id, so only it was ever in the id registry)
+/// stay connected; `terminate` still returns, wakes every worker out of
+/// `recv`, joins them, and the android-13+ session — driven by two
+/// workers, so `Live(2)` — dies whole instead of being skipped as
+/// "still live".
+#[test]
+fn terminate_ends_every_session_and_joins_workers() {
+    // r34 (the default profile): the minting path with no session id, so
+    // nothing in the id registry ever knew this session. A server speaks
+    // one profile, so the two paths need two servers.
+    let r34_path = tmp_sock("term34");
+    let r34_server = RpcServer::setup_unix_server(&r34_path).expect("bind r34");
+    r34_server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    let r34_bg = r34_server.run_background();
+    wait_for_sock(&r34_path);
+    let r34 = RpcSession::setup_unix_client(&r34_path).expect("r34 connect");
+    let r34_root = EchoProxy(r34.get_root().expect("root"));
+    assert_eq!(r34_root.echo("r34").unwrap(), "r34");
+
+    // android-13+ with two outgoing connections: a `Live(2)` server
+    // session, which `RpcSession::shutdown` used to skip as "still live".
+    let a13_path = tmp_sock("term13");
+    let a13_server = RpcServer::setup_unix_server(&a13_path).expect("bind a13");
+    a13_server.set_android13plus(2);
+    a13_server.set_max_threads(2);
+    a13_server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    let a13_bg = a13_server.run_background();
+    wait_for_sock(&a13_path);
+    let a13 = RpcSession::setup_unix_client_android13plus_with_config(
+        RpcUnixClientConfig::path(&a13_path, 2).outgoing_connections(2),
+    )
+    .expect("android-13+ connect");
+    let a13_root = EchoProxy(a13.get_root().expect("root"));
+    assert_eq!(a13_root.echo("a13").unwrap(), "a13");
+    let sid: [u8; 32] = a13
+        .get_session_id()
+        .expect("sid")
+        .as_slice()
+        .try_into()
+        .unwrap();
+    assert!(
+        poll_until(|| a13_server.session_live_conns(&sid) == Some(2)),
+        "two outgoing connections drive the android-13+ session: {:?}",
+        a13_server.session_live_conns(&sid)
+    );
+
+    // Off-thread with a channel deadline: a `terminate` that blocks on a
+    // connected client must fail the test, not hang the runner.
+    for (name, server) in [("r34", &r34_server), ("android-13+", &a13_server)] {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
+        let terminating = Arc::clone(server);
+        let t = std::thread::spawn(move || {
+            terminating.terminate();
+            let _ = tx.send(());
+        });
+        match rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(()) | Err(RecvTimeoutError::Disconnected) => {}
+            Err(RecvTimeoutError::Timeout) => {
+                panic!("{name}: terminate blocked with a client still connected")
+            }
+        }
+        t.join().expect("terminate thread");
+    }
+    r34_bg.join().expect("r34 accept loop");
+    a13_bg.join().expect("android-13+ accept loop");
+    // Every worker exited (their `Arc<RpcServer>` clones are gone) and the
+    // android-13+ session is dead, not merely "still live".
+    for (name, server) in [("r34", &r34_server), ("android-13+", &a13_server)] {
+        assert!(
+            poll_until(|| Arc::strong_count(server) == 1),
+            "{name}: a worker still holds the server ({} refs)",
+            Arc::strong_count(server)
+        );
+    }
+    assert!(
+        poll_until(|| matches!(a13_server.session_live_conns(&sid), None | Some(0))),
+        "the android-13+ session must be dead after terminate"
+    );
+    assert!(
+        r34_root.echo("after").is_err(),
+        "the r34 connection was ended"
+    );
+    assert!(
+        a13_root.echo("after").is_err(),
+        "the android-13+ connection was ended"
+    );
+    let _ = std::fs::remove_file(&r34_path);
+    let _ = std::fs::remove_file(&a13_path);
+}
+
+/// Plan 2-21 B-2 — a service that ends its own server calls `terminate`
+/// from inside a handler, on the very worker thread `terminate` would
+/// join. That handle is skipped; the worker exits when the handler
+/// returns, and nothing deadlocks.
+#[test]
+fn terminate_from_a_handler_does_not_join_itself() {
+    const STOP_DESC: &str = "rsbinder.test.IStopper";
+    struct Stopper(Mutex<Option<Arc<RpcServer>>>);
+    impl Remotable for Stopper {
+        fn descriptor() -> &'static str {
+            STOP_DESC
+        }
+        fn on_transact(
+            &self,
+            _code: TransactionCode,
+            _reader: &mut Parcel,
+            reply: &mut Parcel,
+        ) -> Result<()> {
+            if let Some(server) = self.0.lock().unwrap().take() {
+                server.terminate();
+            }
+            reply.write(&Status::from(StatusCode::Ok))
+        }
+        fn on_dump(&self, _w: &mut dyn std::io::Write, _a: &[String]) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    let path = tmp_sock("termre");
+    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    // The service holds the server until the call takes it, so the strong
+    // count below can reach 1 once the worker is gone.
+    server.set_root(Interface::as_binder(&Binder::new(Stopper(Mutex::new(
+        Some(Arc::clone(&server)),
+    )))));
+    let bg = server.run_background();
+    wait_for_sock(&path);
+    let client = RpcSession::setup_unix_client(&path).expect("connect");
+    let root = client.get_root().expect("root");
+
+    let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
+    let caller = std::thread::spawn(move || {
+        let rp = (*root)
+            .as_any()
+            .downcast_ref::<RpcProxy>()
+            .expect("RpcProxy");
+        let d = rp.build_request(STOP_DESC).expect("request");
+        // The reply is written after the transport went down, so the call
+        // ends in an error — what matters is that it ends.
+        let _ = rp.transact(FIRST_CALL_TRANSACTION, &d, 0);
+        let _ = tx.send(());
+    });
+    match rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(()) | Err(RecvTimeoutError::Disconnected) => {}
+        Err(RecvTimeoutError::Timeout) => panic!("terminate from a handler deadlocked"),
+    }
+    caller.join().expect("caller thread");
+    bg.join().expect("accept loop");
+    assert!(
+        poll_until(|| Arc::strong_count(&server) == 1),
+        "the handler's own worker must exit on its own ({} refs)",
+        Arc::strong_count(&server)
+    );
+    client.shutdown();
+    let _ = std::fs::remove_file(&path);
+}
+
 /// AC-20.6 — `shutdown` ends and joins the incoming threads; the server
 /// sees the session go.
 #[test]

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -3621,6 +3621,61 @@ fn c_server_death_is_eager_with_incoming() {
     let _ = std::fs::remove_file(&path);
 }
 
+/// Plan 2-21 C-0 — a local `shutdown` ends the serve loop the same way
+/// wherever its worker is: parked in `recv`, or inside a handler whose
+/// reply then has nowhere to go. Both report `EndedBy::Local` with an
+/// intact stream, so `into_result` is `Ok(())`. It used to be `Ok(())`
+/// or `Err(DeadObject)` depending on which of the two the worker
+/// happened to be doing — a contract no rustdoc could state.
+#[test]
+fn local_shutdown_ends_the_serve_loop_the_same_way_parked_or_dispatching() {
+    use rsbinder::rpc::transport::UnixTransport;
+    use rsbinder::rpc::{AddressSpace, EndedBy};
+
+    for dispatching in [false, true] {
+        let (srv_t, cli_t) = UnixTransport::pair().expect("socketpair");
+        let server = Arc::new(
+            RpcSession::new(Box::new(srv_t), AddressSpace::Acceptor).expect("server session"),
+        );
+        let slow_entered = Arc::new(AtomicBool::new(false));
+        server.set_root(make_service_with_slow_signal(
+            Arc::new(AtomicI64::new(0)),
+            slow_entered.clone(),
+        ));
+        let serving = Arc::clone(&server);
+        let serve = std::thread::spawn(move || serving.serve_blocking());
+        let client =
+            RpcSession::new(Box::new(cli_t), AddressSpace::Initiator).expect("client session");
+        let root = EchoProxy(client.get_root().expect("root"));
+        assert_eq!(root.echo("warm").unwrap(), "warm");
+
+        let caller = dispatching.then(|| {
+            let root = EchoProxy(root.0.clone());
+            std::thread::spawn(move || {
+                let mut d = root.rp().build_request(DESC).expect("request");
+                d.write(&300i32).expect("arg");
+                // Ends in an error once the session is shut down under it.
+                let _ = root.rp().transact(TX_SLOW, &d, 0);
+            })
+        });
+        if dispatching {
+            assert!(
+                poll_until(|| slow_entered.load(Ordering::SeqCst)),
+                "the handler must be running when the session is shut down"
+            );
+        }
+        server.shutdown();
+        let end = serve.join().expect("serve thread");
+        assert_eq!(end.by, EndedBy::Local, "dispatching={dispatching}: {end}");
+        assert!(end.is_clean(), "dispatching={dispatching}: {end}");
+        assert_eq!(end.into_result(), Ok(()), "dispatching={dispatching}");
+        if let Some(c) = caller {
+            c.join().expect("caller thread");
+        }
+        client.shutdown();
+    }
+}
+
 /// Plan 2-21 B-4 — an `AF_INET` fd handed to `from_preconnected_fd` is
 /// wrapped in `TcpDebugTransport` and goes straight into the android-13+
 /// handshake, whose first byte is a raw write. Without that transport's

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -1647,7 +1647,7 @@ fn b2_local_max_outgoing_one_skips_fan_out_byte_identical_to_founding_only() {
 /// threads to make the pool actually reach the attached slot.
 ///
 /// **Mutant gate**: dropping the `confirm_attach` call restores
-/// `Ok(2)` for both bogus ids and re-poisons the pool (the echo loop
+/// `Ok(2)` for both bogus ids and re-corrupts the pool (the echo loop
 /// then fails ~1/4 of its calls).
 #[test]
 fn attach_with_a_bogus_session_id_is_refused_at_attach_time() {
@@ -3003,8 +3003,8 @@ fn a_outside_handler_call_without_outgoing_slot_fails_fast() {
             },
         };
         assert!(
-            matches!(r, Err(StatusCode::FailedTransaction)),
-            "oneway={oneway}: expected FailedTransaction, got {r:?}"
+            matches!(r, Err(StatusCode::WouldBlock)),
+            "oneway={oneway}: expected WouldBlock, got {r:?}"
         );
     }
     assert_eq!(h.root.echo("still in sync").unwrap(), "still in sync");
@@ -3056,8 +3056,8 @@ fn a_served_slot_never_taken_by_outside_transact() {
             let _ = tx.send(drive(&cb, i % 2 == 1));
         });
         match rx.recv_timeout(Duration::from_secs(5)) {
-            Ok(Err(StatusCode::FailedTransaction)) => {}
-            other => panic!("attempt {i}: expected FailedTransaction, got {other:?}"),
+            Ok(Err(StatusCode::WouldBlock)) => {}
+            other => panic!("attempt {i}: expected WouldBlock, got {other:?}"),
         }
     }
     stop.store(true, Ordering::SeqCst);
@@ -4099,11 +4099,11 @@ impl Remotable for ShutdownCbRef {
 }
 
 /// A client with `incoming_connections > 0` that loses its only
-/// `Outgoing` slot to a reply-deadline poison must still declare the
+/// `Outgoing` slot to a reply-deadline retirement must still declare the
 /// session dead: the surviving callback slot keeps the pool non-empty,
 /// but nothing reads a request written on it, so without the
 /// last-outgoing check the session stayed `Live` forever — every later
-/// transact answered `FailedTransaction` with no obituary and no
+/// transact answered `WouldBlock` with no obituary and no
 /// `RpcState::clear`.
 #[test]
 fn c_losing_the_last_outgoing_slot_declares_death_with_incoming() {

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -310,8 +310,8 @@ fn poll_until(mut f: impl FnMut() -> bool) -> bool {
     f()
 }
 
-/// **RAII test cleanup** — guarantees `shutdown` + `bg.join` +
-/// `join_workers` + socket-file removal on **any** drop path, including
+/// **RAII test cleanup** — guarantees `stop_accepting` + `bg.join` +
+/// `terminate` + socket-file removal on **any** drop path, including
 /// an `assert!`/`unwrap`/`expect` panic mid-test. Without this an
 /// assertion failure leaks the background accept loop + every spawned
 /// `serve_blocking` worker into the test binary process for the
@@ -339,7 +339,7 @@ impl ServeCleanup {
 }
 impl Drop for ServeCleanup {
     fn drop(&mut self) {
-        self.server.shutdown();
+        self.server.stop_accepting();
         if let Some(h) = self.bg.take() {
             // A panic in the background accept loop is a real SUT
             // bug (`RpcServer::run()` is supposed to return cleanly).
@@ -363,7 +363,10 @@ impl Drop for ServeCleanup {
                 );
             }
         }
-        self.server.join_workers();
+        // `terminate`, not `join_workers`: a client a test left connected
+        // (or parked in another thread) would otherwise hang the whole
+        // binary here instead of failing that test.
+        self.server.terminate();
         if let Some(path) = &self.path {
             let _ = std::fs::remove_file(path);
         }
@@ -1218,7 +1221,7 @@ fn a0b_multi_connection_shared_session() {
     // would also pass for an unrelated
     // error (e.g. handshake itself failed). Lock the contract to the
     // single status this reject produces: the server `drop(transport)`
-    // closes the socket, and a disconnect folds to `PeerClosed` and
+    // closes the socket, and a disconnect folds to `EndOfStream` and
     // then `StatusCode::DeadObject` (see `rsbinder/src/rpc/mod.rs`,
     // `From<io::Error> for RpcError`, kind-preserving in both
     // directions per
@@ -1233,7 +1236,7 @@ fn a0b_multi_connection_shared_session() {
     assert_eq!(
         err,
         StatusCode::DeadObject,
-        "unknown id reject must surface as DeadObject (the PeerClosed path)"
+        "unknown id reject must surface as DeadObject (the EndOfStream path)"
     );
     assert!(
         poll_until(|| server.rejected_unknown_id_count() == 1),
@@ -1287,7 +1290,7 @@ fn a0b_multi_connection_shared_session() {
 
     drop(root1);
     drop(c1);
-    // _cu's Drop handles shutdown/bg.join/join_workers/remove_file —
+    // _cu's Drop handles stop_accepting/bg.join/terminate/remove_file —
     // a panic above does not leak worker threads + socket file.
 }
 
@@ -1874,13 +1877,13 @@ fn standalone_attach_session_with_a_bogus_id_fails_to_build() {
 /// successful handshake but before the per-slot enqueue; in production
 /// the `shutdown.load()` gate at that point sees a *sub-microsecond*
 /// window between an accepted late attach and a concurrent
-/// `server.shutdown()`, so the branch is otherwise only observable by
+/// `server.stop_accepting()`, so the branch is otherwise only observable by
 /// code inspection + the `rejected_unknown_id_count` counter.
 ///
 /// The `__set_attach_shutdown_probe` `#[doc(hidden)]` test-only barrier
 /// makes the window deterministic: it
 /// fires after the codec check passes and *before* `shutdown.load()`,
-/// so the test can park the worker, flip `server.shutdown()`, then
+/// so the test can park the worker, flip `server.stop_accepting()`, then
 /// release the worker. The worker re-reads the now-true flag and
 /// takes the reject branch — exactly the production semantics, with
 /// no scheduler-luck dependency.
@@ -1960,7 +1963,7 @@ fn shutdown_gate_e2e_rejects_attach_during_handshake_stall() {
         .expect("attach worker should reach the shutdown barrier");
 
     // Flip shutdown *while* the worker is parked at the probe.
-    server.shutdown();
+    server.stop_accepting();
 
     // Release the worker — it re-reads `shutdown.load() == true`
     // and takes the reject branch (drops the transport).
@@ -2663,7 +2666,7 @@ impl rsbinder::DeathRecipient for DeathFlag {
 /// connection drops** (AOSP `RpcState::sendObituaries`). The peer that
 /// wants the notification runs a serve loop (the AOSP "incoming
 /// thread" requirement); when the server process is killed the
-/// client's `serve_blocking` ends on `PeerClosed` and delivers the
+/// client's `serve_blocking` ends on `EndOfStream` and delivers the
 /// obituary. Also covers `unlink_to_death` (an unlinked recipient must
 /// NOT fire) and the post-death `link_to_death`→`DeadObject` contract.
 ///
@@ -2827,11 +2830,12 @@ struct HeldSetup {
     _cu: ServeCleanup,
 }
 /// `HeldSetup::drop` runs before its fields drop: stop the client's
-/// incoming-connection threads first, or `ServeCleanup::join_workers`
-/// would wait on a founding connection those threads keep open.
+/// incoming-connection threads first, so the client ends the session on
+/// its own terms rather than having `ServeCleanup`'s `terminate` end it
+/// from the server side underneath those threads.
 impl Drop for HeldSetup {
     fn drop(&mut self) {
-        self.client.shutdown();
+        self.client.close_session();
     }
 }
 /// Everything `boot_held_cfg` can vary.
@@ -2882,14 +2886,13 @@ fn boot_held_cfg(tag: &str, cfg: HeldCfg) -> HeldSetup {
         RpcSession::setup_unix_client(&path).expect("connect")
     };
     // From here on a panic must still shut the session down: its incoming
-    // threads hold the connection open, and `ServeCleanup`'s `join_workers`
-    // would then wait on a server worker forever — turning a setup failure
-    // into a hang instead of a report.
+    // threads keep the session alive, and a setup failure would otherwise
+    // leak them into the rest of the suite.
     struct ClientGuard(Option<RpcSession>);
     impl Drop for ClientGuard {
         fn drop(&mut self) {
             if let Some(c) = self.0.take() {
-                c.shutdown();
+                c.close_session();
             }
         }
     }
@@ -3125,7 +3128,7 @@ fn handshake_timeout_bounds_a_silent_peer() {
     let root = EchoProxy(client.get_root().expect("root"));
     // Longer than the handshake deadline: a leaked deadline fails here.
     assert_eq!(root.slow(500).map(|_| "ok"), Ok("ok"));
-    client.shutdown();
+    client.close_session();
 
     drop(keep);
     std::mem::drop(acceptor);
@@ -3501,11 +3504,10 @@ fn b_incoming_over_server_cap_is_refused() {
         RpcUnixClientConfig::path(&path, 2).incoming_connections(3),
     );
     // The regression this guards against *admits* the third slot. Leaking
-    // that session would leave its incoming threads serving, and the panic
-    // below would then hang the whole binary in `ServeCleanup`'s
-    // `join_workers` instead of failing.
+    // that session would leave its incoming threads serving past the panic
+    // below, into the rest of the suite.
     if let Ok(s) = &r {
-        s.shutdown();
+        s.close_session();
     }
     assert!(
         matches!(r, Err(StatusCode::DeadObject)),
@@ -3531,12 +3533,12 @@ fn b_entry_client_open_with_incoming() {
     let client = rsbinder::Client::open_with(&uri, |o, _| o.incoming_connections = Some(1))
         .expect("open with incoming");
     let session = client.session().expect("rpc session");
-    // Read first, shut down, then assert: a session with a live incoming
-    // thread that is never shut down hangs the fixture's `join_workers`,
-    // so a failing assertion here must not skip the `shutdown`.
+    // Read first, close, then assert: a session with a live incoming
+    // thread that is never closed leaks that thread into the rest of the
+    // suite, so a failing assertion here must not skip the `close_session`.
     let slots = session.__slot_count();
     let threads = session.__incoming_thread_count();
-    session.shutdown();
+    session.close_session();
     assert_eq!(slots, 2);
     assert_eq!(threads, 1);
     let r34 = format!("unix://{}", path.display());
@@ -3614,10 +3616,10 @@ fn c_server_death_is_eager_with_incoming() {
         rx_l.recv_timeout(Duration::from_secs(3)).is_ok(),
         "the failed call declares the session dead"
     );
-    eager.shutdown();
+    eager.close_session();
     assert_eq!(eager.__incoming_thread_live_count(), 0);
     assert_eq!(eager.__incoming_thread_count(), 0);
-    lazy.shutdown();
+    lazy.close_session();
     let _ = std::fs::remove_file(&path);
 }
 
@@ -3664,7 +3666,7 @@ fn local_shutdown_ends_the_serve_loop_the_same_way_parked_or_dispatching() {
                 "the handler must be running when the session is shut down"
             );
         }
-        server.shutdown();
+        server.close_session();
         let end = serve.join().expect("serve thread");
         assert_eq!(end.by, EndedBy::Local, "dispatching={dispatching}: {end}");
         assert!(end.is_clean(), "dispatching={dispatching}: {end}");
@@ -3672,7 +3674,7 @@ fn local_shutdown_ends_the_serve_loop_the_same_way_parked_or_dispatching() {
         if let Some(c) = caller {
             c.join().expect("caller thread");
         }
-        client.shutdown();
+        client.close_session();
     }
 }
 
@@ -3733,7 +3735,7 @@ fn terminate_ends_every_session_and_joins_workers() {
     assert_eq!(r34_root.echo("r34").unwrap(), "r34");
 
     // android-13+ with two outgoing connections: a `Live(2)` server
-    // session, which `RpcSession::shutdown` used to skip as "still live".
+    // session, which `close_session` must end although it is "still live".
     let a13_path = tmp_sock("term13");
     let a13_server = RpcServer::setup_unix_server(&a13_path).expect("bind a13");
     a13_server.set_android13plus(2);
@@ -3866,7 +3868,7 @@ fn terminate_from_a_handler_does_not_join_itself() {
         "the handler's own worker must exit on its own ({} refs)",
         Arc::strong_count(&server)
     );
-    client.shutdown();
+    client.close_session();
     let _ = std::fs::remove_file(&path);
 }
 
@@ -3898,7 +3900,7 @@ fn c_shutdown_joins_incoming_threads() {
     let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
     let shutting = h.client.clone();
     let t = std::thread::spawn(move || {
-        shutting.shutdown();
+        shutting.close_session();
         let _ = tx.send(());
     });
     match rx.recv_timeout(Duration::from_secs(5)) {
@@ -3909,8 +3911,9 @@ fn c_shutdown_joins_incoming_threads() {
         Err(RecvTimeoutError::Disconnected) => {}
         Err(RecvTimeoutError::Timeout) => {
             // Report the failure instead of hanging the runner: dropping `h`
-            // would run `HeldSetup::drop` → `join_workers()`, which a regression
-            // that leaves the transports up would never return from.
+            // would run `HeldSetup::drop` → `ServeCleanup`'s `terminate`, which
+            // ends the same wedged session and joins the same workers — a
+            // regression that leaves the transports up would never return.
             std::mem::forget(h);
             panic!("shutdown deadlocked");
         }
@@ -3929,7 +3932,7 @@ fn c_shutdown_joins_incoming_threads() {
     assert_eq!(h.client.__incoming_thread_live_count(), 0);
     assert_eq!(h.client.__incoming_thread_count(), 0);
     // Idempotent.
-    h.client.shutdown();
+    h.client.close_session();
     let server = Arc::clone(&h.server);
     assert!(
         poll_until(|| server.session_slot_count(&sid).is_none_or(|n| n == 0)),
@@ -3945,7 +3948,7 @@ impl rsbinder::DeathRecipient for ShutdownOnDeath {
     fn binder_died(&self, _who: &rsbinder::WIBinder) {
         self.1.store(true, Ordering::SeqCst);
         if let Some(s) = self.0.lock().unwrap().take() {
-            s.shutdown();
+            s.close_session();
         }
     }
 }
@@ -3980,7 +3983,7 @@ fn c_shutdown_from_death_recipient_does_not_deadlock() {
     let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
     let victim = h.client.clone();
     let t = std::thread::spawn(move || {
-        victim.shutdown();
+        victim.close_session();
         let _ = tx.send(());
     });
     match rx.recv_timeout(Duration::from_secs(10)) {
@@ -3990,7 +3993,7 @@ fn c_shutdown_from_death_recipient_does_not_deadlock() {
         Err(RecvTimeoutError::Disconnected) => {}
         Err(RecvTimeoutError::Timeout) => {
             // The session is wedged, so dropping the fixture would block in
-            // `ServeCleanup`'s `join_workers` and turn this failure into a CI
+            // `ServeCleanup`'s `terminate` and turn this failure into a CI
             // timeout. Leak it and report instead.
             std::mem::forget(h);
             panic!("shutdown from a death recipient deadlocked");
@@ -4021,7 +4024,7 @@ impl Remotable for ShutdownCb {
         // Echo like `EchoSvc` so `drive(.., false)` can assert on the reply.
         let a: String = r.read()?;
         if let Some(s) = self.0.lock().unwrap().as_ref() {
-            s.shutdown();
+            s.close_session();
         }
         reply.write(&Status::from(StatusCode::Ok))?;
         reply.write(&a)
@@ -4079,7 +4082,7 @@ fn c_shutdown_from_callback_handler_does_not_self_join() {
     // `shutdown` returned — poll for it.
     assert!(poll_until(|| h.client.__incoming_thread_live_count() == 0));
     assert_eq!(h.client.__incoming_thread_count(), 0);
-    h.client.shutdown();
+    h.client.close_session();
     assert!(matches!(h.root.echo("dead"), Err(StatusCode::DeadObject)));
     *holder.0.lock().unwrap() = None;
 }

--- a/rsbinder/tests/rpc_shared_memory.rs
+++ b/rsbinder/tests/rpc_shared_memory.rs
@@ -111,7 +111,7 @@ impl Bound {
     }
 
     fn finish(self, bg: thread::JoinHandle<()>) {
-        self.server.shutdown();
+        self.server.stop_accepting();
         let _ = bg.join();
         #[cfg(not(target_os = "android"))]
         let _ = std::fs::remove_file(&self.path);

--- a/rsbinder/tests/rpc_tls.rs
+++ b/rsbinder/tests/rpc_tls.rs
@@ -215,7 +215,7 @@ fn tls_over_unix_socket_e2e() {
 /// A TCP end without a TLS `close_notify` is not a clean close. On the
 /// one backend built for untrusted networks that is what a truncation
 /// attack looks like, so the transport reports it as
-/// [`RpcError::UncleanEndOfStream`] — not the `PeerClosed` a
+/// [`RpcError::UncleanEndOfStream`] — not the `EndOfStream` a
 /// `close_notify` yields — even at a frame boundary, where the plain
 /// framing reader would otherwise see a clean end of stream.
 #[test]
@@ -253,15 +253,15 @@ fn tls_shutdown_is_a_clean_close_for_the_peer() {
             .expect("client handshake");
     server.join().unwrap();
     match client.recv_frame() {
-        Err(RpcError::PeerClosed) => {}
-        other => panic!("expected the clean PeerClosed after close_notify, got {other:?}"),
+        Err(RpcError::EndOfStream) => {}
+        other => panic!("expected the clean EndOfStream after close_notify, got {other:?}"),
     }
 }
 
 /// Plan 2-21 D-3 — our own `shutdown()` wakes our own reader with an end
 /// of stream that carries no `close_notify` from the peer. That is the
 /// shape of a cut, but it is ours: the transport reports the clean
-/// `PeerClosed`, not `UncleanEndOfStream`, so a session this end shut
+/// `EndOfStream`, not `UncleanEndOfStream`, so a session this end shut
 /// down ends its serve loop cleanly. A second `shutdown()` is `Ok`.
 #[test]
 fn tls_local_shutdown_is_a_clean_end_for_our_own_reader() {
@@ -286,7 +286,7 @@ fn tls_local_shutdown_is_a_clean_end_for_our_own_reader() {
     client.shutdown().expect("shutdown");
     client.shutdown().expect("a second shutdown is Ok");
     match client.recv_frame() {
-        Err(RpcError::PeerClosed) => {}
+        Err(RpcError::EndOfStream) => {}
         other => panic!("our own shutdown must read as a clean end, got {other:?}"),
     }
     let _ = done_tx.send(());
@@ -603,7 +603,7 @@ fn setup_tcp_server_tls_e2e() {
 
     drop(root);
     drop(client);
-    server.shutdown();
+    server.stop_accepting();
     let _ = bg.join();
 }
 
@@ -692,7 +692,7 @@ fn vsock_tls_loopback_e2e() {
 
     drop(root);
     drop(client);
-    server.shutdown();
+    server.stop_accepting();
     let _ = bg.join();
 }
 
@@ -754,6 +754,6 @@ fn setup_unix_server_tls_e2e() {
 
     drop(root);
     drop(client);
-    server.shutdown();
+    server.stop_accepting();
     let _ = bg.join();
 }

--- a/rsbinder/tests/rpc_tls.rs
+++ b/rsbinder/tests/rpc_tls.rs
@@ -293,6 +293,63 @@ fn tls_local_shutdown_is_a_clean_end_for_our_own_reader() {
     server.join().unwrap();
 }
 
+/// A `shutdown()` racing this end's own in-flight send still leaves the
+/// peer a clean end — `UncleanEndOfStream` stays reserved for a stream
+/// somebody cut.
+///
+/// Only the thread holding `wlock` may put records on the wire, so a
+/// `shutdown` that queued `close_notify` while a send held the lock has
+/// to wait for it; cutting the socket there would strand the alert and
+/// hand the peer a boundary end with no close signal —
+/// `UncleanEndOfStream`, which projects to `DeadObject`, where a
+/// deliberate close owes `EndOfStream`. Waiting is bounded, so a peer
+/// that has stopped reading still cannot hold teardown.
+///
+/// The window is a few instructions wide, so this races it repeatedly
+/// rather than pinning one interleaving. A cut *mid-frame* is a different
+/// (correct) outcome and reads as `Truncated`, so the assertion names the
+/// one error that must never appear rather than the one that must.
+#[test]
+fn tls_shutdown_racing_a_send_is_still_a_clean_close_for_the_peer() {
+    for round in 0..48u64 {
+        let srv_cfg = server_config(SRV_CRT, SRV_KEY);
+        let (s_srv, s_cli) = UnixStream::pair().expect("unix socketpair");
+        let (t_tx, t_rx) = std::sync::mpsc::channel::<Arc<TlsTransport>>();
+        let sender = thread::spawn(move || {
+            let t = Arc::new(
+                TlsTransport::accept_stream(Box::new(s_srv), srv_cfg).expect("server handshake"),
+            );
+            t_tx.send(Arc::clone(&t)).expect("hand the transport over");
+            // Small frames so a send never parks in the socket write and
+            // the boundary between two of them comes round often — that
+            // boundary is what the shutdown has to hit.
+            while t.send_frame(b"tick").is_ok() {}
+        });
+        let client =
+            TlsTransport::connect_stream(Box::new(s_cli), "localhost", client_config_trusting(CA))
+                .expect("client handshake");
+        let server_t = t_rx.recv().expect("transport from the sender thread");
+        // Walk the delay across the rounds so the shutdown lands at a
+        // different point of the send loop each time.
+        let closer = thread::spawn(move || {
+            thread::sleep(std::time::Duration::from_micros(round * 40));
+            server_t.shutdown().expect("shutdown");
+        });
+        let end = loop {
+            match client.recv_frame() {
+                Ok(f) => assert_eq!(f, b"tick", "frames must arrive intact until the end"),
+                Err(e) => break e,
+            }
+        };
+        assert!(
+            !matches!(end, RpcError::UncleanEndOfStream),
+            "round {round}: a shutdown racing a send left the peer an unclean end"
+        );
+        closer.join().unwrap();
+        sender.join().unwrap();
+    }
+}
+
 /// The one-call TCP+TLS client
 /// constructor `RpcSession::setup_tcp_client_tls` — TCP-connect + TLS
 /// handshake + R34 session — interoperates with a TLS server end to end.

--- a/rsbinder/tests/rpc_tls.rs
+++ b/rsbinder/tests/rpc_tls.rs
@@ -293,22 +293,27 @@ fn tls_local_shutdown_is_a_clean_end_for_our_own_reader() {
     server.join().unwrap();
 }
 
-/// A `shutdown()` racing this end's own in-flight send still leaves the
-/// peer a clean end — `UncleanEndOfStream` stays reserved for a stream
-/// somebody cut.
+/// A `shutdown()` racing this end's own in-flight send: the peer reads
+/// every frame that send was told went out, then a clean end.
 ///
-/// Only the thread holding `wlock` may put records on the wire, so a
-/// `shutdown` that queued `close_notify` while a send held the lock has
-/// to wait for it; cutting the socket there would strand the alert and
-/// hand the peer a boundary end with no close signal —
-/// `UncleanEndOfStream`, which projects to `DeadObject`, where a
-/// deliberate close owes `EndOfStream`. Waiting is bounded, so a peer
-/// that has stopped reading still cannot hold teardown.
+/// Two promises, both of which a shutdown that simply cut the socket
+/// broke. The peer's: `UncleanEndOfStream` is reserved for a stream
+/// somebody cut, so a deliberate close owes it `close_notify` — and only
+/// the thread holding `wlock` may put that on the wire, so `shutdown` has
+/// to wait for the send in flight rather than strand the alert. The
+/// sender's: `Ok` means the frame went out. A send that started after
+/// `shutdown` is refused, and the alert is queued only once the lock is
+/// held, so no frame can be encrypted behind it — where the peer, having
+/// read the alert, would discard it (RFC 8446 §6.1) after the sender was
+/// told `Ok`. The wait is bounded, so a peer that has stopped reading
+/// still cannot hold teardown.
 ///
 /// The window is a few instructions wide, so this races it repeatedly
-/// rather than pinning one interleaving. A cut *mid-frame* is a different
-/// (correct) outcome and reads as `Truncated`, so the assertion names the
-/// one error that must never appear rather than the one that must.
+/// rather than pinning one interleaving, and counts on both ends: every
+/// `Ok` the sender saw is a frame the peer received, and the end the peer
+/// reads is never an unclean one. A cut *mid-frame* would read as
+/// `Truncated`, and the frame it cut was reported failed, so the counts
+/// still agree — the assertion tolerates it without naming it.
 #[test]
 fn tls_shutdown_racing_a_send_is_still_a_clean_close_for_the_peer() {
     for round in 0..48u64 {
@@ -322,8 +327,13 @@ fn tls_shutdown_racing_a_send_is_still_a_clean_close_for_the_peer() {
             t_tx.send(Arc::clone(&t)).expect("hand the transport over");
             // Small frames so a send never parks in the socket write and
             // the boundary between two of them comes round often — that
-            // boundary is what the shutdown has to hit.
-            while t.send_frame(b"tick").is_ok() {}
+            // boundary is what the shutdown has to hit. Count what this
+            // end was told went out.
+            let mut sent_ok = 0usize;
+            while t.send_frame(b"tick").is_ok() {
+                sent_ok += 1;
+            }
+            sent_ok
         });
         let client =
             TlsTransport::connect_stream(Box::new(s_cli), "localhost", client_config_trusting(CA))
@@ -335,9 +345,13 @@ fn tls_shutdown_racing_a_send_is_still_a_clean_close_for_the_peer() {
             thread::sleep(std::time::Duration::from_micros(round * 40));
             server_t.shutdown().expect("shutdown");
         });
+        let mut received = 0usize;
         let end = loop {
             match client.recv_frame() {
-                Ok(f) => assert_eq!(f, b"tick", "frames must arrive intact until the end"),
+                Ok(f) => {
+                    assert_eq!(f, b"tick", "frames must arrive intact until the end");
+                    received += 1;
+                }
                 Err(e) => break e,
             }
         };
@@ -346,7 +360,11 @@ fn tls_shutdown_racing_a_send_is_still_a_clean_close_for_the_peer() {
             "round {round}: a shutdown racing a send left the peer an unclean end"
         );
         closer.join().unwrap();
-        sender.join().unwrap();
+        let sent_ok = sender.join().unwrap();
+        assert_eq!(
+            received, sent_ok,
+            "round {round}: the sender was told {sent_ok} frames went out, the peer read {received}"
+        );
     }
 }
 

--- a/rsbinder/tests/rpc_tls.rs
+++ b/rsbinder/tests/rpc_tls.rs
@@ -212,6 +212,52 @@ fn tls_over_unix_socket_e2e() {
     server.join().unwrap();
 }
 
+/// A TCP end without a TLS `close_notify` is not a clean close. On the
+/// one backend built for untrusted networks that is what a truncation
+/// attack looks like, so the transport reports it as
+/// [`RpcError::UncleanEndOfStream`] — not the `PeerClosed` a
+/// `close_notify` yields — even at a frame boundary, where the plain
+/// framing reader would otherwise see a clean end of stream.
+#[test]
+fn tls_eof_without_close_notify_is_unclean() {
+    let srv_cfg = server_config(SRV_CRT, SRV_KEY);
+    let (s_srv, s_cli) = UnixStream::pair().expect("unix socketpair");
+    let server = thread::spawn(move || {
+        let t = TlsTransport::accept_stream(Box::new(s_srv), srv_cfg).expect("server handshake");
+        // Dropped without `shutdown()`: the fd closes, no close_notify goes out.
+        drop(t);
+    });
+    let client =
+        TlsTransport::connect_stream(Box::new(s_cli), "localhost", client_config_trusting(CA))
+            .expect("client handshake");
+    server.join().unwrap();
+    match client.recv_frame() {
+        Err(RpcError::UncleanEndOfStream) => {}
+        other => panic!("expected UncleanEndOfStream at a frame boundary, got {other:?}"),
+    }
+}
+
+/// The transport's own `shutdown()` sends `close_notify` before the
+/// socket shutdown, so a deliberate local close is the clean end on the
+/// peer — the unclean report above is reserved for a stream that was cut.
+#[test]
+fn tls_shutdown_is_a_clean_close_for_the_peer() {
+    let srv_cfg = server_config(SRV_CRT, SRV_KEY);
+    let (s_srv, s_cli) = UnixStream::pair().expect("unix socketpair");
+    let server = thread::spawn(move || {
+        let t = TlsTransport::accept_stream(Box::new(s_srv), srv_cfg).expect("server handshake");
+        t.shutdown().expect("shutdown");
+    });
+    let client =
+        TlsTransport::connect_stream(Box::new(s_cli), "localhost", client_config_trusting(CA))
+            .expect("client handshake");
+    server.join().unwrap();
+    match client.recv_frame() {
+        Err(RpcError::PeerClosed) => {}
+        other => panic!("expected the clean PeerClosed after close_notify, got {other:?}"),
+    }
+}
+
 /// The one-call TCP+TLS client
 /// constructor `RpcSession::setup_tcp_client_tls` — TCP-connect + TLS
 /// handshake + R34 session — interoperates with a TLS server end to end.

--- a/rsbinder/tests/rpc_tls.rs
+++ b/rsbinder/tests/rpc_tls.rs
@@ -258,6 +258,41 @@ fn tls_shutdown_is_a_clean_close_for_the_peer() {
     }
 }
 
+/// Plan 2-21 D-3 — our own `shutdown()` wakes our own reader with an end
+/// of stream that carries no `close_notify` from the peer. That is the
+/// shape of a cut, but it is ours: the transport reports the clean
+/// `PeerClosed`, not `UncleanEndOfStream`, so a session this end shut
+/// down ends its serve loop cleanly. A second `shutdown()` is `Ok`.
+#[test]
+fn tls_local_shutdown_is_a_clean_end_for_our_own_reader() {
+    let srv_cfg = server_config(SRV_CRT, SRV_KEY);
+    let (s_srv, s_cli) = UnixStream::pair().expect("unix socketpair");
+    let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
+    let server = thread::spawn(move || {
+        let t = TlsTransport::accept_stream(Box::new(s_srv), srv_cfg).expect("server handshake");
+        // One frame proves the server's handshake I/O is over before the
+        // client shuts down — a client `SHUT_RD` while the server still has
+        // a post-handshake write pending fails that write with `EPIPE` on
+        // Linux. Then the server holds its end until the client has looked,
+        // so the only end the client sees is the one it made itself.
+        t.send_frame(b"hello").expect("send after handshake");
+        let _ = done_rx.recv();
+        drop(t);
+    });
+    let client =
+        TlsTransport::connect_stream(Box::new(s_cli), "localhost", client_config_trusting(CA))
+            .expect("client handshake");
+    assert_eq!(client.recv_frame().expect("server's frame"), b"hello");
+    client.shutdown().expect("shutdown");
+    client.shutdown().expect("a second shutdown is Ok");
+    match client.recv_frame() {
+        Err(RpcError::PeerClosed) => {}
+        other => panic!("our own shutdown must read as a clean end, got {other:?}"),
+    }
+    let _ = done_tx.send(());
+    server.join().unwrap();
+}
+
 /// The one-call TCP+TLS client
 /// constructor `RpcSession::setup_tcp_client_tls` — TCP-connect + TLS
 /// handshake + R34 session — interoperates with a TLS server end to end.

--- a/rsbinder/tests/rpc_transport_conformance.rs
+++ b/rsbinder/tests/rpc_transport_conformance.rs
@@ -20,11 +20,10 @@
 //! `vsock` is not here: it needs a VM peer (its own tests are `#[ignore]`),
 //! and its behaviour is inferred from `vsock(7)`, not measured.
 //!
-//! This suite's first run found a deadlock: `UnixTransport::shutdown` took
-//! the fd-mode leftover lock before shutting the socket down, and a reader
-//! parked in `recvmsg` holds that lock until the socket wakes it. Every
-//! `shutdown` here runs under a deadline so the next such bug fails
-//! instead of hanging the runner.
+//! An fd-mode reader parked in `recvmsg` holds the leftover lock until the
+//! socket wakes it, so a `shutdown` that takes that lock first deadlocks
+//! against it. Every `shutdown` here runs under a deadline, so such a bug
+//! fails the test instead of hanging the runner.
 //!
 //! Separate test binary, `#![cfg(feature = "rpc")]`.
 
@@ -70,16 +69,16 @@ enum PeerSend {
 }
 
 fn unix_peer_send() -> PeerSend {
-    if cfg!(target_os = "linux") {
-        PeerSend::FailsAtOnce
-    } else {
+    if cfg!(target_os = "macos") {
         PeerSend::Accepted
+    } else {
+        PeerSend::FailsAtOnce
     }
 }
 
 /// `shutdown` on its own thread under a deadline: a shutdown that blocks
-/// (this suite found one — a lock held by a parked reader) must fail the
-/// test, not hang the runner.
+/// — on a lock a parked reader holds, say — must fail the test, not hang
+/// the runner.
 fn shutdown_within(name: &str, t: &Shared) {
     let (tx, rx) = std::sync::mpsc::sync_channel::<Result<(), RpcError>>(1);
     let t = Arc::clone(t);
@@ -155,13 +154,23 @@ fn queued_then_shutdown(
 /// returns the end of stream — within a bound, on every backend.
 fn blocked_reader_is_woken(name: &str, local: &Shared, fd_mode: bool) {
     let (tx, rx) = std::sync::mpsc::sync_channel::<Result<Vec<u8>, RpcError>>(1);
+    let (started_tx, started_rx) = std::sync::mpsc::sync_channel::<()>(1);
     let reader = {
         let local = Arc::clone(local);
         std::thread::spawn(move || {
+            let _ = started_tx.send(());
             let _ = tx.send(recv(&*local, fd_mode));
         })
     };
+    started_rx.recv().expect("the reader thread started");
     std::thread::sleep(Duration::from_millis(50));
+    // The reader has to still be parked, or the end of stream asserted
+    // below is just a read of an already-shut connection and the wake-up
+    // this test exists for never runs.
+    assert!(
+        matches!(rx.try_recv(), Err(std::sync::mpsc::TryRecvError::Empty)),
+        "{name}: the reader must still be parked when we shut down"
+    );
     shutdown_within(name, local);
     match rx.recv_timeout(Duration::from_secs(2)) {
         Ok(Err(RpcError::EndOfStream)) => {}
@@ -172,14 +181,28 @@ fn blocked_reader_is_woken(name: &str, local: &Shared, fd_mode: bool) {
     reader.join().expect("reader thread");
 }
 
+/// The suite's own read deadline, armed on both ends of every pair. The
+/// reads here expect an end of stream that a regressed `shutdown` would
+/// never produce — the peer is still alive — and libtest has no per-test
+/// timeout, so without this such a regression hangs the runner instead of
+/// failing the assertion. Longer than every `recv_timeout` bound below, so
+/// the assertion is still what reports the failure.
+fn armed(pair: (Shared, Shared)) -> (Shared, Shared) {
+    for t in [&pair.0, &pair.1] {
+        t.set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("arm the suite's read deadline");
+    }
+    pair
+}
+
 fn unix_pair() -> (Shared, Shared) {
     let (a, b) = UnixTransport::pair().expect("socketpair");
-    (Arc::new(a), Arc::new(b))
+    armed((Arc::new(a), Arc::new(b)))
 }
 
 fn mem_pair() -> (Shared, Shared) {
     let (a, b) = MemTransport::pair();
-    (Arc::new(a), Arc::new(b))
+    armed((Arc::new(a), Arc::new(b)))
 }
 
 #[test]
@@ -246,7 +269,7 @@ mod tcp {
 
     fn tcp_pair() -> (Shared, Shared) {
         let (client, server) = TcpDebugTransport::pair_loopback().expect("loopback pair");
-        (Arc::new(client), Arc::new(server))
+        armed((Arc::new(client), Arc::new(server)))
     }
 
     #[test]
@@ -318,7 +341,7 @@ mod tls {
         let client = TlsTransport::connect_stream(Box::new(s_cli), "localhost", cli_cfg)
             .expect("client handshake");
         let server = server.join().expect("server thread");
-        (Arc::new(client), Arc::new(server))
+        armed((Arc::new(client), Arc::new(server)))
     }
 
     #[test]

--- a/rsbinder/tests/rpc_transport_conformance.rs
+++ b/rsbinder/tests/rpc_transport_conformance.rs
@@ -11,11 +11,11 @@
 //! refactor that quietly relies on a queued frame vanishing (or
 //! surviving) fails here, on whichever platform it would have been wrong.
 //!
-//! | backend | queued frame, then local shutdown | blocked reader | peer after our shutdown | 2nd shutdown |
-//! |---|---|---|---|---|
-//! | unix, unix fd-mode, tls (over unix) | **macOS:** end of stream (queue dropped) · **Linux:** the frame, then end of stream | end of stream | reads end of stream; its first send **fails at once on Linux (`EPIPE`), is accepted on macOS** | `Ok` |
-//! | tcp_debug | as above | end of stream | reads end of stream; its first send is **accepted on both** — TCP reports the reset on a later write | `Ok` |
-//! | mem | the frame, then end of stream (models Linux unix) | end of stream (≤ one 20 ms tick) | reads end of stream; its sends fail at once | `Ok` |
+//! | backend | queued frame, then local shutdown | blocked reader | peer after our shutdown | our send after our shutdown | 2nd shutdown |
+//! |---|---|---|---|---|---|
+//! | unix, unix fd-mode, tls (over unix) | **macOS:** end of stream (queue dropped) · **Linux:** the frame, then end of stream | end of stream | reads end of stream; its first send **fails at once on Linux (`EPIPE`), is accepted on macOS** | fails at once, `EndOfStream` (tls: refused before the lock) | `Ok` |
+//! | tcp_debug | as above | end of stream | reads end of stream; its first send is **accepted on both** — TCP reports the reset on a later write | fails at once, `EndOfStream` | `Ok` |
+//! | mem | the frame, then end of stream (models Linux unix) | end of stream (≤ one 20 ms tick) | reads end of stream; its sends fail at once | fails at once, `EndOfStream` | `Ok` |
 //!
 //! `vsock` is not here: it needs a VM peer (its own tests are `#[ignore]`),
 //! and its behaviour is inferred from `vsock(7)`, not measured.
@@ -181,6 +181,26 @@ fn blocked_reader_is_woken(name: &str, local: &Shared, fd_mode: bool) {
     reader.join().expect("reader thread");
 }
 
+/// Scenario E: this end's own first send after its own shutdown fails —
+/// as the end of stream, on every backend and platform.
+///
+/// The trait says a shutdown makes this end's later sends fail; the
+/// session's send rule reads every failure but `Timeout` as "retire the
+/// slot", and `Ok` as "the frame went out". A backend that let a send
+/// through after its own shutdown would report `Ok` for a frame the peer
+/// never reads — a socket cut in both directions refuses at once with
+/// `EPIPE`, `mem` by design, and `tls` gates the send itself: its cut is
+/// deferred behind the close signal, and a frame accepted in between would
+/// be one the peer discards after reading the alert (RFC 8446 §6.1).
+fn our_send_after_our_shutdown_fails(name: &str, local: &Shared) {
+    shutdown_within(name, local);
+    let sent = local.send_frame(b"after");
+    assert!(
+        matches!(sent, Err(RpcError::EndOfStream)),
+        "{name}: our own send after our own shutdown fails as the end of stream, got {sent:?}"
+    );
+}
+
 /// The suite's own read deadline, armed on both ends of every pair. The
 /// reads here expect an end of stream that a regressed `shutdown` would
 /// never produce — the peer is still alive — and libtest has no per-test
@@ -244,6 +264,12 @@ fn unix_fd_mode_blocked_reader_is_woken() {
 }
 
 #[test]
+fn unix_our_send_after_our_shutdown_fails() {
+    let (local, _peer) = unix_pair();
+    our_send_after_our_shutdown_fails("unix", &local);
+}
+
+#[test]
 fn mem_queued_frame_then_shutdown() {
     let (local, peer) = mem_pair();
     queued_then_shutdown(
@@ -260,6 +286,12 @@ fn mem_queued_frame_then_shutdown() {
 fn mem_blocked_reader_is_woken() {
     let (local, _peer) = mem_pair();
     blocked_reader_is_woken("mem", &local, false);
+}
+
+#[test]
+fn mem_our_send_after_our_shutdown_fails() {
+    let (local, _peer) = mem_pair();
+    our_send_after_our_shutdown_fails("mem", &local);
 }
 
 #[cfg(feature = "rpc-tcp-debug")]
@@ -291,6 +323,12 @@ mod tcp {
     fn tcp_debug_blocked_reader_is_woken() {
         let (local, _peer) = tcp_pair();
         blocked_reader_is_woken("tcp_debug", &local, false);
+    }
+
+    #[test]
+    fn tcp_debug_our_send_after_our_shutdown_fails() {
+        let (local, _peer) = tcp_pair();
+        our_send_after_our_shutdown_fails("tcp_debug", &local);
     }
 }
 
@@ -362,5 +400,11 @@ mod tls {
     fn tls_blocked_reader_is_woken() {
         let (local, _peer) = tls_pair();
         blocked_reader_is_woken("tls", &local, false);
+    }
+
+    #[test]
+    fn tls_our_send_after_our_shutdown_fails() {
+        let (local, _peer) = tls_pair();
+        our_send_after_our_shutdown_fails("tls", &local);
     }
 }

--- a/rsbinder/tests/rpc_transport_conformance.rs
+++ b/rsbinder/tests/rpc_transport_conformance.rs
@@ -1,0 +1,343 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Plan 2-21 D-7 — what every in-tree transport's `shutdown` does, pinned
+//! per backend **and per platform**.
+//!
+//! The contract on `RpcTransport::shutdown` says that what happens to
+//! bytes already received is platform- and backend-dependent and must not
+//! be assumed. This suite is what keeps that sentence true rather than
+//! merely written: it asserts the measured behaviour, so the next
+//! refactor that quietly relies on a queued frame vanishing (or
+//! surviving) fails here, on whichever platform it would have been wrong.
+//!
+//! | backend | queued frame, then local shutdown | blocked reader | peer after our shutdown | 2nd shutdown |
+//! |---|---|---|---|---|
+//! | unix, unix fd-mode, tls (over unix) | **macOS:** end of stream (queue dropped) · **Linux:** the frame, then end of stream | end of stream | reads end of stream; its first send **fails at once on Linux (`EPIPE`), is accepted on macOS** | `Ok` |
+//! | tcp_debug | as above | end of stream | reads end of stream; its first send is **accepted on both** — TCP reports the reset on a later write | `Ok` |
+//! | mem | the frame, then end of stream (models Linux unix) | end of stream (≤ one 20 ms tick) | reads end of stream; its sends fail at once | `Ok` |
+//!
+//! `vsock` is not here: it needs a VM peer (its own tests are `#[ignore]`),
+//! and its behaviour is inferred from `vsock(7)`, not measured.
+//!
+//! This suite's first run found a deadlock: `UnixTransport::shutdown` took
+//! the fd-mode leftover lock before shutting the socket down, and a reader
+//! parked in `recvmsg` holds that lock until the socket wakes it. Every
+//! `shutdown` here runs under a deadline so the next such bug fails
+//! instead of hanging the runner.
+//!
+//! Separate test binary, `#![cfg(feature = "rpc")]`.
+
+#![cfg(feature = "rpc")]
+
+use std::sync::mpsc::RecvTimeoutError;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rsbinder::rpc::transport::{MemTransport, UnixTransport};
+use rsbinder::rpc::{RpcError, RpcTransport};
+
+type Shared = Arc<dyn RpcTransport>;
+
+/// What a reader finds after a local shutdown when a frame had already
+/// reached the local kernel queue (or channel).
+#[derive(Clone, Copy)]
+enum Queued {
+    /// Delivered first, then the end of stream (Linux; `mem`).
+    Delivered,
+    /// Gone: the very next read is the end of stream (macOS).
+    Dropped,
+}
+
+/// The socket backends follow the kernel; `mem` follows Linux by design.
+fn socket_expectation() -> Queued {
+    if cfg!(target_os = "macos") {
+        Queued::Dropped
+    } else {
+        Queued::Delivered
+    }
+}
+
+/// What the peer's *first* send after our shutdown does — measured, and
+/// three different answers.
+#[derive(Clone, Copy)]
+enum PeerSend {
+    /// Refused at once (`EPIPE`): Linux `AF_UNIX`, and `mem` by design.
+    FailsAtOnce,
+    /// Accepted (and discarded, or reset on a later write): macOS
+    /// `AF_UNIX`, and TCP on both platforms.
+    Accepted,
+}
+
+fn unix_peer_send() -> PeerSend {
+    if cfg!(target_os = "linux") {
+        PeerSend::FailsAtOnce
+    } else {
+        PeerSend::Accepted
+    }
+}
+
+/// `shutdown` on its own thread under a deadline: a shutdown that blocks
+/// (this suite found one — a lock held by a parked reader) must fail the
+/// test, not hang the runner.
+fn shutdown_within(name: &str, t: &Shared) {
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Result<(), RpcError>>(1);
+    let t = Arc::clone(t);
+    let h = std::thread::spawn(move || {
+        let _ = tx.send(t.shutdown());
+    });
+    match rx.recv_timeout(Duration::from_secs(2)) {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => panic!("{name}: shutdown failed: {e}"),
+        Err(RecvTimeoutError::Timeout) => panic!("{name}: shutdown blocked"),
+        Err(RecvTimeoutError::Disconnected) => panic!("{name}: shutdown thread died"),
+    }
+    h.join().expect("shutdown thread");
+}
+
+fn recv(t: &dyn RpcTransport, fd_mode: bool) -> Result<Vec<u8>, RpcError> {
+    if fd_mode {
+        t.recv_frame_with_fds().map(|(frame, _fds)| frame)
+    } else {
+        t.recv_frame()
+    }
+}
+
+/// Scenario A (queued frame), C (idempotence) and D (the peer's view).
+fn queued_then_shutdown(
+    name: &str,
+    local: &Shared,
+    peer: &Shared,
+    fd_mode: bool,
+    queued: Queued,
+    peer_send: PeerSend,
+) {
+    peer.send_frame(b"queued")
+        .expect("peer sends into our queue");
+    shutdown_within(name, local);
+    if let Queued::Delivered = queued {
+        assert_eq!(
+            recv(&**local, fd_mode).expect("the queued frame is still delivered"),
+            b"queued",
+            "{name}: a frame queued before shutdown is delivered on this platform"
+        );
+    }
+    let end = recv(&**local, fd_mode);
+    assert!(
+        matches!(end, Err(RpcError::PeerClosed)),
+        "{name}: after shutdown (and any queued frame) the read is the end of stream, got {end:?}"
+    );
+    // A second shutdown is Ok (idempotent).
+    shutdown_within(name, local);
+    // The peer: our shutdown is its end of stream.
+    let peer_end = peer.recv_frame();
+    assert!(
+        matches!(peer_end, Err(RpcError::PeerClosed)),
+        "{name}: the peer reads our shutdown as its end of stream, got {peer_end:?}"
+    );
+    // Its first send afterwards is measured per backend and platform (the
+    // table in the module doc); if it changes, the table and the
+    // `shutdown` contract change with it.
+    let sent = peer.send_frame(b"x");
+    match peer_send {
+        PeerSend::FailsAtOnce => assert!(
+            sent.is_err(),
+            "{name}: the peer's first send after our shutdown fails at once here, got {sent:?}"
+        ),
+        PeerSend::Accepted => assert!(
+            sent.is_ok(),
+            "{name}: the peer's first send after our shutdown is accepted here, got {sent:?}"
+        ),
+    }
+}
+
+/// Scenario B: a reader parked in `recv` is woken by a local shutdown and
+/// returns the end of stream — within a bound, on every backend.
+fn blocked_reader_is_woken(name: &str, local: &Shared, fd_mode: bool) {
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Result<Vec<u8>, RpcError>>(1);
+    let reader = {
+        let local = Arc::clone(local);
+        std::thread::spawn(move || {
+            let _ = tx.send(recv(&*local, fd_mode));
+        })
+    };
+    std::thread::sleep(Duration::from_millis(50));
+    shutdown_within(name, local);
+    match rx.recv_timeout(Duration::from_secs(2)) {
+        Ok(Err(RpcError::PeerClosed)) => {}
+        Ok(other) => panic!("{name}: the woken reader must see the end of stream, got {other:?}"),
+        Err(RecvTimeoutError::Timeout) => panic!("{name}: shutdown did not wake the parked reader"),
+        Err(RecvTimeoutError::Disconnected) => panic!("{name}: the reader thread died"),
+    }
+    reader.join().expect("reader thread");
+}
+
+fn unix_pair() -> (Shared, Shared) {
+    let (a, b) = UnixTransport::pair().expect("socketpair");
+    (Arc::new(a), Arc::new(b))
+}
+
+fn mem_pair() -> (Shared, Shared) {
+    let (a, b) = MemTransport::pair();
+    (Arc::new(a), Arc::new(b))
+}
+
+#[test]
+fn unix_queued_frame_then_shutdown() {
+    let (local, peer) = unix_pair();
+    queued_then_shutdown(
+        "unix",
+        &local,
+        &peer,
+        false,
+        socket_expectation(),
+        unix_peer_send(),
+    );
+}
+
+#[test]
+fn unix_blocked_reader_is_woken() {
+    let (local, _peer) = unix_pair();
+    blocked_reader_is_woken("unix", &local, false);
+}
+
+#[test]
+fn unix_fd_mode_queued_frame_then_shutdown() {
+    let (local, peer) = unix_pair();
+    queued_then_shutdown(
+        "unix fd-mode",
+        &local,
+        &peer,
+        true,
+        socket_expectation(),
+        unix_peer_send(),
+    );
+}
+
+#[test]
+fn unix_fd_mode_blocked_reader_is_woken() {
+    let (local, _peer) = unix_pair();
+    blocked_reader_is_woken("unix fd-mode", &local, true);
+}
+
+#[test]
+fn mem_queued_frame_then_shutdown() {
+    let (local, peer) = mem_pair();
+    queued_then_shutdown(
+        "mem",
+        &local,
+        &peer,
+        false,
+        Queued::Delivered,
+        PeerSend::FailsAtOnce,
+    );
+}
+
+#[test]
+fn mem_blocked_reader_is_woken() {
+    let (local, _peer) = mem_pair();
+    blocked_reader_is_woken("mem", &local, false);
+}
+
+#[cfg(feature = "rpc-tcp-debug")]
+mod tcp {
+    use super::*;
+    use rsbinder::rpc::transport::TcpDebugTransport;
+
+    fn tcp_pair() -> (Shared, Shared) {
+        let (client, server) = TcpDebugTransport::pair_loopback().expect("loopback pair");
+        (Arc::new(client), Arc::new(server))
+    }
+
+    #[test]
+    fn tcp_debug_queued_frame_then_shutdown() {
+        let (local, peer) = tcp_pair();
+        // TCP accepts the first write on both platforms and reports the
+        // reset on a later one.
+        queued_then_shutdown(
+            "tcp_debug",
+            &local,
+            &peer,
+            false,
+            socket_expectation(),
+            PeerSend::Accepted,
+        );
+    }
+
+    #[test]
+    fn tcp_debug_blocked_reader_is_woken() {
+        let (local, _peer) = tcp_pair();
+        blocked_reader_is_woken("tcp_debug", &local, false);
+    }
+}
+
+#[cfg(feature = "rpc-tls")]
+mod tls {
+    use super::*;
+    use rsbinder::rpc::rustls::pki_types::pem::PemObject;
+    use rsbinder::rpc::rustls::pki_types::{CertificateDer, PrivateKeyDer};
+    use rsbinder::rpc::rustls::{ClientConfig, RootCertStore, ServerConfig};
+    use rsbinder::rpc::transport::TlsTransport;
+    use std::os::unix::net::UnixStream;
+
+    const CA: &str = include_str!("tls_fixtures/ca.crt");
+    const SRV_CRT: &str = include_str!("tls_fixtures/srv.crt");
+    const SRV_KEY: &str = include_str!("tls_fixtures/srv.key");
+
+    fn certs(pem: &str) -> Vec<CertificateDer<'static>> {
+        CertificateDer::pem_slice_iter(pem.as_bytes())
+            .collect::<Result<_, _>>()
+            .expect("parse certs")
+    }
+
+    /// Both handshakes complete before the pair is handed out, so no
+    /// post-handshake write is still pending when a test shuts an end down.
+    fn tls_pair() -> (Shared, Shared) {
+        let (s_srv, s_cli) = UnixStream::pair().expect("unix socketpair");
+        let srv_cfg = Arc::new(
+            ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(
+                    certs(SRV_CRT),
+                    PrivateKeyDer::from_pem_slice(SRV_KEY.as_bytes()).expect("key"),
+                )
+                .expect("server config"),
+        );
+        let server = std::thread::spawn(move || {
+            TlsTransport::accept_stream(Box::new(s_srv), srv_cfg).expect("server handshake")
+        });
+        let mut roots = RootCertStore::empty();
+        for c in certs(CA) {
+            roots.add(c).expect("add ca");
+        }
+        let cli_cfg = Arc::new(
+            ClientConfig::builder()
+                .with_root_certificates(roots)
+                .with_no_client_auth(),
+        );
+        let client = TlsTransport::connect_stream(Box::new(s_cli), "localhost", cli_cfg)
+            .expect("client handshake");
+        let server = server.join().expect("server thread");
+        (Arc::new(client), Arc::new(server))
+    }
+
+    #[test]
+    fn tls_queued_frame_then_shutdown() {
+        let (local, peer) = tls_pair();
+        // Over a unix socketpair here, so the peer's send follows AF_UNIX.
+        queued_then_shutdown(
+            "tls",
+            &local,
+            &peer,
+            false,
+            socket_expectation(),
+            unix_peer_send(),
+        );
+    }
+
+    #[test]
+    fn tls_blocked_reader_is_woken() {
+        let (local, _peer) = tls_pair();
+        blocked_reader_is_woken("tls", &local, false);
+    }
+}

--- a/rsbinder/tests/rpc_transport_conformance.rs
+++ b/rsbinder/tests/rpc_transport_conformance.rs
@@ -124,7 +124,7 @@ fn queued_then_shutdown(
     }
     let end = recv(&**local, fd_mode);
     assert!(
-        matches!(end, Err(RpcError::PeerClosed)),
+        matches!(end, Err(RpcError::EndOfStream)),
         "{name}: after shutdown (and any queued frame) the read is the end of stream, got {end:?}"
     );
     // A second shutdown is Ok (idempotent).
@@ -132,7 +132,7 @@ fn queued_then_shutdown(
     // The peer: our shutdown is its end of stream.
     let peer_end = peer.recv_frame();
     assert!(
-        matches!(peer_end, Err(RpcError::PeerClosed)),
+        matches!(peer_end, Err(RpcError::EndOfStream)),
         "{name}: the peer reads our shutdown as its end of stream, got {peer_end:?}"
     );
     // Its first send afterwards is measured per backend and platform (the
@@ -164,7 +164,7 @@ fn blocked_reader_is_woken(name: &str, local: &Shared, fd_mode: bool) {
     std::thread::sleep(Duration::from_millis(50));
     shutdown_within(name, local);
     match rx.recv_timeout(Duration::from_secs(2)) {
-        Ok(Err(RpcError::PeerClosed)) => {}
+        Ok(Err(RpcError::EndOfStream)) => {}
         Ok(other) => panic!("{name}: the woken reader must see the end of stream, got {other:?}"),
         Err(RecvTimeoutError::Timeout) => panic!("{name}: shutdown did not wake the parked reader"),
         Err(RecvTimeoutError::Disconnected) => panic!("{name}: the reader thread died"),

--- a/rsbinder/tests/rpc_vsock.rs
+++ b/rsbinder/tests/rpc_vsock.rs
@@ -123,7 +123,7 @@ fn vsock_loopback_e2e() {
     // Teardown — explicit shutdown + bg.join (same shape as UDS tests).
     drop(root);
     drop(client);
-    server.shutdown();
+    server.stop_accepting();
     let _ = bg.join();
 }
 
@@ -170,7 +170,7 @@ fn vsock_shutdown_wakes_blocked_recv() {
         "recv must not return a frame after shutdown: {got:?}"
     );
     reader.join().expect("reader thread");
-    server.shutdown();
+    server.stop_accepting();
     // Join the workers before the accept loop, as the sibling test does:
     // a worker still serving this client would otherwise outlive the test.
     server.join_workers();
@@ -179,7 +179,7 @@ fn vsock_shutdown_wakes_blocked_recv() {
     }
 }
 
-/// Plan 2-20 (`RpcSession::shutdown` on a vsock session): a user
+/// Plan 2-20 (`RpcSession::close_session` on a vsock session): a user
 /// `serve_blocking` thread ends, the death recipient fires, and the
 /// server sees the connection go — the whole teardown path over vsock.
 #[test]
@@ -216,7 +216,7 @@ fn vsock_session_shutdown_ends_serve_thread() {
     let serve = std::thread::spawn(move || serving.serve_blocking());
 
     std::thread::sleep(Duration::from_millis(200));
-    client.shutdown();
+    client.close_session();
     assert!(
         rx.recv_timeout(Duration::from_secs(3)).is_ok(),
         "shutdown must fire the linked recipient"
@@ -228,7 +228,7 @@ fn vsock_session_shutdown_ends_serve_thread() {
     );
     drop(root);
     drop(client);
-    server.shutdown();
+    server.stop_accepting();
     server.join_workers();
     // Surface an accept-loop panic instead of discarding it — a future
     // regression there would otherwise leave every test green.

--- a/rsbinder/tests/source_invariants.rs
+++ b/rsbinder/tests/source_invariants.rs
@@ -107,9 +107,11 @@ fn prose_does_not_restate_refuted_shutdown_claims() {
 /// than one site now that `find_conn` / `find_conn_pinned` return
 /// `Err(StatusCode::DeadObject)` (not `expect`-panic) when their reentrant
 /// slot lookup misses. The six sanctioned callers are the slot's own
-/// `serve_blocking_on` exit; `client_transact`'s three slot-retiring paths (a
-/// transport-level send failure, a stale-reply read failure, and the reply
-/// wait's refusal of a slot a nested call marked unreadable) — all retire a slot whose
+/// `serve_blocking_on` exit; `retire_after_failed_send`, the one rule every
+/// outbound frame's transport-level send failure funnels through;
+/// `client_transact`'s two reply-wait slot-retiring paths (a reply wait that
+/// failed to arm, read, decode or nested-dispatch, and the reply wait's
+/// refusal of a slot a nested call marked unreadable) — all retire a slot whose
 /// peer is gone / stream is desynced so it is never
 /// reused, and the send-failure one is what lets a serve-less client session
 /// reach death detection (`remove_slot`'s empty-pool hook, Plan 2-17 A.1b);
@@ -146,8 +148,8 @@ fn remove_slot_has_exactly_six_callers() {
         "RpcSessionInner::remove_slot must have exactly six callers. \
          Found {} call sites: {:#?}\n\
          INVARIANT: only serve_blocking_on's exit path, \
-         client_transact's send-failure / stale-reply / unreadable-slot \
-         retirements, the \
+         retire_after_failed_send, client_transact's failed-reply-wait / \
+         unreadable-slot retirements, the \
          incoming-connection attach's spawn-failure rollback, and the \
          callback attach's init-write-failure rollback may call remove_slot — \
          find_conn / find_conn_pinned must return DeadObject (not panic) \

--- a/rsbinder/tests/source_invariants.rs
+++ b/rsbinder/tests/source_invariants.rs
@@ -39,13 +39,78 @@ fn visit<F: FnMut(&Path, &str)>(dir: &Path, f: &mut F) {
     }
 }
 
+/// Prose the code contradicts. Each phrase below was once written in a serve-loop
+/// rustdoc or the CHANGELOG and later shown false: the serve loop's `Ok(())` is
+/// reached by a local `RpcSession::shutdown` exactly as by a peer close, and
+/// what a transport `shutdown` does to bytes already received is platform- and
+/// backend-dependent (macOS discards the kernel queue, Linux keeps it, `mem`
+/// discards logically, a transport may hold a buffered leftover). The same
+/// claim tends to be restated in several places and corrected in one, so this
+/// pins every `.rs` under `src/` plus `CHANGELOG.md`: a restatement trips the
+/// build rather than the next reviewer. Rephrase, don't route around — if a
+/// phrase is needed to state something *true*, narrow the phrase here.
+#[test]
+fn prose_does_not_restate_refuted_shutdown_claims() {
+    const FORBIDDEN: &[&str] = &[
+        // Peer-agency shorthands for an end of stream that either side reaches.
+        "until the peer closes",
+        "until peer closes",
+        "peer closed (clean)",
+        "peer that closed cleanly",
+        // Absolute claims about what `shutdown` does to received bytes.
+        "drops neither",
+        "discards neither",
+    ];
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let src_root = manifest.join("src");
+    if !src_root.is_dir() {
+        eprintln!("skipping: sources not reachable at {}", src_root.display());
+        return;
+    }
+    // Line 0 marks a phrase that only appears once comment lines are joined —
+    // a wrapped rustdoc sentence evades a per-line scan otherwise.
+    let mut hits: Vec<(PathBuf, usize, &str)> = Vec::new();
+    let mut scan = |path: &Path, content: &str| {
+        for (i, line) in content.lines().enumerate() {
+            for phrase in FORBIDDEN {
+                if line.contains(phrase) {
+                    hits.push((path.to_path_buf(), i + 1, phrase));
+                }
+            }
+        }
+        let joined = content
+            .split_whitespace()
+            .filter(|w| !matches!(*w, "///" | "//!" | "//"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        for phrase in FORBIDDEN {
+            let per_line = hits
+                .iter()
+                .any(|(p, l, ph)| p == path && *l > 0 && ph == phrase);
+            if !per_line && joined.contains(phrase) {
+                hits.push((path.to_path_buf(), 0, phrase));
+            }
+        }
+    };
+    visit(&src_root, &mut scan);
+    let changelog = manifest.join("../CHANGELOG.md");
+    if let Ok(content) = fs::read_to_string(&changelog) {
+        scan(&changelog, &content);
+    }
+    assert!(
+        hits.is_empty(),
+        "prose restates a refuted shutdown claim — see this test's doc: {hits:#?}"
+    );
+}
+
 /// `RpcSessionInner::remove_slot` is private to `rpc/session.rs` and safe to call from more
 /// than one site now that `find_conn` / `find_conn_pinned` return
 /// `Err(StatusCode::DeadObject)` (not `expect`-panic) when their reentrant
-/// slot lookup misses. The five sanctioned callers are the slot's own
-/// `serve_blocking_on` exit; `client_transact`'s two poison paths (a
-/// transport-level send failure, and a stale-reply read failure) — both
-/// retire a slot whose peer is gone / stream is desynced so it is never
+/// slot lookup misses. The six sanctioned callers are the slot's own
+/// `serve_blocking_on` exit; `client_transact`'s three slot-retiring paths (a
+/// transport-level send failure, a stale-reply read failure, and the reply
+/// wait's refusal of a slot a nested call poisoned) — all retire a slot whose
+/// peer is gone / stream is desynced so it is never
 /// reused, and the send-failure one is what lets a serve-less client session
 /// reach death detection (`remove_slot`'s empty-pool hook, Plan 2-17 A.1b);
 /// and the two attach rollbacks, which un-push a slot the peer will never be
@@ -58,7 +123,7 @@ fn visit<F: FnMut(&Path, &str)>(dir: &Path, f: &mut F) {
 /// caller counts too: raise the number deliberately rather than route around
 /// it.
 #[test]
-fn remove_slot_has_exactly_five_callers() {
+fn remove_slot_has_exactly_six_callers() {
     let src_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     // `CARGO_MANIFEST_DIR` is baked in at compile time, so a binary copied
     // elsewhere (a device push, for one) cannot see the sources. Skip loudly
@@ -77,11 +142,12 @@ fn remove_slot_has_exactly_five_callers() {
     );
     assert_eq!(
         hits.len(),
-        5,
-        "RpcSessionInner::remove_slot must have exactly five callers. \
+        6,
+        "RpcSessionInner::remove_slot must have exactly six callers. \
          Found {} call sites: {:#?}\n\
          INVARIANT: only serve_blocking_on's exit path, \
-         client_transact's send-failure / stale-reply poisons, the \
+         client_transact's send-failure / stale-reply / poisoned-slot \
+         retirements, the \
          incoming-connection attach's spawn-failure rollback, and the \
          callback attach's init-write-failure rollback may call remove_slot — \
          find_conn / find_conn_pinned must return DeadObject (not panic) \

--- a/rsbinder/tests/source_invariants.rs
+++ b/rsbinder/tests/source_invariants.rs
@@ -109,7 +109,7 @@ fn prose_does_not_restate_refuted_shutdown_claims() {
 /// slot lookup misses. The six sanctioned callers are the slot's own
 /// `serve_blocking_on` exit; `client_transact`'s three slot-retiring paths (a
 /// transport-level send failure, a stale-reply read failure, and the reply
-/// wait's refusal of a slot a nested call poisoned) — all retire a slot whose
+/// wait's refusal of a slot a nested call marked unreadable) — all retire a slot whose
 /// peer is gone / stream is desynced so it is never
 /// reused, and the send-failure one is what lets a serve-less client session
 /// reach death detection (`remove_slot`'s empty-pool hook, Plan 2-17 A.1b);
@@ -146,7 +146,7 @@ fn remove_slot_has_exactly_six_callers() {
         "RpcSessionInner::remove_slot must have exactly six callers. \
          Found {} call sites: {:#?}\n\
          INVARIANT: only serve_blocking_on's exit path, \
-         client_transact's send-failure / stale-reply / poisoned-slot \
+         client_transact's send-failure / stale-reply / unreadable-slot \
          retirements, the \
          incoming-connection attach's spawn-failure rollback, and the \
          callback attach's init-write-failure rollback may call remove_slot — \

--- a/rsbinder/tests/source_invariants.rs
+++ b/rsbinder/tests/source_invariants.rs
@@ -41,7 +41,7 @@ fn visit<F: FnMut(&Path, &str)>(dir: &Path, f: &mut F) {
 
 /// Prose the code contradicts. Each phrase below was once written in a serve-loop
 /// rustdoc or the CHANGELOG and later shown false: the serve loop's `Ok(())` is
-/// reached by a local `RpcSession::shutdown` exactly as by a peer close, and
+/// reached by a local `RpcSession::close_session` exactly as by a peer close, and
 /// what a transport `shutdown` does to bytes already received is platform- and
 /// backend-dependent (macOS discards the kernel queue, Linux keeps it, `mem`
 /// discards logically, a transport may hold a buffered leftover). The same

--- a/tests/tests/entry_rpc.rs
+++ b/tests/tests/entry_rpc.rs
@@ -78,7 +78,8 @@ fn entry_serve_and_connect_over_unix() {
 /// ends the server: the workers are woken and joined instead of waited
 /// on, and the client's next call fails. The guard is dropped on another
 /// thread under a deadline so a regression fails the test rather than
-/// hanging it — this is the order that used to block forever.
+/// hanging it: the guard's `stop_accepting` → join → `terminate` order is
+/// what this pins.
 #[test]
 fn entry_guard_drop_ends_a_connected_client() {
     let sock = SockPath::new("guard-drop");
@@ -205,11 +206,38 @@ fn entry_options_apply_to_rpc_server() {
 /// carrying it to a `set_read_timeout`/`connect_timeout` that rejects it
 /// as an opaque I/O error, or (worse) dropping the caller's bound.
 ///
-/// **Mutant gate**: removing the check in `rpc_connect` turns this into
-/// a connect attempt whose failure names neither the option nor the
-/// reason.
+/// The zero is asserted on the **versioned** endpoint, where the option
+/// does apply: without the facade's check the value reaches
+/// `HandshakeDeadline::arm`, whose refusal is an opaque I/O error
+/// (`Unknown`), so the assertion below is a real gate on the facade. The
+/// r34 wire has no connection handshake for the option to bound, so there
+/// it is refused whatever its value — `ClientOptions` promises an option
+/// that does not apply is `BadValue`, never ignored.
 #[test]
 fn entry_zero_handshake_timeout_is_refused() {
+    let sock13 = SockPath::new("zerohs13");
+    let _guard13 = rsbinder::serve(&sock13.uri("?profile=android13plus"))
+        .expect("serve")
+        .add("svc", tagged("svc"))
+        .expect("add")
+        .spawn()
+        .expect("spawn");
+
+    let err = rsbinder::Client::open_with(&sock13.uri("?profile=android13plus"), |o, _| {
+        o.handshake_timeout = Some(std::time::Duration::ZERO)
+    })
+    .expect_err("a zero handshake deadline must be refused before any connect");
+    assert_eq!(err, rsbinder::StatusCode::BadValue);
+
+    // Control: on the same endpoint a positive deadline connects.
+    let ok = rsbinder::Client::open_with(&sock13.uri("?profile=android13plus"), |o, _| {
+        o.handshake_timeout = Some(std::time::Duration::from_secs(5))
+    })
+    .and_then(|c| c.binder("svc"));
+    assert!(ok.is_ok(), "a positive deadline still connects");
+
+    // The r34 wire has no handshake phase, so the option is refused there
+    // whatever its value.
     let sock = SockPath::new("zerohs");
     let _guard = rsbinder::serve(&sock.uri(""))
         .expect("serve")
@@ -217,19 +245,11 @@ fn entry_zero_handshake_timeout_is_refused() {
         .expect("add")
         .spawn()
         .expect("spawn");
-
     let err = rsbinder::Client::open_with(&sock.uri(""), |o, _| {
-        o.handshake_timeout = Some(std::time::Duration::ZERO)
-    })
-    .expect_err("a zero handshake deadline must be refused");
-    assert_eq!(err, rsbinder::StatusCode::BadValue);
-
-    // Control: a positive deadline on the same endpoint connects.
-    let ok = rsbinder::Client::open_with(&sock.uri(""), |o, _| {
         o.handshake_timeout = Some(std::time::Duration::from_secs(5))
     })
-    .and_then(|c| c.binder("svc"));
-    assert!(ok.is_ok(), "a positive deadline still connects");
+    .expect_err("handshake_timeout does not apply to the r34 wire");
+    assert_eq!(err, rsbinder::StatusCode::BadValue);
 }
 
 /// `connect_async` (feature `tokio`) resolves through `spawn_blocking`

--- a/tests/tests/entry_rpc.rs
+++ b/tests/tests/entry_rpc.rs
@@ -74,6 +74,36 @@ fn entry_serve_and_connect_over_unix() {
     hello.r#ping().unwrap();
 }
 
+/// Plan 2-21 B-2 — dropping the guard while a client is still connected
+/// ends the server: the workers are woken and joined instead of waited
+/// on, and the client's next call fails. The guard is dropped on another
+/// thread under a deadline so a regression fails the test rather than
+/// hanging it — this is the order that used to block forever.
+#[test]
+fn entry_guard_drop_ends_a_connected_client() {
+    let sock = SockPath::new("guard-drop");
+    let guard = rsbinder::serve(&sock.uri(""))
+        .expect("serve")
+        .add("svc", tagged("svc"))
+        .expect("add")
+        .spawn()
+        .expect("spawn");
+    let svc: Strong<dyn IRpcSmoke> = rsbinder::connect(&sock.uri("#svc")).expect("connect");
+    assert_eq!(svc.r#echo("x").unwrap(), "svc:x");
+
+    let dropped = std::thread::spawn(move || drop(guard));
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !dropped.is_finished() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "ServerGuard::drop blocked with a client connected"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    dropped.join().expect("drop thread");
+    assert!(svc.r#echo("after").is_err(), "the server ended the session");
+}
+
 /// `Client` resolves several names on one session; dropping it leaves
 /// the proxies working (D5).
 #[test]


### PR DESCRIPTION
## Summary

Plan 2-21. This branch started as one fix — a nested call that lost the stream let the outer frame take a stray `REPLY` as its own — and across seven review→fix rounds the shutdown/teardown defects around it kept coming back in new forms. Three independent audits (transport layer, session/server lifecycle, vocabulary) reached the same conclusion: there was no type for *why a connection ended*. That verdict was spread over a `Result<bool>`, a `StatusCode` (`DeadObject` carried five causes) and a `poisoned: bool`, and whatever did not fit went into prose, which no compiler checks. Two amplifiers made it worse: **macOS discards the kernel receive queue on a local `shutdown` while Linux keeps it** (measured, not inferred), and the hermetic `mem` transport modelled macOS.

The branch adds the missing type and fixes the defects around it, in five phases:

- **A** — close out the original fix (a reentrant frame that loses the stream marks its slot unreadable; both readers of a slot refuse to interpret another frame on it), plus a prose gate in `tests/source_invariants.rs` that fails when a refuted shutdown claim is written back into rustdoc or the CHANGELOG.
- **B** — independent defects: a TLS stream ending without `close_notify` is no longer a clean close (`RpcError::UncleanEndOfStream`); `RpcServer::terminate` ends connected sessions and joins the workers, so a dropped `ServerGuard` no longer blocks while a client stays connected; the fd-mode leftover buffer is cleared on shutdown; `tcp_debug` gets raw I/O; a serve slot's role is read before the loop.
- **C** — the type: `rpc::SessionEnd { by, stream, reason }` returned by `serve_blocking*`, with `into_result()` as the single projection (`Lost` → `DeadObject`); a local shutdown ends every loop of the session deterministically, whether the worker is parked in `recv` or inside a handler; `RpcError::leaves_frame_boundary_intact` is the one owner of the boundary classification; an unreadable slot is refused at selection, and a request that was never sent fails with `WouldBlock` rather than `TimedOut`.
- **D** — the transport contract: `RpcTransport::shutdown` is required, idempotent, and documented per backend and platform; `RpcError::DeadlineMidFrame`; `mem` models the Linux queue; `tests/rpc_transport_conformance.rs` pins what every backend's shutdown does on each platform — it caught a deadlock in the fd-mode reader on its first run.
- **E** — vocabulary: `shutdown` now names one operation, the transport half-close. `RpcServer::shutdown` → `stop_accepting`, `ServerGuard::shutdown` → `stop_and_join`, `RpcSession::shutdown` → `close_session`, `TlsStream::shutdown` → `shutdown_stream`, and `RpcError::PeerClosed` → `EndOfStream` (it never knew who ended the stream). The R1 borrow discipline is extended to the RPC thread-locals, and the book gains "How a connection ends".

Breaking changes are listed under `### Migrating from 0.10.0` in the CHANGELOG. No wire change: every existing RPC suite is green and the success paths are byte-identical.

## Verification

| | macOS (`rpc,rpc-tcp-debug,rpc-tls`) | Linux (`+rpc-vsock`, kernel Rust binder box) |
|---|---|---|
| `cargo test -p rsbinder` | 476 passed / 0 failed | 500 passed / 0 failed |
| check, clippy `-D warnings`, fmt, doc | green | green |
| rpc-off, `--no-default-features`, example-hello | green | green |

Linux was mandatory for every shutdown-related item: macOS discards the queue, so the wrong assumption passes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
