### PR TITLE
Refuse binders that cross the IPC stack boundary, and make a gateway one line

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,14 +123,20 @@ jobs:
         # targets are ungated), or excluded here on purpose:
         #   * rsbinder/tests/rpc_vsock.rs — every test in it is `#[ignore]`d
         #     (needs a peer VM or the `vsock_loopback` module), so running it
-        #     yields nothing; `rpc-suite` still builds it via the
-        #     `--features rpc-vsock` matrix step.
+        #     yields nothing; the `test` job's
+        #     `cargo clippy --all-targets --all-features` is what type-checks
+        #     it (the `rpc-vsock` matrix step is a plain `cargo build`, which
+        #     compiles lib + bins only, never `tests/`).
         #   * rsbinder/tests/loom_cache_pin.rs — `cfg(loom)`, empty without
         #     `RUSTFLAGS="--cfg loom"`; a loom run is a manual exercise.
         #   * tests/tests/mesh_rpc.rs, tests/tests/mesh_kernel.rs — the
         #     multi-process mesh: minutes-expensive, and `mesh_kernel` needs
         #     /dev/binder plus a live rsb_hub, so integration-test.yml owns
         #     both.
+        #   * tests/tests/gateway_kernel.rs — every test in it is `#[ignore]`d
+        #     and needs /dev/binder plus a live rsb_hub to drive an RPC client
+        #     through a gateway to a kernel service, so integration-test.yml
+        #     owns it.
         # Adding a test target means adding it to one of those lines, or to
         # this list with the reason it cannot run here.
         run: |
@@ -182,7 +188,7 @@ jobs:
         # workflow.
         run: |
           cargo test -p rsbinder --features rpc --lib rpc::
-          cargo test -p rsbinder --features rpc --test rpc_e2e --test rpc_scenarios --test rpc_server --test rpc_fd --test rpc_shared_memory --test rpc_transport_conformance --test source_invariants
+          cargo test -p rsbinder --features rpc --test rpc_e2e --test rpc_scenarios --test rpc_server --test rpc_fd --test rpc_shared_memory --test rpc_cross_stack --test rpc_transport_conformance --test source_invariants
           cargo test -p rsbinder --features rpc-tls,rpc-tcp-debug --test rpc_tls --test rpc_transport_conformance
       - name: RPC accessor (hermetic, requires android_16 — gap-fill)
         # `rpc_accessor.rs` is `#![cfg(all(feature = "rpc", feature =
@@ -199,12 +205,13 @@ jobs:
         # --workspace --no-run` included. Every hermetic `rpc` target of the
         # crate is therefore named here: `entry_rpc` (the
         # `serve`/`connect`/`Client` gate), `codegen_shapes`, the async stub
-        # adapter, `get_calling_uid` over RPC, and the `@EnforcePermission`
-        # deny. `macro_cross` needs `macros` too and is on the next step; the
-        # two mesh targets are integration-test.yml's (see the ledger on
+        # adapter, `get_calling_uid` over RPC, the `@EnforcePermission` deny,
+        # and `gateway_rpc` (the re-publish/`Rewrap` gate). `macro_cross`
+        # needs `macros` too and is on the next step; the two mesh targets and
+        # `gateway_kernel` are integration-test.yml's (see the ledger on
         # `linux-build`'s "Check test builds").
         run: |
-          cargo test -p tests --features rpc --test rpc_generated_stub --test entry_rpc --test codegen_shapes \
+          cargo test -p tests --features rpc --test rpc_generated_stub --test entry_rpc --test gateway_rpc --test codegen_shapes \
             --test rpc_async --test rpc_calling_identity --test rpc_enforce_permission_deny
           cargo test -p tests --features rpc-tcp-debug --test rpc_generated_stub
       - name: Interface macro (plan 2-19 — golden equivalence, UI, e2e, interop)
@@ -256,7 +263,7 @@ jobs:
         # `rpc-suite` for the feature-gate reasoning.
         run: |
           cargo test -p rsbinder --features rpc --lib rpc::
-          cargo test -p rsbinder --features rpc --test rpc_e2e --test rpc_scenarios --test rpc_server --test rpc_fd --test rpc_shared_memory --test rpc_transport_conformance --test source_invariants
+          cargo test -p rsbinder --features rpc --test rpc_e2e --test rpc_scenarios --test rpc_server --test rpc_fd --test rpc_shared_memory --test rpc_cross_stack --test rpc_transport_conformance --test source_invariants
           cargo test -p rsbinder --features rpc-tls,rpc-tcp-debug --test rpc_tls --test rpc_transport_conformance
           cargo test -p rsbinder --features rpc,android_16 --test rpc_accessor
       - name: AIDL compiler tests (hermetic — plan 3 AC-3.4)

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -255,6 +255,21 @@ jobs:
             exit 1
           }
 
+      - name: Run gateway_kernel (RPC client -> gateway -> kernel service)
+        run: |
+          # Plan 2-22 Phase E. A socket client reaching a kernel-binder
+          # service through a gateway process that re-publishes an
+          # upstream proxy (`BnFoo::new_binder(proxy)`). #[ignore]'d: it
+          # needs /dev/binder + a permissive rsb_hub, both up already. It
+          # spawns its own kernel service (a re-exec of the test binary),
+          # so it is independent of the shared test_service. Also pins
+          # that handing the kernel proxy over directly is refused.
+          RUST_BACKTRACE=1 cargo test -p tests --features rpc --test gateway_kernel -- --ignored || {
+            echo "::error::gateway_kernel (rpc -> gateway -> kernel) failed"
+            cp -f rsb_hub.log artifacts/gateway-rsb_hub.log 2>/dev/null || true
+            exit 1
+          }
+
       - name: Restart test_service for test_death_recipient
         run: |
           # Each #[ignore]'d destructive test consumes a live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ short form — and the first entry is the only one no compiler will catch.
   it and neither can your build. If you meant the default, pass the newly
   public `DEFAULT_MAX_BINDER_THREADS`. `init_default()` and a `binder://` URI
   without `?threads=` are unchanged.
+- **`RpcServer::set_root` / `RpcSession::set_root` return `Result<()>`.** They
+  now refuse a *remote* binder (see *Changed*), so they have a value to
+  report. An unused `Result` is only a warning, so a build without
+  `-D warnings` still compiles and the refusal goes unnoticed: add `?` or
+  `.expect(...)` at every call. Nothing else about them changed.
 - **`rpc::transport::TlsStream` gained a required `shutdown_stream()`.**
   Custom stream implementations must add
   `fn shutdown_stream(&self) -> std::io::Result<()>` (shut the underlying
@@ -486,6 +491,24 @@ short form — and the first entry is the only one no compiler will catch.
 
 ### Changed
 
+- **rsbinder:** writing a binder that belongs to the *other* IPC stack — an
+  RPC proxy into a kernel parcel, or a kernel proxy into an RPC parcel — is
+  now refused at **write time** with `InvalidOperation`, matching libbinder
+  (`Parcel::flattenBinder`, `RpcState::onBinderLeaving`). It used to be
+  accepted and then fail on the receiver's *first call* with
+  `UnknownTransaction`, which pointed at the wrong process. rsbinder already
+  refused the third case libbinder does (a proxy from an unrelated RPC
+  session); that check is now pinned by a test. Registration refuses the same
+  mistake up front: `serve(rpc://…).add`, `RpcServer::add_service`,
+  `RpcServer::set_root` and `RpcSession::set_root` reject a remote binder. To
+  re-publish a service reached over one transport on another, wrap the proxy
+  in a local `Bn*` — `BnFoo::new_binder(proxy)`, the gateway pattern — rather
+  than forwarding the binder itself. Kernel `hub::add_service` is unchanged:
+  re-registering a proxy with the system service manager is legitimate.
+- **`RpcServer::set_root` and `RpcSession::set_root` return `Result<()>`**
+  (was `()`), so they can report the refusal above. Callers passing a local
+  binder are unaffected apart from handling the value — `?` in a function
+  that returns `Result`, `.expect("set_root")` in a test.
 - **rsbinder (RPC):** a non-nested call on a session with no connection to
   send on — a server calling a client callback outside any handler, the
   client having opened no incoming connection — now fails immediately with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,19 @@ short form — and the first entry is the only one no compiler will catch.
 
 ### Added
 
+- **rsbinder:** a **gateway** is now one line. `Strong<I>` implements
+  `Interface` (delegating to the binder it holds), and generated interfaces —
+  from `.aidl` and from `#[interface]` alike — implement themselves for
+  `Strong<dyn IFoo>`, so a proxy satisfies `BnFoo::new_binder`'s bound:
+  `serve(uri)?.add("foo", BnFoo::new_binder(upstream_proxy))?` re-publishes a
+  service reached over one transport onto another. `getInterfaceVersion` /
+  `getInterfaceHash` report the *upstream's* values, not the delegating
+  module's. Binder-typed arguments still have to be re-wrapped by hand — see
+  the book's [cross-transport chapter], which also covers what stops at a
+  gateway (caller identity, fd rights, uid, death, one worker per forwarded
+  call), and `example-hello`'s new `gateway_service` binary.
+
+  [cross-transport chapter]: https://hiking90.github.io/rsbinder/cross-transport-services.html
 - **rsbinder (RPC):** client-side **incoming (callback) connections** —
   `RpcUnixClientConfig::incoming_connections(n)`,
   `RpcSession::add_incoming_connection_android13plus_with_config`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,15 @@ short form — and the first entry is the only one no compiler will catch.
   call), and `example-hello`'s new `gateway_service` binary.
 
   [cross-transport chapter]: https://hiking90.github.io/rsbinder/cross-transport-services.html
+- **`rsbinder::bridge::Rewrap`** — one local wrapper per remote binder, for
+  gateways that forward a binder *argument*. Re-wrapping inline
+  (`BnCallback::new_binder(cb.clone())`) is correct per call and wrong across
+  calls: it mints a new object each time, so an upstream that pairs
+  `register(cb)` with `unregister(cb)` by identity never matches the second.
+  `Rewrap::new(|p| BnCallback::new_binder(p))` then `.wrap(cb)` returns the
+  same object for the same live remote. It holds only weak references, so it
+  never keeps a wrapper alive; entries go when the remote dies (death
+  notification), when the wrapper is dropped, or on `purge_dead()`.
 - **rsbinder (RPC):** client-side **incoming (callback) connections** —
   `RpcUnixClientConfig::incoming_connections(n)`,
   `RpcSession::add_incoming_connection_android13plus_with_config`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,7 +226,7 @@ short form — and the first entry is the only one no compiler will catch.
   (`BnCallback::new_binder(cb.clone())`) is correct per call and wrong across
   calls: it mints a new object each time, so an upstream that pairs
   `register(cb)` with `unregister(cb)` by identity never matches the second.
-  `Rewrap::new(|p| BnCallback::new_binder(p))` then `.wrap(cb)` returns the
+  `Rewrap::new(BnCallback::new_binder)` then `.wrap(cb)` returns the
   same object for the same live remote. It holds only weak references, so it
   never keeps a wrapper alive; entries go when the remote dies (death
   notification), when the wrapper is dropped, or on `purge_dead()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -525,8 +525,10 @@ short form — and the first entry is the only one no compiler will catch.
   `RpcServer::set_root` and `RpcSession::set_root` reject a remote binder. To
   re-publish a service reached over one transport on another, wrap the proxy
   in a local `Bn*` — `BnFoo::new_binder(proxy)`, the gateway pattern — rather
-  than forwarding the binder itself. Kernel `hub::add_service` is unchanged:
-  re-registering a proxy with the system service manager is legitimate.
+  than forwarding the binder itself. Kernel `hub::add_service` still takes a
+  *kernel* proxy — re-registering one with the system service manager is
+  legitimate — but an RPC proxy is refused there too, by the write-time check
+  above.
 - **`RpcServer::set_root` and `RpcSession::set_root` return `Result<()>`**
   (was `()`), so they can report the refusal above. Callers passing a local
   binder are unaffected apart from handling the value — `?` in a function

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -115,5 +115,10 @@ canonical example):
   even need the `rpc` Cargo feature). Mixing the two costs only what
   each side already costs in isolation — there is no shared singleton
   between them.
+- **Binder objects do not cross between the two.** Writing a proxy of one
+  stack into a parcel of the other is refused with `InvalidOperation`
+  (AOSP does the same). To let a client of one stack reach a service on
+  the other, use an Accessor or a gateway —
+  [Cross-Transport Services § Bridging](./cross-transport-services.md).
 
 See [RPC Transport](./rpc-transport.md) for the full story.

--- a/book/src/cross-transport-services.md
+++ b/book/src/cross-transport-services.md
@@ -112,9 +112,11 @@ let hello: Strong<dyn IHello> = rsbinder::Client::open_with("tls://host:9000", |
 ```
 
 `ServeOptions`: `threads`, `max_connections`, `handshake_timeout`,
-`idle_timeout`, `authorizer`, `tls`, `fd_modes`, `call_restriction`.
+`idle_timeout`, `reply_timeout`, `authorizer`, `tls`, `fd_modes`,
+`call_restriction`.
 `ClientOptions`: `tls` / `tls_server_name`, `session_id`,
-`outgoing_connections`, `fd_mode`, `timeout`, `driver`.
+`outgoing_connections`, `incoming_connections`, `fd_mode`, `timeout`,
+`handshake_timeout`, `driver`.
 
 `Client::open_with`'s closure also receives the parsed `Endpoint`, so an
 option that applies to only some transports is set from the endpoint rather
@@ -235,8 +237,8 @@ What a gateway costs, all of it visible in B:
 cargo run -p example-hello --bin hello_service                 # C, on kernel binder
 cargo run -p example-hello --features rpc --bin gateway_service \
     binder://my.hello unix:///tmp/rsb_gw.sock                  # B
-cargo run -p example-hello --features rpc --bin hello_client \
-    unix:///tmp/rsb_gw.sock#hello                              # A
+cargo run -p example-hello --features rpc --bin unified_client \
+    unix:///tmp/rsb_gw.sock                                    # A
 ```
 
 ## What the URI does *not* hide

--- a/book/src/cross-transport-services.md
+++ b/book/src/cross-transport-services.md
@@ -134,6 +134,90 @@ An option that does not apply to the transport (a TLS config on
 silently ignored. Users who want that checked at compile time use the
 low-level types directly.
 
+## Bridging two transports in one process
+
+Everything above moves *one* service onto whichever transport you pick. A
+different problem is reaching a service that lives on the *other* transport
+— a socket client that needs a kernel service, or the reverse. rsbinder has
+three answers, and which one applies depends on the direction:
+
+| Direction | Mechanism | Where |
+|---|---|---|
+| kernel client → socket service | **Accessor** (`IAccessor`, Android 16 / `rsb_hub`) — the service manager hands the client a connection to the socket | [RPC Transport § Bridging](./rpc-transport.md) |
+| one service, both transports | **dual-hosting** — the same `Bn*` passed to two `serve(...).add(...)` calls | this chapter |
+| socket client → kernel service | **gateway** — a process that re-publishes an upstream proxy as a local service | below |
+
+None of the three moves raw bytes between the stacks. A binder that belongs
+to one stack **cannot be written into a parcel of the other**: rsbinder
+refuses it at write time with `InvalidOperation`, exactly as libbinder does
+(`Parcel::flattenBinder`, `RpcState::onBinderLeaving`). There is no
+transparent bridge, and building one is a non-goal — a generic byte
+forwarder would silently change the caller identity, fd rights, stability
+and oneway ordering that the two stacks define differently.
+
+### The gateway
+
+A gateway process B connects to the upstream service C and publishes it
+again on its own endpoint. Because `Bn*::new_binder` accepts anything
+implementing the interface, and a typed handle implements the interface it
+points at, that is one line:
+
+```rust
+// B: reach C over kernel binder, re-publish it on a Unix socket.
+let upstream: Strong<dyn IHello> = rsbinder::connect("binder://my.hello")?;
+
+rsbinder::serve("unix:///tmp/rsb_gw.sock")?
+    .add("hello", BnHello::new_binder(upstream))?   // <- the gateway
+    .run()?;
+```
+
+Passing the *proxy* instead — `.add("hello", upstream.as_binder())` — is the
+mistake this refuses (`InvalidOperation` at `add`). Wrapping is not
+ceremony: the `Bn*` is a **local** binder that B owns, and that is what
+makes it publishable.
+
+**The rule: every binder object crossing B is unwrapped by B and wrapped
+again. Plain data flows through untouched.** So a method with a binder
+argument — a callback registration, say — needs B to override just that
+method and re-wrap the argument before forwarding it:
+
+```rust
+fn register(&self, cb: &Strong<dyn ICallback>) -> BinderResult<()> {
+    self.upstream.register(&BnCallback::new_binder(cb.clone()))
+}
+```
+
+Forwarding `cb` as-is fails with `InvalidOperation`, reported back to the
+original caller. Note each `new_binder` makes a *new* object, so C sees a
+different callback identity every time; an interface that pairs
+register/unregister by identity needs B to cache one wrapper per upstream
+callback.
+
+What a gateway costs, all of it visible in B:
+
+- **Identity.** C sees *B* as its caller, not A. C's `@EnforcePermission`
+  checks pass with B's credentials, so authenticating A is B's job —
+  `ServeOptions::authorizer` on B's endpoint.
+- **File descriptors.** They only cross a Unix-domain link, and only with
+  FD passing negotiated on that hop.
+- **Uid.** Over TCP or vsock, B cannot learn A's uid at all.
+- **Plaintext TCP** is bring-up only; a real deployment uses TLS or a
+  Unix socket.
+- **Death.** There are now two lifetimes. A's proxy dies when B goes away;
+  B's upstream dies when C does. B does not forward one as the other.
+- **Threads.** Each forwarded call occupies one of B's RPC workers for the
+  whole upstream round trip — size `ServeOptions::threads` accordingly.
+
+`example-hello` ships a runnable one:
+
+```text
+cargo run -p example-hello --bin hello_service                 # C, on kernel binder
+cargo run -p example-hello --features rpc --bin gateway_service \
+    binder://my.hello unix:///tmp/rsb_gw.sock                  # B
+cargo run -p example-hello --features rpc --bin hello_client \
+    unix:///tmp/rsb_gw.sock#hello                              # A
+```
+
 ## What the URI does *not* hide
 
 Moving a service between transports changes its trust boundary — read

--- a/book/src/cross-transport-services.md
+++ b/book/src/cross-transport-services.md
@@ -188,10 +188,31 @@ fn register(&self, cb: &Strong<dyn ICallback>) -> BinderResult<()> {
 ```
 
 Forwarding `cb` as-is fails with `InvalidOperation`, reported back to the
