### PR TITLE
docs: prepare the 0.11.0 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,6 +287,21 @@ jobs:
           # here rather than beside the primitives.
           cargo test -p tests --features rpc,macros --test data_serde
 
+      - name: Data-serialization example (`.aidl` path — runs, not just builds)
+        # `serde_demo` is the one example that needs no binder device, no
+        # service manager and no peer, so CI can actually *run* it instead of
+        # only compiling it. Its asserts are the book's *Storing Values*
+        # claims — the round trip, both directions of version skew across an
+        # appended `.aidl` field, the strict read, and the write-time fd
+        # refusal — so a regression in any of them fails here rather than in a
+        # reader's terminal.
+        #
+        # `--features rpc` only, deliberately: `data_serde` above covers the
+        # `macros` declaration and this covers the `.aidl` one, which is the
+        # path the chapter is written around and the one every non-Rust
+        # consumer would use.
+        run: cargo run -p example-hello --features rpc --bin serde_demo
+
       - name: V5 parallel-safety soak (default test-threads, 5x)
         run: |
           for i in 1 2 3 4 5; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This changelog starts at 0.9.0. For earlier releases, see the
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-09-09
+
 ### Migrating from 0.10.0
 
 The short form of this release's breaking changes; *Changed* and *Removed*
@@ -371,7 +373,8 @@ a big-endian host.
   Forward compatibility comes from the parcelable's length header, so wrap
   what you store in a parcelable rather than storing a bare scalar. Behind
   the `rpc` feature, which is where the parcel mode it uses lives. See the
-  book's *Storing Values*.
+  book's *Storing Values*, and `example-hello`'s `serde_demo` for the whole
+  thing running against real `.aidl` definitions.
 
 - **rsbinder:** a **gateway** is now one line. `Strong<I>` implements
   `Interface` (delegating to the binder it holds), and generated interfaces —
@@ -1019,6 +1022,20 @@ a big-endian host.
   remains public. `Parcel::set_for_rpc` is `pub(crate)` as well: production
   code reaches the RPC mode through the session, and `rsbinder::to_bytes`
   covers the data case.
+- **rsbinder (kernel binder):** a driver that consumed only part of the queued
+  command buffer used to `panic!`; it now writes the diagnosis to stderr and
+  **aborts the process**, as AOSP `LOG_ALWAYS_FATAL`s there. The remainder was
+  never seen by the kernel, so the reference counts and buffer ownership this
+  process believes in are no longer the kernel's — and a panic was not a way
+  out, because the reply path's `catch_unwind` would catch it and resume
+  transacting on that desynchronized stream. stderr rather than `log`, so a
+  consumer that installed no logger does not die mute.
+- **rsbinder (kernel binder):** a failed `BINDER_WRITE_READ` now names the
+  command the driver refused. The errno alone cannot tell a caller's bug from
+  a driver one, and `write_consumed` is the offset the driver gave up at — so
+  the command starting there is decoded into the log line, and an
+  over-released proxy's `BC_RELEASE` or a `BC_FREE_BUFFER` for a buffer
+  already returned now says which it was.
 
 ### Removed
 
@@ -1723,6 +1740,14 @@ a big-endian host.
   `to_bytes` on a `ParcelableHolder` read out of an RPC transaction now
   returns `BadType` instead of bytes; resolving it first with
   `get_parcelable::<T>` gives a value that encodes as usual.
+- **rsbinder (kernel binder):** a caught panic on the reply path leaked a
+  kernel transaction buffer. The recovery truncated the whole outgoing command
+  parcel to drop the half-written `BC_REPLY` — but on a looper thread
+  `flush_if_needed` never flushes, so a nested call's `BC_FREE_BUFFER` could
+  still be queued in the same parcel, and dropping it left the kernel holding
+  a buffer nothing would ever reclaim. The recovery now rewinds to the mark
+  taken before the reply was written, as the normal failure path and
+  `transact` already did.
 
 ## [0.10.0] - 2026-07-11
 
@@ -2020,6 +2045,7 @@ A large body of correctness work from multiple review and audit rounds
 - Addressed RUSTSEC-2025-0134 by replacing `rustls-pemfile` with
   `rustls-pki-types`.
 
-[Unreleased]: https://github.com/hiking90/rsbinder/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/hiking90/rsbinder/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/hiking90/rsbinder/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/hiking90/rsbinder/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/hiking90/rsbinder/compare/v0.8.0...v0.9.0

--- a/README.md
+++ b/README.md
@@ -95,6 +95,27 @@ Write service registration and lookup **once** and pick kernel binder or RPC by 
 
 See [Cross-Transport Services](book/src/cross-transport-services.md), [Security & Authorization](book/src/security.md), and [Async Service](book/src/async-service.md) in the book.
 
+## Interfaces without `.aidl`
+
+For an rsbinder ↔ rsbinder interface, `#[rsbinder::interface]` declares it as a plain Rust trait — no `.aidl` file, no `build.rs`, no generated-code directory. `&mut T` is an out parameter, `Option<T>` is nullable, `#[oneway]` drops the reply. `#[derive(Parcelable)]` and `#[derive(BinderEnum)]` do the same for the data types.
+
+```rust
+#[rsbinder::interface(descriptor = "com.example.IHello")]
+pub trait IHello {
+    fn echo(&self, msg: &str) -> rsbinder::BinderResult<String>;
+}
+```
+
+Not a second code generator: the macros run the same templates as the AIDL front-end, so a trait here and the equivalent `.aidl` produce **byte-for-byte identical** code. `.aidl` stays canonical for anything an Android tool or another language reads. Opt in with the `macros` feature; see [Interface Macros](book/src/interface-macros.md).
+
+## Storing values
+
+`rsbinder::to_bytes` / `from_bytes` write a value the way its interface already describes it, so an AIDL schema can be a file format too and a project need not maintain a second description in protobuf or serde. The bytes are the IPC bytes, and the wire is fixed little-endian, so a file written on an aarch64 phone reads on an x86_64 server. Binders and file descriptors are refused at write time rather than stored as something that refers to nothing. Needs the `rpc` feature; see [Storing Values](book/src/data-serialization.md).
+
+```
+$ cargo run -p example-hello --features rpc --bin serde_demo   # no device, no socket
+```
+
 ## Prerequisites to build and test
 
 There are two transport paths. Pick whichever fits your environment.
@@ -168,6 +189,9 @@ Complete API parity is not a goal — rsbinder's architecture differs from `libb
 - [x] Tokio async support.
 - [x] Removed all `todo!()` / `unimplemented!()` macros.
 - [x] Compatibility testing with Binder on Android.
+- [x] Shared memory (`IMemory` / `MemoryHeapBase` / `MemoryDealer`).
+- [x] Interface macros — `#[rsbinder::interface]` without `.aidl`.
+- [x] Parcel data serialization (`to_bytes` / `from_bytes`).
 
 **RPC transport**
 - [x] RPC transport (binder-over-socket).

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -12,6 +12,7 @@
     - [Parcelable](./aidl-parcelable.md)
     - [Enum and Union](./aidl-enum-union.md)
     - [Annotations](./aidl-annotations.md)
+- [Interface Macros (no `.aidl`)](./interface-macros.md)
 - [Service Development](./service-development.md)
     - [Service Patterns](./service-patterns.md)
     - [Async Service](./async-service.md)

--- a/book/src/aidl-annotations.md
+++ b/book/src/aidl-annotations.md
@@ -1,8 +1,8 @@
 # AIDL Annotations
 
-AIDL annotations modify how the code generator produces Rust code from `.aidl` files. They control everything from trait derivation and backing types to nullability and interface stability. This chapter covers the annotations relevant to the Rust backend in rsbinder, with examples showing how each annotation affects the generated code.
+Annotations modify what the code generator emits from an `.aidl` file — trait derivation, backing types, nullability, interface stability. Some that AOSP enforces are recognized here but not checked; each section below says which.
 
-If you are new to AIDL data types, read the [AIDL Data Types](./aidl-data-types.md) chapter first. Annotations build on those type mappings by adding metadata that changes how types are generated, serialized, or constrained.
+If you have not read [AIDL Data Types](./aidl-data-types.md) yet, start there: annotations adjust those mappings rather than replacing them.
 
 ## @RustDerive
 
@@ -157,12 +157,12 @@ pub struct RecursiveList {
 
 The `Box` indirection is necessary because without it, `RecursiveList` would contain itself directly, making the type infinitely large.
 
-In rsbinder, the `Box<T>` wrapping is driven by **self-reference detection in
-the code generator**, not by the `heap=true` parameter — the parameter is
-accepted for AOSP-faithful AIDL syntax compatibility but does not itself
-control the wrapping. Whenever a parcelable field references the enclosing
-parcelable's own type, the generator emits `Box<...>` around it to give the
-struct a known size. Keep the `heap=true` form when writing AIDL that must
+In rsbinder the `Box<T>` comes from the generator's own **cycle analysis**, not
+from `heap=true`, which is accepted for AOSP syntax compatibility and then
+ignored. A field is boxed whenever it can reach its own enclosing type by
+value — a cycle of any length, not just a direct self-reference — and is left
+alone when the path runs through an interface handle or a `Vec` element, which
+already keep the type finite. Keep writing `heap=true` if the same AIDL must
 also compile under the AOSP toolchain.
 
 For non-recursive optional fields, plain `@nullable` is sufficient and avoids the extra heap allocation.
@@ -312,14 +312,12 @@ exist so every method can declare its permission posture).
 
 ## Summary
 
-The following table provides a quick reference for all annotations covered in this chapter.
-
 | Annotation | Applies To | Rust Effect |
 |------------|------------|-------------|
 | `@RustDerive` | parcelable, union | Adds `derive` attributes (`Clone`, `Copy`, `PartialEq`) |
 | `@Backing` | enum | Sets the backing integer type (`i8`, `i32`, `i64`) |
 | `@nullable` | field, param, return | Maps to `Option<T>` |
-| `@nullable(heap=true)` | field | AOSP-faithful syntax for recursive fields; rsbinder boxes self-referential fields automatically (parameter accepted but not required) |
+| `@nullable(heap=true)` | field | `heap=true` is ignored; rsbinder boxes a field its own cycle analysis finds recursive |
 | `@utf8InCpp` | String | No effect in Rust (strings are always UTF-8) |
 | `@Descriptor` | interface | Overrides the wire descriptor string |
 | `@VintfStability` | parcelable, interface | Stamps `Stability::Vintf`; structural constraints not enforced |

--- a/book/src/aidl-data-types.md
+++ b/book/src/aidl-data-types.md
@@ -2,8 +2,6 @@
 
 AIDL (Android Interface Definition Language) defines the interface contract between a Binder service and its clients. When you write an `.aidl` file, `rsbinder-aidl` generates Rust code that maps each AIDL type to the corresponding Rust type. Understanding these mappings is essential for implementing services and calling them correctly from client code.
 
-This chapter covers the supported AIDL data types, how they map to Rust, and common patterns you will encounter when working with rsbinder.
-
 ## Primitive Types
 
 The following table shows how AIDL primitive types map to Rust types. Input parameters (`in`) are passed by value or by reference. Only *non-scalar* types — arrays, parcelables, and nullable references — may be `out`/`inout`; the generator rejects a primitive or a `String` marked `out`/`inout` at compile time (it has no fixed slot to write back into).
@@ -21,8 +19,10 @@ The following table shows how AIDL primitive types map to Rust types. Input para
 | @utf8InCpp String | &str | — (not allowed) | Same mapping in rsbinder |
 | T[] | &[T] | &mut Vec\<T\> | |
 | @nullable T | Option\<&T\> | &mut Option\<T\> | A nullable `String` input is `Option<&str>` |
-| IBinder | &SIBinder | | |
-| ParcelFileDescriptor | &ParcelFileDescriptor | | |
+| @nullable T[] | Option\<&[T]\> | &mut Option\<Vec\<T\>\> | For a primitive or enum element. A non-primitive element keeps its own `Option`: `&mut Option<Vec<Option<T>>>` |
+| IBinder | &SIBinder | &mut Option\<SIBinder\> | |
+| ParcelFileDescriptor | &ParcelFileDescriptor | &mut Option\<ParcelFileDescriptor\> | |
+| An interface | &Strong\<dyn I\> | &mut Option\<Strong\<dyn I\>\> | |
 
 Here is an AIDL interface that exercises the primitive types:
 
@@ -181,20 +181,8 @@ Use `inout` when the service needs to read the existing value and modify it in p
 
 ## Tips
 