-original caller. Note each `new_binder` makes a *new* object, so C sees a
-different callback identity every time; an interface that pairs
-register/unregister by identity needs B to cache one wrapper per upstream
-callback.
+original caller.
+
+That inline `new_binder` is correct for one call and wrong across calls:
+each one mints a *new* object, so `register(cb)` and `unregister(cb)` reach C
+as two unrelated binders and the removal matches nothing.
+[`bridge::Rewrap`](https://docs.rs/rsbinder/latest/rsbinder/bridge/struct.Rewrap.html)
+is the table that fixes it — same remote in, same local out:
+
+```rust
+struct Gateway {
+    upstream: Strong<dyn IFoo>,
+    callbacks: Rewrap<dyn ICallback>,   // Rewrap::new(|p| BnCallback::new_binder(p))
+}
+
+fn register(&self, cb: &Strong<dyn ICallback>) -> BinderResult<()> {
+    self.upstream.register(&self.callbacks.wrap(cb))
+}
+fn unregister(&self, cb: &Strong<dyn ICallback>) -> BinderResult<()> {
+    self.upstream.unregister(&self.callbacks.wrap(cb))   // the same object
+}
+```
+
+It holds only weak references, so it never keeps a wrapper alive: the
+wrapper lives as long as C holds it, and the entry goes when the remote dies
+or the wrapper is dropped.
 
 What a gateway costs, all of it visible in B:
 

--- a/book/src/cross-transport-services.md
+++ b/book/src/cross-transport-services.md
@@ -201,7 +201,7 @@ is the table that fixes it — same remote in, same local out:
 ```rust
 struct Gateway {
     upstream: Strong<dyn IFoo>,
-    callbacks: Rewrap<dyn ICallback>,   // Rewrap::new(|p| BnCallback::new_binder(p))
+    callbacks: Rewrap<dyn ICallback>,   // Rewrap::new(BnCallback::new_binder)
 }
 
 fn register(&self, cb: &Strong<dyn ICallback>) -> BinderResult<()> {

--- a/book/src/rpc-transport.md
+++ b/book/src/rpc-transport.md
@@ -625,6 +625,11 @@ process-local registry when the service manager returns nothing.
 Both sides of the Accessor pattern have been validated against real
 Android 16 `libbinder` on the emulator.
 
+The Accessor solves one direction — a **kernel** client reaching an RPC
+service. For the reverse, and for the rule that binder objects never cross
+between the two stacks, see
+[Cross-Transport Services § Bridging two transports in one process](./cross-transport-services.md).
+
 ## Async over RPC
 
 The blocking I/O the RPC stack uses is **deliberate** — it matches

--- a/book/src/rpc-transport.md
+++ b/book/src/rpc-transport.md
@@ -83,7 +83,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let server = RpcServer::setup_unix_server(RPC_SOCKET)?;
 
     // Publish a root binder. Clients fetch this via get_root().
-    server.set_root(BnHello::new_binder(IHelloService {}).as_binder());
+    server.set_root(BnHello::new_binder(IHelloService {}).as_binder())?;
 
     // Accept loop runs on this thread until stop_accepting().
     server.run()?;
@@ -197,7 +197,7 @@ The server picks the highest version both sides advertise:
 // Server: offer up to android-16 wire v2.
 let server = RpcServer::setup_unix_server("/tmp/foo.sock")?;
 server.set_android13plus(2);
-server.set_root(my_root);
+server.set_root(my_root)?;
 
 // Client: offer up to v2. Negotiation picks min(client, server).
 let session = RpcSession::setup_unix_client_android13plus(
@@ -345,7 +345,7 @@ let config = Arc::new(
 
 // TCP is TLS-only by design: there is no plaintext-TCP server constructor.
 let server = RpcServer::setup_tcp_server_tls("0.0.0.0:9999", config)?;
-server.set_root(my_root_binder);
+server.set_root(my_root_binder)?;
 server.run()?;                              // or server.run_background()
 ```
 
@@ -599,7 +599,7 @@ rsbinder implements **both sides** of this pattern:
   let sock = PathBuf::from("/data/local/tmp/my.sock");
   let server = RpcServer::setup_unix_server(&sock)?;
   server.set_android13plus(2);
-  server.set_root(my_root);
+  server.set_root(my_root)?;
   let _bg = server.run_background();
 
   // 2. Vend an IAccessor that hands clients an fd connected to

--- a/book/src/security.md
+++ b/book/src/security.md
@@ -99,6 +99,21 @@ fn authorize() -> rsbinder::status::Result<()> {
 `Caller` and `PeerIdentity` are `#[non_exhaustive]`, so the compiler forces
 a catch-all arm — which nudges you toward a fail-closed default.
 
+### Identity stops at a bridge
+
+A [gateway or Accessor](./cross-transport-services.md) re-publishes an
+upstream service on another transport, and the caller identity **does not
+travel with the call**. In `A → B → C`, C's handler sees `B` — B's uid, B's
+certificate, B's `sid`. C's `@EnforcePermission` checks therefore pass with
+B's credentials, and a uid allowlist in C authorizes B, not A.
+
+That makes B the trust boundary. If C is meant to be reachable only by
+certain callers, B has to enforce it, on B's own endpoint — via
+`ServeOptions::authorizer`, or a `calling_caller()` check in the forwarding
+method. A gateway that forwards unconditionally *widens* C's exposure to
+everyone who can reach B, which over TCP or vsock is everyone who can reach
+the port, since B cannot learn A's uid there at all.
+
 ## Four ways to authorize
 
 | When | Use |

--- a/example-hello/Cargo.toml
+++ b/example-hello/Cargo.toml
@@ -40,6 +40,15 @@ required-features = ["rpc"]
 name = "unified_client"
 required-features = ["rpc"]
 
+# The gateway: front an `IHello` reached over one transport on another,
+# with `BnHello::new_binder(upstream_proxy)`. See
+# `book/src/cross-transport-services.md`.
+#   cargo run -p example-hello --features rpc --bin gateway_service \
+#       binder://my.hello unix:///tmp/rsb_gw.sock
+[[bin]]
+name = "gateway_service"
+required-features = ["rpc"]
+
 # Plan 2-16 handler-side authorization example: the service impl authorizes
 # each call via `rsbinder::calling_caller()` and denies with EX_SECURITY.
 # Uses `rsbinder::Caller` / `rpc::PeerIdentity`, so gated on the `rpc` feature.

--- a/example-hello/src/bin/gateway_service.rs
+++ b/example-hello/src/bin/gateway_service.rs
@@ -1,0 +1,69 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! A **gateway**: connect to `IHello` on one transport and re-publish it
+//! on another. The whole bridge is the `BnHello::new_binder(upstream)`
+//! below — a typed handle implements the interface it points at, so a
+//! proxy satisfies `new_binder`'s bound and becomes a local binder this
+//! process owns and can publish anywhere.
+//!
+//! This is the answer to "a socket client needs a kernel service"; the
+//! reverse direction is the Accessor (see the book). It is *not* a
+//! transparent bridge — see `book/src/cross-transport-services.md` for
+//! what stops at the gateway (caller identity, fds, uid, death, one
+//! worker per forwarded call).
+//!
+//! ```text
+//! # 1. C — the real service, on kernel binder
+//! cargo run -p example-hello --bin hello_service
+//!
+//! # 2. B — this gateway
+//! cargo run -p example-hello --features rpc --bin gateway_service \
+//!     binder://my.hello unix:///tmp/rsb_gw.sock
+//!
+//! # 3. A — an ordinary client, which never learns C exists
+//! cargo run -p example-hello --features rpc --bin unified_client \
+//!     unix:///tmp/rsb_gw.sock
+//! ```
+//!
+//! Either URI may name either transport, so the same binary also fronts
+//! an RPC service on kernel binder (`unix:///tmp/x.sock#my.hello
+//! binder://`) or bridges two sockets.
+
+use env_logger::Env;
+use example_hello::*;
+use rsbinder::Strong;
+
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
+
+    let mut args = std::env::args().skip(1);
+    let (Some(upstream_uri), Some(listen_uri)) = (args.next(), args.next()) else {
+        eprintln!(
+            "usage: gateway_service <upstream-uri> <listen-uri>\n\
+             \n\
+             e.g. gateway_service binder://{SERVICE_NAME} unix:///tmp/rsb_gw.sock\n\
+             \n\
+             The upstream URI names the service to front; the listen URI is\n\
+             where this process re-publishes it under the same name."
+        );
+        std::process::exit(2);
+    };
+
+    // The upstream service, reached however its URI says.
+    let upstream: Strong<dyn IHello> = rsbinder::connect(&upstream_uri)?;
+    println!("gateway_service: upstream {upstream_uri} is up");
+
+    // The bridge. `upstream` is a proxy, but `Strong<dyn IHello>`
+    // implements `IHello`, so `new_binder` accepts it and hands back a
+    // *local* binder that forwards every call.
+    //
+    // Handing the proxy over directly — `.add(SERVICE_NAME,
+    // upstream.as_binder())` — is refused with `InvalidOperation`: a
+    // binder of one stack cannot be published on the other.
+    rsbinder::serve(&listen_uri)?
+        .add(SERVICE_NAME, BnHello::new_binder(upstream))?
+        .run()?;
+
+    Ok(())
+}

--- a/example-hello/src/bin/rpc_accessor_register_interop_server.rs
+++ b/example-hello/src/bin/rpc_accessor_register_interop_server.rs
@@ -159,7 +159,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let _ = std::fs::remove_file(&sock_path);
     let server: Arc<RpcServer> = RpcServer::setup_unix_server(&sock_path)?;
     server.set_android13plus(max_version);
-    server.set_root(Interface::as_binder(&Binder::new(Interop)));
+    server.set_root(Interface::as_binder(&Binder::new(Interop)))?;
     let _bg = server.run_background();
 
     // 4) IAccessor binder via `LocalAccessor` (AOSP `createAccessor`

--- a/example-hello/src/bin/rpc_fd_interop_server.rs
+++ b/example-hello/src/bin/rpc_fd_interop_server.rs
@@ -128,7 +128,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // byte only because this is set; v0 stays `None` (AOSP forbids fds
     // there), v1+ carries fds over `SCM_RIGHTS`.
     server.set_supported_fd_modes(&[rsbinder::rpc::FileDescriptorTransportMode::Unix]);
-    server.set_root(Interface::as_binder(&Binder::new(Interop)));
+    server.set_root(Interface::as_binder(&Binder::new(Interop)))?;
 
     println!("[rsbinder-server] READY android13plus(v{max_version}) fd=unix on {sock}");
     server.run()?;

--- a/example-hello/src/bin/rpc_multiconn_interop_server.rs
+++ b/example-hello/src/bin/rpc_multiconn_interop_server.rs
@@ -260,7 +260,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         oneway_log: Mutex::new(Vec::new()),
         in_flight: AtomicI32::new(0),
         sched: Arc::new(Mutex::new(None)),
-    })));
+    })))?;
 
     println!("[rsbinder-server] READY v2 max_threads={max_threads} on {sock}");
     // Block in the accept loop; the launcher drives every transact.

--- a/rsbinder-aidl/src/generator.rs
+++ b/rsbinder-aidl/src/generator.rs
@@ -570,6 +570,32 @@ pub mod {{mod}} {
         }
         {%- endfor %}
     }
+    /// A typed handle implements the interface it points at, so a proxy can be
+    /// re-published as a local service on another transport in one line:
+    /// `{{ bn_name }}::new_binder(upstream)` (the **gateway** pattern —
+    /// `new_binder` takes any `T: {{ name }} + Send + Sync + 'static`).
+    /// Binder-typed arguments still have to be re-wrapped by hand; a proxy
+    /// forwarded as-is is refused at the stack boundary.
+    impl {{ name }} for {{crate}}::Strong<dyn {{ name }}> {
+        {%- for member in fn_members %}
+        fn r#{{ member.identifier }}({{ member.args }}) -> {{crate}}::BinderResult<{{ member.return_type }}> {
+            (**self).r#{{ member.identifier }}({{ member.func_call_params }})
+        }
+        {%- endfor %}
+        {%- if version %}
+        // Report the *upstream* version, not this module's constant: a gateway
+        // speaks for the service it fronts. The trait's default body would
+        // silently answer with `VERSION` if this override were dropped.
+        fn r#getInterfaceVersion(&self) -> {{crate}}::BinderResult<i32> {
+            (**self).r#getInterfaceVersion()
+        }
+        {%- endif %}
+        {%- if hash %}
+        fn r#getInterfaceHash(&self) -> {{crate}}::BinderResult<String> {
+            (**self).r#getInterfaceHash()
+        }
+        {%- endif %}
+    }
     fn on_transact(
         _service: &dyn {{ name }}, _code: {{crate}}::TransactionCode, _reader: &mut {{crate}}::Parcel, _reply: &mut {{crate}}::Parcel) -> {{crate}}::Result<()> {
         match _code {

--- a/rsbinder-aidl/tests/test_arrays.rs
+++ b/rsbinder-aidl/tests/test_arrays.rs
@@ -162,6 +162,23 @@ pub mod ITestService {
             self.0.r#FillOutStructuredParcelable(_arg_parcel)
         }
     }
+    /// A typed handle implements the interface it points at, so a proxy can be
+    /// re-published as a local service on another transport in one line:
+    /// `BnTestService::new_binder(upstream)` (the **gateway** pattern —
+    /// `new_binder` takes any `T: ITestService + Send + Sync + 'static`).
+    /// Binder-typed arguments still have to be re-wrapped by hand; a proxy
+    /// forwarded as-is is refused at the stack boundary.
+    impl ITestService for rsbinder::Strong<dyn ITestService> {
+        fn r#ReverseBoolean(&self, _arg_input: &[bool], _arg_repeated: &mut Vec<bool>) -> rsbinder::BinderResult<Vec<bool>> {
+            (**self).r#ReverseBoolean(_arg_input, _arg_repeated)
+        }
+        fn r#RepeatNullableIntArray(&self, _arg_input: Option<&[i32]>) -> rsbinder::BinderResult<Option<Vec<i32>>> {
+            (**self).r#RepeatNullableIntArray(_arg_input)
+        }
+        fn r#FillOutStructuredParcelable(&self, _arg_parcel: &mut super::StructuredParcelable::StructuredParcelable) -> rsbinder::BinderResult<()> {
+            (**self).r#FillOutStructuredParcelable(_arg_parcel)
+        }
+    }
     fn on_transact(
         _service: &dyn ITestService, _code: rsbinder::TransactionCode, _reader: &mut rsbinder::Parcel, _reply: &mut rsbinder::Parcel) -> rsbinder::Result<()> {
         match _code {
@@ -392,6 +409,17 @@ pub mod FixedSizeArrayExample {
                 self.0.r#Repeat2dParcelables(_arg_input, _arg_repeated)
             }
         }
+        /// A typed handle implements the interface it points at, so a proxy can be
+        /// re-published as a local service on another transport in one line:
+        /// `BnRepeatFixedSizeArray::new_binder(upstream)` (the **gateway** pattern —
+        /// `new_binder` takes any `T: IRepeatFixedSizeArray + Send + Sync + 'static`).
+        /// Binder-typed arguments still have to be re-wrapped by hand; a proxy
+        /// forwarded as-is is refused at the stack boundary.
+        impl IRepeatFixedSizeArray for rsbinder::Strong<dyn IRepeatFixedSizeArray> {
+            fn r#Repeat2dParcelables(&self, _arg_input: &[[super::IntParcelable::IntParcelable; 3]; 2], _arg_repeated: &mut [[super::IntParcelable::IntParcelable; 3]; 2]) -> rsbinder::BinderResult<[[super::IntParcelable::IntParcelable; 3]; 2]> {
+                (**self).r#Repeat2dParcelables(_arg_input, _arg_repeated)
+            }
+        }
         fn on_transact(
             _service: &dyn IRepeatFixedSizeArray, _code: rsbinder::TransactionCode, _reader: &mut rsbinder::Parcel, _reply: &mut rsbinder::Parcel) -> rsbinder::Result<()> {
             match _code {
@@ -488,6 +516,14 @@ pub mod FixedSizeArrayExample {
         impl IEmptyInterface for BpEmptyInterface {
         }
         impl IEmptyInterface for rsbinder::Binder<BnEmptyInterface> {
+        }
+        /// A typed handle implements the interface it points at, so a proxy can be
+        /// re-published as a local service on another transport in one line:
+        /// `BnEmptyInterface::new_binder(upstream)` (the **gateway** pattern —
+        /// `new_binder` takes any `T: IEmptyInterface + Send + Sync + 'static`).
+        /// Binder-typed arguments still have to be re-wrapped by hand; a proxy
+        /// forwarded as-is is refused at the stack boundary.
+        impl IEmptyInterface for rsbinder::Strong<dyn IEmptyInterface> {
         }
         fn on_transact(
             _service: &dyn IEmptyInterface, _code: rsbinder::TransactionCode, _reader: &mut rsbinder::Parcel, _reply: &mut rsbinder::Parcel) -> rsbinder::Result<()> {

--- a/rsbinder-aidl/tests/test_enums_unions.rs
+++ b/rsbinder-aidl/tests/test_enums_unions.rs
@@ -417,6 +417,17 @@ pub mod ITestService {
             self.0.r#RepeatByteEnum(_arg_token)
         }
     }
+    /// A typed handle implements the interface it points at, so a proxy can be
+    /// re-published as a local service on another transport in one line:
+    /// `BnTestService::new_binder(upstream)` (the **gateway** pattern —
+    /// `new_binder` takes any `T: ITestService + Send + Sync + 'static`).
+    /// Binder-typed arguments still have to be re-wrapped by hand; a proxy
+    /// forwarded as-is is refused at the stack boundary.
+    impl ITestService for rsbinder::Strong<dyn ITestService> {
+        fn r#RepeatByteEnum(&self, _arg_token: super::ByteEnum::ByteEnum) -> rsbinder::BinderResult<super::ByteEnum::ByteEnum> {
+            (**self).r#RepeatByteEnum(_arg_token)
+        }
+    }
     fn on_transact(
         _service: &dyn ITestService, _code: rsbinder::TransactionCode, _reader: &mut rsbinder::Parcel, _reply: &mut rsbinder::Parcel) -> rsbinder::Result<()> {
         match _code {

--- a/rsbinder-aidl/tests/test_interfaces.rs
+++ b/rsbinder-aidl/tests/test_interfaces.rs
@@ -100,6 +100,14 @@ pub mod ArrayOfInterfaces {
         }
         impl IEmptyInterface for rsbinder::Binder<BnEmptyInterface> {
         }
+        /// A typed handle implements the interface it points at, so a proxy can be
+        /// re-published as a local service on another transport in one line:
+        /// `BnEmptyInterface::new_binder(upstream)` (the **gateway** pattern —
+        /// `new_binder` takes any `T: IEmptyInterface + Send + Sync + 'static`).
+        /// Binder-typed arguments still have to be re-wrapped by hand; a proxy
+        /// forwarded as-is is refused at the stack boundary.
+        impl IEmptyInterface for rsbinder::Strong<dyn IEmptyInterface> {
+        }
         fn on_transact(
             _service: &dyn IEmptyInterface, _code: rsbinder::TransactionCode, _reader: &mut rsbinder::Parcel, _reply: &mut rsbinder::Parcel) -> rsbinder::Result<()> {
             match _code {
@@ -177,6 +185,17 @@ pub mod ArrayOfInterfaces {
         impl IMyInterface for rsbinder::Binder<BnMyInterface> {
             fn r#methodWithInterfaces(&self, _arg_iface: &rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>, _arg_nullable_iface: Option<&rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>, _arg_iface_array_in: &[rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>], _arg_iface_array_out: &mut Vec<Option<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>>, _arg_iface_array_inout: &mut Vec<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>, _arg_nullable_iface_array_in: Option<&[Option<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>]>, _arg_nullable_iface_array_out: &mut Option<Vec<Option<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>>>, _arg_nullable_iface_array_inout: &mut Option<Vec<Option<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>>>) -> rsbinder::BinderResult<Option<Vec<Option<String>>>> {
                 self.0.r#methodWithInterfaces(_arg_iface, _arg_nullable_iface, _arg_iface_array_in, _arg_iface_array_out, _arg_iface_array_inout, _arg_nullable_iface_array_in, _arg_nullable_iface_array_out, _arg_nullable_iface_array_inout)
+            }
+        }
+        /// A typed handle implements the interface it points at, so a proxy can be
+        /// re-published as a local service on another transport in one line:
+        /// `BnMyInterface::new_binder(upstream)` (the **gateway** pattern —
+        /// `new_binder` takes any `T: IMyInterface + Send + Sync + 'static`).
+        /// Binder-typed arguments still have to be re-wrapped by hand; a proxy
+        /// forwarded as-is is refused at the stack boundary.
+        impl IMyInterface for rsbinder::Strong<dyn IMyInterface> {
+            fn r#methodWithInterfaces(&self, _arg_iface: &rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>, _arg_nullable_iface: Option<&rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>, _arg_iface_array_in: &[rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>], _arg_iface_array_out: &mut Vec<Option<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>>, _arg_iface_array_inout: &mut Vec<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>, _arg_nullable_iface_array_in: Option<&[Option<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>]>, _arg_nullable_iface_array_out: &mut Option<Vec<Option<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>>>, _arg_nullable_iface_array_inout: &mut Option<Vec<Option<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>>>) -> rsbinder::BinderResult<Option<Vec<Option<String>>>> {
+                (**self).r#methodWithInterfaces(_arg_iface, _arg_nullable_iface, _arg_iface_array_in, _arg_iface_array_out, _arg_iface_array_inout, _arg_nullable_iface_array_in, _arg_nullable_iface_array_out, _arg_nullable_iface_array_inout)
             }
         }
         fn on_transact(

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -1278,6 +1278,12 @@ impl<I: FromIBinder + ?Sized> Deref for Strong<I> {
 /// parcel, which the stack-boundary check refuses — wrapping it in a `Bn*` is
 /// exactly what makes it publishable. See the book's
 /// [cross-transport chapter](https://hiking90.github.io/rsbinder/cross-transport-services.html).
+///
+/// `dump` forwards to the handle's target, but a *proxy* target has no
+/// `Interface::dump` of its own (remote dump is
+/// [`ProxyHandle::dump`](crate::ProxyHandle::dump), a different signature — an
+/// fd, not a writer), so it takes the trait's no-op default: a dump sent to a
+/// gateway succeeds and returns nothing. Dump the upstream service directly.
 impl<I: FromIBinder + ?Sized> Interface for Strong<I> {
     fn as_binder(&self) -> SIBinder {
         (**self).as_binder()

--- a/rsbinder/src/binder.rs
+++ b/rsbinder/src/binder.rs
@@ -1249,6 +1249,45 @@ impl<I: FromIBinder + ?Sized> Deref for Strong<I> {
     }
 }
 
+/// A typed handle is itself an [`Interface`], forwarding to the binder it
+/// holds.
+///
+/// This is what lets a **gateway** — a process that re-publishes a service it
+/// reached over one transport onto another — be one line. `Bn*::new_binder`
+/// accepts any `T: IFoo + Send + Sync + 'static`, and the AIDL generator emits
+/// `impl IFoo for Strong<dyn IFoo>` (every method forwarding through `Deref`),
+/// so `BnFoo::new_binder(proxy)` wraps a remote proxy in a *local* binder that
+/// this process owns and can publish anywhere:
+///
+/// ```ignore
+/// // B: reached C over the kernel; re-publishes it on a socket.
+/// let upstream: Strong<dyn IFoo> = rsbinder::connect("binder://my.foo")?;
+/// rsbinder::serve("unix:///tmp/gw.sock")?
+///     .add("foo", BnFoo::new_binder(upstream))?
+///     .run()?;
+/// ```
+///
+/// The `Interface` half has to live here rather than beside the generated
+/// `impl`: `Strong` is an rsbinder type, so a user crate writing
+/// `impl Interface for Strong<dyn IFoo>` violates the orphan rule (E0117 —
+/// `Strong` is not `#[fundamental]`). The generated interface `impl` is fine
+/// there because `IFoo` is local to the user's crate.
+///
+/// Note `as_binder` on a handle wrapping a **proxy** returns that *remote*
+/// binder. Serializing the handle directly therefore hands the proxy to the
+/// parcel, which the stack-boundary check refuses — wrapping it in a `Bn*` is
+/// exactly what makes it publishable. See the book's
+/// [cross-transport chapter](https://hiking90.github.io/rsbinder/cross-transport-services.html).
+impl<I: FromIBinder + ?Sized> Interface for Strong<I> {
+    fn as_binder(&self) -> SIBinder {
+        (**self).as_binder()
+    }
+
+    fn dump(&self, writer: &mut dyn std::io::Write, args: &[String]) -> Result<()> {
+        (**self).dump(writer, args)
+    }
+}
+
 impl<I: FromIBinder + Debug + ?Sized> Debug for Strong<I> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         Debug::fmt(&**self, f)

--- a/rsbinder/src/bridge.rs
+++ b/rsbinder/src/bridge.rs
@@ -1,0 +1,247 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helpers for a process that sits between two others.
+//!
+//! A **gateway** re-publishes a service it reached over one transport onto
+//! another (see the book's [cross-transport chapter]). Plain data flows
+//! through it untouched, but every *binder object* crossing it has to be
+//! unwrapped and wrapped again: a proxy of one session cannot enter a parcel
+//! of another, and rsbinder refuses it at write time.
+//!
+//! Wrapping is one call — `BnFoo::new_binder(proxy)`. Doing it *per
+//! forwarded call* is the trap: each `new_binder` mints a new object, so the
+//! upstream sees a different callback identity every time and any interface
+//! that pairs registration with removal by identity breaks.
+//! [`Rewrap`](crate::bridge::Rewrap) is the memo table that fixes it — same
+//! remote in, same local out.
+//!
+//! [cross-transport chapter]: https://hiking90.github.io/rsbinder/cross-transport-services.html
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::binder::{DeathRecipient, FromIBinder, Interface, SIBinder, Strong, WIBinder};
+
+/// One remote → one local wrapper, for as long as the pair is alive.
+///
+/// # Why it exists
+///
+/// A gateway forwarding `register(cb)` must hand its upstream a binder of
+/// its own, not the caller's proxy. Written inline that is
+/// `BnCallback::new_binder(cb.clone())`, which is correct per call and wrong
+/// across calls: `register(cb)` then `unregister(cb)` arrive upstream as two
+/// unrelated objects, so the removal matches nothing.
+///
+/// `Rewrap` keeps the mapping, so the second call re-uses the wrapper the
+/// first one made:
+///
+/// ```ignore
+/// struct Gateway {
+///     upstream: Strong<dyn IFoo>,
+///     callbacks: Rewrap<dyn ICallback>,
+/// }
+///
+/// // once, at construction:
+/// callbacks: Rewrap::new(|p| BnCallback::new_binder(p)),
+///
+/// fn register(&self, cb: &Strong<dyn ICallback>) -> BinderResult<()> {
+///     self.upstream.register(&self.callbacks.wrap(cb))
+/// }
+/// fn unregister(&self, cb: &Strong<dyn ICallback>) -> BinderResult<()> {
+///     self.upstream.unregister(&self.callbacks.wrap(cb))   // same object
+/// }
+/// ```
+///
+/// # Lifetimes
+///
+/// The table holds **weak** references to both halves, so it never keeps a
+/// wrapper alive on its own: the wrapper lives exactly as long as the
+/// upstream holds it. Once the upstream drops it — or the remote dies, or
+/// its session ends — the entry stops matching and the next `wrap` mints a
+/// fresh object, which is the correct answer at that point.
+///
+/// Dead entries are also removed eagerly, by a death notification on the
+/// remote, and swept whenever the table is next written to; [`purge_dead`]
+/// forces a sweep.
+///
+/// Identity is the remote's `Arc` address, *confirmed* by upgrading the
+/// stored weak reference and comparing binders — an address alone would be
+/// vulnerable to allocator reuse after a remote is dropped.
+///
+/// `Rewrap` is transport-agnostic: the remote may be an RPC proxy or a
+/// kernel one.
+///
+/// [`purge_dead`]: Self::purge_dead
+pub struct Rewrap<I: FromIBinder + ?Sized> {
+    // Boxed rather than a fn pointer: `BnFoo::new_binder` is a generic fn
+    // item, and coercing one to a pointer leans on inference at every call
+    // site. A closure — `Rewrap::new(|p| BnFoo::new_binder(p))` — always
+    // resolves.
+    #[allow(clippy::type_complexity)]
+    make_local: Box<dyn Fn(Strong<I>) -> Strong<I> + Send + Sync>,
+    // `Arc`, not a plain field, so a `Reaper` can hold a `Weak` to just the
+    // map — keeping the death recipient free of `I` and out of any cycle.
+    entries: Arc<Mutex<HashMap<usize, Entry>>>,
+}
+
+struct Entry {
+    remote: WIBinder,
+    local: WIBinder,
+    /// The death link holds only a weak reference to its recipient, so the
+    /// table has to own the `Arc` or the notification would never fire.
+    /// Dropping the entry lets the recipient die, which makes the link inert.
+    _reaper: Arc<Reaper>,
+}
+
+impl Entry {
+    /// The live `(remote, local)` pair, or `None` if either half is gone.
+    fn live(&self) -> Option<(SIBinder, SIBinder)> {
+        Some((self.remote.upgrade().ok()?, self.local.upgrade().ok()?))
+    }
+}
+
+/// Removes one entry when its remote dies. Holds a `Weak` to the table so a
+/// live death link cannot keep the gateway's table alive.
+struct Reaper {
+    table: std::sync::Weak<Mutex<HashMap<usize, Entry>>>,
+    key: usize,
+}
+
+impl DeathRecipient for Reaper {
+    fn binder_died(&self, _who: &WIBinder) {
+        let Some(entries) = self.table.upgrade() else {
+            return;
+        };
+        let mut entries = entries.lock().expect("rewrap table poisoned");
+        // The key is an address, and an address gets reused. Only drop the
+        // entry if it is still the dead one — otherwise this notification
+        // would evict a live wrapper that happens to sit at the same
+        // address, silently changing the identity the upstream sees.
+        if entries.get(&self.key).is_some_and(|e| e.live().is_none()) {
+            entries.remove(&self.key);
+        }
+    }
+}
+
+impl<I: FromIBinder + ?Sized> Rewrap<I> {
+    /// Build a table whose wrappers are made by `make_local`.
+    ///
+    /// `make_local` is normally `|p| BnFoo::new_binder(p)` — the generated
+    /// delegating impl means the proxy satisfies `new_binder`'s bound.
+    pub fn new(make_local: impl Fn(Strong<I>) -> Strong<I> + Send + Sync + 'static) -> Self {
+        Self {
+            make_local: Box::new(make_local),
+            entries: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// The local wrapper for `remote`, minting one on first sight.
+    ///
+    /// Calling this twice with the same live remote returns the *same*
+    /// object, which is the point. It is infallible: anything that would
+    /// make the cached answer wrong (a dead remote, a dropped wrapper, an
+    /// interface cast that no longer holds) falls back to a fresh wrapper.
+    pub fn wrap(&self, remote: &Strong<I>) -> Strong<I> {
+        let remote_binder = remote.as_binder();
+        let key = key_of(&remote_binder);
+
+        if let Some(hit) = self.lookup(key, &remote_binder) {
+            return hit;
+        }
+
+        // Mint outside the lock: `make_local` is user code and
+        // `link_to_death` reaches the driver / the RPC session. Holding the
+        // table lock across either invites a deadlock, and a re-entrant
+        // `wrap` from inside `make_local` would deadlock outright
+        // (`std::sync::Mutex` is not reentrant).
+        let local = (self.make_local)(remote.clone());
+        let reaper = Arc::new(Reaper {
+            table: Arc::downgrade(&self.entries),
+            key,
+        });
+        // Best effort: a local binder has no death to report
+        // (`InvalidOperation`), and a proxy whose peer is already gone
+        // returns `DeadObject`. Either way the sweep below still collects
+        // the entry.
+        let _ = remote_binder.link_to_death_arc(&reaper);
+
+        let mut entries = self.entries.lock().expect("rewrap table poisoned");
+        // Another thread may have raced us to the same remote. Its wrapper
+        // is as good as ours and may already be upstream, so it wins; ours
+        // is dropped, taking its death link with it.
+        if let Some((r, l)) = entries.get(&key).and_then(Entry::live) {
+            if r == remote_binder {
+                if let Ok(existing) = <I as FromIBinder>::try_from(l) {
+                    return existing;
+                }
+            }
+        }
+        // Swept on the miss path only: minting a binder and a death link
+        // already costs far more than scanning a table this size, and it
+        // bounds the table without a timer.
+        entries.retain(|_, e| e.live().is_some());
+        entries.insert(
+            key,
+            Entry {
+                remote: SIBinder::downgrade(&remote_binder),
+                local: SIBinder::downgrade(&local.as_binder()),
+                _reaper: reaper,
+            },
+        );
+        local
+    }
+
+    /// Drop every entry whose remote or wrapper is gone, and report how many
+    /// went. `wrap` sweeps too; this is for a gateway that wants to reclaim
+    /// on its own schedule, and for tests.
+    pub fn purge_dead(&self) -> usize {
+        let mut entries = self.entries.lock().expect("rewrap table poisoned");
+        let before = entries.len();
+        entries.retain(|_, e| e.live().is_some());
+        before - entries.len()
+    }
+
+    /// How many pairs the table currently holds, dead ones included (see
+    /// [`purge_dead`](Self::purge_dead)).
+    pub fn len(&self) -> usize {
+        self.entries.lock().expect("rewrap table poisoned").len()
+    }
+
+    /// Whether the table holds no pairs at all.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn lookup(&self, key: usize, remote_binder: &SIBinder) -> Option<Strong<I>> {
+        let entries = self.entries.lock().expect("rewrap table poisoned");
+        let (r, l) = entries.get(&key).and_then(Entry::live)?;
+        // Confirm identity: the address may have been reused by an unrelated
+        // binder since the entry was made.
+        (&r == remote_binder)
+            .then(|| <I as FromIBinder>::try_from(l).ok())
+            .flatten()
+    }
+}
+
+// No `Default`: the only factory that needs no arguments is `|p| p`, which
+// hands the remote straight back and is then refused at the boundary — a
+// silently wrong table is worse than none.
+
+impl<I: FromIBinder + ?Sized> std::fmt::Debug for Rewrap<I> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Rewrap").field("len", &self.len()).finish()
+    }
+}
+
+/// The identity key: the address of the binder's `Arc` allocation, thinned
+/// so two trait-object vtables for the same allocation cannot disagree.
+///
+/// Stable for the binder's lifetime — both stacks dedup their proxies
+/// (`ProcessState::handle_to_proxy` for kernel, `RpcState::remote_proxies`
+/// for RPC), so the same remote resolves to the same `Arc` while any strong
+/// reference to it is alive. It is only a *hint*: `wrap` confirms with the
+/// stored weak reference before trusting a hit.
+fn key_of(binder: &SIBinder) -> usize {
+    Arc::as_ptr(binder.as_arc()) as *const () as usize
+}

--- a/rsbinder/src/bridge.rs
+++ b/rsbinder/src/bridge.rs
@@ -43,7 +43,7 @@ use crate::binder::{DeathRecipient, FromIBinder, Interface, SIBinder, Strong, WI
 /// }
 ///
 /// // once, at construction:
-/// callbacks: Rewrap::new(|p| BnCallback::new_binder(p)),
+/// callbacks: Rewrap::new(BnCallback::new_binder),
 ///
 /// fn register(&self, cb: &Strong<dyn ICallback>) -> BinderResult<()> {
 ///     self.upstream.register(&self.callbacks.wrap(cb))
@@ -74,10 +74,8 @@ use crate::binder::{DeathRecipient, FromIBinder, Interface, SIBinder, Strong, WI
 ///
 /// [`purge_dead`]: Self::purge_dead
 pub struct Rewrap<I: FromIBinder + ?Sized> {
-    // Boxed rather than a fn pointer: `BnFoo::new_binder` is a generic fn
-    // item, and coercing one to a pointer leans on inference at every call
-    // site. A closure — `Rewrap::new(|p| BnFoo::new_binder(p))` — always
-    // resolves.
+    // `Box<dyn Fn>` rather than a fn pointer so a capturing closure is also
+    // accepted; `new` takes `impl Fn`, so `BnFoo::new_binder` passes as-is.
     #[allow(clippy::type_complexity)]
     make_local: Box<dyn Fn(Strong<I>) -> Strong<I> + Send + Sync>,
     // `Arc`, not a plain field, so a `Reaper` can hold a `Weak` to just the
@@ -157,7 +155,7 @@ impl DeathRecipient for Reaper {
 impl<I: FromIBinder + ?Sized> Rewrap<I> {
     /// Build a table whose wrappers are made by `make_local`.
     ///
-    /// `make_local` is normally `|p| BnFoo::new_binder(p)` — the generated
+    /// `make_local` is normally `BnFoo::new_binder` itself — the generated
     /// delegating impl means the proxy satisfies `new_binder`'s bound.
     pub fn new(make_local: impl Fn(Strong<I>) -> Strong<I> + Send + Sync + 'static) -> Self {
         Self {

--- a/rsbinder/src/bridge.rs
+++ b/rsbinder/src/bridge.rs
@@ -65,9 +65,9 @@ use crate::binder::{DeathRecipient, FromIBinder, Interface, SIBinder, Strong, WI
 /// remote, and swept whenever the table is next written to; [`purge_dead`]
 /// forces a sweep.
 ///
-/// Identity is the remote's `Arc` address, *confirmed* by upgrading the
-/// stored weak reference and comparing binders — an address alone would be
-/// vulnerable to allocator reuse after a remote is dropped.
+/// Identity is the remote's `Arc` address. A live entry holds its own weak
+/// reference to that allocation, so the address cannot be recycled while the
+/// entry stands; a hit is still confirmed against the stored binder.
 ///
 /// `Rewrap` is transport-agnostic: the remote may be an RPC proxy or a
 /// kernel one.
@@ -90,8 +90,7 @@ struct Entry {
     local: WIBinder,
     /// The death link holds only a weak reference to its recipient, so the
     /// table has to own the `Arc` or the notification would never fire.
-    /// Dropping the entry lets the recipient die, which makes the link inert.
-    _reaper: Arc<Reaper>,
+    reaper: Arc<Reaper>,
 }
 
 impl Entry {
@@ -99,6 +98,36 @@ impl Entry {
     fn live(&self) -> Option<(SIBinder, SIBinder)> {
         Some((self.remote.upgrade().ok()?, self.local.upgrade().ok()?))
     }
+
+    /// Undo the death link: dropping the entry only makes it inert, and a
+    /// proxy's recipient list never shrinks on its own. Call with the table
+    /// lock released — this reaches into the proxy.
+    fn unlink(&self) {
+        if let Ok(remote) = self.remote.upgrade() {
+            let _ = remote.unlink_to_death_arc(&self.reaper);
+        }
+    }
+}
+
+/// The one place an entry leaves the table outside `Drop` and
+/// `Reaper::binder_died`: it takes every entry whose remote or wrapper is
+/// gone and, when `insert` is given, installs it — returning the swept
+/// entries *and* whatever the insert displaced. Dropping an `Entry` in place
+/// only makes it inert (`Entry::unlink`), so the caller must unlink every
+/// entry returned here, once it has dropped the table lock.
+fn take_removed(entries: &mut HashMap<usize, Entry>, insert: Option<(usize, Entry)>) -> Vec<Entry> {
+    let keys: Vec<usize> = entries
+        .iter()
+        .filter(|(_, e)| e.live().is_none())
+        .map(|(k, _)| *k)
+        .collect();
+    let mut removed: Vec<Entry> = keys.iter().filter_map(|k| entries.remove(k)).collect();
+    if let Some((key, entry)) = insert {
+        // A key whose entry is still live is re-filled rather than swept —
+        // the displaced entry leaves the table like any other removal.
+        removed.extend(entries.insert(key, entry));
+    }
+    removed
 }
 
 /// Removes one entry when its remote dies. Holds a `Weak` to the table so a
@@ -109,18 +138,19 @@ struct Reaper {
 }
 
 impl DeathRecipient for Reaper {
-    fn binder_died(&self, _who: &WIBinder) {
+    fn binder_died(&self, who: &WIBinder) {
         let Some(entries) = self.table.upgrade() else {
             return;
         };
         let mut entries = entries.lock().expect("rewrap table poisoned");
-        // The key is an address, and an address gets reused. Only drop the
-        // entry if it is still the dead one — otherwise this notification
-        // would evict a live wrapper that happens to sit at the same
-        // address, silently changing the identity the upstream sees.
-        if entries.get(&self.key).is_some_and(|e| e.live().is_none()) {
+        // Evict only the binder that died: the slot may have been re-keyed
+        // since this link was made. Its remote is still alive here — both
+        // obituary drivers hold a strong reference across the callback — so
+        // liveness cannot stand in for identity.
+        if entries.get(&self.key).is_some_and(|e| e.remote == *who) {
             entries.remove(&self.key);
         }
+        // No unlink: the link dies with the proxy that is reporting it.
     }
 }
 
@@ -151,9 +181,8 @@ impl<I: FromIBinder + ?Sized> Rewrap<I> {
         }
 
         // Mint outside the lock: `make_local` is user code and
-        // `link_to_death` reaches the driver / the RPC session. Holding the
-        // table lock across either invites a deadlock, and a re-entrant
-        // `wrap` from inside `make_local` would deadlock outright
+        // `link_to_death` reaches the driver / the RPC session, and a
+        // re-entrant `wrap` from inside `make_local` would deadlock
         // (`std::sync::Mutex` is not reentrant).
         let local = (self.make_local)(remote.clone());
         let reaper = Arc::new(Reaper {
@@ -162,17 +191,21 @@ impl<I: FromIBinder + ?Sized> Rewrap<I> {
         });
         // Best effort: a local binder has no death to report
         // (`InvalidOperation`), and a proxy whose peer is already gone
-        // returns `DeadObject`. Either way the sweep below still collects
-        // the entry.
+        // returns `DeadObject`. Either way a *later* sweep — the next `wrap`
+        // miss, or `purge_dead` — collects the entry once either half is
+        // gone; this call's sweep runs before the entry is inserted.
         let _ = remote_binder.link_to_death_arc(&reaper);
 
         let mut entries = self.entries.lock().expect("rewrap table poisoned");
         // Another thread may have raced us to the same remote. Its wrapper
-        // is as good as ours and may already be upstream, so it wins; ours
-        // is dropped, taking its death link with it.
+        // is as good as ours and may already be upstream, so it wins —
+        // unless it no longer casts to `I`, in which case ours displaces it
+        // below and the displaced entry is unlinked with the others.
         if let Some((r, l)) = entries.get(&key).and_then(Entry::live) {
             if r == remote_binder {
                 if let Ok(existing) = <I as FromIBinder>::try_from(l) {
+                    drop(entries);
+                    let _ = remote_binder.unlink_to_death_arc(&reaper);
                     return existing;
                 }
             }
@@ -180,26 +213,45 @@ impl<I: FromIBinder + ?Sized> Rewrap<I> {
         // Swept on the miss path only: minting a binder and a death link
         // already costs far more than scanning a table this size, and it
         // bounds the table without a timer.
-        entries.retain(|_, e| e.live().is_some());
-        entries.insert(
-            key,
-            Entry {
-                remote: SIBinder::downgrade(&remote_binder),
-                local: SIBinder::downgrade(&local.as_binder()),
-                _reaper: reaper,
-            },
+        let dead = take_removed(
+            &mut entries,
+            Some((
+                key,
+                Entry {
+                    remote: SIBinder::downgrade(&remote_binder),
+                    local: SIBinder::downgrade(&local.as_binder()),
+                    reaper,
+                },
+            )),
         );
+        drop(entries);
+        // Unlink outside the lock: it takes the proxy's recipient lock and
+        // can reach the driver, and R1 forbids holding a lock across a
+        // binder entry point.
+        for e in &dead {
+            e.unlink();
+        }
         local
     }
 
     /// Drop every entry whose remote or wrapper is gone, and report how many
     /// went. `wrap` sweeps too; this is for a gateway that wants to reclaim
     /// on its own schedule, and for tests.
+    ///
+    /// Not a pure table sweep: an entry collected because its *wrapper* is
+    /// gone is also unlinked from its still-live remote, so a kernel proxy
+    /// that loses its last recipient here emits `BC_CLEAR_DEATH_NOTIFICATION`
+    /// and flushes it to the driver. An entry collected because the remote
+    /// itself is gone costs nothing extra — there is no proxy left to unlink.
     pub fn purge_dead(&self) -> usize {
-        let mut entries = self.entries.lock().expect("rewrap table poisoned");
-        let before = entries.len();
-        entries.retain(|_, e| e.live().is_some());
-        before - entries.len()
+        let dead = {
+            let mut entries = self.entries.lock().expect("rewrap table poisoned");
+            take_removed(&mut entries, None)
+        };
+        for e in &dead {
+            e.unlink();
+        }
+        dead.len()
     }
 
     /// How many pairs the table currently holds, dead ones included (see
@@ -208,7 +260,8 @@ impl<I: FromIBinder + ?Sized> Rewrap<I> {
         self.entries.lock().expect("rewrap table poisoned").len()
     }
 
-    /// Whether the table holds no pairs at all.
+    /// Whether the table holds no pairs at all — dead ones included, like
+    /// [`len`](Self::len).
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -216,11 +269,37 @@ impl<I: FromIBinder + ?Sized> Rewrap<I> {
     fn lookup(&self, key: usize, remote_binder: &SIBinder) -> Option<Strong<I>> {
         let entries = self.entries.lock().expect("rewrap table poisoned");
         let (r, l) = entries.get(&key).and_then(Entry::live)?;
-        // Confirm identity: the address may have been reused by an unrelated
-        // binder since the entry was made.
+        // Confirm identity, in case the slot was re-keyed since the entry.
         (&r == remote_binder)
             .then(|| <I as FromIBinder>::try_from(l).ok())
             .flatten()
+    }
+}
+
+impl<I: FromIBinder + ?Sized> Drop for Rewrap<I> {
+    fn drop(&mut self) {
+        // Dropping the table removes every entry, and the links outlive it
+        // otherwise: the `Arc<Reaper>`s go, but each proxy keeps a dead
+        // `Weak` in its recipient list, which on the kernel arm blocks every
+        // later `BC_REQUEST`/`BC_CLEAR` transition.
+        let dead: Vec<Entry> = {
+            // Never panic in a `Drop`: drain a poisoned table instead.
+            let mut entries = self
+                .entries
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            entries.drain().map(|(_, e)| e).collect()
+        };
+        for e in &dead {
+            // A panic out of `unlink` (poisoned proxy lock, driver, thread-local
+            // teardown) would abort under an unwind and skip the rest. Catching
+            // it leaves that entry's link registered on the remote, so log it.
+            if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| e.unlink())).is_err() {
+                log::error!(
+                    "Rewrap::drop: unlink panicked; a death link is left registered on the remote"
+                );
+            }
+        }
     }
 }
 
@@ -234,14 +313,9 @@ impl<I: FromIBinder + ?Sized> std::fmt::Debug for Rewrap<I> {
     }
 }
 
-/// The identity key: the address of the binder's `Arc` allocation, thinned
-/// so two trait-object vtables for the same allocation cannot disagree.
-///
-/// Stable for the binder's lifetime — both stacks dedup their proxies
-/// (`ProcessState::handle_to_proxy` for kernel, `RpcState::remote_proxies`
-/// for RPC), so the same remote resolves to the same `Arc` while any strong
-/// reference to it is alive. It is only a *hint*: `wrap` confirms with the
-/// stored weak reference before trusting a hit.
+// Identity key: the `Arc`'s data address, thinned so two vtables for the same
+// allocation cannot disagree. Stable while `Entry.remote`'s `Weak` reserves
+// the allocation.
 fn key_of(binder: &SIBinder) -> usize {
     Arc::as_ptr(binder.as_arc()) as *const () as usize
 }

--- a/rsbinder/src/entry/server.rs
+++ b/rsbinder/src/entry/server.rs
@@ -221,9 +221,10 @@ impl Server {
     /// socket server, because the binder that would leave this process is the
     /// proxy itself and no stack accepts one from the other (see the
     /// [gateway section] of the book — wrap it in a `Bn*` instead:
-    /// `BnFoo::new_binder(proxy)`). The kernel arm keeps allowing it:
-    /// re-registering a proxy with the system service manager is a legitimate
-    /// use.
+    /// `BnFoo::new_binder(proxy)`). The kernel arm still accepts a *kernel*
+    /// proxy — re-registering one with the system service manager is a
+    /// legitimate use — but an RPC proxy is refused there too, by the same
+    /// stack-boundary check, when the registration parcel is written.
     ///
     /// [gateway section]: https://hiking90.github.io/rsbinder/cross-transport-services.html
     pub fn add(mut self, name: &str, svc: impl Into<SIBinder>) -> Result<Self> {

--- a/rsbinder/src/entry/server.rs
+++ b/rsbinder/src/entry/server.rs
@@ -215,11 +215,29 @@ impl Server {
     /// Publish `svc` under `name`. Kernel: registered with the system
     /// service manager immediately. RPC: queued and registered in the
     /// server's directory when it starts.
+    ///
+    /// An RPC endpoint refuses a **remote** binder with
+    /// [`StatusCode::InvalidOperation`]: a proxy cannot be re-published on a
+    /// socket server, because the binder that would leave this process is the
+    /// proxy itself and no stack accepts one from the other (see the
+    /// [gateway section] of the book — wrap it in a `Bn*` instead:
+    /// `BnFoo::new_binder(proxy)`). The kernel arm keeps allowing it:
+    /// re-registering a proxy with the system service manager is a legitimate
+    /// use.
+    ///
+    /// [gateway section]: https://hiking90.github.io/rsbinder/cross-transport-services.html
     pub fn add(mut self, name: &str, svc: impl Into<SIBinder>) -> Result<Self> {
         let binder = svc.into();
         if self.uri.endpoint.is_kernel() {
             crate::hub::add_service(name, binder).map_err(StatusCode::from)?;
         } else {
+            if (*binder).is_remote() {
+                log::error!(
+                    "serve(...).add({name}): refusing a remote binder on an RPC endpoint; \
+                     wrap it in a local Bn* (gateway) instead"
+                );
+                return Err(StatusCode::InvalidOperation);
+            }
             self.pending.push((name.to_string(), binder));
         }
         Ok(self)

--- a/rsbinder/src/lib.rs
+++ b/rsbinder/src/lib.rs
@@ -166,6 +166,8 @@ pub mod binder_async;
 mod binder_object;
 /// BinderFS filesystem utilities
 pub mod binderfs;
+/// Helpers for a process bridging two transports (the gateway pattern)
+pub mod bridge;
 /// Error types and result handling
 pub mod error;
 /// File descriptor wrapper for IPC

--- a/rsbinder/src/parcelable.rs
+++ b/rsbinder/src/parcelable.rs
@@ -491,6 +491,19 @@ impl SerializeOption for SIBinder {
 
         match this {
             Some(binder) => {
+                // AOSP `Parcel::flattenBinder`: "Sending a socket binder over
+                // kernel binder is prohibited" → `INVALID_OPERATION`. Must stay
+                // *before* `binder.into()`, which calls `ProcessState::as_self()`
+                // and would panic in a pure-RPC process that never initialized it.
+                #[cfg(feature = "rpc")]
+                if (**binder)
+                    .as_any()
+                    .downcast_ref::<crate::rpc::RpcProxy>()
+                    .is_some()
+                {
+                    log::error!("Sending a socket (RPC) binder over kernel binder is prohibited");
+                    return Err(StatusCode::InvalidOperation);
+                }
                 parcel.write::<flat_binder_object>(&binder.into())?;
                 if crate::sdk_at_least(30) {
                     parcel.write::<i32>(&binder.stability().into())?;

--- a/rsbinder/src/rpc/mod.rs
+++ b/rsbinder/src/rpc/mod.rs
@@ -33,7 +33,7 @@
 //! // Server: bind, publish a root binder, accept in the background.
 //! let server = RpcServer::setup_unix_server("/tmp/demo.sock").unwrap();
 //! # let root: rsbinder::SIBinder = unimplemented!();
-//! server.set_root(root);
+//! server.set_root(root).unwrap();
 //! let _bg = server.run_background();
 //!
 //! // Client: connect, (optionally) negotiate, fetch the root object.
@@ -124,6 +124,20 @@ pub use transport::{CertId, PeerIdentity, RpcTransport};
 pub use rustls;
 
 use std::fmt;
+
+/// Reject a remote binder at registration time.
+///
+/// An RPC server / session can only publish objects this process owns. A proxy
+/// put here would either be handed back to its own peer or refused later, when
+/// the parcel is written (AOSP `RpcState::onBinderLeaving`); catching it at
+/// registration turns a confusing late failure into an immediate one.
+pub(crate) fn refuse_remote(binder: &crate::SIBinder, what: &str) -> crate::Result<()> {
+    if (**binder).is_remote() {
+        log::error!("{what}: refusing a remote binder; wrap it in a local Bn* (gateway) instead");
+        return Err(crate::StatusCode::InvalidOperation);
+    }
+    Ok(())
+}
 
 /// Result type for the RPC transport / protocol layer.
 ///

--- a/rsbinder/src/rpc/server.rs
+++ b/rsbinder/src/rpc/server.rs
@@ -665,8 +665,13 @@ impl RpcServer {
     }
 
     /// Publish the single root object (android `setRootObject`).
-    pub fn set_root(&self, binder: SIBinder) {
+    ///
+    /// Refuses a **remote** binder with [`StatusCode::InvalidOperation`] — see
+    /// [`add_service`](Self::add_service) for why.
+    pub fn set_root(&self, binder: SIBinder) -> Result<()> {
+        super::refuse_remote(&binder, "RpcServer::set_root")?;
         *self.root.lock().expect("root poisoned") = Some(binder);
+        Ok(())
     }
 
     /// Register a named service. The first call installs a built-in
@@ -674,7 +679,15 @@ impl RpcServer {
     /// service map, so every later call is an O(1) insert seen through the
     /// same root — no rebuild or root swap. Clients reach it via
     /// [`RpcSession::get_service`].
+    ///
+    /// Refuses a **remote** binder with [`StatusCode::InvalidOperation`]:
+    /// publishing a proxy here can never work. A proxy of *this* session would
+    /// be handed straight back to its own peer; a proxy of another session or
+    /// of kernel binder is refused when the parcel is written
+    /// (AOSP `RpcState::onBinderLeaving`). Wrap it in a local `Bn*` instead —
+    /// `BnFoo::new_binder(proxy)` — which is the gateway pattern.
     pub fn add_service(&self, name: &str, binder: SIBinder) -> Result<()> {
+        super::refuse_remote(&binder, "RpcServer::add_service")?;
         self.named
             .lock()
             .expect("named poisoned")
@@ -1012,7 +1025,12 @@ impl RpcServer {
         // taking the session's.
         let root = self.root.lock().expect("root poisoned").clone();
         if let Some(root) = root {
-            session.set_root(root);
+            // Unreachable: `set_root` / `add_service` already refused a remote
+            // root, so this can only fail on an invariant break. Logged, not
+            // panicked — we are on the accept loop.
+            if let Err(e) = session.set_root(root) {
+                log::error!("RPC: server root rejected by the new session: {e:?}");
+            }
         }
         let max_threads = *self.max_threads.lock().expect("max_threads poisoned");
         session.set_max_threads(max_threads);

--- a/rsbinder/src/rpc/session.rs
+++ b/rsbinder/src/rpc/session.rs
@@ -2340,6 +2340,13 @@ impl RpcSessionInner {
                     // Pinned in the parcel past the send, so its DEC_STRONG cannot precede the reply that names it.
                     parcel.rpc_pin_binder(b.clone());
                     rp.address()
+                } else if (**b).is_remote() {
+                    // AOSP `RpcState::onBinderLeaving`: "Cannot send binder proxy
+                    // over sockets" → `INVALID_OPERATION`. The `RpcProxy` arm above
+                    // has already consumed every RPC-backed remote, so a binder that
+                    // still reports `is_remote()` here is a kernel proxy.
+                    log::error!("RPC: cannot send a kernel binder proxy over sockets");
+                    return Err(StatusCode::InvalidOperation);
                 } else {
                     // A local object leaving this process: `on_binder_leaving`
                     // bumps its `timesSent`. Record the address so a send
@@ -3959,8 +3966,13 @@ impl RpcSession {
     }
 
     /// Publish the server's root object (returned by `get_root`).
-    pub fn set_root(&self, binder: SIBinder) {
+    ///
+    /// Refuses a **remote** binder with [`StatusCode::InvalidOperation`] — see
+    /// [`RpcServer::add_service`](crate::rpc::RpcServer::add_service).
+    pub fn set_root(&self, binder: SIBinder) -> Result<()> {
+        super::refuse_remote(&binder, "RpcSession::set_root")?;
         *self.inner.shared.root.lock().expect("root poisoned") = Some(binder);
+        Ok(())
     }
 
     /// Client: fetch the peer's root object as an [`RpcProxy`]-backed

--- a/rsbinder/src/rpc/strong_session_tests.rs
+++ b/rsbinder/src/rpc/strong_session_tests.rs
@@ -121,7 +121,7 @@ fn pair_with_root(root: SIBinder) -> (RpcSession, RpcSession, UnixStream) {
     let st = UnixTransport::from_stream(a).expect("transport");
     let ct = UnixTransport::from_stream(b).expect("transport");
     let server = RpcSession::new(Box::new(st), AddressSpace::Acceptor).expect("server");
-    server.set_root(root);
+    server.set_root(root).expect("set_root");
     let client = RpcSession::new(Box::new(ct), AddressSpace::Initiator).expect("client");
     (server, client, server_dup)
 }
@@ -291,7 +291,9 @@ fn argument_proxy_dec_strong_follows_the_reply_on_the_serving_connection() {
     ));
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(2);
-    server.set_root(Interface::as_binder(&Binder::new(Holder::default())));
+    server
+        .set_root(Interface::as_binder(&Binder::new(Holder::default())))
+        .expect("set_root");
     let bg = server.run_background();
     for _ in 0..400 {
         if path.exists() {

--- a/rsbinder/tests/macro_interface.rs
+++ b/rsbinder/tests/macro_interface.rs
@@ -240,6 +240,40 @@ fn macro_interface_descriptor_is_the_attribute_value() {
     );
 }
 
+/// AC-22.9. `#[interface]` renders through the same generator as `.aidl`
+/// (plan 2-19 D1), so the delegating `impl IFoo for Strong<dyn IFoo>` is
+/// there too — a proxy satisfies `Bn*::new_binder`'s bound and the
+/// gateway spelling compiles and forwards on this path as well.
+#[test]
+fn macro_interface_gateway_republishes_a_proxy() {
+    let up = SockPath::new("gwup");
+    let down = SockPath::new("gwdown");
+
+    let _c = rsbinder::serve(&up.uri(""))
+        .expect("serve")
+        .add(
+            "echo",
+            BnMacroEcho::new_binder(Echo {
+                pinged: Arc::new(Mutex::new(0)),
+            }),
+        )
+        .expect("add")
+        .spawn()
+        .expect("spawn");
+
+    let upstream: Strong<dyn IMacroEcho> = rsbinder::connect(&up.uri("#echo")).expect("connect");
+    let _b = rsbinder::serve(&down.uri(""))
+        .expect("serve")
+        .add("echo", BnMacroEcho::new_binder(upstream))
+        .expect("the macro path yields the same one-line gateway")
+        .spawn()
+        .expect("spawn");
+
+    let via: Strong<dyn IMacroEcho> = rsbinder::connect(&down.uri("#echo")).expect("connect");
+    assert_eq!(via.echo("hi").unwrap(), "echo:hi");
+    assert_eq!(via.add(40, 2).unwrap(), 42);
+}
+
 #[test]
 fn macro_interface_can_reference_itself() {
     let sock = SockPath::new("chain");

--- a/rsbinder/tests/rpc_accessor.rs
+++ b/rsbinder/tests/rpc_accessor.rs
@@ -198,7 +198,7 @@ impl EchoServerGuard {
         let server = RpcServer::setup_unix_server(&path).expect("bind");
         server.set_android13plus(2); // android-16 v2 ceiling
         server.set_max_threads(2);
-        server.set_root(make_echo(calls.clone()));
+        server.set_root(make_echo(calls.clone())).expect("set_root");
         let bg = server.run_background();
         wait_for_sock(&path);
         EchoServerGuard {
@@ -274,6 +274,38 @@ fn accessor_arm_resolves_root_and_echoes() {
     // Drop the user-visible root: the wrapper's `Drop` must release the
     // inner proxy first (best-effort DEC_STRONG), then the session
     // (peer-side serve loop exits on EndOfStream). No leak / no panic.
+    drop(root);
+}
+
+/// AC-22.1. The `AccessorRoot` wrapper the bridge hands back is an RPC
+/// binder in a trench coat, so a kernel parcel must refuse it too.
+///
+/// `AccessorRoot::as_any` deliberately forwards to the inner `RpcProxy`
+/// (so `as_remote` / `as_proxy` see the concrete type); that forward is
+/// what makes the one check in `SerializeOption for SIBinder` cover the
+/// wrapper without a second branch. Dropping the forward turns this red.
+#[test]
+fn kernel_parcel_refuses_the_accessor_root_wrapper() {
+    let server = EchoServerGuard::start("xstack");
+    let addconn_calls = Arc::new(AtomicU32::new(0));
+    let accessor = make_mock_accessor(MockAccessor {
+        server_path: server.path.clone(),
+        name: "test.echo".to_string(),
+        add_connection_error: None,
+        addconnection_calls: addconn_calls.clone(),
+        nonblocking: false,
+    });
+
+    let swm = resolve_accessor("test.echo", accessor).expect("bridge resolves");
+    let root = swm.r#service.expect("bridge yields an RPC root binder");
+
+    let mut p = Parcel::new();
+    assert_eq!(
+        p.write(&root).unwrap_err(),
+        StatusCode::InvalidOperation,
+        "AC-22.1: an Accessor-bridged RPC root cannot cross into kernel binder"
+    );
+
     drop(root);
 }
 

--- a/rsbinder/tests/rpc_cross_stack.rs
+++ b/rsbinder/tests/rpc_cross_stack.rs
@@ -6,9 +6,10 @@
 //! discovered later by the receiver.
 //!
 //! libbinder refuses the same three writes with `INVALID_OPERATION`
-//! (`Parcel.cpp` `flattenBinder`, `RpcState.cpp` `onBinderLeaving`).
-//! rsbinder used to accept two of them and fail on the receiver's first
-//! call with `UnknownTransaction`. See `plans/2-22-*`.
+//! (`Parcel.cpp` `flattenBinder`, `RpcState.cpp` `onBinderLeaving`), and
+//! rsbinder refuses all three at the same points — so no such binder ever
+//! reaches a receiver that could only answer it with `UnknownTransaction`.
+//! See `plans/2-22-*`.
 //!
 //! Hermetic: `mem`/`unix` transports only, and deliberately **never**
 //! initializes `ProcessState` — the kernel-parcel checks must fire
@@ -32,9 +33,6 @@ use rsbinder::{
 // ---- fixtures -------------------------------------------------------
 
 const DESC: &str = "rsbinder.test.ICrossStack";
-
-struct Svc;
-impl Interface for Svc {}
 
 struct BnSvc;
 impl Remotable for BnSvc {
@@ -146,7 +144,7 @@ fn kernelish() -> SIBinder {
     SIBinder::new(Arc::new(KernelishProxy)).expect("SIBinder::new")
 }
 
-// ---- A-4.1 / A-4.2: kernel parcel ← RPC proxy -----------------------
+// ---- AC-22.1: kernel parcel ← RPC proxy -----------------------------
 
 /// AC-22.1. A kernel-mode `Parcel` refuses an RPC proxy, in every shape
 /// the single `SerializeOption for SIBinder` funnel is reached through,
@@ -206,7 +204,7 @@ fn local_binder_still_writes_into_an_rpc_parcel() {
         .expect("AC-22.5: a local binder must still cross into an RPC parcel");
 }
 
-// ---- A-4.4: RPC parcel ← kernel proxy -------------------------------
+// ---- AC-22.2: RPC parcel ← kernel proxy -----------------------------
 
 /// AC-22.2. An RPC-mode `Parcel` refuses a remote binder that is not
 /// RPC-backed — i.e. a kernel proxy. Without the check the binder is
@@ -225,20 +223,21 @@ fn rpc_parcel_refuses_kernel_proxy() {
         "AC-22.2: a kernel proxy cannot be written into an RPC parcel"
     );
 
-    // And no local node was registered for it on the way out.
+    // And no local node was registered for it on the way out. The parcel
+    // belongs to the *client* session, so that is the side whose table the
+    // `else` arm would have grown.
     assert_eq!(
-        pair.server.as_ref().unwrap().local_node_count(),
-        1,
+        pair.client.local_node_count(),
+        0,
         "AC-22.2: the refused binder must not have been registered as a local node"
     );
 }
 
-// ---- A-4.5: RPC parcel ← another session's RPC proxy ----------------
+// ---- AC-22.3: RPC parcel ← another session's proxy ------------------
 
-/// AC-22.3. Pins the check rsbinder already had: an `RpcProxy` belonging
-/// to a *different* session is refused, because its address means
-/// nothing to this peer (AOSP `onBinderLeaving`). Removing the
-/// `ptr::eq` guard makes this `Ok`.
+/// AC-22.3. An `RpcProxy` belonging to a *different* session is refused,
+/// because its address means nothing to this peer (AOSP
+/// `onBinderLeaving`). Removing the `ptr::eq` guard makes this `Ok`.
 #[test]
 fn rpc_parcel_refuses_another_sessions_proxy() {
     let one = Pair::new();
@@ -262,7 +261,7 @@ fn rpc_parcel_refuses_another_sessions_proxy() {
         .expect("AC-22.3: this session's own proxy may travel back home");
 }
 
-// ---- A-4.8: registration-time refusal -------------------------------
+// ---- AC-22.4: registration-time refusal -----------------------------
 
 /// AC-22.4. `RpcServer::set_root` / `add_service` and
 /// `RpcSession::set_root` refuse a remote binder up front, rather than
@@ -274,8 +273,8 @@ fn registration_refuses_a_remote_binder() {
 
     // Bound but never run — this test only exercises the registration
     // guards, so no accept loop is needed.
-    let path = tmp_sock("reg");
-    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    let path = SockPath::new("reg");
+    let server = RpcServer::setup_unix_server(&path.0).expect("bind");
     assert_eq!(
         server.set_root(proxy.clone()).unwrap_err(),
         StatusCode::InvalidOperation,
@@ -308,33 +307,41 @@ fn registration_refuses_a_remote_binder() {
         "AC-22.4: RpcSession::set_root refuses a remote binder"
     );
     session.set_root(local_root()).expect("local root accepted");
-
-    let _ = std::fs::remove_file(&path);
 }
 
-fn tmp_sock(tag: &str) -> std::path::PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "rsb_xstack_{}_{}_{}.sock",
-        tag,
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    p
+/// A socket path that unlinks itself, so a failing assertion above does
+/// not leave the file behind.
+struct SockPath(std::path::PathBuf);
+
+impl SockPath {
+    fn new(tag: &str) -> Self {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "rsb_xstack_{}_{}_{}.sock",
+            tag,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        SockPath(p)
+    }
 }
 
-/// AC-22.5. `Svc` exists only to keep the fixture honest about the
-/// `Interface`/`Remotable` split; assert it is a *local* binder so the
-/// tests above are refusing something the same code path would
-/// otherwise have accepted.
+impl Drop for SockPath {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+/// AC-22.5. Assert the fixture root is a *local* binder, so the tests
+/// above are refusing something the same code path would otherwise have
+/// accepted.
 #[test]
 fn fixture_root_is_local() {
     assert!(
         !(*local_root()).is_remote(),
         "the fixture root must be local, or every rejection above is vacuous"
     );
-    let _ = Svc;
 }

--- a/rsbinder/tests/rpc_cross_stack.rs
+++ b/rsbinder/tests/rpc_cross_stack.rs
@@ -1,0 +1,340 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! The boundary between the two IPC stacks — kernel binder
+//! (`/dev/binder`) and socket RPC — is refused at **write time**, not
+//! discovered later by the receiver.
+//!
+//! libbinder refuses the same three writes with `INVALID_OPERATION`
+//! (`Parcel.cpp` `flattenBinder`, `RpcState.cpp` `onBinderLeaving`).
+//! rsbinder used to accept two of them and fail on the receiver's first
+//! call with `UnknownTransaction`. See `plans/2-22-*`.
+//!
+//! Hermetic: `mem`/`unix` transports only, and deliberately **never**
+//! initializes `ProcessState` — the kernel-parcel checks must fire
+//! before `flat_binder_object::from` calls `ProcessState::as_self()`,
+//! so a pure-RPC process (macOS, or any Linux process that never opened
+//! `/dev/binder`) gets the rejection rather than a panic.
+
+#![cfg(feature = "rpc")]
+
+use std::mem::ManuallyDrop;
+use std::sync::Arc;
+use std::thread;
+
+use rsbinder::rpc::transport::MemTransport;
+use rsbinder::rpc::{AddressSpace, RpcServer, RpcSession};
+use rsbinder::{
+    Binder, DeathRecipient, IBinder, Interface, Parcel, Remotable, Result, SIBinder, StatusCode,
+    Transactable, TransactionCode, WIBinder,
+};
+
+// ---- fixtures -------------------------------------------------------
+
+const DESC: &str = "rsbinder.test.ICrossStack";
+
+struct Svc;
+impl Interface for Svc {}
+
+struct BnSvc;
+impl Remotable for BnSvc {
+    fn descriptor() -> &'static str {
+        DESC
+    }
+    fn on_transact(&self, _: TransactionCode, _: &mut Parcel, _: &mut Parcel) -> Result<()> {
+        Err(StatusCode::UnknownTransaction)
+    }
+    fn on_dump(&self, _: &mut dyn std::io::Write, _: &[String]) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn local_root() -> SIBinder {
+    Interface::as_binder(&Binder::new(BnSvc))
+}
+
+/// A served RPC session pair. The server half runs `serve_blocking` on
+/// its own thread; dropping the guard tears it down.
+struct Pair {
+    client: RpcSession,
+    server: Option<RpcSession>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl Pair {
+    fn new() -> Self {
+        let (a, b) = MemTransport::pair();
+        let server = RpcSession::new(Box::new(a), AddressSpace::Acceptor).expect("server session");
+        server.set_root(local_root()).expect("set_root");
+        let serving = server.clone();
+        let thread = thread::spawn(move || {
+            let _ = serving.serve_blocking();
+        });
+        let client = RpcSession::new(Box::new(b), AddressSpace::Initiator).expect("client session");
+        Self {
+            client,
+            server: Some(server),
+            thread: Some(thread),
+        }
+    }
+
+    /// The peer's root, as an `RpcProxy`-backed `SIBinder`.
+    fn remote_root(&self) -> SIBinder {
+        self.client.get_root().expect("get_root")
+    }
+}
+
+impl Drop for Pair {
+    fn drop(&mut self) {
+        // `close_session` (not a bare drop) — `self.client` outlives this
+        // body, so the transport stays open and `serve_blocking` would park
+        // in `recv` forever waiting for an EOF that never comes.
+        if let Some(s) = self.server.take() {
+            s.close_session();
+        }
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+    }
+}
+
+/// A binder that claims to be remote but is not RPC-backed — what a
+/// kernel `ProxyHandle` looks like to the RPC write path. Built by hand
+/// so the test needs no `/dev/binder`.
+struct KernelishProxy;
+
+impl IBinder for KernelishProxy {
+    fn link_to_death(&self, _: std::sync::Weak<dyn DeathRecipient>) -> Result<()> {
+        Err(StatusCode::InvalidOperation)
+    }
+    fn unlink_to_death(&self, _: std::sync::Weak<dyn DeathRecipient>) -> Result<()> {
+        Err(StatusCode::InvalidOperation)
+    }
+    fn ping_binder(&self) -> Result<()> {
+        Ok(())
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn as_transactable(&self) -> Option<&dyn Transactable> {
+        None
+    }
+    fn descriptor(&self) -> &str {
+        "rsbinder.test.IKernelish"
+    }
+    fn is_remote(&self) -> bool {
+        true
+    }
+    fn inc_strong(&self, _: &SIBinder) -> Result<()> {
+        Ok(())
+    }
+    fn attempt_inc_strong(&self) -> bool {
+        true
+    }
+    fn dec_strong(&self, _: Option<ManuallyDrop<SIBinder>>) -> Result<()> {
+        Ok(())
+    }
+    fn inc_weak(&self, _: &WIBinder) -> Result<()> {
+        Ok(())
+    }
+    fn dec_weak(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn kernelish() -> SIBinder {
+    SIBinder::new(Arc::new(KernelishProxy)).expect("SIBinder::new")
+}
+
+// ---- A-4.1 / A-4.2: kernel parcel ← RPC proxy -----------------------
+
+/// AC-22.1. A kernel-mode `Parcel` refuses an RPC proxy, in every shape
+/// the single `SerializeOption for SIBinder` funnel is reached through,
+/// and **without** touching `ProcessState`.
+///
+/// The panic-vs-reject distinction is the point: `From<&SIBinder> for
+/// flat_binder_object` calls `ProcessState::as_self()`, which panics in
+/// a process that never initialized it. Moving the check after that
+/// conversion turns this test red on macOS.
+#[test]
+fn kernel_parcel_refuses_rpc_proxy() {
+    let pair = Pair::new();
+    let proxy = pair.remote_root();
+
+    // Bare `SIBinder`.
+    let mut p = Parcel::new();
+    assert_eq!(
+        p.write(&proxy).unwrap_err(),
+        StatusCode::InvalidOperation,
+        "AC-22.1: an RPC proxy cannot be written into a kernel parcel"
+    );
+
+    // `Option<SIBinder>` — same funnel via `SerializeOption`.
+    let mut p = Parcel::new();
+    assert_eq!(
+        p.write(&Some(proxy.clone())).unwrap_err(),
+        StatusCode::InvalidOperation,
+        "AC-22.1: Option<SIBinder> takes the same funnel"
+    );
+
+    // `Vec<SIBinder>` — the array path, one element deep.
+    let mut p = Parcel::new();
+    assert_eq!(
+        p.write(&vec![proxy.clone()]).unwrap_err(),
+        StatusCode::InvalidOperation,
+        "AC-22.1: Vec<SIBinder> takes the same funnel"
+    );
+
+    // A null `Option` still writes: the rejection is about the object,
+    // not about the parcel being kernel-mode.
+    let mut p = Parcel::new();
+    p.write(&None::<SIBinder>)
+        .expect("a null binder is still writable into a kernel parcel");
+}
+
+/// AC-22.5. The rejection is *type*-based, not mode-based: a local
+/// `Binder<T>` still serializes into an RPC parcel, and a local binder
+/// is what the kernel path has always accepted.
+#[test]
+fn local_binder_still_writes_into_an_rpc_parcel() {
+    let pair = Pair::new();
+    let remote = pair.remote_root();
+    let rp = (*remote).as_remote().expect("as_remote");
+    let mut data = rp.prepare_transact(false).expect("prepare_transact");
+
+    data.write(&local_root())
+        .expect("AC-22.5: a local binder must still cross into an RPC parcel");
+}
+
+// ---- A-4.4: RPC parcel ← kernel proxy -------------------------------
+
+/// AC-22.2. An RPC-mode `Parcel` refuses a remote binder that is not
+/// RPC-backed — i.e. a kernel proxy. Without the check the binder is
+/// registered as a *local* node and the peer's first call to it dies
+/// with `UnknownTransaction`.
+#[test]
+fn rpc_parcel_refuses_kernel_proxy() {
+    let pair = Pair::new();
+    let remote = pair.remote_root();
+    let rp = (*remote).as_remote().expect("as_remote");
+    let mut data = rp.prepare_transact(false).expect("prepare_transact");
+
+    assert_eq!(
+        data.write(&kernelish()).unwrap_err(),
+        StatusCode::InvalidOperation,
+        "AC-22.2: a kernel proxy cannot be written into an RPC parcel"
+    );
+
+    // And no local node was registered for it on the way out.
+    assert_eq!(
+        pair.server.as_ref().unwrap().local_node_count(),
+        1,
+        "AC-22.2: the refused binder must not have been registered as a local node"
+    );
+}
+
+// ---- A-4.5: RPC parcel ← another session's RPC proxy ----------------
+
+/// AC-22.3. Pins the check rsbinder already had: an `RpcProxy` belonging
+/// to a *different* session is refused, because its address means
+/// nothing to this peer (AOSP `onBinderLeaving`). Removing the
+/// `ptr::eq` guard makes this `Ok`.
+#[test]
+fn rpc_parcel_refuses_another_sessions_proxy() {
+    let one = Pair::new();
+    let two = Pair::new();
+
+    let foreign = one.remote_root();
+    let remote_two = two.remote_root();
+    let rp = (*remote_two).as_remote().expect("as_remote");
+    let mut data = rp.prepare_transact(false).expect("prepare_transact");
+
+    assert_eq!(
+        data.write(&foreign).unwrap_err(),
+        StatusCode::InvalidOperation,
+        "AC-22.3: a proxy from an unrelated RPC session is refused"
+    );
+
+    // Same session's own proxy is fine — the guard is about identity,
+    // not about proxies in general.
+    let mut data = rp.prepare_transact(false).expect("prepare_transact");
+    data.write(&remote_two)
+        .expect("AC-22.3: this session's own proxy may travel back home");
+}
+
+// ---- A-4.8: registration-time refusal -------------------------------
+
+/// AC-22.4. `RpcServer::set_root` / `add_service` and
+/// `RpcSession::set_root` refuse a remote binder up front, rather than
+/// letting it fail on the first parcel that carries it.
+#[test]
+fn registration_refuses_a_remote_binder() {
+    let pair = Pair::new();
+    let proxy = pair.remote_root();
+
+    // Bound but never run — this test only exercises the registration
+    // guards, so no accept loop is needed.
+    let path = tmp_sock("reg");
+    let server = RpcServer::setup_unix_server(&path).expect("bind");
+    assert_eq!(
+        server.set_root(proxy.clone()).unwrap_err(),
+        StatusCode::InvalidOperation,
+        "AC-22.4: RpcServer::set_root refuses a remote binder"
+    );
+    assert_eq!(
+        server.add_service("gw", proxy.clone()).unwrap_err(),
+        StatusCode::InvalidOperation,
+        "AC-22.4: RpcServer::add_service refuses a remote binder"
+    );
+    // A local binder still registers.
+    server.set_root(local_root()).expect("local root accepted");
+    server
+        .add_service("gw", local_root())
+        .expect("local service accepted");
+
+    // A kernel proxy is refused the same way — the rule is `is_remote`,
+    // not "is an RpcProxy".
+    assert_eq!(
+        server.set_root(kernelish()).unwrap_err(),
+        StatusCode::InvalidOperation,
+        "AC-22.4: a kernel proxy is refused at registration too"
+    );
+
+    let (c, _d) = MemTransport::pair();
+    let session = RpcSession::new(Box::new(c), AddressSpace::Acceptor).expect("session");
+    assert_eq!(
+        session.set_root(proxy).unwrap_err(),
+        StatusCode::InvalidOperation,
+        "AC-22.4: RpcSession::set_root refuses a remote binder"
+    );
+    session.set_root(local_root()).expect("local root accepted");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+fn tmp_sock(tag: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "rsb_xstack_{}_{}_{}.sock",
+        tag,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    p
+}
+
+/// AC-22.5. `Svc` exists only to keep the fixture honest about the
+/// `Interface`/`Remotable` split; assert it is a *local* binder so the
+/// tests above are refusing something the same code path would
+/// otherwise have accepted.
+#[test]
+fn fixture_root_is_local() {
+    assert!(
+        !(*local_root()).is_remote(),
+        "the fixture root must be local, or every rejection above is vacuous"
+    );
+    let _ = Svc;
+}

--- a/rsbinder/tests/rpc_e2e.rs
+++ b/rsbinder/tests/rpc_e2e.rs
@@ -277,7 +277,7 @@ fn make_root() -> SIBinder {
 /// server session so the caller can assert node accounting.
 fn run_scenario(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>) {
     let server = RpcSession::new(server_t, AddressSpace::Acceptor).expect("RpcSession::new");
-    server.set_root(make_root());
+    server.set_root(make_root()).expect("set_root");
     let server_for_thread = server.clone();
     let handle = thread::spawn(move || {
         let _ = server_for_thread.serve_blocking();
@@ -347,7 +347,7 @@ fn rpc_call_via_generalized_remote_proxy_trait() {
 
     let (a, b) = MemTransport::pair();
     let server = RpcSession::new(Box::new(a), AddressSpace::Acceptor).expect("RpcSession::new");
-    server.set_root(make_root());
+    server.set_root(make_root()).expect("set_root");
     let h = thread::spawn(move || {
         let _ = server.serve_blocking();
     });

--- a/rsbinder/tests/rpc_fd.rs
+++ b/rsbinder/tests/rpc_fd.rs
@@ -172,7 +172,9 @@ fn fd_roundtrip_when_both_opt_in_over_uds() {
     let path = tmp_sock("ok");
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_supported_fd_modes(&[FdMode::Unix]);
-    server.set_root(Interface::as_binder(&Binder::new(BnFd(Box::new(FdSvc)))));
+    server
+        .set_root(Interface::as_binder(&Binder::new(BnFd(Box::new(FdSvc)))))
+        .expect("set_root");
     let bg = server.run_background();
     wait_sock(&path);
 
@@ -227,7 +229,9 @@ fn fd_rejected_without_mutual_opt_in() {
     let path = tmp_sock("noopt");
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     // intentionally NOT set_supported_fd_modes
-    server.set_root(Interface::as_binder(&Binder::new(BnFd(Box::new(FdSvc)))));
+    server
+        .set_root(Interface::as_binder(&Binder::new(BnFd(Box::new(FdSvc)))))
+        .expect("set_root");
     let bg = server.run_background();
     wait_sock(&path);
 
@@ -261,7 +265,9 @@ fn fd_rejected_on_non_uds_transport() {
     let (a, b) = MemTransport::pair();
     let server = RpcSession::new(Box::new(a), AddressSpace::Acceptor).expect("RpcSession::new");
     server.set_supported_fd_modes(&[FdMode::Unix]);
-    server.set_root(Interface::as_binder(&Binder::new(BnFd(Box::new(FdSvc)))));
+    server
+        .set_root(Interface::as_binder(&Binder::new(BnFd(Box::new(FdSvc)))))
+        .expect("set_root");
     let srv = server.clone();
     let h = thread::spawn(move || {
         let _ = srv.serve_blocking();
@@ -308,7 +314,9 @@ fn fd_v1plus_aosp_roundtrip_both_directions() {
         let server = RpcServer::setup_unix_server(&path).expect("bind");
         server.set_android13plus(ver); // versioned AOSP wire
         server.set_supported_fd_modes(&[FdMode::Unix]); // opt in
-        server.set_root(Interface::as_binder(&Binder::new(BnFd(Box::new(FdSvc)))));
+        server
+            .set_root(Interface::as_binder(&Binder::new(BnFd(Box::new(FdSvc)))))
+            .expect("set_root");
         let bg = server.run_background();
         wait_sock(&path);
 
@@ -374,7 +382,9 @@ fn fd_v1_abstract_unix_roundtrip_arg() {
     server.set_android13plus(1);
     server.set_max_threads(2);
     server.set_supported_fd_modes(&[FdMode::Unix]);
-    server.set_root(Interface::as_binder(&Binder::new(BnFd(Box::new(FdSvc)))));
+    server
+        .set_root(Interface::as_binder(&Binder::new(BnFd(Box::new(FdSvc)))))
+        .expect("set_root");
     let bg = server.run_background();
 
     let client = RpcSession::setup_unix_client_android13plus_with_config(

--- a/rsbinder/tests/rpc_scenarios.rs
+++ b/rsbinder/tests/rpc_scenarios.rs
@@ -372,10 +372,12 @@ fn boot(tag: &str) -> Booted {
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     let delay_entered = Arc::new(AtomicBool::new(false));
     let delay_done = Arc::new(AtomicI64::new(0));
-    server.set_root(make_service(
-        Arc::clone(&delay_entered),
-        Arc::clone(&delay_done),
-    ));
+    server
+        .set_root(make_service(
+            Arc::clone(&delay_entered),
+            Arc::clone(&delay_done),
+        ))
+        .expect("set_root");
     let bg = server.run_background();
     let cu = ServeCleanup {
         server: Arc::clone(&server),

--- a/rsbinder/tests/rpc_server.rs
+++ b/rsbinder/tests/rpc_server.rs
@@ -381,7 +381,9 @@ fn real_process_e2e_and_negotiation() {
     if let Ok(path) = std::env::var("RSB_RPC_SERVER") {
         let server = RpcServer::setup_unix_server(&path).expect("bind");
         server.set_max_threads(2);
-        server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+        server
+            .set_root(make_service(Arc::new(AtomicI64::new(0))))
+            .expect("set_root");
         let _ = server.run(); // blocks until killed
         std::process::exit(0);
     }
@@ -430,7 +432,9 @@ fn real_process_abstract_unix_socket_e2e() {
         let server = RpcServer::setup_unix_server_abstract(name.as_bytes()).expect("bind abstract");
         server.set_android13plus(2);
         server.set_max_threads(3);
-        server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+        server
+            .set_root(make_service(Arc::new(AtomicI64::new(0))))
+            .expect("set_root");
         let _ = server.run();
         std::process::exit(0);
     }
@@ -510,7 +514,9 @@ fn real_process_abstract_unix_socket_e2e() {
 fn concurrent_calls_single_shared_session() {
     let path = tmp_sock("shared");
     let server = RpcServer::setup_unix_server(&path).expect("bind");
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -556,7 +562,9 @@ fn concurrent_calls_single_shared_session() {
 fn concurrent_clients_isolated_sessions() {
     let path = tmp_sock("iso");
     let server = RpcServer::setup_unix_server(&path).expect("bind");
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -597,7 +605,9 @@ fn concurrent_clients_isolated_sessions() {
 fn max_connections_admission_bound() {
     let path = tmp_sock("admit");
     let server = RpcServer::setup_unix_server(&path).expect("bind");
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     server.set_max_connections(2);
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
@@ -667,7 +677,9 @@ fn max_connections_admission_bound() {
 fn silent_r34_peer_released_by_handshake_deadline() {
     let path = tmp_sock("silent_r34");
     let server = RpcServer::setup_unix_server(&path).expect("bind");
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     // One slot so a pinned silent peer is directly observable, and a short
     // deadline to keep the test fast + deterministic.
     server.set_max_connections(1);
@@ -706,7 +718,9 @@ fn oneway_fifo_and_nonblocking() {
     let path = tmp_sock("ow");
     let counter = Arc::new(AtomicI64::new(0));
     let server = RpcServer::setup_unix_server(&path).expect("bind");
-    server.set_root(make_service(counter.clone()));
+    server
+        .set_root(make_service(counter.clone()))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -747,7 +761,9 @@ fn oneway_fifo_and_nonblocking() {
 fn nested_callback_no_deadlock() {
     let path = tmp_sock("nest");
     let server = RpcServer::setup_unix_server(&path).expect("bind");
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -777,7 +793,9 @@ fn nested_callback_no_deadlock() {
 fn client_timeout_on_hung_server() {
     let path = tmp_sock("to");
     let server = RpcServer::setup_unix_server(&path).expect("bind");
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -827,7 +845,9 @@ fn android13plus_profile_e2e() {
         let server = RpcServer::setup_unix_server(&path).expect("bind");
         server.set_android13plus(smax); // opt in to the versioned wire
         server.set_max_threads(2);
-        server.set_root(make_service(counter.clone()));
+        server
+            .set_root(make_service(counter.clone()))
+            .expect("set_root");
         let bg = server.run_background();
         let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
         wait_for_sock(&path);
@@ -898,7 +918,9 @@ fn abstract_unix_socket_e2e() {
     let r34_name = format!("rsb_rpc_abs_r34_{}", std::process::id()).into_bytes();
     let server = RpcServer::setup_unix_server_abstract(&r34_name).expect("bind abstract r34");
     assert!(server.path().is_none());
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu_r34 = ServeCleanup {
         server: Arc::clone(&server),
@@ -915,7 +937,9 @@ fn abstract_unix_socket_e2e() {
     assert!(server.path().is_none());
     server.set_android13plus(2);
     server.set_max_threads(2);
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu_a13 = ServeCleanup {
         server: Arc::clone(&server),
@@ -946,7 +970,9 @@ fn abstract_unix_socket_e2e() {
     let fan_server = RpcServer::setup_unix_server_abstract(&fan_name).expect("bind fan-out");
     fan_server.set_android13plus(2);
     fan_server.set_max_threads(3);
-    fan_server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    fan_server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let fan_bg = fan_server.run_background();
     let _cu_fan = ServeCleanup {
         server: Arc::clone(&fan_server),
@@ -1036,7 +1062,7 @@ fn tls_android13plus_nested_callback_e2e() {
             let t = TlsTransport::accept(tcp, srv_cfg).expect("server TLS handshake");
             let session = RpcSession::accept_android13plus(Box::new(t), smax)
                 .expect("server android-13+ accept");
-            session.set_root(make_service(counter));
+            session.set_root(make_service(counter)).expect("set_root");
             let _ = session.serve_blocking();
         });
 
@@ -1102,7 +1128,9 @@ fn tls_android13plus_nested_callback_e2e() {
 fn r34_profile_reports_no_wire_version() {
     let path = tmp_sock("r34_ver");
     let server = RpcServer::setup_unix_server(&path).expect("bind");
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -1167,7 +1195,9 @@ fn a0b_multi_connection_shared_session() {
                                  // a multi-conn scenario, so AOSP `setMaxIncomingThreads(2)` is its
                                  // natural setup step.
     server.set_max_threads(2);
-    server.set_root(make_service(counter.clone()));
+    server
+        .set_root(make_service(counter.clone()))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -1331,7 +1361,9 @@ fn ac_12_f8_attach_unifies_to_single_inner() {
     server.set_android13plus(1);
     // Opt into 2 incoming slots (default 1 ⇒ founding-only).
     server.set_max_threads(2);
-    server.set_root(make_service(counter.clone()));
+    server
+        .set_root(make_service(counter.clone()))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -1422,7 +1454,9 @@ fn ac_12_4_set_max_threads_caps_incoming_slots() {
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(1);
     server.set_max_threads(2);
-    server.set_root(make_service(counter.clone()));
+    server
+        .set_root(make_service(counter.clone()))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -1509,7 +1543,9 @@ fn b2_fan_out_creates_n_outgoing_slots_when_local_max_outgoing_is_n() {
     // N = 3 (founding + 2 fan-out attaches). Cap is server-side; the
     // helper learns it via `negotiate` and mints exactly N - 1 extras.
     server.set_max_threads(3);
-    server.set_root(make_service(counter.clone()));
+    server
+        .set_root(make_service(counter.clone()))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -1589,7 +1625,9 @@ fn b2_local_max_outgoing_one_skips_fan_out_byte_identical_to_founding_only() {
     // Server is multi-conn-capable but the client opts out — fan-out
     // must NOT run regardless.
     server.set_max_threads(2);
-    server.set_root(make_service(counter.clone()));
+    server
+        .set_root(make_service(counter.clone()))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -1626,7 +1664,9 @@ fn b2_local_max_outgoing_one_skips_fan_out_byte_identical_to_founding_only() {
     let server2 = RpcServer::setup_unix_server(&path2).expect("bind");
     server2.set_android13plus(1);
     server2.set_max_threads(2);
-    server2.set_root(make_service(counter.clone()));
+    server2
+        .set_root(make_service(counter.clone()))
+        .expect("set_root");
     let bg2 = server2.run_background();
     let _cu2 = ServeCleanup::new(Arc::clone(&server2), bg2, path2.clone());
     wait_for_sock(&path2);
@@ -1658,7 +1698,9 @@ fn attach_with_a_bogus_session_id_is_refused_at_attach_time() {
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(1);
     server.set_max_threads(4);
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -1738,7 +1780,9 @@ fn attach_past_the_server_slot_cap_is_refused_at_attach_time() {
     server.set_android13plus(1);
     // Founding + exactly one attach.
     server.set_max_threads(2);
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -1786,7 +1830,9 @@ fn attach_max_version_below_the_session_version_is_bad_type() {
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(2);
     server.set_max_threads(3);
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -1825,7 +1871,9 @@ fn r34_server_reports_an_android13plus_client_as_a_dead_peer() {
     let path = tmp_sock("profmix");
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     // No `set_android13plus`: the default r34 wire.
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -1854,7 +1902,9 @@ fn standalone_attach_session_with_a_bogus_id_fails_to_build() {
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(1);
     server.set_max_threads(3);
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -1907,7 +1957,9 @@ fn shutdown_gate_e2e_rejects_attach_during_handshake_stall() {
     // increment of `rejected_unknown_id` we want to observe is the
     // shutdown-arm one.
     server.set_max_threads(2);
-    server.set_root(make_service(counter.clone()));
+    server
+        .set_root(make_service(counter.clone()))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -2021,7 +2073,9 @@ fn f7_shared_node_survives_sibling_proxy_drop() {
     server.set_android13plus(1);
     // Opt into 2 incoming slots (founding + attached).
     server.set_max_threads(2);
-    server.set_root(make_service(counter.clone()));
+    server
+        .set_root(make_service(counter.clone()))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -2106,7 +2160,9 @@ fn f7_excess_receipt_no_leak_single_client() {
     let counter = Arc::new(AtomicI64::new(0));
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(1);
-    server.set_root(make_service(counter.clone()));
+    server
+        .set_root(make_service(counter.clone()))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -2175,7 +2231,9 @@ fn pool_distributes_concurrent_calls_across_outgoing_slots() {
     // ⇒ 2 incoming slots at the server. Default cap = 1 would reject
     // the attach, defeating the pool-distribution scenario.
     server.set_max_threads(2);
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -2239,7 +2297,9 @@ fn pool_exhausted_condvar_blocks_not_busy_loops() {
     // 2 incoming slots (founding + attached); 3 client
     // threads observe the cv-wait band.
     server.set_max_threads(2);
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -2330,10 +2390,12 @@ fn pool_nested_callback_pins_to_forced_slot_single_thread() {
     server.set_android13plus(1);
     // 2 incoming slots (founding + forced slot-2 echo).
     server.set_max_threads(2);
-    server.set_root(make_service_with_slow_signal(
-        Arc::new(AtomicI64::new(0)),
-        Arc::clone(&slow_entered),
-    ));
+    server
+        .set_root(make_service_with_slow_signal(
+            Arc::new(AtomicI64::new(0)),
+            Arc::clone(&slow_entered),
+        ))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -2401,7 +2463,9 @@ fn ac_12_2_extended_cross_slot_nested_callback_multi_thread() {
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(1);
     server.set_max_threads(2);
-    server.set_root(make_service(counter.clone()));
+    server
+        .set_root(make_service(counter.clone()))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -2458,7 +2522,9 @@ fn pool_oneway_fifo_under_concurrent_twoway_multi_outgoing() {
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(1);
     server.set_max_threads(2);
-    server.set_root(make_service(counter.clone()));
+    server
+        .set_root(make_service(counter.clone()))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -2678,7 +2744,9 @@ impl rsbinder::DeathRecipient for DeathFlag {
 fn rpc_death_recipient_fires_on_session_drop() {
     if let Ok(path) = std::env::var("RSB_RPC_DEATH_SERVER") {
         let server = RpcServer::setup_unix_server(&path).expect("bind");
-        server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+        server
+            .set_root(make_service(Arc::new(AtomicI64::new(0))))
+            .expect("set_root");
         let _ = server.run(); // blocks until killed
         std::process::exit(0);
     }
@@ -2773,7 +2841,9 @@ fn authorizer_gate_rejects_before_any_rpc_byte() {
     {
         let path = tmp_sock("authz_no");
         let server = RpcServer::setup_unix_server(&path).expect("bind");
-        server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+        server
+            .set_root(make_service(Arc::new(AtomicI64::new(0))))
+            .expect("set_root");
         server.set_authorizer(|_peer| false);
         let bg = server.run_background();
         let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
@@ -2791,7 +2861,9 @@ fn authorizer_gate_rejects_before_any_rpc_byte() {
     {
         let path = tmp_sock("authz_yes");
         let server = RpcServer::setup_unix_server(&path).expect("bind");
-        server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+        server
+            .set_root(make_service(Arc::new(AtomicI64::new(0))))
+            .expect("set_root");
         server.set_authorizer(|peer| matches!(peer, PeerIdentity::Local { .. }));
         let bg = server.run_background();
         let _cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
@@ -2871,7 +2943,7 @@ fn boot_held_cfg(tag: &str, cfg: HeldCfg) -> HeldSetup {
     }
     server.set_max_threads(cfg.max_threads);
     let root_local = make_service_with_hold(Arc::new(AtomicI64::new(0)), Arc::clone(&held));
-    server.set_root(root_local.clone());
+    server.set_root(root_local.clone()).expect("set_root");
     let bg = server.run_background();
     let cu = ServeCleanup::new(Arc::clone(&server), bg, path.clone());
     wait_for_sock(&path);
@@ -3117,7 +3189,9 @@ fn handshake_timeout_bounds_a_silent_peer() {
     let path2 = tmp_sock("hs_ok");
     let server = RpcServer::setup_unix_server(&path2).expect("bind");
     server.set_android13plus(2);
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let bg = server.run_background();
     let _cu = ServeCleanup::new(Arc::clone(&server), bg, path2.clone());
     wait_for_sock(&path2);
@@ -3556,7 +3630,9 @@ fn c_server_death_is_eager_with_incoming() {
     if let Ok(path) = std::env::var("RSB_RPC_DEATH_A13_SERVER") {
         let server = RpcServer::setup_unix_server(&path).expect("bind");
         server.set_android13plus(2);
-        server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+        server
+            .set_root(make_service(Arc::new(AtomicI64::new(0))))
+            .expect("set_root");
         let _ = server.run(); // blocks until killed
         std::process::exit(0);
     }
@@ -3640,10 +3716,12 @@ fn local_shutdown_ends_the_serve_loop_the_same_way_parked_or_dispatching() {
             RpcSession::new(Box::new(srv_t), AddressSpace::Acceptor).expect("server session"),
         );
         let slow_entered = Arc::new(AtomicBool::new(false));
-        server.set_root(make_service_with_slow_signal(
-            Arc::new(AtomicI64::new(0)),
-            slow_entered.clone(),
-        ));
+        server
+            .set_root(make_service_with_slow_signal(
+                Arc::new(AtomicI64::new(0)),
+                slow_entered.clone(),
+            ))
+            .expect("set_root");
         let serving = Arc::clone(&server);
         let serve = std::thread::spawn(move || serving.serve_blocking());
         let client =
@@ -3699,7 +3777,9 @@ fn preconnected_inet_fd_handshakes_over_tcp_debug() {
     let path = tmp_sock("pcfd");
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     server.set_android13plus(2);
-    server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     server.serve_connection(Box::new(server_t));
 
     let client = RpcSession::from_preconnected_fd(OwnedFd::from(client_stream), 2)
@@ -3727,7 +3807,9 @@ fn terminate_ends_every_session_and_joins_workers() {
     // one profile, so the two paths need two servers.
     let r34_path = tmp_sock("term34");
     let r34_server = RpcServer::setup_unix_server(&r34_path).expect("bind r34");
-    r34_server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    r34_server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let r34_bg = r34_server.run_background();
     wait_for_sock(&r34_path);
     let r34 = RpcSession::setup_unix_client(&r34_path).expect("r34 connect");
@@ -3740,7 +3822,9 @@ fn terminate_ends_every_session_and_joins_workers() {
     let a13_server = RpcServer::setup_unix_server(&a13_path).expect("bind a13");
     a13_server.set_android13plus(2);
     a13_server.set_max_threads(2);
-    a13_server.set_root(make_service(Arc::new(AtomicI64::new(0))));
+    a13_server
+        .set_root(make_service(Arc::new(AtomicI64::new(0))))
+        .expect("set_root");
     let a13_bg = a13_server.run_background();
     wait_for_sock(&a13_path);
     let a13 = RpcSession::setup_unix_client_android13plus_with_config(
@@ -3837,9 +3921,11 @@ fn terminate_from_a_handler_does_not_join_itself() {
     let server = RpcServer::setup_unix_server(&path).expect("bind");
     // The service holds the server until the call takes it, so the strong
     // count below can reach 1 once the worker is gone.
-    server.set_root(Interface::as_binder(&Binder::new(Stopper(Mutex::new(
-        Some(Arc::clone(&server)),
-    )))));
+    server
+        .set_root(Interface::as_binder(&Binder::new(Stopper(Mutex::new(
+            Some(Arc::clone(&server)),
+        )))))
+        .expect("set_root");
     let bg = server.run_background();
     wait_for_sock(&path);
     let client = RpcSession::setup_unix_client(&path).expect("connect");

--- a/rsbinder/tests/rpc_shared_memory.rs
+++ b/rsbinder/tests/rpc_shared_memory.rs
@@ -146,7 +146,10 @@ fn imemory_window_roundtrips_over_uds_with_fd_mode() {
     let bound = Bound::new("ok");
     bound.server.set_supported_fd_modes(&[FdMode::Unix]);
     let served = serve(0);
-    bound.server.set_root(served.root.clone());
+    bound
+        .server
+        .set_root(served.root.clone())
+        .expect("set_root");
     let bg = bound.run();
 
     let client = bound.connect(true);
@@ -202,7 +205,10 @@ fn read_only_heap_is_read_only_at_the_client() {
     let served = serve(FLAG_READ_ONLY);
     // The owner may still write.
     served.heap.write_at(served.window_offset, b"ro").unwrap();
-    bound.server.set_root(served.root.clone());
+    bound
+        .server
+        .set_root(served.root.clone())
+        .expect("set_root");
     let bg = bound.run();
 
     let client = bound.connect(true);
@@ -233,7 +239,10 @@ fn bare_imemoryheap_root_maps() {
     let bound = Bound::new("heap");
     bound.server.set_supported_fd_modes(&[FdMode::Unix]);
     let heap = Arc::new(MemoryHeapBase::new(page(), 0).unwrap());
-    bound.server.set_root(export_heap(heap.clone()));
+    bound
+        .server
+        .set_root(export_heap(heap.clone()))
+        .expect("set_root");
     let bg = bound.run();
 
     let client = bound.connect(true);
@@ -261,7 +270,10 @@ fn bare_imemoryheap_root_maps() {
 fn heap_fd_rejected_without_fd_mode() {
     let bound = Bound::new("nofd");
     let served = serve(0);
-    bound.server.set_root(served.root.clone());
+    bound
+        .server
+        .set_root(served.root.clone())
+        .expect("set_root");
     let bg = bound.run();
 
     let client = bound.connect(false);
@@ -323,7 +335,8 @@ fn dealer_allocations_share_one_mapping_through_heap_cache() {
     let offsets: Vec<usize> = allocs.iter().map(|a| a.offset()).collect();
     bound
         .server
-        .set_root(Interface::as_binder(&Binder::new(BnAllocs(allocs))));
+        .set_root(Interface::as_binder(&Binder::new(BnAllocs(allocs))))
+        .expect("set_root");
     let bg = bound.run();
 
     let client = bound.connect(true);

--- a/rsbinder/tests/rpc_tls.rs
+++ b/rsbinder/tests/rpc_tls.rs
@@ -146,9 +146,11 @@ fn tls_valid_cert_e2e_and_peer_identity() {
         let t = TlsTransport::accept(tcp, srv_cfg).expect("server handshake");
         let session =
             RpcSession::new(Box::new(t), AddressSpace::Acceptor).expect("RpcSession::new");
-        session.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
-            PingSvc,
-        )))));
+        session
+            .set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+                PingSvc,
+            )))))
+            .expect("set_root");
         let _ = session.serve_blocking();
     });
 
@@ -189,9 +191,11 @@ fn tls_over_unix_socket_e2e() {
             .expect("server TLS handshake over unix");
         let session =
             RpcSession::new(Box::new(t), AddressSpace::Acceptor).expect("RpcSession::new");
-        session.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
-            PingSvc,
-        )))));
+        session
+            .set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+                PingSvc,
+            )))))
+            .expect("set_root");
         let _ = session.serve_blocking();
     });
 
@@ -381,9 +385,11 @@ fn setup_tcp_client_tls_convenience_e2e() {
         let t = TlsTransport::accept(tcp, srv_cfg).expect("server handshake");
         let session =
             RpcSession::new(Box::new(t), AddressSpace::Acceptor).expect("RpcSession::new");
-        session.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
-            PingSvc,
-        )))));
+        session
+            .set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+                PingSvc,
+            )))))
+            .expect("set_root");
         let _ = session.serve_blocking();
     });
 
@@ -659,9 +665,11 @@ fn setup_tcp_server_tls_e2e() {
     let srv_cfg = server_config(SRV_CRT, SRV_KEY);
     let server =
         RpcServer::setup_tcp_server_tls("127.0.0.1:0", srv_cfg).expect("setup_tcp_server_tls");
-    server.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
-        PingSvc,
-    )))));
+    server
+        .set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+            PingSvc,
+        )))))
+        .expect("set_root");
     let addr = server.tcp_address().expect("tcp_address");
     // Accessor gates: tcp_address Some, path None.
     assert!(server.path().is_none(), "TCP server has no fs path");
@@ -716,9 +724,11 @@ fn vsock_tls_loopback_e2e() {
     let srv_cfg = server_config(SRV_CRT, SRV_KEY);
     let server = RpcServer::setup_vsock_server_tls(VMADDR_CID_LOCAL, TLS_TEST_PORT, srv_cfg)
         .expect("setup_vsock_server_tls");
-    server.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
-        PingSvc,
-    )))));
+    server
+        .set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+            PingSvc,
+        )))))
+        .expect("set_root");
     assert_eq!(
         server.vsock_address(),
         Some((VMADDR_CID_LOCAL, TLS_TEST_PORT))
@@ -794,9 +804,11 @@ fn setup_unix_server_tls_e2e() {
     };
     let srv_cfg = server_config(SRV_CRT, SRV_KEY);
     let server = RpcServer::setup_unix_server_tls(&path, srv_cfg).expect("setup_unix_server_tls");
-    server.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
-        PingSvc,
-    )))));
+    server
+        .set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+            PingSvc,
+        )))))
+        .expect("set_root");
     assert_eq!(
         server.path(),
         Some(path.as_path()),

--- a/rsbinder/tests/rpc_vsock.rs
+++ b/rsbinder/tests/rpc_vsock.rs
@@ -101,9 +101,11 @@ fn vsock_loopback_e2e() {
     // Same `RpcServer` API as UDS, vsock-backed listener.
     let server =
         RpcServer::setup_vsock_server(VMADDR_CID_LOCAL, TEST_PORT).expect("setup_vsock_server");
-    server.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
-        PingSvc,
-    )))));
+    server
+        .set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+            PingSvc,
+        )))))
+        .expect("set_root");
     // Accessor gates: vsock_address `Some`, fs path `None`.
     assert_eq!(server.vsock_address(), Some((VMADDR_CID_LOCAL, TEST_PORT)));
     assert_eq!(server.path(), None, "vsock server has no filesystem entry");
@@ -140,9 +142,11 @@ fn vsock_shutdown_wakes_blocked_recv() {
 
     let port = TEST_PORT + 1;
     let server = RpcServer::setup_vsock_server(VMADDR_CID_LOCAL, port).expect("setup_vsock_server");
-    server.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
-        PingSvc,
-    )))));
+    server
+        .set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+            PingSvc,
+        )))))
+        .expect("set_root");
     let bg = server.run_background();
 
     let t: Arc<dyn RpcTransport> =
@@ -198,9 +202,11 @@ fn vsock_session_shutdown_ends_serve_thread() {
 
     let port = TEST_PORT + 2;
     let server = RpcServer::setup_vsock_server(VMADDR_CID_LOCAL, port).expect("setup_vsock_server");
-    server.set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
-        PingSvc,
-    )))));
+    server
+        .set_root(Interface::as_binder(&Binder::new(BnPing(Box::new(
+            PingSvc,
+        )))))
+        .expect("set_root");
     let bg = server.run_background();
 
     let client_t = VsockTransport::connect(VMADDR_CID_LOCAL, port).expect("client connect");

--- a/tests/tests/codegen_shapes.rs
+++ b/tests/tests/codegen_shapes.rs
@@ -66,7 +66,7 @@ fn root() -> SIBinder {
 
 fn run(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>) {
     let server = RpcSession::new(server_t, AddressSpace::Acceptor).expect("RpcSession::new");
-    server.set_root(root());
+    server.set_root(root()).expect("set_root");
     let server_for_thread = server.clone();
     let handle = thread::spawn(move || {
         let _ = server_for_thread.serve_blocking();

--- a/tests/tests/entry_rpc.rs
+++ b/tests/tests/entry_rpc.rs
@@ -162,14 +162,19 @@ fn entry_add_refuses_a_remote_binder() {
         "AC-22.4: a proxy cannot be re-published on another RPC server"
     );
 
-    // A local service on the same endpoint is still accepted — the
-    // refusal is about the binder, not about `b`.
+    // The gateway spelling — the same proxy, wrapped in a local `Bn*` —
+    // is accepted, and forwards to the upstream service.
+    let upstream: Strong<dyn IRpcSmoke> = client.get("svc").expect("svc");
     let _down = rsbinder::serve(&b.uri(""))
         .expect("serve")
-        .add("svc", tagged("downstream"))
-        .expect("add")
+        .add("svc", BnRpcSmoke::new_binder(upstream))
+        .expect("gateway add")
         .spawn()
         .expect("spawn");
+
+    let via_gateway: Strong<dyn IRpcSmoke> =
+        rsbinder::connect(&b.uri("#svc")).expect("connect through gateway");
+    assert_eq!(via_gateway.r#echo("x").unwrap(), "upstream:x");
 }
 
 /// Misuse is loud and early: a `#service` on `Client::open`, no service

--- a/tests/tests/entry_rpc.rs
+++ b/tests/tests/entry_rpc.rs
@@ -134,6 +134,44 @@ fn entry_client_multi_lookup_and_proxy_outlives_client() {
     assert_eq!(second.r#echo("b").unwrap(), "second:b");
 }
 
+/// AC-22.4. Re-publishing a proxy of server A on server B is refused at
+/// `add`, not left to fail on B's first client call. This is the mistake
+/// the gateway pattern exists for: wrap the proxy in a local `Bn*`
+/// (`BnRpcSmoke::new_binder(proxy)`) instead of forwarding the binder.
+#[test]
+fn entry_add_refuses_a_remote_binder() {
+    let a = SockPath::new("gw_up");
+    let b = SockPath::new("gw_down");
+
+    let _up = rsbinder::serve(&a.uri(""))
+        .expect("serve")
+        .add("svc", tagged("upstream"))
+        .expect("add")
+        .spawn()
+        .expect("spawn");
+
+    let client = rsbinder::Client::open(&a.uri("")).expect("open");
+
+    let refused = rsbinder::serve(&b.uri(""))
+        .expect("serve")
+        .add("svc", client.binder("svc").expect("binder"))
+        .err();
+    assert_eq!(
+        refused,
+        Some(StatusCode::InvalidOperation),
+        "AC-22.4: a proxy cannot be re-published on another RPC server"
+    );
+
+    // A local service on the same endpoint is still accepted — the
+    // refusal is about the binder, not about `b`.
+    let _down = rsbinder::serve(&b.uri(""))
+        .expect("serve")
+        .add("svc", tagged("downstream"))
+        .expect("add")
+        .spawn()
+        .expect("spawn");
+}
+
 /// Misuse is loud and early: a `#service` on `Client::open`, no service
 /// on `connect`, an option for the wrong transport, and an unknown
 /// scheme are all `BadValue`.

--- a/tests/tests/gateway_kernel.rs
+++ b/tests/tests/gateway_kernel.rs
@@ -38,24 +38,40 @@ use rpcsmoke::IRpcSmoke::{BnRpcSmoke, IRpcSmoke};
 
 /// The child blocks in the kernel thread pool forever; reap it however
 /// the test ends, including on a panic.
-struct KillOnDrop<'a>(&'a mut std::process::Child);
-impl Drop for KillOnDrop<'_> {
+struct KillOnDrop(std::process::Child);
+impl KillOnDrop {
+    /// `Some(status)` once the child has exited — it should not, until we
+    /// kill it, so a status here means it failed to come up.
+    fn exited(&mut self) -> Option<std::process::ExitStatus> {
+        self.0.try_wait().expect("try_wait")
+    }
+}
+impl Drop for KillOnDrop {
     fn drop(&mut self) {
         let _ = self.0.kill();
         let _ = self.0.wait();
     }
 }
 
-struct KernelSvc;
+struct KernelSvc {
+    pings: std::sync::atomic::AtomicU32,
+}
 impl Interface for KernelSvc {}
 impl IRpcSmoke for KernelSvc {
     fn r#echo(&self, s: &str) -> rsbinder::status::Result<String> {
+        // `"pings"` is the read-back channel for the oneway below: it has no
+        // reply of its own, so the count has to ride a twoway call.
+        if s == "pings" {
+            let n = self.pings.load(std::sync::atomic::Ordering::SeqCst);
+            return Ok(format!("kernel:{n}"));
+        }
         Ok(format!("kernel:{s}"))
     }
     fn r#add(&self, a: i32, b: i32) -> rsbinder::status::Result<i32> {
         Ok(a + b)
     }
     fn r#ping(&self) -> rsbinder::status::Result<()> {
+        self.pings.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         Ok(())
     }
 }
@@ -67,7 +83,12 @@ fn rpc_client_reaches_a_kernel_service_through_a_gateway() {
     if let Ok(name) = std::env::var("RSB_GW_KERNEL_SERVICE") {
         rsbinder::serve("binder://")
             .expect("serve kernel")
-            .add(&name, BnRpcSmoke::new_binder(KernelSvc))
+            .add(
+                &name,
+                BnRpcSmoke::new_binder(KernelSvc {
+                    pings: std::sync::atomic::AtomicU32::new(0),
+                }),
+            )
             .expect("addService (needs a permissive service manager)")
             .run()
             .expect("kernel thread pool");
@@ -81,7 +102,7 @@ fn rpc_client_reaches_a_kernel_service_through_a_gateway() {
     let uri = format!("unix://{}", sock.display());
 
     let exe = std::env::current_exe().expect("current_exe");
-    let mut c = std::process::Command::new(exe)
+    let child = std::process::Command::new(exe)
         .args([
             "--ignored",
             "--exact",
@@ -91,13 +112,28 @@ fn rpc_client_reaches_a_kernel_service_through_a_gateway() {
         .env("RSB_GW_KERNEL_SERVICE", &name)
         .spawn()
         .expect("spawn kernel service child");
-    let _kill = KillOnDrop(&mut c);
+    let mut kill = KillOnDrop(child);
 
     // B — the gateway: a kernel proxy of C, re-published on a socket.
-    // `connect("binder://…")` waits for the registration (AOSP
-    // `waitForService`), so no sleep is needed here.
-    let upstream: Strong<dyn IRpcSmoke> =
-        rsbinder::connect(&format!("binder://{name}")).expect("kernel lookup");
+    // Polled rather than `connect("binder://…")`: `waitForService` waits
+    // forever on a name that is never registered, so a child that dies on
+    // `addService` (a service manager that is not permissive) would hang
+    // the job instead of failing the test.
+    let client = rsbinder::Client::open("binder://").expect("kernel client");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let upstream: Strong<dyn IRpcSmoke> = loop {
+        if let Some(s) = client.try_get::<dyn IRpcSmoke>(&name).expect("try_get") {
+            break s;
+        }
+        if let Some(st) = kill.exited() {
+            panic!("kernel service child exited before registering {name}: {st}");
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "{name} was never registered"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    };
     assert!(
         (*upstream.as_binder()).is_remote(),
         "the gateway must be fronting a real kernel proxy, not a local node"
@@ -132,10 +168,18 @@ fn rpc_client_reaches_a_kernel_service_through_a_gateway() {
     );
     assert_eq!(a.r#add(40, 2).expect("add through the gateway"), 42);
 
-    // A oneway call has no reply to wait on; pair it with a twoway call
-    // so the assertion below cannot pass on an unflushed queue.
+    // A oneway call has no reply to wait on, and the kernel does not order
+    // it against a twoway that follows — so read the service's own counter
+    // back until it lands. A gateway that swallowed `ping` fails here.
     a.r#ping().expect("oneway through the gateway");
-    assert_eq!(a.r#echo("barrier").unwrap(), "kernel:barrier");
+    let ping_deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while a.r#echo("pings").expect("read the ping count") != "kernel:1" {
+        assert!(
+            std::time::Instant::now() < ping_deadline,
+            "AC-22.12: the oneway ping never reached the kernel service"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
 
     let _ = std::fs::remove_file(&sock);
 }

--- a/tests/tests/gateway_kernel.rs
+++ b/tests/tests/gateway_kernel.rs
@@ -1,0 +1,141 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Plan 2-22 Phase E — the gateway across the two *real* stacks:
+//! `A (rpc) → B (gateway) → C (kernel binder)`.
+//!
+//! The hermetic Phase B tests (`gateway_rpc.rs`) put RPC on both hops,
+//! which proves the delegating `impl` but not the thing the gateway
+//! exists for: reaching a **kernel** service from a socket client. Here
+//! C is registered with the service manager, B holds a kernel proxy to
+//! it and re-publishes that proxy on a Unix socket, and A speaks only
+//! RPC.
+//!
+//! C runs in a **child process**, and it has to: a process that looks up
+//! its own service gets its local node back from the driver
+//! (`BINDER_TYPE_BINDER`, not a handle), so an in-process C would leave B
+//! holding a local binder and prove nothing. The child is this same test
+//! binary re-executed with `RSB_GW_KERNEL_SERVICE` set — the pattern
+//! `rsbinder/tests/rpc_server.rs` already uses.
+//!
+//! Requires a real binder device (`/dev/binder`, Linux+binderfs or
+//! Android) and a service manager permissive enough to accept
+//! `addService` for an arbitrary name (`rsb_hub --insecure-allow-all`).
+//! Hence `#[ignore]`:
+//!
+//! ```text
+//! cargo test -p tests --features rpc --test gateway_kernel -- --ignored --nocapture
+//! ```
+
+#![cfg(all(feature = "rpc", any(target_os = "linux", target_os = "android")))]
+#![allow(non_snake_case)]
+
+use rsbinder::{Interface, Strong};
+
+include!(concat!(env!("OUT_DIR"), "/rpc_smoke.rs"));
+
+use rpcsmoke::IRpcSmoke::{BnRpcSmoke, IRpcSmoke};
+
+/// The child blocks in the kernel thread pool forever; reap it however
+/// the test ends, including on a panic.
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+struct KernelSvc;
+impl Interface for KernelSvc {}
+impl IRpcSmoke for KernelSvc {
+    fn r#echo(&self, s: &str) -> rsbinder::status::Result<String> {
+        Ok(format!("kernel:{s}"))
+    }
+    fn r#add(&self, a: i32, b: i32) -> rsbinder::status::Result<i32> {
+        Ok(a + b)
+    }
+    fn r#ping(&self) -> rsbinder::status::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+#[ignore = "requires kernel binder (/dev/binder) + a permissive service manager; run on REMOTE_LINUX/emulator"]
+fn rpc_client_reaches_a_kernel_service_through_a_gateway() {
+    // Child role (C): publish on kernel binder and block.
+    if let Ok(name) = std::env::var("RSB_GW_KERNEL_SERVICE") {
+        rsbinder::serve("binder://")
+            .expect("serve kernel")
+            .add(&name, BnRpcSmoke::new_binder(KernelSvc))
+            .expect("addService (needs a permissive service manager)")
+            .run()
+            .expect("kernel thread pool");
+        std::process::exit(0);
+    }
+
+    let name = format!("rsbinder.test.gw.{}", std::process::id());
+    let mut sock = std::env::temp_dir();
+    sock.push(format!("rsb_gw_kernel.{}.sock", std::process::id()));
+    let _ = std::fs::remove_file(&sock);
+    let uri = format!("unix://{}", sock.display());
+
+    let exe = std::env::current_exe().expect("current_exe");
+    let mut c = std::process::Command::new(exe)
+        .args([
+            "--ignored",
+            "--exact",
+            "rpc_client_reaches_a_kernel_service_through_a_gateway",
+            "--nocapture",
+        ])
+        .env("RSB_GW_KERNEL_SERVICE", &name)
+        .spawn()
+        .expect("spawn kernel service child");
+    let _kill = KillOnDrop(&mut c);
+
+    // B — the gateway: a kernel proxy of C, re-published on a socket.
+    // `connect("binder://…")` waits for the registration (AOSP
+    // `waitForService`), so no sleep is needed here.
+    let upstream: Strong<dyn IRpcSmoke> =
+        rsbinder::connect(&format!("binder://{name}")).expect("kernel lookup");
+    assert!(
+        (*upstream.as_binder()).is_remote(),
+        "the gateway must be fronting a real kernel proxy, not a local node"
+    );
+
+    // Handing that kernel proxy straight to an RPC server is the mistake
+    // the gateway exists to replace — refused here, against a real
+    // `/dev/binder` proxy rather than a hand-built stand-in.
+    let refused = rsbinder::serve(&uri)
+        .expect("serve rpc")
+        .add("smoke", upstream.as_binder())
+        .err();
+    assert_eq!(
+        refused,
+        Some(rsbinder::StatusCode::InvalidOperation),
+        "AC-22.4: a kernel proxy cannot be published on an RPC server"
+    );
+
+    let _b = rsbinder::serve(&uri)
+        .expect("serve rpc")
+        .add("smoke", BnRpcSmoke::new_binder(upstream))
+        .expect("AC-22.12: a kernel proxy wrapped in a Bn* is publishable over RPC")
+        .spawn()
+        .expect("spawn rpc");
+
+    // A — pure RPC; it never learns the kernel exists.
+    let a: Strong<dyn IRpcSmoke> = rsbinder::connect(&format!("{uri}#smoke")).expect("A→B");
+    assert_eq!(
+        a.r#echo("hi").expect("echo through the gateway"),
+        "kernel:hi",
+        "AC-22.12: the answer comes from the kernel service"
+    );
+    assert_eq!(a.r#add(40, 2).expect("add through the gateway"), 42);
+
+    // A oneway call has no reply to wait on; pair it with a twoway call
+    // so the assertion below cannot pass on an unflushed queue.
+    a.r#ping().expect("oneway through the gateway");
+    assert_eq!(a.r#echo("barrier").unwrap(), "kernel:barrier");
+
+    let _ = std::fs::remove_file(&sock);
+}

--- a/tests/tests/gateway_rpc.rs
+++ b/tests/tests/gateway_rpc.rs
@@ -138,7 +138,7 @@ impl Drop for SockPath {
 
 fn msg(seq: i32, origin: &str) -> MeshMessage {
     MeshMessage {
-        r#seq: seq,
+        seq,
         r#nonce: 0xfeed_face,
         r#origin: origin.to_string(),
         r#originKind: NodeKind::RPC,
@@ -303,7 +303,7 @@ fn gateway_rewrapping_a_callback_reaches_the_original_observer() {
             "mesh",
             BnMeshNode::new_binder(RewrappingGateway {
                 upstream: c_proxy,
-                observers: Rewrap::new(|p| BnMeshObserver::new_binder(p)),
+                observers: Rewrap::new(BnMeshObserver::new_binder),
             }),
         )
         .expect("add B")
@@ -475,7 +475,7 @@ impl IMeshNode for Recorder {
 #[test]
 fn rewrap_returns_one_local_object_per_remote() {
     let sock = SockPath::new("rewrap");
-    let rewrap = Rewrap::new(|p| BnMeshObserver::new_binder(p));
+    let rewrap = Rewrap::new(BnMeshObserver::new_binder);
     // The table is inside the service, so probe it through the calls.
     let svc = Recorder {
         rewrap,
@@ -513,7 +513,7 @@ fn rewrap_returns_one_local_object_per_remote() {
 /// the "remote" here is a local binder, which `wrap` treats the same way.
 #[test]
 fn rewrap_holds_nothing_alive_and_collects_dead_entries() {
-    let rewrap: Rewrap<dyn IMeshObserver> = Rewrap::new(|p| BnMeshObserver::new_binder(p));
+    let rewrap: Rewrap<dyn IMeshObserver> = Rewrap::new(BnMeshObserver::new_binder);
     assert!(rewrap.is_empty());
 
     let remote = BnMeshObserver::new_binder(CountingObserver(Arc::new(AtomicI32::new(0))));

--- a/tests/tests/gateway_rpc.rs
+++ b/tests/tests/gateway_rpc.rs
@@ -1,0 +1,418 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Plan 2-22 Phase B — the **gateway**: a process that re-publishes a
+//! service it reached over one transport onto another.
+//!
+//! The whole point is that it costs one line. The generator emits
+//! `impl IFoo for Strong<dyn IFoo>` (delegating through `Deref`) and
+//! rsbinder has a blanket `Interface for Strong<I>`, so a proxy
+//! satisfies `Bn*::new_binder`'s `T: IFoo + Send + Sync + 'static`
+//! bound and becomes a *local* binder this process owns:
+//!
+//! ```ignore
+//! serve(b).add("mesh", BnMeshNode::new_binder(proxy_of_c))
+//! ```
+//!
+//! What it does **not** do is hide the stack boundary: a binder-typed
+//! argument forwarded as-is is still refused (`InvalidOperation`), and
+//! re-wrapping it is the gateway's job. Both halves are pinned here.
+//!
+//! Hermetic, in-process (three sessions over `unix://`), no kernel
+//! binder — runs on macOS. Separate `#![cfg(feature = "rpc")]` binary.
+
+#![cfg(feature = "rpc")]
+#![allow(non_snake_case)]
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicI32, AtomicI64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use rsbinder::{Interface, StatusCode, Strong};
+
+include!(concat!(env!("OUT_DIR"), "/mesh.rs"));
+
+use mesh::IMeshNode::{BnMeshNode, IMeshNode};
+use mesh::IMeshObserver::{BnMeshObserver, IMeshObserver};
+use mesh::MeshMessage::MeshMessage;
+use mesh::MeshValue::MeshValue;
+use mesh::NodeKind::NodeKind;
+
+// ---- the upstream service (node C) ----------------------------------
+
+#[derive(Default)]
+struct MeshNodeImpl {
+    name: String,
+    received: AtomicI32,
+    total: AtomicI64,
+    observers: Mutex<Vec<Strong<dyn IMeshObserver>>>,
+}
+
+impl Interface for MeshNodeImpl {}
+
+impl IMeshNode for MeshNodeImpl {
+    fn r#exchange(&self, req: &MeshMessage) -> rsbinder::status::Result<MeshMessage> {
+        self.received.fetch_add(1, Ordering::Relaxed);
+        Ok(MeshMessage {
+            r#seq: req.r#seq + 1,
+            r#nonce: req.r#nonce,
+            r#origin: self.name.clone(),
+            r#originKind: NodeKind::RPC,
+            r#blob: req.r#blob.clone(),
+        })
+    }
+
+    fn r#accumulate(&self, v: &MeshValue) -> rsbinder::status::Result<i64> {
+        let delta = match v {
+            MeshValue::I(i) => *i as i64,
+            MeshValue::L(l) => *l,
+            MeshValue::S(s) => s.len() as i64,
+        };
+        Ok(self.total.fetch_add(delta, Ordering::Relaxed) + delta)
+    }
+
+    fn r#notify(&self, msg: &MeshMessage) -> rsbinder::status::Result<()> {
+        self.received.fetch_add(1, Ordering::Relaxed);
+        let obs = self.observers.lock().expect("observers").clone();
+        for o in obs {
+            let _ = o.r#onEvent(msg);
+        }
+        Ok(())
+    }
+
+    fn r#registerObserver(&self, obs: &Strong<dyn IMeshObserver>) -> rsbinder::status::Result<()> {
+        self.observers.lock().expect("observers").push(obs.clone());
+        Ok(())
+    }
+
+    fn r#receivedCount(&self) -> rsbinder::status::Result<i32> {
+        Ok(self.received.load(Ordering::Relaxed))
+    }
+}
+
+fn upstream(name: &str) -> Strong<dyn IMeshNode> {
+    BnMeshNode::new_binder(MeshNodeImpl {
+        name: name.to_string(),
+        ..Default::default()
+    })
+}
+
+// ---- an observer A can register -------------------------------------
+
+struct CountingObserver(Arc<AtomicI32>);
+impl Interface for CountingObserver {}
+impl IMeshObserver for CountingObserver {
+    fn r#onEvent(&self, _msg: &MeshMessage) -> rsbinder::status::Result<()> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+// ---- scaffolding ----------------------------------------------------
+
+struct SockPath(PathBuf);
+impl SockPath {
+    fn new(tag: &str) -> Self {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "rsb_gw_{}_{}_{}.sock",
+            tag,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        SockPath(p)
+    }
+    fn uri(&self, frag: &str) -> String {
+        format!("unix://{}{frag}", self.0.display())
+    }
+}
+impl Drop for SockPath {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn msg(seq: i32, origin: &str) -> MeshMessage {
+    MeshMessage {
+        r#seq: seq,
+        r#nonce: 0xfeed_face,
+        r#origin: origin.to_string(),
+        r#originKind: NodeKind::RPC,
+        r#blob: vec![1, 2, 3, 4],
+    }
+}
+
+// ---- AC-22.7: the one-line gateway ----------------------------------
+
+/// A → B → C, where B publishes nothing of its own: it hands the
+/// generator's delegating `impl` straight to `new_binder`. Values must
+/// round-trip through both hops unchanged.
+#[test]
+fn gateway_forwards_calls_with_no_handwritten_delegate() {
+    let c_sock = SockPath::new("c");
+    let b_sock = SockPath::new("b");
+
+    // C — the real service.
+    let _c = rsbinder::serve(&c_sock.uri(""))
+        .expect("serve C")
+        .add("mesh", upstream("node-c"))
+        .expect("add C")
+        .spawn()
+        .expect("spawn C");
+
+    // B — the gateway. One line: connect, then re-publish.
+    let c_proxy: Strong<dyn IMeshNode> = rsbinder::connect(&c_sock.uri("#mesh")).expect("B→C");
+    let _b = rsbinder::serve(&b_sock.uri(""))
+        .expect("serve B")
+        .add("mesh", BnMeshNode::new_binder(c_proxy))
+        .expect("AC-22.7: a proxy wrapped in a Bn* is publishable")
+        .spawn()
+        .expect("spawn B");
+
+    // A — talks only to B, but the answers come from C.
+    let a: Strong<dyn IMeshNode> = rsbinder::connect(&b_sock.uri("#mesh")).expect("A→B");
+
+    let reply = a.r#exchange(&msg(7, "node-a")).expect("exchange");
+    assert_eq!(reply.r#seq, 8, "seq must come back incremented by C");
+    assert_eq!(reply.r#origin, "node-c", "the answer is C's, not B's");
+    assert_eq!(reply.r#nonce, 0xfeed_face, "nonce echoed through both hops");
+    assert_eq!(reply.r#blob, vec![1, 2, 3, 4], "byte array survives 2 hops");
+
+    assert_eq!(a.r#accumulate(&MeshValue::I(5)).unwrap(), 5);
+    assert_eq!(a.r#accumulate(&MeshValue::L(10)).unwrap(), 15);
+    assert_eq!(
+        a.r#accumulate(&MeshValue::S("abc".into())).unwrap(),
+        18,
+        "the accumulator lives in C — B holds no state"
+    );
+
+    assert_eq!(
+        a.r#receivedCount().unwrap(),
+        1,
+        "only `exchange` counts as received"
+    );
+}
+
+// ---- AC-22.8: binder arguments are NOT forwarded for free -----------
+
+/// The gateway's limit, pinned. A binder argument travelling A→B→C is a
+/// proxy of session A being written into a parcel of session C, which
+/// the boundary refuses — the caller sees the failure, and the plain
+/// delegate cannot fix it.
+#[test]
+fn gateway_refuses_a_forwarded_callback() {
+    let c_sock = SockPath::new("cbc");
+    let b_sock = SockPath::new("cbb");
+
+    let _c = rsbinder::serve(&c_sock.uri(""))
+        .expect("serve C")
+        .add("mesh", upstream("node-c"))
+        .expect("add C")
+        .spawn()
+        .expect("spawn C");
+
+    let c_proxy: Strong<dyn IMeshNode> = rsbinder::connect(&c_sock.uri("#mesh")).expect("B→C");
+    let _b = rsbinder::serve(&b_sock.uri(""))
+        .expect("serve B")
+        .add("mesh", BnMeshNode::new_binder(c_proxy))
+        .expect("add B")
+        .spawn()
+        .expect("spawn B");
+
+    let a: Strong<dyn IMeshNode> = rsbinder::connect(&b_sock.uri("#mesh")).expect("A→B");
+    let hits = Arc::new(AtomicI32::new(0));
+    let obs = BnMeshObserver::new_binder(CountingObserver(hits.clone()));
+
+    let err = a
+        .r#registerObserver(&obs)
+        .expect_err("AC-22.8: forwarding a callback binder across sessions must fail");
+    assert_eq!(
+        rsbinder::StatusCode::from(err),
+        StatusCode::InvalidOperation,
+        "AC-22.8: the failure is the stack-boundary refusal, reported to A"
+    );
+}
+
+/// The remedy, and the reason Phase D exists: B re-wraps the callback in
+/// a `Bn*` of its own before passing it on. Then C's `notify` reaches
+/// A's observer — through two hops and two re-wraps.
+#[test]
+fn gateway_rewrapping_a_callback_reaches_the_original_observer() {
+    let c_sock = SockPath::new("rwc");
+    let b_sock = SockPath::new("rwb");
+
+    // A server→client callback needs a connection the server may send on
+    // outside the reply, which is what `incoming_connections` opens (plan
+    // 2-20); it rides the versioned wire, hence `?profile=android13plus`
+    // on both ends of both hops.
+    const A13: &str = "?profile=android13plus";
+    let callback_ready = |o: &mut rsbinder::ClientOptions, _: &rsbinder::Endpoint| {
+        o.incoming_connections = Some(1);
+    };
+
+    let _c = rsbinder::serve(&format!("{}{A13}", c_sock.uri("")))
+        .expect("serve C")
+        .add("mesh", upstream("node-c"))
+        .expect("add C")
+        .spawn()
+        .expect("spawn C");
+
+    // B's delegate overrides exactly one method: the one with a binder
+    // argument. Everything else rides the generated delegation.
+    struct RewrappingGateway(Strong<dyn IMeshNode>);
+    impl Interface for RewrappingGateway {}
+    impl IMeshNode for RewrappingGateway {
+        fn r#exchange(&self, req: &MeshMessage) -> rsbinder::status::Result<MeshMessage> {
+            self.0.r#exchange(req)
+        }
+        fn r#accumulate(&self, v: &MeshValue) -> rsbinder::status::Result<i64> {
+            self.0.r#accumulate(v)
+        }
+        fn r#notify(&self, msg: &MeshMessage) -> rsbinder::status::Result<()> {
+            self.0.r#notify(msg)
+        }
+        fn r#registerObserver(
+            &self,
+            obs: &Strong<dyn IMeshObserver>,
+        ) -> rsbinder::status::Result<()> {
+            // The re-wrap: a *local* binder of B's, delegating to A's
+            // observer. Phase D's helper replaces this hand-written line
+            // and keeps one local object per remote.
+            self.0
+                .r#registerObserver(&BnMeshObserver::new_binder(obs.clone()))
+        }
+        fn r#receivedCount(&self) -> rsbinder::status::Result<i32> {
+            self.0.r#receivedCount()
+        }
+    }
+
+    let b_to_c = rsbinder::Client::open_with(&format!("{}{A13}", c_sock.uri("")), callback_ready)
+        .expect("B→C");
+    let c_proxy: Strong<dyn IMeshNode> = b_to_c.get("mesh").expect("B→C mesh");
+    let _b = rsbinder::serve(&format!("{}{A13}", b_sock.uri("")))
+        .expect("serve B")
+        .add("mesh", BnMeshNode::new_binder(RewrappingGateway(c_proxy)))
+        .expect("add B")
+        .spawn()
+        .expect("spawn B");
+
+    let a_to_b = rsbinder::Client::open_with(&format!("{}{A13}", b_sock.uri("")), callback_ready)
+        .expect("A→B");
+    let a: Strong<dyn IMeshNode> = a_to_b.get("mesh").expect("A→B mesh");
+    let hits = Arc::new(AtomicI32::new(0));
+    let obs = BnMeshObserver::new_binder(CountingObserver(hits.clone()));
+    a.r#registerObserver(&obs)
+        .expect("re-wrapped observer lands");
+
+    a.r#notify(&msg(1, "node-a")).expect("oneway notify");
+
+    // `notify` is oneway on both hops, so wait for the callback rather
+    // than assuming it has already run.
+    for _ in 0..400 {
+        if hits.load(Ordering::SeqCst) > 0 {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        1,
+        "AC-22.8: a re-wrapped callback reaches the original observer"
+    );
+}
+
+// ---- AC-22.13: the gateway reports the upstream's version -----------
+
+mod trunk_v1_gen {
+    include!(concat!(env!("OUT_DIR"), "/trunk_v1.rs"));
+}
+mod trunk_v2_gen {
+    include!(concat!(env!("OUT_DIR"), "/trunk_v2.rs"));
+}
+
+use trunk_v1_gen::android::aidl::test::trunk::ITrunkStableTest::{
+    BnTrunkStableTest as BnTrunkV1, ITrunkStableTest as ITrunkV1,
+    MyParcelable::MyParcelable as V1Parcelable,
+};
+use trunk_v2_gen::android::aidl::test::trunk::ITrunkStableTest::{
+    BnTrunkStableTest as BnTrunkV2, ITrunkStableTest as ITrunkV2,
+};
+
+struct TrunkV1Svc;
+impl Interface for TrunkV1Svc {}
+impl ITrunkV1 for TrunkV1Svc {
+    fn r#repeatParcelable(&self, input: &V1Parcelable) -> rsbinder::status::Result<V1Parcelable> {
+        Ok(input.clone())
+    }
+    fn r#repeatEnum(
+        &self,
+        input: trunk_v1_gen::android::aidl::test::trunk::ITrunkStableTest::MyEnum::MyEnum,
+    ) -> rsbinder::status::Result<
+        trunk_v1_gen::android::aidl::test::trunk::ITrunkStableTest::MyEnum::MyEnum,
+    > {
+        Ok(input)
+    }
+    fn r#repeatUnion(
+        &self,
+        input: &trunk_v1_gen::android::aidl::test::trunk::ITrunkStableTest::MyUnion::MyUnion,
+    ) -> rsbinder::status::Result<
+        trunk_v1_gen::android::aidl::test::trunk::ITrunkStableTest::MyUnion::MyUnion,
+    > {
+        Ok(input.clone())
+    }
+    fn r#callMyCallback(
+        &self,
+        _cb: &Strong<
+            dyn trunk_v1_gen::android::aidl::test::trunk::ITrunkStableTest::IMyCallback::IMyCallback,
+        >,
+    ) -> rsbinder::status::Result<()> {
+        Ok(())
+    }
+}
+
+/// A gateway speaks for the service it fronts, including its *version*.
+///
+/// The trait's `getInterfaceVersion` has a default body returning the
+/// **generating module's** `VERSION`, so a delegate that forgets to
+/// override it still compiles and quietly answers with its own number.
+/// Here C is built from the frozen V1 AIDL (`VERSION` 1, hash
+/// `88311b…`) and B from V2 (`VERSION` 2, hash `notfrozen`) — same
+/// descriptor, so the proxy casts across. A must see **C's** values;
+/// dropping the override in the generated delegating impl turns this
+/// red with 2 / "notfrozen".
+#[test]
+fn gateway_reports_the_upstream_version_and_hash() {
+    let c_sock = SockPath::new("verc");
+    let b_sock = SockPath::new("verb");
+
+    let _c = rsbinder::serve(&c_sock.uri(""))
+        .expect("serve C")
+        .add("trunk", BnTrunkV1::new_binder(TrunkV1Svc))
+        .expect("add C")
+        .spawn()
+        .expect("spawn C");
+
+    // B sees C through the *V2* stub and re-publishes it with the V2 `Bn`.
+    let c_proxy: Strong<dyn ITrunkV2> = rsbinder::connect(&c_sock.uri("#trunk")).expect("B→C");
+    let _b = rsbinder::serve(&b_sock.uri(""))
+        .expect("serve B")
+        .add("trunk", BnTrunkV2::new_binder(c_proxy))
+        .expect("add B")
+        .spawn()
+        .expect("spawn B");
+
+    let a: Strong<dyn ITrunkV2> = rsbinder::connect(&b_sock.uri("#trunk")).expect("A→B");
+    assert_eq!(
+        a.r#getInterfaceVersion().expect("version"),
+        1,
+        "AC-22.13: the gateway reports C's version, not its own module's"
+    );
+    assert_eq!(
+        a.r#getInterfaceHash().expect("hash"),
+        "88311b9118fb6fe9eff4a2ca19121de0587f6d5f",
+        "AC-22.13: and C's hash"
+    );
+}

--- a/tests/tests/gateway_rpc.rs
+++ b/tests/tests/gateway_rpc.rs
@@ -28,6 +28,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicI32, AtomicI64, Ordering};
 use std::sync::{Arc, Mutex};
 
+use rsbinder::bridge::Rewrap;
 use rsbinder::{Interface, StatusCode, Strong};
 
 include!(concat!(env!("OUT_DIR"), "/mesh.rs"));
@@ -261,31 +262,35 @@ fn gateway_rewrapping_a_callback_reaches_the_original_observer() {
         .expect("spawn C");
 
     // B's delegate overrides exactly one method: the one with a binder
-    // argument. Everything else rides the generated delegation.
-    struct RewrappingGateway(Strong<dyn IMeshNode>);
+    // argument. Everything else rides the generated delegation. The
+    // re-wrap goes through `Rewrap`, so the same observer always yields
+    // the same local object (see `rewrap_*` below).
+    struct RewrappingGateway {
+        upstream: Strong<dyn IMeshNode>,
+        observers: Rewrap<dyn IMeshObserver>,
+    }
     impl Interface for RewrappingGateway {}
     impl IMeshNode for RewrappingGateway {
         fn r#exchange(&self, req: &MeshMessage) -> rsbinder::status::Result<MeshMessage> {
-            self.0.r#exchange(req)
+            self.upstream.r#exchange(req)
         }
         fn r#accumulate(&self, v: &MeshValue) -> rsbinder::status::Result<i64> {
-            self.0.r#accumulate(v)
+            self.upstream.r#accumulate(v)
         }
         fn r#notify(&self, msg: &MeshMessage) -> rsbinder::status::Result<()> {
-            self.0.r#notify(msg)
+            self.upstream.r#notify(msg)
         }
         fn r#registerObserver(
             &self,
             obs: &Strong<dyn IMeshObserver>,
         ) -> rsbinder::status::Result<()> {
             // The re-wrap: a *local* binder of B's, delegating to A's
-            // observer. Phase D's helper replaces this hand-written line
-            // and keeps one local object per remote.
-            self.0
-                .r#registerObserver(&BnMeshObserver::new_binder(obs.clone()))
+            // observer. `Rewrap` mints it once and hands the same object
+            // back on every later call for the same observer.
+            self.upstream.r#registerObserver(&self.observers.wrap(obs))
         }
         fn r#receivedCount(&self) -> rsbinder::status::Result<i32> {
-            self.0.r#receivedCount()
+            self.upstream.r#receivedCount()
         }
     }
 
@@ -294,7 +299,13 @@ fn gateway_rewrapping_a_callback_reaches_the_original_observer() {
     let c_proxy: Strong<dyn IMeshNode> = b_to_c.get("mesh").expect("B→C mesh");
     let _b = rsbinder::serve(&format!("{}{A13}", b_sock.uri("")))
         .expect("serve B")
-        .add("mesh", BnMeshNode::new_binder(RewrappingGateway(c_proxy)))
+        .add(
+            "mesh",
+            BnMeshNode::new_binder(RewrappingGateway {
+                upstream: c_proxy,
+                observers: Rewrap::new(|p| BnMeshObserver::new_binder(p)),
+            }),
+        )
         .expect("add B")
         .spawn()
         .expect("spawn B");
@@ -414,5 +425,131 @@ fn gateway_reports_the_upstream_version_and_hash() {
         a.r#getInterfaceHash().expect("hash"),
         "88311b9118fb6fe9eff4a2ca19121de0587f6d5f",
         "AC-22.13: and C's hash"
+    );
+}
+
+// ---- AC-22.11: Rewrap keeps one local object per remote -------------
+
+/// A `Rewrap` server: it hands every observer it is given to `Rewrap` and
+/// records what came back, so a test can ask whether two registrations of
+/// the same remote produced the same local object.
+struct Recorder {
+    rewrap: Rewrap<dyn IMeshObserver>,
+    seen: Mutex<Vec<Strong<dyn IMeshObserver>>>,
+}
+impl Interface for Recorder {}
+impl IMeshNode for Recorder {
+    fn r#exchange(&self, req: &MeshMessage) -> rsbinder::status::Result<MeshMessage> {
+        Ok(req.clone())
+    }
+    fn r#accumulate(&self, _v: &MeshValue) -> rsbinder::status::Result<i64> {
+        Ok(0)
+    }
+    fn r#notify(&self, _msg: &MeshMessage) -> rsbinder::status::Result<()> {
+        Ok(())
+    }
+    fn r#registerObserver(&self, obs: &Strong<dyn IMeshObserver>) -> rsbinder::status::Result<()> {
+        self.seen.lock().expect("seen").push(self.rewrap.wrap(obs));
+        Ok(())
+    }
+    /// Reports how many **distinct** local objects `Rewrap` handed out —
+    /// the number the test cares about. Without the table this equals the
+    /// number of `registerObserver` calls.
+    fn r#receivedCount(&self) -> rsbinder::status::Result<i32> {
+        let seen = self.seen.lock().expect("seen");
+        let mut distinct: Vec<rsbinder::SIBinder> = Vec::new();
+        for s in seen.iter() {
+            let b = s.as_binder();
+            if !distinct.contains(&b) {
+                distinct.push(b);
+            }
+        }
+        Ok(distinct.len() as i32)
+    }
+}
+
+/// AC-22.11. The same remote wrapped twice is the same local binder; a
+/// different remote is a different one. This is what makes an upstream's
+/// `register(cb)` / `unregister(cb)` pair up — without it the second call
+/// names an object the upstream has never seen.
+#[test]
+fn rewrap_returns_one_local_object_per_remote() {
+    let sock = SockPath::new("rewrap");
+    let rewrap = Rewrap::new(|p| BnMeshObserver::new_binder(p));
+    // The table is inside the service, so probe it through the calls.
+    let svc = Recorder {
+        rewrap,
+        seen: Mutex::new(Vec::new()),
+    };
+    let _s = rsbinder::serve(&sock.uri(""))
+        .expect("serve")
+        .add("mesh", BnMeshNode::new_binder(svc))
+        .expect("add")
+        .spawn()
+        .expect("spawn");
+
+    let client = rsbinder::Client::open(&sock.uri("")).expect("open");
+    let node: Strong<dyn IMeshNode> = client.get("mesh").expect("mesh");
+
+    let one = BnMeshObserver::new_binder(CountingObserver(Arc::new(AtomicI32::new(0))));
+    let two = BnMeshObserver::new_binder(CountingObserver(Arc::new(AtomicI32::new(0))));
+
+    node.r#registerObserver(&one).expect("register one");
+    node.r#registerObserver(&one).expect("register one again");
+    node.r#registerObserver(&two).expect("register two");
+
+    // Everything above crossed a real session, so the service saw three
+    // separate proxy arrivals — but two of them name the same remote
+    // object, and `Rewrap` must collapse those onto one wrapper.
+    assert_eq!(
+        node.r#receivedCount().unwrap(),
+        2,
+        "AC-22.11: three registrations of two remotes must yield two wrappers"
+    );
+}
+
+/// The table holds only weak references, so it neither keeps a wrapper
+/// alive nor grows without bound. Driven directly (no session needed):
+/// the "remote" here is a local binder, which `wrap` treats the same way.
+#[test]
+fn rewrap_holds_nothing_alive_and_collects_dead_entries() {
+    let rewrap: Rewrap<dyn IMeshObserver> = Rewrap::new(|p| BnMeshObserver::new_binder(p));
+    assert!(rewrap.is_empty());
+
+    let remote = BnMeshObserver::new_binder(CountingObserver(Arc::new(AtomicI32::new(0))));
+
+    let first = rewrap.wrap(&remote);
+    let second = rewrap.wrap(&remote);
+    assert_eq!(
+        first.as_binder(),
+        second.as_binder(),
+        "AC-22.11: the same remote must map to the same local object"
+    );
+    assert_eq!(rewrap.len(), 1, "one remote, one entry");
+
+    // Nothing else holds the wrapper: dropping both handles must let it go,
+    // because the table's reference is weak.
+    drop(first);
+    drop(second);
+    assert_eq!(
+        rewrap.purge_dead(),
+        1,
+        "AC-22.11: an entry whose wrapper is gone is collected"
+    );
+    assert!(rewrap.is_empty());
+
+    // And a later call mints a fresh one rather than resurrecting.
+    let third = rewrap.wrap(&remote);
+    assert_eq!(rewrap.len(), 1);
+    drop(third);
+
+    // A different remote is a different entry.
+    let other = BnMeshObserver::new_binder(CountingObserver(Arc::new(AtomicI32::new(0))));
+    let a = rewrap.wrap(&remote);
+    let b = rewrap.wrap(&other);
+    assert_ne!(
+        a.as_binder(),
+        b.as_binder(),
+        "AC-22.11: distinct remotes must not collapse onto one wrapper"
     );
 }

--- a/tests/tests/rpc_async.rs
+++ b/tests/tests/rpc_async.rs
@@ -89,7 +89,9 @@ fn run(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>) {
     let handle = rt.handle().clone();
 
     let server = RpcSession::new(server_t, AddressSpace::Acceptor).expect("RpcSession::new");
-    server.set_root(async_root(TokioRuntime(handle.clone())));
+    server
+        .set_root(async_root(TokioRuntime(handle.clone())))
+        .expect("set_root");
     let server_for_thread = server.clone();
     let jh = thread::spawn(move || {
         let _ = server_for_thread.serve_blocking();

--- a/tests/tests/rpc_calling_identity.rs
+++ b/tests/tests/rpc_calling_identity.rs
@@ -65,7 +65,7 @@ fn root() -> SIBinder {
 
 fn run(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>) {
     let server = RpcSession::new(server_t, AddressSpace::Acceptor).expect("RpcSession::new");
-    server.set_root(root());
+    server.set_root(root()).expect("set_root");
     let server_for_thread = server.clone();
     let handle = thread::spawn(move || {
         let _ = server_for_thread.serve_blocking();

--- a/tests/tests/rpc_enforce_permission_deny.rs
+++ b/tests/tests/rpc_enforce_permission_deny.rs
@@ -71,7 +71,7 @@ fn root() -> SIBinder {
 
 fn run(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>) {
     let server = RpcSession::new(server_t, AddressSpace::Acceptor).expect("RpcSession::new");
-    server.set_root(root());
+    server.set_root(root()).expect("set_root");
     let server_for_thread = server.clone();
     let handle = thread::spawn(move || {
         let _ = server_for_thread.serve_blocking();

--- a/tests/tests/rpc_generated_stub.rs
+++ b/tests/tests/rpc_generated_stub.rs
@@ -58,7 +58,7 @@ fn root() -> SIBinder {
 
 fn run(server_t: Box<dyn RpcTransport>, client_t: Box<dyn RpcTransport>) {
     let server = RpcSession::new(server_t, AddressSpace::Acceptor).expect("RpcSession::new");
-    server.set_root(root());
+    server.set_root(root()).expect("set_root");
     let server_for_thread = server.clone();
     let handle = thread::spawn(move || {
         let _ = server_for_thread.serve_blocking();


### PR DESCRIPTION
rsbinder has two IPC stacks — kernel binder (`/dev/binder`) and socket RPC — and a
binder belonging to one cannot travel in a parcel of the other. libbinder refuses all
three such writes with `INVALID_OPERATION`. rsbinder refused one of them and let the
other two through: the write succeeded, the binder was published as a *local* node,
and the failure surfaced later as `UnknownTransaction` on the receiver's first call —
pointing at the wrong process.

On top of that, the structure that legitimately crosses the boundary — a **gateway**,
a process that re-publishes a service it reached over one transport onto another —
was possible but undocumented and expensive: `Bn*::new_binder` takes anything
implementing the interface, but `Strong<dyn IFoo>` did not implement `IFoo`, so every
gateway hand-wrote a delegate with one forwarding method per AIDL method.

## What changed

**Refuse at the boundary** (`3fe908e`). Both missing checks are in, at the same points
libbinder uses (`Parcel::flattenBinder`, `RpcState::onBinderLeaving`). The kernel-side
check sits *before* `flat_binder_object::from`, which calls `ProcessState::as_self()`:
a pure-RPC process must get the rejection, not a panic. The third case — a proxy from
an unrelated RPC session — was already refused but had no test; it has one now.
Registration refuses the same mistake up front: `serve(rpc).add`,
`RpcServer::add_service`, `RpcServer::set_root`, `RpcSession::set_root`.

**A gateway is one line** (`440c2d8`). The generator emits
`impl IFoo for Strong<dyn IFoo>`; rsbinder carries the `Interface` half as a blanket
impl, because `Strong` is ours and not `#[fundamental]`, so a user crate writing it
hits the orphan rule. `#[interface]` renders through the same generator and gains the
delegation for free. The delegating impl overrides `getInterfaceVersion`/`getInterfaceHash`
rather than inheriting the trait defaults, which return the *generating module's*
constants — without the override a gateway compiles and quietly reports its own
version instead of the one it fronts.

**Docs and an example** (`c650dbd`). The book chapter now names all three ways across
the boundary (Accessor, dual-hosting, gateway), states the rule they obey, and spells
out what stops at a gateway: C sees B as its caller, fds need a Unix hop, uid is
unavailable over TCP/vsock, death is two lifetimes, one worker per forwarded call.
`example-hello` gains `gateway_service`.

**A real kernel gate** (`b292ec5`). `A(rpc) → B(gateway) → C(kernel binder)`, `#[ignore]`d,
wired into the Linux binder CI job.

**`bridge::Rewrap`** (`7e69a78`). A gateway forwarding a binder *argument* must re-wrap
it, and doing that inline mints a new object per call — so an upstream pairing
`register(cb)` with `unregister(cb)` by identity never matches the second. `Rewrap` is
the memo table: same live remote in, same local object out, weak on both halves so it
never keeps a wrapper alive.

**Review fixes** (`0c5409e`, `f351dd1`, `a5196e1`). A five-round review of the above;
see those commits for the detail. The substantive ones: the AIDL goldens had not been
updated for the new template block (and `cargo test -p rsbinder-aidl` was missing from
the verification set), three new test binaries were unreachable from CI, `Rewrap`'s
death-link bookkeeping leaked in four places, and two tests could not fail.

`a5196e1` is worth reading on its own. Nothing prunes a dead `Weak` from a proxy's
recipient list, and `link_to_death` subscribes to the kernel only while that list is
empty — so an unlink skipped during cleanup silently costs an unrelated later caller
its death notification on that proxy, with the registration still returning `Ok`.
`Drop` already caught a per-entry panic; `wrap` and `purge_dead` did not, and one
driver hiccup makes that abandonment deterministic (`ProxyHandle::link_to_death` holds
its `recipients` write guard across `talk_with_driver`, which panics on an
under-consumed write buffer and poisons the guard). All three now share one helper
that finishes the list and re-raises for the non-`Drop` callers.

## Breaking

`RpcServer::set_root` and `RpcSession::set_root` return `Result<()>` (was `()`), so
they can report the refusal. An unused `Result` is only a warning, so a build without
`-D warnings` still compiles and the refusal goes unnoticed — add `?` or `.expect(...)`.
Nothing else about them changed. Kernel `hub::add_service` is untouched: re-registering
a proxy with the system service manager is legitimate.

## Verification

Wire format unchanged, so no Android STAGE3 run.

- **macOS**: rsbinder 489 · tests crate all green · rsbinder-aidl 45 · rsbinder-macros
  golden + trybuild · `fmt`/`clippy -D warnings`/`doc` · rpc-off and
  `--no-default-features`
- **Linux (kernel binder + binderfs)**: rsbinder 388 + integration · tests crate 142 +
  integration · clippy with `rpc-vsock`
- **Phase E on real `/dev/binder`**: `gateway_kernel -- --ignored` PASS

Each new guard was mutation-tested and confirmed to fail when removed — including the
silent one: deleting the generated `getInterfaceVersion` override still compiles and
only changes the reported value (2/"notfrozen" instead of 1/"88311b…"), which the
trunk-stable fixture catches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