-Here are a few practical details to keep in mind when working with AIDL data types in rsbinder:
-
-- **The `byte` type has a subtle difference between single values and arrays.** A single `byte` parameter maps to `i8` (signed), but when used in the `ReverseByte` pattern, array elements use `u8` (unsigned). This matches Android's Binder behavior where byte arrays are treated as unsigned.
-
-- **Rust strings are always UTF-8, so `@utf8InCpp` has no special behavior.** In Android's C++ backend, this annotation switches between `String16` (UTF-16) and `std::string` (UTF-8). Since Rust's `String` type is inherently UTF-8, both `String` and `@utf8InCpp String` produce identical code.
-
-- **Arrays in AIDL map to slices for input and `Vec` for output.** Input arrays use `&[T]`, which is efficient because no allocation is needed on the caller side. Output arrays and return values use `Vec<T>`, giving the service ownership of the returned data.
-
-- **Nullable types use `Option`.** This is idiomatic Rust and avoids the null pointer pitfalls found in C++ and Java Binder implementations. Always check for `None` on the client side when calling methods that return nullable types.
-
-- **Direction tags affect performance.** An `inout` parameter requires serialization in both directions. If you only need data to flow one way, use `in` or `out` to reduce the amount of data copied over the Binder transaction.
-
-- **Return values are always `Result`.** Every AIDL method in rsbinder returns `rsbinder::BinderResult<T>`, allowing services to report errors using `Status` codes. Even void methods return `rsbinder::BinderResult<()>`.
-
-- **`char` is UTF-16, not UTF-8.** The AIDL `char` type maps to Rust's `u16`, representing a single UTF-16 code unit. This is not the same as Rust's native `char` type, which is a Unicode scalar value. Be mindful of this difference when working with character data.
+- **`char` is not Rust's `char`.** AIDL `char` is one UTF-16 code unit and maps to `u16`; Rust's `char` is a Unicode scalar value. They are not interchangeable.
+- **`byte` is signed alone and unsigned in an array.** A `byte` parameter is `i8`, but `byte[]` elements are `u8` — matching how Android treats byte arrays.
+- **Every method returns `BinderResult<T>`,** a void one included (`BinderResult<()>`), because any call can fail in transport.
 
 For more information on AIDL syntax and features, refer to the [Android AIDL documentation](https://source.android.com/docs/core/architecture/aidl).

--- a/book/src/aidl-enum-union.md
+++ b/book/src/aidl-enum-union.md
@@ -1,8 +1,6 @@
 # Enum and Union
 
-AIDL supports two powerful type constructs beyond simple interfaces and parcelables: **enums** and **unions**. Enums provide named integer constants with type safety, while unions represent a value that can be one of several different types. Both are fully supported by rsbinder's AIDL compiler and map naturally to Rust constructs.
-
-This chapter covers how to define enums and unions in AIDL, how they translate to Rust code, and how to use them in practice.
+Beyond interfaces and parcelables, AIDL has **enums** — named integer constants — and **unions** — a value that is one of several types at a time. Both map onto Rust, though the enum mapping is not the one you would guess.
 
 ## Enum Types
 
@@ -220,15 +218,11 @@ union UnionInUnion {
 
 This allows building complex tagged-value hierarchies that are fully type-safe on the Rust side.
 
-## Tips and Best Practices
+## Tips
 
-- **Specify `@Backing` explicitly** for enums. It is optional (the default is `byte`), but stating it makes the wire format and the Rust integer type unambiguous to readers.
-- **The union default is always the first field.** Order your fields accordingly, placing the most common or natural default first.
-- **Use `@RustDerive(Clone=true, PartialEq=true)`** on unions so they can be compared and cloned in Rust. Without this, you cannot use `==` or `.clone()` on union values.
-- **Union constants are module-level**, not variants. Access them as `Union::S1`, not through any variant.
-- **Enum `enum_values()`** returns all defined constants, which is useful for exhaustive testing or validation loops.
-- **Forward compatibility**: Because AIDL enums are backed by integers, a service may receive values not defined in the current enum. Design your code to handle unknown values gracefully.
-- **Tag enums** use lowercase field names (e.g., `Union::Tag::ns`, not `Union::Tag::Ns`), matching the original AIDL field names.
+- **Specify `@Backing` explicitly.** It is optional — the default is `byte` — but stating it makes the wire format unambiguous to a reader.
+- **Handle values you never declared.** An AIDL enum is an integer on the wire, so a peer built against a newer definition can send one the current enum does not name. That is the point of the newtype mapping; do not assume the set is closed.
+- **Tags keep the AIDL field names**, so they are lowercase: `Union::Tag::ns`, not `Union::Tag::Ns`.
 
 ## Further Reading
 

--- a/book/src/aidl-guide.md
+++ b/book/src/aidl-guide.md
@@ -4,6 +4,8 @@ AIDL (Android Interface Definition Language) is the contract between a Binder se
 
 If you have not yet seen rsbinder running end-to-end, read [Hello, World!](./hello-world.md) first — it shows where AIDL fits into a complete project.
 
+> With rsbinder on both ends, [Interface Macros](./interface-macros.md) declares the same interface as a Rust trait instead — same compiler, same generated code. Read this guide either way: it describes the type system both paths share.
+
 ## Chapters
 
 - **[Data Types](./aidl-data-types.md)** — Primitive, string, array, list, map, and interface types, and how each one maps to Rust on the `in` / `out` / `inout` side. Start here.
@@ -11,13 +13,4 @@ If you have not yet seen rsbinder running end-to-end, read [Hello, World!](./hel
 - **[Enum and Union](./aidl-enum-union.md)** — Backed enums (newtype structs in Rust, for wire-stable forward compatibility) and unions (tagged variants).
 - **[Annotations](./aidl-annotations.md)** — `@RustDerive`, `@nullable`, `@Backing`, `@JavaDerive`-equivalents, and the other annotations the Rust backend honors.
 
-## How to use this guide
-
-The chapters are roughly ordered by how often you need each topic when building a new service:
-
-1. Skim **Data Types** so you know what AIDL primitives translate to in Rust.
-2. Read **Parcelable** when you need to pass structured data.
-3. Reach for **Enum and Union** when designing variant payloads or constant sets.
-4. Consult **Annotations** as a reference whenever the generated Rust does not look the way you expect.
-
-Once you are comfortable with the AIDL surface, move on to [Service Development](./service-development.md) for the runtime patterns that put these types to work.
+Read them in that order the first time; *Annotations* is a reference to come back to when the generated Rust does not look the way you expected. Then move on to [Service Development](./service-development.md) for the runtime patterns that put these types to work.

--- a/book/src/aidl-parcelable.md
+++ b/book/src/aidl-parcelable.md
@@ -1,8 +1,6 @@
 # Parcelable
 
-Parcelable types are user-defined data structures that can be serialized and sent across Binder IPC boundaries. They are defined in AIDL `.aidl` files, and the `rsbinder-aidl` code generator automatically produces Rust structs from them. Parcelable types are the primary way to pass structured data between a Binder service and its clients.
-
-Unlike primitive types (such as `int`, `String`, or `boolean`), which AIDL handles natively, parcelable types let you group related fields into a single, coherent structure. This is essential for any non-trivial service interface.
+A parcelable is a user-defined struct that can cross the Binder boundary. You declare it in an `.aidl` file and `rsbinder-aidl` generates the Rust struct and its codec — it is how any non-trivial interface passes structured data.
 
 ## Basic Parcelable Definition
 
@@ -137,7 +135,7 @@ When the client passes `None`, the service receives `None` and can return `None`
 
 ## Recursive Structures
 
-AIDL supports self-referential parcelable types. In AOSP-faithful AIDL the recursive field is marked `@nullable(heap=true)`, signalling to the C++ and Java backends that the inner value lives on the heap so the struct has a finite, known size at compile time. rsbinder accepts the same syntax for source compatibility, but the actual `Box<T>` wrapping is emitted by the code generator whenever a field references the enclosing parcelable's own type — the `heap=true` parameter is not what triggers it.
+AIDL supports self-referential parcelable types. In AOSP-faithful AIDL the recursive field is marked `@nullable(heap=true)`, signalling to the C++ and Java backends that the inner value lives on the heap so the struct has a finite, known size at compile time. rsbinder accepts the same syntax for source compatibility but ignores `heap=true`: it boxes a field whenever that field can reach its own enclosing type by value, which covers a cycle of any length, not only a direct self-reference. A type reached through an interface handle or a `Vec` element keeps the enclosing type finite and is not boxed.
 
 AIDL definition (from `RecursiveList.aidl` in the test suite):
 
@@ -148,7 +146,7 @@ parcelable RecursiveList {
 }
 ```
 
-This generates a Rust struct where `next` has the type `Option<Box<RecursiveList>>`. The `@nullable` part makes it `Option`, and the self-reference detection adds the `Box` wrapper that gives the type a known size. Together they enable a linked-list pattern.
+This generates a Rust struct where `next` has the type `Option<Box<RecursiveList>>`: `@nullable` makes it `Option`, and the cycle analysis adds the `Box`.
 
 Rust usage (based on the `test_reverse_recursive_list` test):
 
@@ -247,13 +245,11 @@ Key points about `ParcelableHolder`:
 
 ## Tips
 
-Here are some practical guidelines when working with parcelable types in rsbinder:
-
 - **Always use `@RustDerive(Clone=true)`** if you need to clone parcelable values. This is required for patterns like `input.cloned()` with nullable parameters. Only add it when all fields in the parcelable actually implement `Clone`.
 
 - **Use `@RustDerive(PartialEq=true)`** when you need to compare parcelable instances in assertions or business logic. As with `Clone`, all fields must implement `PartialEq`.
 
-- **`@nullable(heap=true)` is required for recursive types.** Without it, the compiler will reject the type due to infinite size. Use this annotation on any self-referential field.
+- **`@nullable` is what you need on a recursive field, not `heap=true`.** Write `heap=true` for source compatibility with AOSP if you like, but rsbinder-aidl ignores it: the `Box` comes from the generator's own cycle analysis, and the `Option` comes from `@nullable`.
 
 - **Default values in AIDL translate to Rust's `Default` trait.** When you write `int count = 5;` in AIDL, calling `MyParcelable::default()` in Rust will produce a struct with `count` set to `5`.
 
@@ -270,4 +266,4 @@ Here are some practical guidelines when working with parcelable types in rsbinde
 
 - **Place each parcelable in its own `.aidl` file.** Following the AIDL convention, each parcelable type should be defined in a separate file whose name matches the type name (e.g., `UserProfile.aidl` for `parcelable UserProfile`).
 
-- **Constants are scoped to the parcelable's module.** When you define `const int MAX_VALUE = 100;` inside a parcelable, access it in Rust as `MyParcelable::MAX_VALUE`, where `MyParcelable` is the generated *module* (import the module, not the struct — the struct itself is `MyParcelable::MyParcelable`). This keeps related constants close to the data they describe.
+- **Constants live on the generated module, not the struct.** Import the module: `MyParcelable::MAX_VALUE` is the constant and `MyParcelable::MyParcelable` is the struct. Importing the struct directly hides the constants.

--- a/book/src/android-build.md
+++ b/book/src/android-build.md
@@ -1,6 +1,6 @@
 # Android Build Environment Setup
 
-This guide will help you set up a complete Android development environment for building and testing **rsbinder** applications.
+What you need to build and test **rsbinder** on Android: the SDK for `adb` and the emulator, the NDK for the native toolchain, and `cargo-ndk` to drive them from cargo.
 
 ## Prerequisites
 
@@ -49,6 +49,11 @@ $ sdkmanager "ndk;26.1.10909125"
 # Check for the latest available version:
 $ sdkmanager --list | grep ndk
 ```
+
+> Use **r27 or later** if you target a device or emulator image with 16 KB
+> memory pages (Android 15 and up). Earlier NDKs link binaries such an image
+> refuses to load. CI builds with r26c, which is fine for the 4 KB images it
+> runs.
 
 #### Method 3: Direct Download
 Download from the [NDK Downloads page](https://developer.android.com/ndk/downloads) and extract manually.

--- a/book/src/android.md
+++ b/book/src/android.md
@@ -1,6 +1,6 @@
 # Android Development
 
-**rsbinder** provides comprehensive support for Android development alongside Linux. Since Android already has a complete Binder IPC environment, you can use **rsbinder**, **rsbinder-aidl**, and the existing Android service manager directly. There's no need to create binder devices or run a separate service manager like on Linux.
+Android already has a complete Binder IPC environment, so **rsbinder** and **rsbinder-aidl** use the existing device nodes and service manager directly. Nothing here needs `rsb_device` or `rsb_hub`, which exist for Linux.
 
 For building in the Android environment, you need to install the Android NDK and set up a Rust build environment that utilizes the NDK.
 
@@ -33,7 +33,7 @@ In your `Cargo.toml`, specify the Android versions you want to support:
 
 ```toml
 [dependencies]
-rsbinder = { version = "0.10", features = ["android_14_plus"] }
+rsbinder = { version = "0.11", features = ["android_14_plus"] }
 ```
 
 Available feature combinations:
@@ -84,7 +84,7 @@ println!("Running on Android {}", version);
 Add `rsproperties` to your dependencies:
 ```toml
 [dependencies]
-rsproperties = "0.5"
+rsproperties = "0.6"
 ```
 
 ### Using Android's Existing Binder Devices
@@ -116,11 +116,14 @@ You do not need to run `rsb_hub` on Android — the system already provides serv
 
 ### Android-Specific Considerations
 
-- **Service Manager**: Uses Android's existing service manager automatically
-- **Permissions**: Respects Android's security model and SELinux policies
-- **Threading**: Integrates with Android's Binder thread pool management
-- **Memory**: Uses Android's shared memory mechanisms (ashmem/memfd)
-- **Stability**: Supports Android's interface stability annotations (@VintfStability)
+- **SELinux** applies as it does to any other process: a denial surfaces as a
+  failed `open` of the device or a refused transaction, not as an rsbinder
+  error.
+- **Shared memory** is allocated with `memfd_create`; a peer's legacy
+  `/dev/ashmem` fd is accepted on the way in. See
+  [Shared Memory](./shared-memory.md).
+- **`@VintfStability`** is honored, including the stability check a
+  `ParcelableHolder` carries on the wire.
 
 ### JNI Integration
 

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -122,3 +122,28 @@ canonical example):
   [Cross-Transport Services § Bridging](./cross-transport-services.md).
 
 See [RPC Transport](./rpc-transport.md) for the full story.
+
+## Parcel byte order
+
+**The data-parcel wire is little-endian on every host**, so a parcel written on
+one machine reads on another and the bytes match what Android's `libbinder`
+sends for the same value. On a little-endian host — every Android target and
+almost every Linux one — this costs nothing; a big-endian host pays a byte
+swap.
+
+Not every byte in a parcel is wire:
+
+| Layer | What | Byte order |
+|---|---|---|
+| Data parcel | scalars, arrays, `String`, the object-free payload | **little-endian** |
+| Kernel command stream | the `BC_*` / `BR_*` ioctl buffer | host-native |
+| UAPI structs | `flat_binder_object`, `binder_transaction_data` | host-native |
+
+The lower two go to the kernel driver, which parses them with native loads. So
+on a big-endian host a *kernel* parcel carrying a binder is a mixture —
+little-endian scalars around a native object header — which is correct: the
+scalars cross to a peer, the object header does not.
+
+The RPC path is verified on big-endian under qemu-user (s390x). The kernel path
+is structurally correct there but unverified, because no big-endian system
+ships binderfs to run it on.

--- a/book/src/async-service.md
+++ b/book/src/async-service.md
@@ -2,9 +2,7 @@
 
 rsbinder supports async/await with the [Tokio](https://tokio.rs/) runtime, making it
 straightforward to build non-blocking Binder services. The `tokio` feature is enabled by
-default in rsbinder, so no extra feature flags are required for most projects. This chapter
-explains how to implement async Binder services, how they differ from their synchronous
-counterparts, and the patterns you will encounter when working with them.
+default in rsbinder, so no extra feature flags are required for most projects.
 
 If you have not yet read the [Hello, World!](./hello-world.md) chapter, it is recommended to
 do so first -- the async concepts here build on the synchronous service and client covered
@@ -354,19 +352,19 @@ runtime.block_on(async {
     let service = BnTestService::new_async_binder(
         TestService::default(), rt(),
     );
-    hub::add_service(service_name, service.as_binder())
+    hub::add_service(service_name, &service)
         .expect("Could not register service");
 
     let versioned_service = BnFooInterface::new_async_binder(
         FooInterface, rt(),
     );
-    hub::add_service(versioned_service_name, versioned_service.as_binder())
+    hub::add_service(versioned_service_name, &versioned_service)
         .expect("Could not register service");
 
     let nested_service = INestedService::BnNestedService::new_async_binder(
         NestedService, rt(),
     );
-    hub::add_service(nested_service_name, nested_service.as_binder())
+    hub::add_service(nested_service_name, &nested_service)
         .expect("Could not register service");
 
     // All services are now registered. Yield to the runtime.
@@ -463,35 +461,20 @@ macro_rules! impl_repeat {
 }
 ```
 
-## Tips and Best Practices
+## Tips
 
-- **Use `#[async_trait]`** from the `async-trait` crate for all async trait implementations.
-  This is required because Rust does not yet have native async trait support in all contexts
-  that rsbinder needs.
-
-- **`into_async::<Tokio>()`** converts a synchronous proxy into an async proxy. Always use
-  this when calling another Binder service from an async context, rather than making blocking
-  calls that could stall the Tokio runtime.
-
-- **`std::future::pending().await`** is the idiomatic way to keep an async service process
-  alive. Unlike the sync approach where `ProcessState::join_thread_pool()` blocks the main
-  thread, the async approach yields to Tokio so the runtime can drive spawned tasks.
-
-- **The `rt()` helper should capture the current runtime handle.** Define it as a function
-  that returns `TokioRuntime(tokio::runtime::Handle::current())` and call it from within the
-  Tokio runtime context.
-
-- **Both sync and async services can coexist in the same process.** You can register some
-  services with `new_binder` and others with `new_async_binder`. They share the same Binder
+- **The runtime flavor is decided by the transport, not by taste.** Kernel
+  binder can use `new_current_thread()`, because the binder thread pool already
+  supplies the worker threads. An **RPC** server must use
+  `new_multi_thread()` — its serve worker calls `rt.block_on(handler)` from a
+  thread outside the runtime, which a `current_thread` runtime cannot serve.
+- **Never block inside an async method.** A CPU-bound or blocking call belongs
+  in `tokio::task::spawn_blocking`, and a call to another binder service
+  belongs behind `into_async::<Tokio>()` — a blocking proxy call from an async
+  method stalls the executor thread.
+- **Sync and async services coexist in one process.** Register some with
+  `new_binder` and others with `new_async_binder`; they share the same binder
   thread pool.
-
-- **Prefer `new_current_thread()`** for the Tokio runtime builder. The Binder thread pool
-  handles multi-threaded transaction dispatching already, so a multi-threaded Tokio runtime
-  is typically unnecessary.
-
-- **Avoid blocking the Tokio runtime.** If your async service method must perform a
-  CPU-intensive or blocking operation, use `tokio::task::spawn_blocking` to move that work
-  off the async executor thread.
 
 ## Summary
 

--- a/book/src/callbacks-and-interfaces.md
+++ b/book/src/callbacks-and-interfaces.md
@@ -2,8 +2,6 @@
 
 Binder IPC is not limited to one-way requests from client to service. Through callback interfaces, a client can pass a Binder object to a service, and the service can call methods on that object. This enables bidirectional communication across process boundaries without requiring the client to register itself as a separate service.
 
-This chapter covers how to define callback interfaces in AIDL, implement them in Rust, manage collections of callbacks, pass raw `IBinder` objects, work with nested interface types, and monitor remote service lifecycle with death recipients.
-
 ## Defining a Callback Interface
 
 A callback interface is a regular AIDL interface. The only difference is in how it is used: instead of being registered with the service manager, it is created by one process and passed to another through a method call.
@@ -259,7 +257,7 @@ assert_eq!(*received, Some(ParcelableWithNested::Status::Status::OK));
 
 The key detail is the fully-qualified path for the nested callback's Binder node: `INestedService::ICallback::BnCallback`. This follows the Rust module hierarchy generated from the AIDL nesting structure.
 
-Note that a client passing a callback object to a service must run a binder thread pool — call `ProcessState::start_thread_pool()` (or park a thread in `join_thread_pool()`) — because the service's `done(..)` invocation arrives as an *inbound* transaction into the client process.
+`done(..)` arrives as an inbound transaction into the client, so a client that passes a callback needs its binder thread pool running.
 
 ### Service-Side Nested Callback Handling
 
@@ -311,50 +309,44 @@ The `binder_died` method is called when the remote process hosting the Binder ob
 
 ### Registering and Unregistering
 
-Death recipients are registered using `link_to_death` and unregistered using `unlink_to_death`. Both methods take a `Weak<dyn DeathRecipient>` reference:
+`link_to_death_arc` takes your `Arc` directly and is what you normally want:
 
 ```rust
 let recipient = Arc::new(MyDeathRecipient {
     write_file: Mutex::new(write_file),
 });
 
-// Register for death notification
-service
-    .as_binder()
-    .link_to_death(Arc::downgrade(
-        &(recipient.clone() as Arc<dyn DeathRecipient>),
-    ))
-    .unwrap();
-
-// Unregister when no longer needed
-service
-    .as_binder()
-    .unlink_to_death(Arc::downgrade(
-        &(recipient.clone() as Arc<dyn DeathRecipient>),
-    ))
-    .unwrap();
+service.link_to_death_arc(&recipient)?;
+// ... later
+service.unlink_to_death_arc(&recipient)?;
 ```
 
-The cast `recipient.clone() as Arc<dyn DeathRecipient>` is necessary to convert from the concrete type to the trait object before calling `Arc::downgrade`. The weak reference ensures that the death recipient does not keep the Binder object alive -- if all strong references are dropped, the Binder object can be cleaned up normally.
+The link holds only a **weak** reference, so it never keeps the recipient alive:
+drop your last `Arc` and the notification silently stops. Keep `recipient` alive
+for as long as you want to hear about the death.
 
-Note that death notifications only work for **remote** Binder objects. Calling `link_to_death` on a local Binder object (one in the same process) will return an error because there is no remote process to monitor.
+`link_to_death` / `unlink_to_death` are the lower-level pair, taking a
+`Weak<dyn DeathRecipient>` you build yourself
+(`Arc::downgrade(&(recipient.clone() as Arc<dyn DeathRecipient>))`) — use them
+when the recipient is already type-erased.
 
-Also note that `binder_died` is delivered as an inbound binder command: the process that links a death recipient must call `ProcessState::start_thread_pool()` (or park a thread in `join_thread_pool()`), or the notification never fires — even a client that otherwise only makes outbound calls.
+Two conditions are easy to miss:
+
+- Death notification works only for a **remote** binder. Linking to a local one
+  returns an error; there is no other process to outlive.
+- `binder_died` arrives as an inbound transaction, so the linking process needs
+  its thread pool running, even if it otherwise only makes outbound calls.
 
 ## Tips
 
-Here are key points to keep in mind when working with callbacks and interfaces in rsbinder:
+- **Equality is binder identity.** Two `Strong<dyn T>` compare equal when they
+  name the same binder object, so a service can tell whether two callbacks
+  arriving by different routes are in fact the same one — which is how you
+  de-duplicate a registration list.
 
-- **Callbacks are full Binder objects.** They cross process boundaries transparently. A callback created in the client process can be invoked by the service process through a standard Binder transaction.
+- **A callback is an inbound path into your process.** Whichever side *hands
+  out* the callback is the side that then serves transactions on it, and needs
+  a thread pool and `Mutex`-protected state to do so.
 
-- **Use `BnXxx::new_binder()` to create callback objects.** The `Bn` (Binder native) wrapper converts your Rust struct into a Binder node that can be sent through Binder transactions. The corresponding `Bp` (Binder proxy) is used automatically on the receiving side.
-
-- **Use `Mutex` to protect shared state.** Binder method calls can arrive on any thread in the thread pool. Any mutable state in your callback or service struct must be protected by `Mutex`, `RwLock`, or another synchronization primitive.
-
-- **Nested types use fully-qualified Rust paths.** A callback `ICallback` nested inside `INestedService` is accessed as `INestedService::ICallback::ICallback` for the trait and `INestedService::ICallback::BnCallback` for the Binder node constructor.
-
-- **Death recipients use `Weak` references.** The `link_to_death` API takes `Weak<dyn DeathRecipient>` to avoid preventing cleanup of the death recipient itself. Keep a strong `Arc` reference alive for as long as you want to receive notifications.
-
-- **`as_binder()` converts typed interfaces to raw `SIBinder`.** This is useful when you need to pass a Binder reference to a method that accepts `IBinder`, or when you need to call Binder-level methods like `link_to_death` or `ping_binder`.
-
-- **Callback equality works through Binder identity.** Two `Strong<dyn T>` references are equal if they point to the same Binder object. This allows you to compare callbacks received from different sources to determine if they refer to the same underlying implementation.
+- **`as_binder()` drops down to `SIBinder`** when you need `IBinder`-typed
+  parameters or binder-level calls like `ping_binder`.

--- a/book/src/cross-transport-services.md
+++ b/book/src/cross-transport-services.md
@@ -105,7 +105,7 @@ rsbinder::serve("tls://0.0.0.0:9000")?
     .add("hello", BnHello::new_binder(MyService))?
     .run()?;
 
-let hello: Strong<dyn IHello> = rsbinder::Client::open_with("tls://host:9000", |o| {
+let hello: Strong<dyn IHello> = rsbinder::Client::open_with("tls://host:9000", |o, _endpoint| {
     o.tls = Some(client_tls_config);
 })?
 .get("hello")?;

--- a/book/src/data-serialization.md
+++ b/book/src/data-serialization.md
@@ -23,23 +23,71 @@ The `#[derive(rsbinder::Parcelable)]` below additionally needs `macros`
 from `.aidl` does not, since the generator emits the `Parcelable` impl
 directly.
 
+Everything on this page is demonstrated end to end, against real `.aidl`
+definitions, by
+[`example-hello/src/bin/serde_demo.rs`](https://github.com/hiking90/rsbinder/blob/master/example-hello/src/bin/serde_demo.rs)
+— it needs no binder device, no service manager and no socket:
+
+```bash
+$ cargo run -p example-hello --features rpc --bin serde_demo
+```
+
 ## What you can store
 
 Anything that implements `Serialize` works, but a type you intend to keep
-should be a parcelable — either generated from `.aidl` or declared with the
-derive:
+should be a **parcelable**. Nothing about the declaration is
+storage-specific — it is an ordinary `.aidl` file, compiled by an ordinary
+`build.rs`:
 
-```rust
-#[derive(rsbinder::Parcelable, Default, Debug, Clone, PartialEq)]
-#[parcelable(descriptor = "myapp.Settings")]
-pub struct Settings {
-    pub volume: i32,
-    pub name: String,
-    pub tags: Vec<String>,
+```aidl
+// aidl/settings/Settings.aidl
+package settings;
+
+@RustDerive(Clone=true, PartialEq=true)
+parcelable Settings {
+    String name = "unnamed";
+    int volume = 50;
+    String[] tags;
+    @nullable String note;
 }
 ```
 
-The derive matters for a reason worth being explicit about. A parcelable
+```rust
+// build.rs — the same call any interface gets.
+rsbinder_aidl::Builder::new()
+    .source(PathBuf::from("aidl/settings/Settings.aidl"))
+    .output(PathBuf::from("settings.rs"))
+    .generate()?;
+```
+
+```rust
+use settings::Settings::Settings;
+
+let value = Settings { name: "studio".into(), volume: 72, ..Default::default() };
+std::fs::write("settings.bin", rsbinder::to_bytes(&value)?)?;
+
+let restored: Settings = rsbinder::from_bytes(&std::fs::read("settings.bin")?)?;
+```
+
+The same type can still be sent through a transaction; storing it is just a
+second destination for the codec the generator already emitted.
+
+If the type has no non-Rust consumer, the [interface
+macros](./interface-macros.md) declare the same thing without a file or a
+build step — the emitted codec is byte-for-byte identical:
+
+```rust
+#[derive(rsbinder::Parcelable, Default, Debug, Clone, PartialEq)]
+#[parcelable(descriptor = "settings.Settings")]
+pub struct Settings {
+    pub name: String,
+    pub volume: i32,
+    pub tags: Vec<String>,
+    pub note: Option<String>,
+}
+```
+
+Being a parcelable matters for a reason worth being explicit about. A parcelable
 writes a length header before its fields, and that header is the entire
 forward-compatibility story: a reader built against an older definition
 stops at the boundary the writer wrote, and a reader built against a newer

--- a/book/src/error-handling.md
+++ b/book/src/error-handling.md
@@ -244,26 +244,21 @@ These conversions are used most often in the `Err(...)` return position of
 service methods, where `.into()` converts a `StatusCode` into the expected
 `Status` type automatically.
 
-## Tips and Best Practices
+## Tips
 
-- **Prefer service-specific errors for application logic.** Use
-  `Status::new_service_specific_error` when the error is meaningful to the
-  caller (e.g., "item not found", "quota exceeded"). Define your error codes
-  as constants so both the service and client can reference them.
+- **Split the two kinds of failure.** `Status::new_service_specific_error` is
+  for what the caller's own logic cares about — "item not found", "quota
+  exceeded" — with the codes declared as constants both sides share. A raw
+  `StatusCode` like `PermissionDenied` or `BadValue` is for the IPC mechanism
+  failing.
 
-- **Use `StatusCode` for infrastructure problems.** Return raw `StatusCode`
-  values like `PermissionDenied` or `BadValue` for errors that relate to the
-  IPC mechanism rather than your application's business logic.
+- **Check `exception_code()` before anything else.** `service_specific_error()`
+  and `transaction_error()` are only meaningful for their own exception code;
+  called on any other, they return zero rather than an error.
 
-- **Always check `exception_code()` first.** The meaning of
-  `service_specific_error()` and `transaction_error()` depends on the
-  exception code. Calling them without checking the exception may return
-  default (zero) values.
+- **Expect `DeadObject` in a long-running client.** A service can restart.
+  `link_to_death` tells you when, so you can reconnect instead of failing
+  every subsequent call.
 
-- **Handle `DeadObject` gracefully.** In long-running clients, the remote
-  service may restart. Consider using death notifications
-  (`link_to_death`) to detect service restarts and re-establish connections.
-
-- **`Status` implements `Display` and `std::error::Error`.** You can use it
-  with `?` in functions that return `Box<dyn std::error::Error>` or with
-  logging macros for human-readable diagnostics.
+- **`Status` implements `Display` and `std::error::Error`,** so it works with
+  `?` in a function returning `Box<dyn Error>` and prints usefully in a log.

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -1,93 +1,40 @@
 # Getting Started
 
-Welcome to **rsbinder**! This guide will help you get started with Binder IPC development using Rust.
+## Pick a stack
 
-## Learning Path
+**rsbinder** ships two, and which one you can use depends on the platform:
 
-If you are new to Binder IPC, we recommend following this learning path:
+- **Kernel binder** — Linux 5.0+ with binderfs enabled, or Android. Talks to
+  the kernel driver through `/dev/binderfs/binder` (Linux) or `/dev/binder`
+  (Android). This is what most of this guide covers.
+- **RPC transport** (binder-over-socket, opt-in via the `rpc` feature) — pure
+  user-space, no kernel driver, no root. Runs on Linux, Android, and
+  **macOS**, over Unix-domain sockets, vsock, or TLS. See
+  [RPC Transport](./rpc-transport.md).
 
-1. **[Overview](./overview.md)** and **[Architecture](./architecture.md)** - Start here to understand Binder IPC fundamentals
-   - Learn about the core concepts and components
-   - Understand the relationship between services and clients
-   - See how AIDL generates Rust code
+macOS has no binder driver, so only the RPC stack works there — enough to
+develop and test RPC services on a workstation without a Linux VM. Windows is
+not supported on either stack.
 
-2. **[Installation](./installation.md)** - Set up your development environment
-   - Install required dependencies
-   - Set up binder devices and service manager
-   - Configure your Rust project
+## Before you start
 
-3. **[Hello World](./hello-world.md)** - Build your first Binder service
-   - Create a simple echo service
-   - Learn AIDL basics
-   - Understand service registration and client communication
+- [ ] Rust 1.85 or later
+- [ ] For kernel binder: a kernel with binder support, or an Android
+      device/emulator
+- [ ] For kernel binder on Linux: a device node created with `rsb_device`, and
+      `rsb_hub` running as the service manager
 
-4. **AIDL Guide** - Dive deeper into AIDL language features:
-   - **[Data Types](./aidl-data-types.md)** - How AIDL types map to Rust types
-   - **[Parcelable](./aidl-parcelable.md)** - Custom data structures for IPC
-   - **[Enum and Union](./aidl-enum-union.md)** - Enum and union type support
-   - **[Annotations](./aidl-annotations.md)** - Code generation annotations
+[Installation](./installation.md) walks through all of these.
 
-5. **Service Development** - Build production-quality services:
-   - **[Service Patterns](./service-patterns.md)** - Advanced service patterns and best practices
-   - **[Async Service](./async-service.md)** - Non-blocking services with tokio
-   - **[Callbacks and Interfaces](./callbacks-and-interfaces.md)** - Bidirectional communication
-   - **[ParcelFileDescriptor](./parcel-file-descriptor.md)** - File descriptor passing
-   - **[Error Handling](./error-handling.md)** - Error types and handling strategies
-   - **[Service Manager (HUB)](./service-manager.md)** - Service registration and discovery
+## The workflow
 
-6. **[RPC Transport](./rpc-transport.md)** - Binder-over-socket:
-   - The opt-in second stack that runs on Linux, Android, and macOS
-   - Unix-domain sockets, vsock, or TLS instead of `/dev/binder`
-   - Same generated AIDL stubs as the kernel-binder path
+1. Define the interface — an `.aidl` file, or a Rust trait with
+   [`#[rsbinder::interface]`](./interface-macros.md).
+2. Generate the Rust from it (`rsbinder-aidl` in a `build.rs`; the macro needs
+   no build step).
+3. Implement the service.
+4. Register it and connect to it — `rsbinder::serve(uri)` and
+   `rsbinder::connect(uri)`.
 
-7. **Platform-specific Setup** - Choose your target platform:
-   - **[Linux Setup](./enable-binder-for-linux.md)** - For Linux development
-   - **[Android Development](./android.md)** - For Android integration
-
-## Platform Requirements
-
-**rsbinder** ships two parallel stacks — pick by platform and use case:
-
-- **Kernel binder** (the default in this guide): Linux 5.0+ with
-  binderfs enabled (the `binderfs` filesystem landed in 5.0), or
-  Android. Talks to the kernel binder driver through
-  `/dev/binderfs/binder` (Linux) or `/dev/binder` (Android).
-- **RPC transport** (binder-over-socket, opt-in via the `rpc`
-  feature): pure user-space, no kernel binder driver. Runs on
-  **Linux, Android, and macOS** over Unix-domain sockets, vsock, or
-  TLS. See the [RPC Transport](./rpc-transport.md) chapter.
-
-> **Windows**: not supported on either stack.
->
-> **macOS**: kernel binder is not supported (no kernel driver), but
-> the RPC transport works natively — useful for developing and
-> testing RPC services on a macOS workstation without a Linux VM.
-
-## Quick Start Checklist
-
-Before diving into development, ensure you have:
-
-- [ ] Rust 1.85+ installed
-- [ ] Linux kernel with binder support enabled (or an Android device/emulator)
-- [ ] Created binder device using `rsb_device` (Linux only)
-- [ ] Service manager (`rsb_hub`) running (Linux only)
-- [ ] Basic understanding of AIDL syntax (covered in the [Hello World](./hello-world.md) tutorial)
-
-## Key Concepts to Understand
-
-- **Services**: Server-side implementations that provide functionality
-- **Clients**: Applications that consume services through proxies
-- **AIDL**: Interface definition language for describing service contracts
-- **Service Manager**: Central registry for service discovery
-- **Parcels**: Serialization format for data exchange
-- **Binder Objects**: References that enable cross-process communication
-
-## Common Development Workflow
-
-1. Define your service interface in an `.aidl` file
-2. Use `rsbinder-aidl` to generate Rust code
-3. Implement your service logic
-4. Register the service with the service manager
-5. Create clients that discover and use your service
-
-Ready to start? Head to the [Overview](./overview.md) section to learn the fundamentals!
+[Hello, World!](./hello-world.md) does all four end to end, and is the fastest
+way to see where each piece fits.

--- a/book/src/hello-world.md
+++ b/book/src/hello-world.md
@@ -18,14 +18,13 @@ publish = false
 edition = "2021"
 
 [dependencies]
-rsbinder = "0.10"
+rsbinder = "0.11"
 async-trait = "0.1"
 env_logger = "0.11"
 
 [build-dependencies]
-rsbinder-aidl = "0.10"
+rsbinder-aidl = "0.11"
 ```
-Add rsbinder and async-trait to [dependencies], and add rsbinder-aidl to [build-dependencies].
 
 ## Create an AIDL File
 Create an aidl folder in the project's top directory to manage AIDL files:
@@ -33,8 +32,6 @@ Create an aidl folder in the project's top directory to manage AIDL files:
 $ mkdir -p aidl/hello
 $ touch aidl/hello/IHello.aidl
 ```
-The reason for creating an additional **hello** folder is to create a namespace for the **hello** package.
-
 > **Directory ↔ package mapping.** The folder name under `aidl/` **must
 > match** the `package` declaration at the top of the `.aidl` file. So
 > `aidl/hello/IHello.aidl` requires `package hello;` (below), and the
@@ -69,8 +66,6 @@ fn main() {
         .unwrap();
 }
 ```
-This uses **rsbinder-aidl** to specify the AIDL source file (`IHello.aidl`) and the generated Rust file name (`hello.rs`), and then generates the code during the build process.
-
 > **Important**: The `build.rs` file must be placed in the project root directory, **not** inside `src/`. If placed in the wrong location, you will get a compile error: `environment variable OUT_DIR not defined at compile time`. Cargo only recognizes `build.rs` at the project root.
 
 ## Create a common library for Client and Service
@@ -98,7 +93,7 @@ pub use crate::hello::IHello::*;
 ## Create a service
 Create the `src/bin/` directory and add the service file. Cargo automatically recognizes `.rs` files under `src/bin/` as binary targets, so no `[[bin]]` section is needed in `Cargo.toml`.
 
-Let's configure the src/bin/hello_service.rs file as follows.
+Create `src/bin/hello_service.rs`:
 ```rust
 use env_logger::Env;
 use rsbinder::*;
@@ -228,11 +223,14 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
 ## Run Hello Service and Client
 
-Before running the service and client, make sure you have the service manager running:
+Before running the service and client, start the service manager. It refuses
+to start without an access-control policy, so a local try-out passes
+`--insecure-allow-all` — see [Access control](./service-manager.md#access-control)
+for the real thing:
 
 ```bash
 # In terminal 1: Start the service manager
-$ rsb_hub
+$ rsb_hub --insecure-allow-all
 ```
 
 Now you can run the service and client:
@@ -264,101 +262,39 @@ MyServiceCallback: my.hello
 Result: Hello World!
 ```
 
-The client demonstrates several advanced features:
-- **Service Discovery**: Lists all available services
-- **Service Callbacks**: Registers for service availability notifications
-- **Death Recipients**: Monitors service lifecycle for cleanup
-- **Type-safe Proxies**: Uses strongly-typed interface for service calls
+Along the way the client also listed the registered services, registered for
+availability notifications, and linked a death recipient.
 
 ### Troubleshooting
 
-If you encounter issues:
-
-1. **"ProcessState is not initialized!"** - `rsbinder::serve("binder://")` / `rsbinder::connect("binder://…")` (or the low-level `ProcessState::init_default()`) must run before any other rsbinder API that touches the binder device
-2. **"environment variable OUT_DIR not defined"** - `build.rs` must be placed in the project root directory (next to `Cargo.toml`), not inside `src/`
-3. **Client blocks without output** - `rsbinder::connect("binder://…")` waits until the service is registered; ensure the service is running
-4. **Permission errors** - Check that binder device has correct permissions (0666)
-5. **Service manager not found** - Verify `rsb_hub` is running
-6. **Build errors** - Ensure all dependencies are correctly specified in Cargo.toml
+1. **"ProcessState is not initialized!"** — `rsbinder::serve("binder://")` / `rsbinder::connect("binder://…")` (or the low-level `ProcessState::init_default()`) must run before any other rsbinder API that touches the binder device.
+2. **"environment variable OUT_DIR not defined"** — `build.rs` must be in the project root, next to `Cargo.toml`, not inside `src/`.
+3. **Client blocks without output** — `rsbinder::connect("binder://…")` waits until the service is registered; make sure the service is running.
+4. **Permission errors** — the binder device node defaults to `0600`, root only. Give it a group with `rsb_device binder --group <group> --mode 0660` and make sure you are in that group.
+5. **Service manager not found** — check that `rsb_hub` is running, and that it did not exit at startup for want of a policy.
 
 ## Next Steps
 
-Congratulations! You've successfully created your first Binder service and client. Here are some next steps to explore:
-
-### Caller Identity and Access Control
-
-Inside a service method, you can identify the calling process using `CallingContext`:
-
-```rust
-use rsbinder::thread_state::CallingContext;
-
-fn echo(&self, echo: &str) -> rsbinder::BinderResult<String> {
-    let caller = CallingContext::default();
-    let caller_uid = caller.uid;
-    let caller_pid = caller.pid;
-    let caller_sid = caller.sid;  // Optional SELinux context
-
-    // Enforce your own access control policy
-    if caller_uid != expected_uid {
-        return Err(rsbinder::Status::from(rsbinder::StatusCode::PermissionDenied));
-    }
-
-    Ok(echo.to_owned())
-}
-```
-
-This is especially useful since **rsbinder** does not enforce any access control policy by itself — it is up to each service to validate callers.
-
-### Error Handling
-
-Services can return service-specific errors to clients using `Status::new_service_specific_error`:
-
-```rust
-fn echo(&self, echo: &str) -> rsbinder::BinderResult<String> {
-    if echo.is_empty() {
-        return Err(rsbinder::Status::new_service_specific_error(-1, None));
-    }
-    Ok(echo.to_owned())
-}
-```
-
-On the client side, these errors can be inspected through the `Status` type to distinguish between transport errors and application-level errors.
-
-### AIDL Annotations
-
-Generated types from AIDL do not derive `Clone` by default, because some AIDL types contain non-cloneable fields such as `ParcelFileDescriptor` (which wraps `OwnedFd`) or `ParcelableHolder` (which contains a `Mutex`).
-
-You can opt-in to `Clone` (and other traits) for specific types using the `@RustDerive` annotation in your AIDL file:
-
-```aidl
-@RustDerive(Clone=true, PartialEq=true)
-parcelable MyData {
-    int id;
-    String name;
-}
-```
-
-`@RustDerive` is supported for **parcelable** and **union** types. This follows the same convention as [Android's AIDL Rust backend](https://source.android.com/docs/core/architecture/aidl/aidl-annotations). The annotation will only compile successfully if all fields in the type actually implement the requested traits.
-
-### Explore More Features
-- **[AIDL Data Types](./aidl-data-types.md)**: Learn how AIDL types map to Rust, including primitives, arrays, strings, and nullable types
-- **[Parcelable](./aidl-parcelable.md)**: Define custom data structures that can be sent across Binder IPC
-- **[Enum and Union](./aidl-enum-union.md)**: Use enum and union types in your AIDL interfaces
-- **[Annotations](./aidl-annotations.md)**: Control code generation with `@RustDerive`, `@Backing`, `@nullable`, and more
-- **[Service Patterns](./service-patterns.md)**: Advanced service patterns including `dump()`, default implementations, and multi-service processes
-- **[Async Service](./async-service.md)**: Use async/await with tokio runtime for non-blocking services
-- **[Callbacks and Interfaces](./callbacks-and-interfaces.md)**: Implement bidirectional communication and death recipients
-- **[ParcelFileDescriptor](./parcel-file-descriptor.md)**: Pass file descriptors across process boundaries
-- **[Error Handling](./error-handling.md)**: Service-specific errors, status codes, and exception handling
-- **[Service Manager (HUB)](./service-manager.md)**: Registration, lookup, notifications, and debug info
-- **API Reference**: See the full API documentation at [docs.rs/rsbinder](https://docs.rs/rsbinder)
+- **[AIDL Data Types](./aidl-data-types.md)** — how AIDL types map to Rust: primitives, arrays, strings, nullable types
+- **[Parcelable](./aidl-parcelable.md)** — custom data structures that cross the Binder boundary
+- **[Enum and Union](./aidl-enum-union.md)** — enum and union types in your interfaces
+- **[Annotations](./aidl-annotations.md)** — `@RustDerive`, `@Backing`, `@nullable`, and the rest
+- **[Interface Macros](./interface-macros.md)** — the same interface as a Rust trait, with no `.aidl` file
+- **[Service Patterns](./service-patterns.md)** — `dump()`, default implementations, multi-service processes
+- **[Async Service](./async-service.md)** — async/await on the tokio runtime
+- **[Callbacks and Interfaces](./callbacks-and-interfaces.md)** — bidirectional communication and death recipients
+- **[ParcelFileDescriptor](./parcel-file-descriptor.md)** — passing file descriptors across processes
+- **[Error Handling](./error-handling.md)** — service-specific errors, status codes, exceptions
+- **[Security & Authorization](./security.md)** — identifying the caller and deciding what it may do
+- **[Service Manager (HUB)](./service-manager.md)** — registration, lookup, notifications, debug info
+- **[docs.rs/rsbinder](https://docs.rs/rsbinder)** — the full API reference
 
 ### Run the Test Suite
 The **rsbinder** project includes a comprehensive test suite ported from Android:
 
 ```bash
 # Terminal 1: Start service manager
-$ cargo run --bin rsb_hub
+$ cargo run --bin rsb_hub -- --insecure-allow-all
 
 # Terminal 2: Start test service
 $ cargo run --bin test_service

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -13,54 +13,42 @@ $ rustc --version  # Should be 1.85+
 Please refer to [Enable binder for Linux](./enable-binder-for-linux.md) for detailed instructions on setting it up.
 
 ## Create binder device file for Linux
-After the binder configuration of the Linux kernel is complete, a binder device file must be created.
+Once the kernel has binder support, create the device node.
 
-### Method 1: Install from crates.io
-Install **rsbinder-tools** and run to create a binder device:
+First, create the group that will own the device and put yourself in it (log
+out and back in, or run `newgrp binder`, for the membership to take effect):
+
+```bash
+$ sudo groupadd -f binder
+$ sudo usermod -aG binder "$USER"
+```
+
+Then install **rsbinder-tools** and create the device:
 
 ```bash
 $ cargo install rsbinder-tools
-# Create the `binder` group and put yourself in it (log out and back in,
-# or use `newgrp binder`, for the membership to take effect)
-$ sudo groupadd -f binder
-$ sudo usermod -aG binder "$USER"
-
-# Create the device, owned by that group. The node's mode is the only gate
-# on who may speak binder at all, so it defaults to 0600 (root only).
 $ sudo rsb_device binder --group binder --mode 0660
 ```
 
-### Method 2: Build from source
-If you prefer to build from source:
+Or, building from source:
 
 ```bash
 $ git clone https://github.com/hiking90/rsbinder.git
 $ cd rsbinder
 $ cargo build --release
-# Create the `binder` group and put yourself in it (log out and back in,
-# or use `newgrp binder`, for the membership to take effect)
-$ sudo groupadd -f binder
-$ sudo usermod -aG binder "$USER"
-
-# Create the device, owned by that group. The node's mode is the only gate
-# on who may speak binder at all, so it defaults to 0600 (root only).
 $ sudo target/release/rsb_device binder --group binder --mode 0660
 ```
 
-The `rsb_device` tool will:
-- Create `/dev/binderfs` directory if it doesn't exist
-- Mount binderfs filesystem
-- Create the specified binder device
-- Set the device node's owning group (`--group`) and mode (`--mode`, default
-  `0600`)
+`rsb_device` creates `/dev/binderfs` if it does not exist, mounts binderfs,
+creates the named device, and applies `--group` and `--mode`.
 
 The mode is not a formality: binder has no in-kernel access control of its
 own, so the device node is the only thing deciding who can speak binder at
 all — the same model as `/dev/kvm` being `0660 root:kvm`. It defaults to
-root-only; grant access deliberately with `--group`.
+`0600`, root only; grant access deliberately with `--group`.
 
 ## Run a service manager for Linux
-If **rsbinder-tools** is already installed, the **rsb_hub** executable is also installed.
+Installing **rsbinder-tools** also installs **rsb_hub**.
 
 `rsb_hub` denies every request that its policy does not allow, and refuses to
 start when it cannot load one, so a first run needs one of two things. For a
@@ -84,10 +72,9 @@ Alternatively, if building from source:
 $ cargo run --bin rsb_hub -- --insecure-allow-all
 ```
 
-The service manager (rsb_hub) provides:
-- Service registration and discovery
-- Service lifecycle management
-- Priority-based service access
+`rsb_hub` is the registry every service registers with and every client looks
+up through. It also enforces per-name access control, and can declare and
+start services on demand — see [Service Manager](./service-manager.md).
 
 ### Using a custom binder device path
 
@@ -116,36 +103,39 @@ Add the following configuration to your Cargo.toml file:
 
 ```toml
 [dependencies]
-rsbinder = "0.10"
+rsbinder = "0.11"
 async-trait = "0.1"
 env_logger = "0.11"  # Optional: for logging
 
 [build-dependencies]
-rsbinder-aidl = "0.10"
+rsbinder-aidl = "0.11"
 ```
 
-### Feature Flags
-**rsbinder** supports various feature flags for different use cases:
+### Feature flags
 
 ```toml
-[dependencies]
-rsbinder = "0.10"  # Default: includes tokio async runtime
-# or
-rsbinder = { version = "0.10", features = ["async"] }  # Async trait support without tokio — use your own async runtime
-# or
-rsbinder = { version = "0.10", default-features = false }  # Synchronous only (no async support)
-# or — opt in to the binder-over-socket stack (see RPC Transport chapter)
-rsbinder = { version = "0.10", features = ["rpc"] }
+rsbinder = "0.11"                                          # default: tokio async
+rsbinder = { version = "0.11", default-features = false }   # synchronous only
+rsbinder = { version = "0.11", features = ["rpc", "macros"] }
 ```
 
-Available features:
-- `tokio` (default): Full tokio async runtime support (includes `async` feature)
-- `async`: Async trait support without tokio runtime — use this when integrating with a different async runtime
-- `rpc`: Enable the RPC transport (binder-over-socket). Add `rpc-vsock`, `rpc-tls`, or `rpc-tcp-debug` to bundle the matching backend. See [RPC Transport](./rpc-transport.md).
-- `android_*`: Android version compatibility flags (see [Android Development](./android.md))
+- `tokio` (default) — full tokio async runtime support (implies `async`).
+- `async` — async-trait support without tokio, for a different runtime.
+- `rpc` — the RPC transport (binder-over-socket). Add `rpc-vsock`, `rpc-tls`,
+  or `rpc-tcp-debug` for the matching backend. See
+  [RPC Transport](./rpc-transport.md).
+- `macros` — `#[rsbinder::interface]` and the `Parcelable` / `BinderEnum`
+  derives: an interface as a Rust trait, with no `.aidl` file and no
+  `build.rs`. See [Interface Macros](./interface-macros.md).
+- `android_*` — Android version compatibility (see
+  [Android Development](./android.md)).
 
-### Crate Purposes:
-- **rsbinder**: Core library providing Binder IPC functionality, including kernel communication, data serialization/deserialization, thread pool management, and service lifecycle.
-- **async-trait**: Required for async interface implementations generated by **rsbinder-aidl**.
-- **rsbinder-aidl**: AIDL-to-Rust code generator, used in build.rs for compile-time code generation.
-- **env_logger**: Optional but recommended for debugging and development logging.
+### What each crate is for
+
+- **rsbinder** — the core library: kernel communication, parcel
+  serialization, thread pool, service lifecycle.
+- **rsbinder-aidl** — the AIDL-to-Rust generator, used from `build.rs`.
+- **async-trait** — required by the async interfaces `rsbinder-aidl`
+  generates.
+- **env_logger** — optional, but the fastest way to see what rsbinder is
+  doing.

--- a/book/src/interface-macros.md
+++ b/book/src/interface-macros.md
@@ -1,0 +1,128 @@
+# Interface Macros (no `.aidl`)
+
+`#[rsbinder::interface]` declares a Binder interface as a Rust trait — no
+`.aidl` file, no `build.rs`, no generated-code directory:
+
+```toml
+rsbinder = { version = "0.11", features = ["macros"] }
+```
+
+```rust
+use rsbinder::{interface, BinderResult, Strong};
+
+#[interface(descriptor = "com.example.IHello")]
+pub trait IHello {
+    fn echo(&self, msg: &str) -> BinderResult<String>;
+    fn fill(&self, values: &mut Vec<i32>) -> BinderResult<()>;   // `&mut` = out
+    #[oneway]
+    fn ping(&self) -> BinderResult<()>;
+}
+
+// `Hello` is your `impl IHello`, plus `impl Interface for Hello {}`.
+rsbinder::serve("binder://")?.add("hello", BnHello::new_binder(Hello))?.run()?;
+let hello: Strong<dyn IHello> = rsbinder::connect("binder://hello")?;
+```
+
+`BnHello`, `BpHello` and `IHelloDefault` appear where you wrote the trait, so
+the service impl, the registration and the call sites read exactly as they do
+on the `.aidl` path.
+
+The macro is not a second code generator: it fills the same
+`rsbinder_aidl::render` structs the AIDL front-end fills and runs the same
+templates. A trait here and the equivalent `.aidl` produce **byte-for-byte
+identical** code, enforced by golden tests. Moving between the two never
+touches a call site and never changes a byte on the wire.
+
+The feature is off by default, because it pulls the AIDL compiler in as a
+proc-macro dependency — a build-time cost that a crate consuming generated
+code has no reason to carry.
+
+## Which path to use
+
+| Use | When |
+|---|---|
+| `#[rsbinder::interface]` | rsbinder on both ends, wire private to both |
+| `.aidl` | An Android service or client, another language on the other end, or a published interface |
+
+`.aidl` is also the only path that carries unions, interface constants,
+`@VintfStability`, `@EnforcePermission`, `ParcelableHolder` fields, generics
+and nested types. The macro has no syntax for those; where a Rust declaration
+could be mistaken for one, it is a compile error naming the reason.
+
+## What a signature means
+
+| Signature | Meaning |
+|---|---|
+| `x: T` (must be `Copy`), `x: &T`, `x: &str`, `x: &[T]` | `in` argument |
+| `x: &mut T` | **`out`** — the server fills the caller's value |
+| `#[inout] x: &mut T` | written **and** read back |
+| `Option<T>` | `@nullable` |
+| `#[oneway]` on a method | no reply; must return `BinderResult<()>` |
+
+What the wire cannot carry is a compile error where you wrote it:
+
+- A primitive cannot be `out` — `.aidl` passes it only `in`. Return it, or use
+  a `Vec<T>` or a parcelable.
+- A primitive has no null form, so `Option<i32>` is refused; so is
+  `Option<Mode>` for a derived enum, which travels as its `repr` scalar.
+- A borrowed type nested inside another (`&[&str]`) has nothing to borrow from
+  once decoded. Use the owned form.
+
+Methods are declared `fn`, not `async fn`. The `async` feature emits the
+`IFooAsync` halves from the same declaration.
+
+## Data types
+
+```rust
+use rsbinder::{BinderEnum, Parcelable};
+
+#[derive(Parcelable, Default, Debug, Clone, PartialEq)]
+#[parcelable(descriptor = "com.example.Config")]
+pub struct Config {
+    pub name: String,
+    pub retries: i32,
+    pub extra: Option<Vec<u8>>,
+}
+
+#[derive(BinderEnum, Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i32)]
+pub enum Mode {
+    #[default]
+    Fast = 0,
+    Safe = 1,
+}
+```
+
+`#[derive(Parcelable)]` emits only the codec, leaving `Default`, `Debug` and
+the rest to the usual derives. `Default` is required: decoding starts from it,
+which is how a field an older writer never wrote gets a value. Named fields
+only — field order is wire order, so **append only**, as in `.aidl`.
+
+`#[derive(BinderEnum)]` needs `#[repr(i8|i32|i64)]`, the AIDL backing type that
+goes on the wire, and an explicit value per variant so the wire value is
+visible at the declaration.
+
+> **A derived enum is closed.** An undeclared value decodes as `BadValue`,
+> where an `.aidl` enum carries it through. For a peer that may send a value
+> your build has never heard of, use `.aidl` or `declare_binder_enum!`.
+
+Either type works with [`to_bytes` / `from_bytes`](./data-serialization.md).
+
+## Rules that bite
+
+**Reordering methods is a wire break.** Transaction codes follow declaration
+order (`FIRST_CALL_TRANSACTION + i`), as in `.aidl` without explicit codes.
+Append at the end.
+
+**Set the descriptor for anything shared.** It defaults to the bare trait name,
+which is fine inside one crate and not across two.
+
+**Spell out-parameter types directly.** A proc macro cannot see through a type
+alias, so `&mut Ids` for `type Ids = Vec<i32>` reads as an opaque named type
+and loses the length word `.aidl` writes for an out vector. Path qualification
+(`std::vec::Vec<i32>`) is matched structurally and is fine; an alias is not.
+
+**A bare path in a signature is your own, `super::` is not.** The generated
+body lands in a module one level below where you wrote the macro and reaches
+your scope through `use super::*;`, so `super::X` names *that* module — a
+signature meaning the parent has to say `crate::X`.

--- a/book/src/overview.md
+++ b/book/src/overview.md
@@ -23,19 +23,18 @@ However, since it is rarely used outside of Android, it is disabled by default i
 
 * **`rsbinder`**: Core library crate for implementing binder service/client functionality.
 * **`rsbinder-aidl`**: AIDL-to-Rust code generator for rsbinder.
-* **`rsbinder-tools`**: CLI tools, including a Binder Service Manager (`rsb_hub`) for Linux.
+* **`rsbinder-macros`**: The same generator, reached from a Rust trait instead of an `.aidl` file. Not a direct dependency — enable `rsbinder`'s `macros` feature. See [Interface Macros](./interface-macros.md).
+* **`rsbinder-tools`**: CLI tools — the Binder Service Manager for Linux (`rsb_hub`), the device setup helper (`rsb_device`), and the registry inspector (`rsb_service`).
 * **`tests`**: Port of Android's binder test cases for client/server testing.
 * **`example-hello`**: Example service/client implementation using rsbinder.
 
-## Key Features of Binder IPC
+## Key Features
 
-- **Object-oriented**: Binder IPC provides a clean and intuitive object-oriented API for inter-process communication.
-- **Efficient**: Binder IPC is designed for high performance and low overhead with efficient data serialization.
-- **Secure**: Binder IPC provides strong security features to prevent unauthorized access and tampering.
-- **Versatile**: Binder IPC can be used for a variety of purposes, including remote procedure calls, data sharing, and event notification.
-- **Cross-platform**: Works on Linux and Android (kernel binder), plus macOS (RPC transport only).
-- **Async/Sync Support**: Supports both synchronous and asynchronous programming models with optional tokio runtime integration.
-- **Two transport stacks**: Kernel binder for on-device IPC, and an opt-in RPC transport (Unix sockets, vsock, or TLS) for cross-process, cross-VM, or cross-host binder calls — both stacks share the same AIDL-generated code.
+- **Object-oriented**: a call is a method call on a remote object, with strong and weak references that work across processes — not a message you frame yourself.
+- **Wire-compatible with Android**: the same protocol as `libbinder`, so an rsbinder client can call a service written in C++ or Java, and the other way round.
+- **Two transport stacks**: kernel binder for on-device IPC, and an opt-in RPC transport (Unix sockets, vsock, or TLS) for cross-process, cross-VM, or cross-host calls — both driven by the same AIDL-generated code.
+- **Cross-platform**: Linux and Android (kernel binder), plus macOS (RPC transport only).
+- **Async/Sync**: both programming models, with optional tokio integration.
 
 ## Core Components
 
@@ -45,6 +44,7 @@ However, since it is rarely used outside of Android, it is disabled by default i
 - **Service Manager**: Centralized service discovery and registration (rsb_hub for Linux)
 - **Thread Pool**: Efficient handling of concurrent IPC transactions
 - **Death Notification**: Service lifecycle management and cleanup
+- **Shared Memory**: Payloads too big to copy through a transaction ([Shared Memory](./shared-memory.md))
 
 ## Resources
 

--- a/book/src/parcel-file-descriptor.md
+++ b/book/src/parcel-file-descriptor.md
@@ -114,26 +114,19 @@ descriptor is duplicated so that each `Vec` owns its own set of file handles.
 
 ## Helper Functions
 
-The test suite defines two small helpers that are useful in application code as
-well.
+Two small helpers cover most of what application code needs.
 
 ### build_pipe
 
-Creates a Unix pipe and returns both ends as `std::fs::File` values:
+Creates a Unix pipe and returns both ends as `std::fs::File` values. `pipe()`
+hands back `OwnedFd`s and `File` converts from one, so no `unsafe` is involved:
 
 ```rust
 use std::fs::File;
-use std::os::unix::io::FromRawFd;
-use rustix::fd::IntoRawFd;
 
 fn build_pipe() -> (File, File) {
-    let fds = rustix::pipe::pipe().expect("error creating pipe");
-    unsafe {
-        (
-            File::from_raw_fd(fds.0.into_raw_fd()),
-            File::from_raw_fd(fds.1.into_raw_fd()),
-        )
-    }
+    let (reader, writer) = rustix::pipe::pipe().expect("error creating pipe");
+    (File::from(reader), File::from(writer))
 }
 ```
 
@@ -169,31 +162,16 @@ wire version. Service and client code using `ParcelFileDescriptor` is
 otherwise unchanged. See
 [RPC Transport](./rpc-transport.md#capabilities) for details.
 
-## Tips and Best Practices
+## Tips
 
-- **Descriptors are duplicated during IPC.** When a `ParcelFileDescriptor` is
-  serialized into a `Parcel`, the kernel duplicates the file descriptor for the
-  receiving process. The sender and receiver each hold independent handles.
+- **Each side owns its own descriptor.** Serializing a `ParcelFileDescriptor`
+  makes the kernel duplicate the fd for the receiver, so the two handles are
+  independent and close order does not matter.
 
-- **Close order does not matter.** Because each side owns an independent
-  duplicate, closing the sender's copy does not affect the receiver, and vice
-  versa.
+- **`ParcelFileDescriptor` is not `Clone`** — it wraps an `OwnedFd`, which owns
+  the descriptor. Use `try_clone()`, and use it before storing or re-returning
+  a descriptor you received.
 
-- **Use `file_from_pfd` for reading and writing.** `ParcelFileDescriptor` does
-  not implement `std::io::Read` or `std::io::Write` directly. Convert it to a
-  `File` (via `try_clone().into()`) to use those traits.
-
-- **Always duplicate before storing.** If your service needs to keep a
-  reference to a received descriptor, clone it with `try_clone()`. Returning
-  or forwarding the original reference without duplication can lead to
-  use-after-close errors.
-
-- **`ParcelFileDescriptor` is not `Clone`.** Because it wraps an `OwnedFd`,
-  which owns the underlying file descriptor, the type cannot derive `Clone`.
-  Use the built-in `try_clone()` (a `fcntl(F_DUPFD_CLOEXEC)` duplication,
-  added in 0.10.0) for explicit duplication, and the `From<OwnedFd>` /
-  `From<std::fs::File>` impls for construction.
-
-- **Error handling.** `try_clone()` can fail if the process has exhausted its
-  file descriptor limit. Propagate the error with `?` (a `StatusCode`
-  converts into `Status` automatically) rather than calling `unwrap()`.
+- **`try_clone()` can fail** when the process is out of file descriptors.
+  Propagate it with `?` rather than `unwrap()`; a `StatusCode` converts into
+  `Status` automatically.

--- a/book/src/redhat-linux.md
+++ b/book/src/redhat-linux.md
@@ -2,11 +2,9 @@
 
 > **Note**: This guide is community-contributed and may require adjustments for your specific system configuration. Please test in a safe environment first.
 
-RedHat-based distributions (RHEL, CentOS, Fedora) do not include Binder IPC support by default. Here are methods to enable it:
+RedHat-based distributions (RHEL, CentOS, Fedora) do not include Binder IPC support by default, so enabling it means building a kernel.
 
 ## Fedora
-
-### Method 1: Custom Kernel Build (Recommended for Fedora)
 
 Fedora provides kernel source packages that can be modified to include binder support:
 
@@ -44,21 +42,9 @@ $ sudo grub2-mkconfig -o /boot/grub2/grub.cfg
 $ sudo reboot
 ```
 
-### Method 2: Third-party Kernel Modules
-
-Some third-party repositories may provide binder modules:
-
-```bash
-# Enable RPM Fusion repositories
-$ sudo dnf install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
-
-# Look for available binder-related packages
-$ dnf search binder android-tools
-```
-
 ## RHEL/CentOS
 
-### Method 1: Build Custom Kernel
+### Build a Custom Kernel
 
 For enterprise distributions, building a custom kernel is often the most reliable approach:
 
@@ -103,19 +89,6 @@ $ sudo grub2-mkconfig -o /boot/grub2/grub.cfg
 $ sudo reboot
 ```
 
-### Method 2: Using ELRepo (CentOS/RHEL)
-
-ELRepo sometimes provides additional kernel modules:
-
-```bash
-# Install ELRepo
-$ sudo rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
-$ sudo dnf install https://www.elrepo.org/elrepo-release-8.el8.elrepo.noarch.rpm
-
-# Search for kernel modules
-$ dnf --enablerepo=elrepo search kernel-ml
-```
-
 ## CentOS Stream
 
 CentOS Stream may have more recent kernels that could include binder support:
@@ -150,18 +123,20 @@ $ grep -E "(ANDROID|BINDER)" /boot/config-$(uname -r)
 
 ## SELinux Considerations
 
-RedHat systems use SELinux which may interfere with binder operations:
+RedHat systems run SELinux, which can deny access to the binder device even
+once the node exists and its mode is right. A denial looks like a failed
+`open` rather than an rsbinder error, so check the audit log before suspecting
+anything else:
 
 ```bash
-# Check SELinux status
 $ sestatus
-
-# Temporarily disable SELinux for testing
-$ sudo setenforce 0
-
-# Create SELinux policy for binder (advanced)
-# This requires creating custom SELinux policies for binder devices
+$ sudo ausearch -m avc -ts recent | grep -i binder
 ```
+
+The fix is a policy module allowing your domain to use the device. Putting the
+whole system in permissive mode (`setenforce 0`) will also make the denial go
+away, but it disables SELinux for everything else on the machine — reach for it
+only to confirm a diagnosis, never as the resting state.
 
 ## Verification
 

--- a/book/src/rpc-transport.md
+++ b/book/src/rpc-transport.md
@@ -26,7 +26,7 @@ distinguish RPC from kernel binder.
 >
 > ```toml
 > [dependencies]
-> rsbinder = { version = "0.10", features = ["rpc"] }
+> rsbinder = { version = "0.11", features = ["rpc"] }
 > ```
 
 ## When to use RPC vs. kernel binder
@@ -226,7 +226,7 @@ Add the matching feature in `Cargo.toml`:
 
 ```toml
 [dependencies]
-rsbinder = { version = "0.10", features = ["rpc", "rpc-vsock"] }
+rsbinder = { version = "0.11", features = ["rpc", "rpc-vsock"] }
 ```
 
 Each backend implements the

--- a/book/src/security.md
+++ b/book/src/security.md
@@ -21,8 +21,6 @@ mirrors AOSP's `IPCThreadState`). So inside a `transact` handler you read
 it with no parameter threading:
 
 ```rust
-use rsbinder::{Caller, ExceptionCode, Status};
-
 impl IExample for MyService {
     fn do_thing(&self, arg: i32) -> rsbinder::BinderResult<()> {
         let uid = rsbinder::get_calling_uid();   // who is calling, right now

--- a/book/src/service-development.md
+++ b/book/src/service-development.md
@@ -1,8 +1,8 @@
 # Service Development
 
-Once your AIDL interface compiles, the next step is building the service that implements it and the client that calls it. This part of the guide collects the runtime patterns you will use day-to-day: how to structure a service, how to go async, how to model bidirectional communication, how to ship file descriptors, how to surface errors, and how to register and discover services through the HUB.
+Once your interface compiles, the rest is the service that implements it and the client that calls it. This part of the guide collects the runtime patterns you will use day-to-day.
 
-If you have not yet built a working service, start with [Hello, World!](./hello-world.md) and then return here for the deeper material.
+If you have not yet built a working service, start with [Hello, World!](./hello-world.md) and come back.
 
 ## Chapters
 
@@ -10,9 +10,8 @@ If you have not yet built a working service, start with [Hello, World!](./hello-
 - **[Async Service](./async-service.md)** — Implementing services with `async fn` on top of the Tokio runtime, and how the async traits differ from their sync counterparts.
 - **[Callbacks and Interfaces](./callbacks-and-interfaces.md)** — Passing `IBinder` objects in either direction, managing callback collections, and watching for remote process death.
 - **[ParcelFileDescriptor](./parcel-file-descriptor.md)** — Sending pipes, files, and sockets across the Binder boundary as owned file descriptors.
+- **[Shared Memory](./shared-memory.md)** — Sharing a mapped region instead of copying it, for payloads a transaction should not carry.
 - **[Error Handling](./error-handling.md)** — The `StatusCode` / `Status` split, exception codes, and how AIDL methods surface both transport-level and application-level failures.
 - **[Service Manager (HUB)](./service-manager.md)** — Registering, looking up, and waiting for services; differences between Linux (`rsb_hub`) and Android's native `servicemanager`; and how it relates to the [RPC transport](./rpc-transport.md).
 
-## Suggested reading order
-
-The chapters are designed to be read in roughly the order above — each builds on the previous one. If you only need to ship a working service quickly, **Service Patterns** plus **Service Manager (HUB)** is enough to get started; the other chapters fill in capabilities as you need them.
+Each builds on the one before it, but to ship a working service you only need **Service Patterns** and **Service Manager (HUB)**; the rest fill in capabilities as you need them.

--- a/book/src/service-manager.md
+++ b/book/src/service-manager.md
@@ -347,11 +347,8 @@ hub::unregister_for_notifications("com.example.myservice", &callback)?;
 The callback will be invoked each time a service matching the given name is
 registered, including if it is re-registered after a restart.
 
-> **Thread pool required.** `onRegistration` arrives as an *inbound* binder
-> transaction, so the client process must call
-> `ProcessState::start_thread_pool()` (or park a thread in
-> `join_thread_pool()`) — otherwise the callback never fires. This applies
-> to any client that receives inbound calls, not just services.
+> **Thread pool required.** `onRegistration` arrives as an inbound binder
+> transaction, so it never fires unless the client is running one.
 
 ## Checking if a Service is Declared
 
@@ -623,9 +620,11 @@ you can obtain the `ServiceManager` instance directly:
 ```rust
 use rsbinder::hub;
 
-// `hub::default()` returns `Result<Arc<ServiceManager>, StatusCode>` because
-// initialization can fail (e.g., binder device unavailable, unsupported SDK).
-// Propagate the error with `?` or handle it with `match`.
+// `hub::default()` returns `Result<Arc<ServiceManager>, StatusCode>` — the
+// error covers things like an unsupported service-manager protocol.
+// Reaching it before `ProcessState::init_default()` is a programming error
+// rather than a runtime condition, so that case panics instead, and every
+// convenience wrapper in `hub` inherits both behaviors.
 let sm = hub::default()?;
 
 // Use methods on the ServiceManager instance
@@ -636,39 +635,18 @@ let services = sm.list_services(hub::DUMP_FLAG_PRIORITY_ALL);
 This is equivalent to using the free functions but allows you to pass the
 service manager as a parameter or store it in a struct.
 
-## Tips and Best Practices
+## Tips
 
-- **Initialize ProcessState first.** Before calling any `hub::` function, you
-  must call `ProcessState::init_default()` (or `ProcessState::init()` with a
-  custom binder path). Failing to do so will panic at runtime.
+- **`ProcessState::init_default()` comes first.** Every `hub::` function
+  panics without it, including the ones whose signature cannot report failure.
 
-- **Use descriptive service names.** Follow a reverse-domain naming convention
-  (e.g., `com.example.myservice`) to avoid name collisions with other
-  services.
+- **Wait, do not poll.** A client that starts before its service should call
+  `wait_for_interface` / `wait_for_service`, which is event-driven when a
+  binder thread pool is running, rather than looping on `check_service`. Use
+  `register_for_notifications` when you need every (re-)registration over
+  time — it, too, needs the thread pool.
 
-- **Wait, don't poll.** If your client starts before the service it depends
-  on, call `wait_for_interface` / `wait_for_service` rather than repeatedly
-  calling `check_service` in a loop — the wait is event-driven when a binder
-  thread pool is running. Use `register_for_notifications` when you need to
-  observe every (re-)registration over time, and remember that the
-  notification callback only fires if the process runs a thread pool.
-
-- **`get_service` / `get_interface` are gone as of 0.11.0.** Their wait
-  behavior differed across Android versions; the `wait_*`, `check_*`, and
-  `try_get_*` families make the blocking and error semantics explicit.
-
-- **Handle registration failures.** `add_service` can fail if the name is
-  invalid or if the caller lacks permission (on Android with SELinux). Always
-  check the result.
-
-- **Prefer the typed `*_interface` variants.** `wait_for_interface`,
-  `check_interface`, and `try_get_interface` return a strongly-typed proxy
-  that provides compile-time guarantees; the `*_service` variants return the
-  raw `SIBinder`.
-
-- **Debug with `list_services` and `get_service_debug_info`.** When
-  troubleshooting, list all registered services and inspect their debug
-  information to verify that services are registered from the expected
-  processes. From a shell, `rsb_service list` / `info` / `dump manager` ask
-  the same questions without writing a program — see
+- **Reach for the shell before writing a program.** `rsb_service list` /
+  `info` / `check` / `dump manager` answer most "is it registered, and who
+  owns it" questions directly — see
   [Inspecting a running HUB](#inspecting-a-running-hub).

--- a/book/src/service-patterns.md
+++ b/book/src/service-patterns.md
@@ -1,8 +1,13 @@
 # Service Patterns
 
-This chapter covers the common patterns for implementing Binder services in rsbinder.
-Whether you are building a simple single-method service or a complex multi-service process,
-the patterns described here will help you structure your code effectively.
+How to structure a service, from a single method to a process hosting several.
+
+> This chapter uses the low-level lifecycle — `ProcessState`, the thread pool,
+> `hub::add_service` — because that is what the pieces actually are.
+> `rsbinder::serve("binder://")?.add(name, binder)?.run()?` performs exactly
+> these steps and is the shorter way to write them; reach past it when you need
+> control a URI does not express. See
+> [Cross-Transport Services](./cross-transport-services.md).
 
 ## Basic Service Structure
 
@@ -117,20 +122,20 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     // Register the primary test service.
     let service = BnTestService::new_binder(TestService::default());
-    hub::add_service(test_service_name, service.as_binder())?;
+    hub::add_service(test_service_name, &service)?;
 
     // Register a versioned interface service.
     let versioned_service = BnFooInterface::new_binder(FooInterface);
-    hub::add_service(versioned_service_name, versioned_service.as_binder())?;
+    hub::add_service(versioned_service_name, versioned_service)?;
 
     // Register a nested service.
     let nested_service = INestedService::BnNestedService::new_binder(NestedService);
-    hub::add_service(nested_service_name, nested_service.as_binder())?;
+    hub::add_service(nested_service_name, nested_service)?;
 
     // Register a fixed-size array service.
     let fixed_size_array_service =
         IRepeatFixedSizeArray::BnRepeatFixedSizeArray::new_binder(FixedSizeArrayService);
-    hub::add_service(fixed_size_array_service_name, fixed_size_array_service.as_binder())?;
+    hub::add_service(fixed_size_array_service_name, fixed_size_array_service)?;
 
     // All services share the same thread pool and process state.
     Ok(ProcessState::join_thread_pool()?)
@@ -181,8 +186,8 @@ The `ping_binder()` method tests whether a service is reachable and responsive.
 It sends a lightweight ping transaction and returns `Ok(())` on success:
 
 ```rust
-let service = get_service();
-assert_eq!(service.as_binder().ping_binder(), Ok(()));
+let hello: Strong<dyn IHello> = rsbinder::connect("binder://my.hello")?;
+assert_eq!(hello.as_binder().ping_binder(), Ok(()));
 ```
 
 This is useful for health checks and for verifying that a service is still alive
@@ -291,9 +296,8 @@ let callback = hub::BnServiceCallback::new_binder(MyServiceCallback);
 hub::register_for_notifications(SERVICE_NAME, &callback)?;
 ```
 
-Note: `onRegistration` is an *inbound* transaction into the client process,
-so the client must call `ProcessState::start_thread_pool()` (or park a thread
-in `join_thread_pool()`) — otherwise the notification never fires.
+`onRegistration` is an inbound transaction, so it needs the thread pool
+running in the client.
 
 ### Death Recipients
 
@@ -318,32 +322,19 @@ service.as_binder().link_to_death(
 
 To stop receiving notifications, call `unlink_to_death` with the same weak reference.
 
-Note: `binder_died` is delivered as an inbound binder command, so a client
-that links a death recipient must call `ProcessState::start_thread_pool()`
-(or park a thread in `join_thread_pool()`) — otherwise `binder_died` never
-fires.
+`binder_died` arrives as an inbound binder command, so it too needs the thread
+pool running in the client.
 
-## Tips and Best Practices
+## Tips
 
-- **`ProcessState::init_default()` must be called before any Binder operations.**
-  Failing to do so will result in a panic.
-- **`start_thread_pool()` is required by any process that receives inbound
-  transactions.** That includes not just services, but also *clients* holding a
-  service-notification callback, a callback object passed to a service, or a death
-  recipient — without a thread pool (or a thread parked in `join_thread_pool()`),
-  those callbacks and `binder_died` never fire. Only a purely-outbound client that
-  makes synchronous calls and receives nothing back can skip it.
-- **Each process needs only one `ProcessState::init_default()` call.** Multiple calls
-  are safe but unnecessary.
-- **`join_thread_pool()` blocks the calling thread.** Place it at the end of `main()`
-  after all setup is complete.
-- **`dump()` is optional but highly useful for debugging.** It provides a standardized
-  way to inspect service state from outside the process.
-- **Use `Mutex` or `RwLock` for mutable service state.** All AIDL methods receive
-  `&self`, so interior mutability is required for state changes.
-- **Service names should follow reverse-domain naming.** For example,
-  `com.example.myservice` or `my.hello`. This prevents name collisions when multiple
-  services are registered.
-- **Error handling**: Return `rsbinder::Status` errors from service methods to
-  communicate failures to clients. Use `Status::new_service_specific_error()` for
-  application-level errors that clients can inspect programmatically.
+- **Anything that *receives* a call needs `start_thread_pool()`** — not only
+  services. A client holding a service-notification callback, a callback object
+  it passed to a service, or a death recipient is receiving inbound
+  transactions, and without a thread pool (or a thread parked in
+  `join_thread_pool()`) those callbacks and `binder_died` simply never fire.
+  Only a purely outbound client can skip it.
+- **`ProcessState::init_default()` comes before any binder call** and panics if
+  it does not — but only once per process; further calls are harmless no-ops.
+- **Name services reverse-domain**, `com.example.myservice`, so two crates in
+  one process cannot collide.
+- **Mutable state needs `Mutex` or `RwLock`.** Every AIDL method takes `&self`.

--- a/book/src/stability-tiers.md
+++ b/book/src/stability-tiers.md
@@ -30,7 +30,8 @@ binder and is not expected to break.
   which are Provisional (below). See [Service Manager](service-manager.md).)
 - **AIDL compiler entry points** — `rsbinder_aidl::Builder::{new, source,
   output, version, generate}`.
-- **rsb_device** binary CLI (binderfs setup).
+- **rsb_device** binary CLI (binderfs setup); `--group` / `--mode` and the
+  `0600` default node are new in 0.11.0.
 
 ## Provisional
 
@@ -56,8 +57,39 @@ tweaks; wire formats are already locked.
 - **IAccessor client / server** (plans 2-13 D.8 + 2-14 D.9 STAGE3
   passed against real `libbinder`).
 - **`rsb_hub`** — `addService` descriptor auto-detect, `getService2`,
-  `checkService2`, `Service::Accessor` routing. Linux-native bringup.
+  `checkService2`, `Service::Accessor` routing. Linux-native bringup. New in
+  0.11.0: per-name access control, service declarations, on-demand start,
+  `dump`, supervisor integration, and the `rsb_service` CLI — the
+  configuration file format is settling with them.
 - **macOS first-class support** (plan 2-9 Phase A+B).
+- **Entry API (new in 0.11.0)** — `serve`, `connect`, `connect_async`,
+  `Client`, `Server`, `ServerGuard`, `ServeOptions`, `ClientOptions`,
+  `Endpoint`. Replaced the `rsbinder::service` facade. The URI grammar and the
+  two option structs are what may still change.
+- **Interface macros (new in 0.11.0, `macros` feature)** —
+  `#[rsbinder::interface]`, `#[derive(Parcelable)]`, `#[derive(BinderEnum)]`.
+  Feature-gated but **not** Experimental: the emitted code is byte-for-byte
+  the `.aidl` code, so the wire is whatever `.aidl` already guarantees. Only
+  the Rust-facing spelling is provisional. See
+  [Interface Macros](./interface-macros.md).
+- **Shared memory (new in 0.11.0)** — `SharedMemory`, `MemoryHeapBase`,
+  `MappedHeap`, `MemoryDealer`, `HeapCache`, and the `IMemory` / `IMemoryHeap`
+  wire (handwritten AOSP wire, not AIDL). STAGE3-gated against real
+  `libbinder` in both directions.
+- **Data serialization (new in 0.11.0)** — `to_bytes` / `from_bytes` (`rpc`
+  feature). The bytes are the IPC bytes, so only the two signatures may still
+  change. See [Storing Values](./data-serialization.md).
+- **Cross-stack bridging (new in 0.11.0)** — `impl Interface for Strong<I>`
+  (a proxy publishes as a local service, so a gateway is one line) and
+  `bridge::Rewrap`. See
+  [Cross-Transport Services](./cross-transport-services.md).
+- **`lazy_service` (new in 0.11.0)** — `LazyServiceRegistrar` and the AOSP
+  `registerService` / client-callback lifecycle, gated against Android's own
+  `servicemanager`.
+- **AIDL compiler, beyond the Stable entry points** —
+  `Builder::{dest_dir, hash}` and the public `render` module, the seam
+  `rsbinder-macros` plugs into. Its input structs are `#[non_exhaustive]`, so
+  a template gaining a field stays a minor release.
 
 ## Experimental (opt-in)
 

--- a/example-hello/Cargo.toml
+++ b/example-hello/Cargo.toml
@@ -131,6 +131,15 @@ name = "shm_service"
 [[bin]]
 name = "shm_client"
 
+# Data serialization: AIDL parcelables stored in a file with
+# `rsbinder::to_bytes` instead of sent in a transaction. Talks to nothing —
+# no binder device, no socket. `rpc` carries the session-less parcel mode
+# `to_bytes` encodes in.
+#   cargo run -p example-hello --features rpc --bin serde_demo
+[[bin]]
+name = "serde_demo"
+required-features = ["rpc"]
+
 # STAGE3 gate for the Android 15 service-manager split: drives the whole
 # `hub` surface against a real AOSP `servicemanager` and checks that every
 # method `android-15.0.0_r6` renumbered still lands where it should. Needs

--- a/example-hello/README.md
+++ b/example-hello/README.md
@@ -1,24 +1,58 @@
 # Examples for **crate rsbinder**
-This crate uses rsbinder to provide examples of how to create a service and a client.
 
-Refer to the following four main files:
+Every example is a `[[bin]]`: run one with
+`cargo run -p example-hello --bin <name>`, adding `--features rpc` where noted.
+The kernel-binder examples need `/dev/binderfs/binder` and a running service
+manager (`rsb_hub`); see the book's *Installation* chapter.
 
-* Example of how to generate Rust code from AIDL
-https://github.com/hiking90/rsbinder/blob/master/example-hello/build.rs
-* Example of how to include generated files
-https://github.com/hiking90/rsbinder/blob/master/example-hello/src/lib.rs
-* Example of how to create a Binder Service
-https://github.com/hiking90/rsbinder/blob/master/example-hello/src/bin/hello_service.rs
-* Example of how to create a Binder Client
-https://github.com/hiking90/rsbinder/blob/master/example-hello/src/bin/hello_client.rs
+## Start here
 
+* [`build.rs`](build.rs) — generating Rust from an `.aidl` file
+* [`src/lib.rs`](src/lib.rs) — including the generated code
+* [`src/bin/hello_service.rs`](src/bin/hello_service.rs) — a Binder service
+* [`src/bin/hello_client.rs`](src/bin/hello_client.rs) — a Binder client
 
+## One codebase, either transport
 
+Needs `--features rpc`.
 
+* [`unified_service.rs`](src/bin/unified_service.rs) /
+  [`unified_client.rs`](src/bin/unified_client.rs) — `rsbinder::serve(uri)`
+  and `connect(uri)`. The same code over kernel binder or RPC; pass `kernel`,
+  `rpc`, or an endpoint URI.
+* [`rpc_hello_service.rs`](src/bin/rpc_hello_service.rs) /
+  [`rpc_hello_client.rs`](src/bin/rpc_hello_client.rs) — the RPC transport on
+  its own: no kernel binder, no root, no service manager.
+* [`gateway_service.rs`](src/bin/gateway_service.rs) — connect on one
+  transport, re-publish on another. The whole bridge is
+  `BnHello::new_binder(upstream)`; see the book's *Cross-Transport Services*
+  chapter for what stops at a gateway.
+* [`authz_service.rs`](src/bin/authz_service.rs) /
+  [`authz_client.rs`](src/bin/authz_client.rs) — handler-side authorization
+  that matches on the transport-tagged caller and denies with `EX_SECURITY`.
 
-Shared memory (one `SharedMemory` region over a `ParcelFileDescriptor`, plus
-`MemoryDealer` frames as `IMemory` binders), over the kernel binder or a
-Unix-socket RPC session — see the book's *Shared Memory* chapter:
+## Storing values
 
-* https://github.com/hiking90/rsbinder/blob/master/example-hello/src/bin/shm_service.rs
-* https://github.com/hiking90/rsbinder/blob/master/example-hello/src/bin/shm_client.rs
+* [`serde_demo.rs`](src/bin/serde_demo.rs) — AIDL parcelables written to a
+  file with `rsbinder::to_bytes` instead of sent in a transaction, from the
+  `.aidl` definitions in [`aidl/settings/`](aidl/settings/). Shows the round
+  trip, both directions of version skew across an appended field, the strict
+  read, and the refusal of a file descriptor at write time. Talks to nothing —
+  no binder device, no socket. See the book's *Storing Values* chapter.
+
+## Shared memory
+
+* [`shm_service.rs`](src/bin/shm_service.rs) /
+  [`shm_client.rs`](src/bin/shm_client.rs) — one `SharedMemory` region over a
+  `ParcelFileDescriptor`, plus `MemoryDealer` frames as `IMemory` binders,
+  over kernel binder or a Unix-socket RPC session. See the book's *Shared
+  Memory* chapter.
+
+## Interop harnesses
+
+The remaining binaries (`rpc_accessor_interop_client`,
+`rpc_accessor_register_interop_server`, `rpc_multiconn_interop_server`,
+`rpc_incoming_interop_client`, `rpc_fd_interop_server`, `a15_qpr_interop`) are
+not tutorials. They are test harnesses that talk to real Android `libbinder`
+on a device or emulator, driven by the scripts under [`cpp/`](cpp/), and they
+live here because they need the same generated stubs as the examples above.

--- a/example-hello/aidl/settings/Endpoint.aidl
+++ b/example-hello/aidl/settings/Endpoint.aidl
@@ -1,0 +1,11 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package settings;
+
+/** A nested parcelable, to show that nesting survives storage too. */
+@RustDerive(Clone=true, PartialEq=true)
+parcelable Endpoint {
+    String host = "localhost";
+    int port = 8080;
+}

--- a/example-hello/aidl/settings/Mode.aidl
+++ b/example-hello/aidl/settings/Mode.aidl
@@ -1,0 +1,12 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package settings;
+
+/** Backed by `int`, so it is four bytes wherever it is stored. */
+@Backing(type="int")
+enum Mode {
+    OFF = 0,
+    ON = 1,
+    AUTO = 2,
+}

--- a/example-hello/aidl/settings/SettingsV1.aidl
+++ b/example-hello/aidl/settings/SettingsV1.aidl
@@ -1,0 +1,21 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package settings;
+
+/**
+ * Version 1 of a stored record.
+ *
+ * Normally this file would simply *become* `SettingsV2.aidl` as the schema
+ * grows. Both versions are kept here, under one build, so `serde_demo` can
+ * play both sides of the version skew in a single process.
+ */
+@RustDerive(Clone=true, PartialEq=true)
+parcelable SettingsV1 {
+    String name = "unnamed";
+    int volume = 50;
+    Mode mode = Mode.AUTO;
+    Endpoint endpoint;
+    String[] tags;
+    @nullable String note;
+}

--- a/example-hello/aidl/settings/SettingsV2.aidl
+++ b/example-hello/aidl/settings/SettingsV2.aidl
@@ -1,0 +1,26 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package settings;
+
+/**
+ * Version 2: {@link SettingsV1} with two fields appended, and nothing else
+ * touched.
+ *
+ * Appending is the only edit a positional format absorbs. Reordering or
+ * removing a field changes what the bytes at each offset mean, and no reader
+ * can detect that — it just decodes the wrong values.
+ */
+@RustDerive(Clone=true, PartialEq=true)
+parcelable SettingsV2 {
+    String name = "unnamed";
+    int volume = 50;
+    Mode mode = Mode.AUTO;
+    Endpoint endpoint;
+    String[] tags;
+    @nullable String note;
+
+    // Appended in v2.
+    int retries = 3;
+    long updatedAtMillis;
+}

--- a/example-hello/build.rs
+++ b/example-hello/build.rs
@@ -28,6 +28,17 @@ fn main() {
     aidl("aidl/authz/IAuthz.aidl", "authz.rs");
     // Shared-memory example interface (`bin/shm_{service,client}`).
     aidl("aidl/shm/IShm.aidl", "shm.rs");
+    // Data-serialization example (`bin/serde_demo`): parcelables stored with
+    // `rsbinder::to_bytes` rather than sent through a transaction. Several
+    // declarations in one package, so they go into one generated file.
+    rsbinder_aidl::Builder::new()
+        .source(PathBuf::from("aidl/settings/Mode.aidl"))
+        .source(PathBuf::from("aidl/settings/Endpoint.aidl"))
+        .source(PathBuf::from("aidl/settings/SettingsV1.aidl"))
+        .source(PathBuf::from("aidl/settings/SettingsV2.aidl"))
+        .output(PathBuf::from("settings.rs"))
+        .generate()
+        .unwrap();
     // Shared with `tests/aidl/shapes/`; `cpp/codegen_shapes_interop.cpp` cross-checks the wire against libbinder.
     aidl(
         "../tests/aidl/shapes/ICodegenShapes.aidl",

--- a/example-hello/src/bin/serde_demo.rs
+++ b/example-hello/src/bin/serde_demo.rs
@@ -1,0 +1,120 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Storing an AIDL parcelable in a file instead of sending it in a
+//! transaction, with [`rsbinder::to_bytes`] / [`rsbinder::from_bytes`].
+//!
+//! The types come from `aidl/settings/*.aidl` and are compiled by `build.rs`
+//! like any other interface — nothing here is specific to storage. That is the
+//! point: an AIDL definition is already a schema, and the generated code is
+//! already a complete serializer, so a project need not describe the same data
+//! a second time in protobuf or serde.
+//!
+//! ```text
+//! cargo run -p example-hello --features rpc --bin serde_demo
+//! ```
+//!
+//! No binder device, no service manager, no socket — this talks to nothing.
+//! The `rpc` feature is required only because `to_bytes` encodes in the
+//! session-less parcel mode that feature carries.
+//!
+//! See `book/src/data-serialization.md`.
+
+use example_hello::settings::{
+    Endpoint::Endpoint, Mode::Mode, SettingsV1::SettingsV1, SettingsV2::SettingsV2, STORE_PATH,
+};
+use rsbinder::{from_bytes, to_bytes, StatusCode};
+
+fn sample() -> SettingsV2 {
+    SettingsV2 {
+        name: "studio".into(),
+        volume: 72,
+        mode: Mode::ON,
+        endpoint: Endpoint {
+            host: "10.0.0.4".into(),
+            port: 9000,
+        },
+        tags: vec!["fast".into(), "한글".into()],
+        note: Some("written by v2".into()),
+        retries: 5,
+        updatedAtMillis: 1_757_000_000_000,
+    }
+}
+
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    // 1. Write a value to a file, read it back, compare.
+    let original = sample();
+    let bytes = to_bytes(&original)?;
+    std::fs::write(STORE_PATH, &bytes)?;
+    println!("wrote {} bytes to {STORE_PATH}", bytes.len());
+
+    let restored: SettingsV2 = from_bytes(&std::fs::read(STORE_PATH)?)?;
+    assert_eq!(restored, original);
+    println!("read back: {restored:?}");
+
+    // 2. A reader built against the OLDER definition reads the newer bytes.
+    //    The parcelable's length header tells it where the value ends, so the
+    //    two fields v2 appended are skipped rather than misread.
+    let as_v1: SettingsV1 = from_bytes(&bytes)?;
+    assert_eq!(as_v1.name, original.name);
+    assert_eq!(as_v1.volume, original.volume);
+    assert_eq!(as_v1.mode, original.mode);
+    assert_eq!(as_v1.endpoint, original.endpoint);
+    assert_eq!(as_v1.tags, original.tags);
+    assert_eq!(as_v1.note, original.note);
+    println!("v1 reader saw v2 bytes, extra fields skipped: {as_v1:?}");
+
+    // 3. A reader built against the NEWER definition reads the older bytes.
+    //    The fields v1 never wrote come back as the AIDL defaults —
+    //    `retries = 3` from the `.aidl`, and `0` for the field with none.
+    let v1_value = SettingsV1 {
+        name: "laptop".into(),
+        volume: 30,
+        mode: Mode::OFF,
+        endpoint: Endpoint::default(),
+        tags: vec!["quiet".into()],
+        note: None,
+    };
+    let v1_bytes = to_bytes(&v1_value)?;
+    let as_v2: SettingsV2 = from_bytes(&v1_bytes)?;
+    assert_eq!(as_v2.name, v1_value.name);
+    assert_eq!(as_v2.retries, 3, "the .aidl default");
+    assert_eq!(as_v2.updatedAtMillis, 0);
+    println!("v2 reader saw v1 bytes, missing fields defaulted: {as_v2:?}");
+
+    // 4. Reading is strict: the input must be consumed exactly. Leftover
+    //    bytes usually mean the file was written as a different type, and
+    //    returning the partial value would hide that behind a plausible
+    //    wrong answer.
+    let mut trailing = bytes.clone();
+    trailing.push(0);
+    assert_eq!(
+        from_bytes::<SettingsV2>(&trailing).unwrap_err(),
+        StatusCode::BadValue
+    );
+    assert_eq!(
+        from_bytes::<SettingsV2>(&bytes[..bytes.len() - 4]).unwrap_err(),
+        StatusCode::NotEnoughData
+    );
+    println!("trailing bytes -> BadValue, truncated -> NotEnoughData");
+
+    // 5. What cannot be stored. A file descriptor means nothing outside the
+    //    process that opened it, so it is refused where it is written —
+    //    before any `dup` — rather than encoded into something that refers
+    //    to nothing. A binder is refused the same way, as `BadType`.
+    let devnull = rsbinder::ParcelFileDescriptor::new(std::fs::File::open("/dev/null")?);
+    assert_eq!(to_bytes(&devnull).unwrap_err(), StatusCode::FdsNotAllowed);
+    println!("a file descriptor is refused at write time: FdsNotAllowed");
+
+    // 6. The bytes are the IPC bytes, and the parcel wire is little-endian on
+    //    every host — so this file reads back on any machine, not only one
+    //    with the same byte order.
+    println!(
+        "volume ({}) is stored as {:02x?}",
+        original.volume,
+        original.volume.to_le_bytes()
+    );
+
+    std::fs::remove_file(STORE_PATH)?;
+    Ok(())
+}

--- a/example-hello/src/lib.rs
+++ b/example-hello/src/lib.rs
@@ -66,6 +66,17 @@ pub mod shm {
     pub const DEALER_SIZE: usize = 1024 * 1024;
 }
 
+/// Data-serialization example (`bin/serde_demo`): AIDL parcelables written to
+/// a file with [`rsbinder::to_bytes`] instead of into a transaction. Carries
+/// two versions of one record so the example can show what a reader built
+/// against the other version sees.
+#[cfg(feature = "rpc")]
+pub mod settings {
+    rsbinder::include_aidl!("settings", self::settings::*);
+    /// File `serde_demo` writes and reads back.
+    pub const STORE_PATH: &str = "/tmp/rsb_settings.bin";
+}
+
 /// Argument shapes the AOSP fixture corpus never uses (`out` scalars with no
 /// `Default`, `@nullable` primitive arrays, non-nullable `inout` binder
 /// arrays). The `.aidl` is shared with the tests crate;

--- a/rsbinder-aidl/README.md
+++ b/rsbinder-aidl/README.md
@@ -5,10 +5,10 @@ This is an AIDL compiler for **rsbinder**.
 Add dependencies to Cargo.toml (check crates.io for the latest version):
 ```toml
 [dependencies]
-rsbinder = "0.10"
+rsbinder = "0.11"
 
 [build-dependencies]
-rsbinder-aidl = { version = "0.10", features = ["async"] }
+rsbinder-aidl = { version = "0.11", features = ["async"] }
 ```
 
 Create a build.rs file:
@@ -40,6 +40,10 @@ rsbinder::include_aidl!("my_service", crate::IMyService::*);
   equivalent). All directories are scanned deterministically; an import
   found under more than one directory is an error, matching AOSP.
 - `.output(name)` — the generated file name, written under `OUT_DIR`.
+- `.dest_dir(path)` — the directory `.output(name)` is resolved against,
+  overriding `OUT_DIR`. Use it outside a `build.rs` — a test generating into
+  a temporary directory, a tool driving several builders — where mutating the
+  process-wide `OUT_DIR` would not be thread-safe.
 - `.version(n)` / `.hash("…")` — stamp the **most recently added file
   source** with stable-AIDL version metadata (AOSP `aidl --version N
   --hash <s>` equivalent); the generated interfaces gain
@@ -51,10 +55,10 @@ rsbinder::include_aidl!("my_service", crate::IMyService::*);
 For environments without async runtime:
 ```toml
 [dependencies]
-rsbinder = { version = "0.10", default-features = false }
+rsbinder = { version = "0.11", default-features = false }
 
 [build-dependencies]
-rsbinder-aidl = "0.10"
+rsbinder-aidl = "0.11"
 ```
 
 ## Error Reporting

--- a/rsbinder-tools/README.md
+++ b/rsbinder-tools/README.md
@@ -60,7 +60,7 @@ For detailed technical information, refer to the [Linux kernel binderfs document
 
 ## rsb_hub
 
-A comprehensive service manager for Linux that replaces Android's service_manager functionality.
+The service manager for Linux — the counterpart of Android's `servicemanager`.
 
 ### Usage
 ```bash
@@ -102,17 +102,14 @@ on the same device exits 1 and says so; give it its own device
 (`rsb_device other && rsb_hub --device other`) to run an independent one.
 
 ### Features
-**rsb_hub** provides a full-featured service management system with:
 
-- **Service Registration**: Allows services to register themselves with unique names
-- **Service Discovery**: Enables clients to find and connect to registered services
-- **Lifecycle Management**: Monitors service health and handles cleanup
-- **Access Control**: Per-name `add` / `find` / `list` policy keyed on caller uid and group, default-deny, reloadable with `SIGHUP`
+- **Service Registration / Discovery**: services register under a unique name; clients look them up by it
+- **Lifecycle Management**: dead services are reaped, and death notifications delivered
+- **Access Control**: per-name `add` / `find` / `list` policy keyed on caller uid and group, default-deny, reloadable with `SIGHUP`
 - **Service Declarations**: `[[service]]` entries answer `isDeclared` / `getDeclaredInstances` / `getConnectionInfo`, the Linux stand-in for VINTF manifests
 - **On-Demand Start**: a lookup that misses a declared service starts it, via systemd or a configured command
-- **Priority Support**: Implements priority-based service access control
-- **Notification System**: Provides callbacks for service availability changes
-- **Debug Information**: Offers service introspection and debugging capabilities
+- **Notification System**: callbacks for service availability changes
+- **Dump Priorities**: `listServices` filters by the AOSP `DUMP_FLAG_PRIORITY_*` flags — a listing filter, not an access-control mechanism
 
 ### API Compatibility
 **rsb_hub** implements the same interface as Android's service manager, ensuring compatibility with existing binder applications. It supports:
@@ -124,15 +121,12 @@ on the same device exits 1 and says so; give it its own device
 - `registerForNotifications()`: Register for service lifecycle notifications
 
 ### Implementation Details
-Built on top of **rsbinder**'s service management APIs, **rsb_hub** provides:
-- Thread-safe service registration and lookup
-- Automatic cleanup of dead services
-- Support for service priorities and access control
-- Access control keyed on the credentials the kernel vouches for (uid), with
-  groups resolved through NSS -- portable to any Linux, and to macOS for the
-  RPC transport, without requiring SELinux
 
-The hub acts as a central registry that bridges the gap between service providers and consumers, making Binder IPC on Linux as seamless as on Android.
+Access control is keyed on the credential the kernel vouches for — the caller
+uid the binder driver fills in itself — with groups resolved through NSS. That
+is what makes the policy portable to any Linux without requiring SELinux.
+Deliberately unused: **pid**, because pid reuse makes every pid-derived
+attribute unsound as an authorization key.
 
 ## rsb_service
 

--- a/rsbinder/src/lib.rs
+++ b/rsbinder/src/lib.rs
@@ -19,6 +19,10 @@
 //!   feature) — a separate stack from the kernel binder path
 //! - **Entry API**: [`serve`] / [`connect`] — publish and look up services
 //!   with one URI-selected transport (kernel binder or RPC)
+//! - **Shared memory**: [`shared_memory`] — payloads too big to copy through
+//!   a transaction (AOSP `IMemory` wire)
+//! - **Interface macros**: `#[rsbinder::interface]` (behind the `macros`
+//!   feature) — an interface as a Rust trait instead of an `.aidl` file
 //!
 //! # Wire byte order
 //!
@@ -97,6 +101,11 @@
 //!   Linux and Android targets only).
 //! - `rpc-tls` — TLS backend over rustls (implies `rpc`). rsbinder never
 //!   invents crypto; the caller supplies the `rustls` configuration.
+//! - `macros` — `#[rsbinder::interface]`, `#[derive(Parcelable)]` and
+//!   `#[derive(BinderEnum)]`: declare an interface as a Rust trait, with no
+//!   `.aidl` file and no `build.rs`. The emitted code is byte-for-byte what
+//!   `.aidl` produces. Off by default: it pulls the AIDL compiler in as a
+//!   proc-macro dependency.
 //! - `android_10` … `android_16`, plus the `android_*_plus` ranges (e.g.
 //!   `android_11_plus`) — select which Android service-manager protocol
 //!   versions to support. Android 10 uses the legacy C service-manager

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,15 +1,12 @@
 # tests
 This is a port of Android's test cases to the rsbinder environment.
 
-There are a total of 96 test cases, of which 93 are currently in a passed state.
-The 3 failed ones require the development of new features.
+Three cases need features rsbinder does not have yet, and CI skips them by
+name:
 
 - [ ] test_vintf_parcelable_holder_cannot_contain_unstable_parcelable
 - [ ] test_vintf_parcelable_holder_cannot_contain_not_vintf_parcelable
 - [ ] test_versioned_unknown_union_field_triggers_error
-
-The previously failing `test_renamed_interface_*` siblings were stabilized
-by closing the proxy-cache races in PR #100.
 
 ## Access-control gates (Linux only)
 


### PR DESCRIPTION
Release preparation for 0.11.0: stamp the changelog, cover what this release
added, and read the whole book against the code it describes.

## Changelog

Closes `[Unreleased]` as `0.11.0` and adds link definitions. Two kernel fixes
landed after the last changelog entry and are recorded now:

- a driver that consumes only part of the queued command buffer aborts rather
  than panicking, since the reply path's `catch_unwind` would otherwise resume
  on a desynchronized stream;
- a caught panic on the reply path rewinds only its own transaction, instead of
  truncating the whole parcel and dropping a nested call's `BC_FREE_BUFFER` —
  which left the kernel holding a buffer nothing would reclaim.

## Book

`#[rsbinder::interface]` shipped in this release with **no book coverage at
all**, so there is a new *Interface Macros* chapter. Also new: the
little-endian parcel wire in *Architecture*, and 0.11.0's surfaces
(entry API, macros, shared memory, `to_bytes`/`from_bytes`, `bridge`,
`lazy_service`, the AIDL `render` module) in *Stability Tiers*.

Then a full read of all 30 pages. Things that were wrong:

| | |
|---|---|
| `aidl-parcelable` / `aidl-annotations` | body and tips contradicted each other on `heap=true`. It is ignored — `Box` comes from the generator's cycle analysis (`declaration_reaches`) |
| `aidl-data-types` | the `out` column for `IBinder` / `ParcelFileDescriptor` was **empty**; 0.11.0 made it `&mut Option<T>` |
| `cross-transport-services` | `Client::open_with`'s closure took one argument; the signature takes two |
| `async-service` | `new_current_thread()` recommended unconditionally — an RPC server needs multi-thread or it hangs |
| `service-manager` | `hub::default()` documented as returning `Err` on an unavailable device; it panics |
| `hello-world` | `$ rsb_hub` no longer starts without a policy, and troubleshooting still advised mode `0666` |
| `installation` / `rsbinder-tools` | "priority-based service access control" — dump priorities are a listing filter |
| `overview` | "strong security features to prevent unauthorized access", while `installation` correctly says binder has no in-kernel access control |
| `parcel-file-descriptor` | `build_pipe` used `unsafe { File::from_raw_fd(..) }` where `File: From<OwnedFd>` works |
| `service-patterns` / `async-service` | `add_service(name, &svc)` and `add_service(name, svc.as_binder())` used in the same file |
| `android` | `rsproperties = "0.5"`; the workspace is on 0.6 |
| `redhat-linux` | recommended `setenforce 0` with no qualification |

Removed what the sidebar or the adjacent paragraph already said — most visibly
`getting-started`, which reproduced `SUMMARY.md`, and `hello-world`, which
explained caller identity, error handling and `@RustDerive` inline and then
linked the three chapters about them. The thread-pool caveat appeared seven
times; it now appears where it bites.

## Example

`to_bytes` / `from_bytes` is sold on "your AIDL definition is already a
schema", but every snippet in the chapter used `#[derive(Parcelable)]` and no
`.aidl`-based example existed anywhere in the tree. This adds
`example-hello/aidl/settings/` and `bin/serde_demo`, which asserts and prints:

```
wrote 148 bytes to /tmp/rsb_settings.bin
read back: SettingsV2 { name: "studio", volume: 72, mode: Mode(1), ... }
v1 reader saw v2 bytes, extra fields skipped: SettingsV1 { ... }
v2 reader saw v1 bytes, missing fields defaulted: SettingsV2 { ..., retries: 3, updatedAtMillis: 0 }
trailing bytes -> BadValue, truncated -> NotEnoughData
a file descriptor is refused at write time: FdsNotAllowed
volume (72) is stored as [48, 00, 00, 00]
```

`retries: 3` comes from the default written in the `.aidl`, which is the point:
a newer reader fills what an older writer never wrote from the schema. The last
line is why the file crosses architectures.

It needs no binder device, no service manager and no peer — the only example
that does not — so `rpc-suite` runs it instead of merely compiling it.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`,
`RUSTDOCFLAGS=-D warnings cargo doc` on both feature sets, `cargo check
--workspace --all-features`, and the `rsbinder-aidl` / `rsbinder-macros` golden
tests. Every book link and `SUMMARY.md` entry resolves; no page is orphaned.
Types newly asserted in the docs were checked against `api/*.txt` and
`tests/tests/codegen_shapes.rs` rather than from memory.

Not included: the `v0.11.0` tag. The changelog is stamped `2026-09-09`; adjust
that line if tagging slips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Dm4bqWFSUpPsEvk1oERCN
