### PR TITLE
feat(aidl): port AOSP type-placement validation and @deprecated codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,121 @@ This changelog starts at 0.9.0. For earlier releases, see the
 
 ## [Unreleased]
 
-## [0.11.0] - 2026-09-10
+### Migrating
+
+- **`rsbinder-aidl` now rejects `.aidl` that AOSP's `aidl` also rejects.** The
+  new checks are listed under *Added*. Each one fires on a contract the AOSP
+  compiler already refuses, so an `.aidl` that builds against both compilers is
+  unaffected — but an rsbinder-only contract that leaned on the missing
+  validation now fails to build. The diagnostic names the rule and the AOSP
+  behavior it mirrors.
+- **`render::ConstMember` and `render::EnumMember` gained a field.**
+  `ConstMember` is now `(identifier, type, initializer, deprecation attribute)`
+  and `EnumMember` is `(identifier, discriminant, deprecation attribute)`. Both
+  are positional tuples that a second front-end fills directly, so this is a
+  compile error at those call sites, not a silent change; pass `String::new()`
+  for the new element to keep the previous output. The `#[non_exhaustive]`
+  render structs (`InterfaceRender`, `ParcelableRender`, `EnumRender`,
+  `FnMembers`, `ParcelableMember`) also gained a `deprecated` field, but they
+  are built through `new()`/`Default`, so those keep compiling.
+- **`error::SemanticError` is now `#[non_exhaustive]`** and gained two variants,
+  `FixedSizeNonFixedField` and `VintfStabilityLeak` (appended, so no existing
+  variant's discriminant moved). An exhaustive `match` over it needs a `_ => …`
+  arm added — once: from here on a new diagnostic is a minor release.
+- **A declaration nested in a `@VintfStability` type is now VINTF-stable** (see
+  *Fixed*), which changes both the wire and a runtime check for it: a
+  `ParcelableHolder` field of such a nested type records VINTF stability
+  instead of the default, and `ParcelableHolder::set_parcelable` now returns
+  `StatusCode::BadValue` for a payload whose own stability does not include
+  VINTF, where it previously succeeded. Nothing in the build warns.
+- **`#[deprecated]` codegen can break a downstream `-D warnings` build.** An
+  existing `.aidl` whose `/** @deprecated … */` javadoc was previously ignored
+  now generates `#[deprecated]`, and by design that warns outside the generated
+  module. Drop the javadoc tag, or allow the lint at the call site.
+
+### Added
+
+- **`rsbinder-aidl`: AIDL type-placement validation matching AOSP.** The
+  `@FixedSize` and `@VintfStability` rules are contract-level — rsbinder
+  generated compiling code either way, so without them an `.aidl` authored here
+  could be refused by AOSP's `aidl`. The `void` and `ParcelableHolder`
+  placements marked below are not contract-level: the code rsbinder generated
+  for them never compiled, and the check turns a rustc error in the generated
+  crate into an AIDL diagnostic.
+  - `@FixedSize` parcelables and unions now require every field to be fixed
+    size, porting AOSP `AidlTypenames::CanBeFixedSize` (primitives, enums,
+    fixed-size arrays of those, and other `@FixedSize` types qualify; `String`,
+    `IBinder`, `ParcelFileDescriptor`, `ParcelableHolder`, `List<T>`,
+    variable-length arrays, and `@nullable` types do not). `@FixedSize` is not
+    inherited by nested declarations, matching AOSP.
+  - `@VintfStability` declarations may only reference `@VintfStability` types.
+    AOSP enforces this compilation-wide through `aidl_interface { stability:
+    "vintf" }`; rsbinder has no such mode and enforces the reference closure
+    that rule implies, which fires on exactly the contracts AOSP refuses. A
+    non-VINTF type may still use a VINTF one.
+  - `ParcelableHolder` is rejected as an array element, as a `List` element, as
+    `@nullable`, as a method argument, as a method return type, and as a union
+    member. The array, `List` and `@nullable` forms are the ones that did not
+    compile (`Vec<ParcelableHolder>` has no `SerializeArray`,
+    `Option<ParcelableHolder>` no `SerializeOption`); the argument, return-type
+    and union-member forms compiled, so those three are contract-level.
+  - `void` is rejected as a parameter type, a field or constant type, and an
+    array or `List` element — none of which compiled. It remains valid as a
+    bare method return type.
+  - A `union` with no fields is rejected, porting AOSP `AidlUnionDecl::
+    CheckValid`. `const` members do not count as fields: the enum rendered for
+    such a union is uninhabited, so its `Default` impl and its `write_to_parcel`
+    match never compiled.
+  - A duplicate argument name in a method is rejected, porting AOSP
+    `AidlMethod::CheckValid`. Both arguments rendered as the same `_arg_<name>`
+    binding, so the defect used to surface as rustc E0415 in the consumer's
+    crate.
+  - A type argument on a type that takes none (`String<int>`, `IBinder<T>`) is
+    rejected, porting AOSP `AidlTypeSpecifier::CheckValid`. The generic was
+    being dropped silently, so `String<int>` compiled as a plain `String`.
+    `List`, `Map` and parameterizable user-defined parcelables are unaffected.
+  - A `const` must have a primitive or `String` type, or an array of those. A
+    handle (`IBinder`, `ParcelFileDescriptor`, `ParcelableHolder`) has no
+    constant form, and a user-defined type is refused by AOSP outright
+    (`AidlConstantDeclaration::CheckValid`). AOSP's set is narrower still —
+    `boolean`, `char` and constant arrays are deliberate rsbinder extensions,
+    pinned by its test suite, and are kept.
+  - A `@VintfStability` declaration may reference a `@RustOnlyStableParcelable`
+    (one declared with `rust_type`) without it being `@VintfStability` itself,
+    matching AOSP's stable-API-parcelable exemption (`IsStableApiParcelable`):
+    there is no generated declaration to carry the annotation.
+- **`rsbinder-aidl`: `@deprecated` javadoc is now emitted as `#[deprecated]`.**
+  A `/** @deprecated note */` block above an interface, parcelable, union,
+  enum, method, field, constant, or enumerator becomes `#[deprecated = "note"]`
+  on the generated item (`#[deprecated]` with no note), following AOSP's
+  `FindDeprecated` rules: only the last comment of the preceding run counts,
+  and only when it is a block comment. Generated modules carry a module-scoped
+  `#![allow(deprecated)]` so the generated proxy and dispatch plumbing does not
+  warn about the items it must name; callers outside the module still do.
+
+### Fixed
+
+- **`rsbinder-aidl`: a nested declaration inside a `@VintfStability` type now
+  inherits that stability.** AOSP resolves `@VintfStability` with a scoped
+  lookup that walks to the enclosing type, so a parcelable nested in a
+  `@VintfStability` parcelable is VINTF-stable. rsbinder read only the
+  declaration's own annotations, so such a nested type reported default
+  stability — which is what a `ParcelableHolder` records for it, making this
+  visible on the wire.
+- **`rsbinder-aidl`: a `@VintfStability` interface published through the sync
+  path registered with the default `System` stability.** The generated
+  `declare_binder_interface!` never emitted a `stability:` field, so the macro
+  fell back to `Stability::default()`. Because `System` does not include
+  `Vintf`, a peer requiring VINTF refused the binder — the annotation had no
+  effect at all on a sync service. AOSP emits the field
+  (`generate_rust.cpp`); rsbinder now does too. Parcelables, unions and the
+  async path were already correct.
+- **`rsbinder-aidl`: a type nested three or more levels deep could not name a
+  type from a grandparent scope.** The enclosing-scope walk in
+  `lookup_decl_from_name` stopped after two levels, so a reference AOSP
+  resolves — `AidlDefinedType::ResolveName` recurses with no depth limit — was
+  rejected as an unknown type, and with a misleading message at that. The walk
+  now runs to the package boundary.
 
 ### Migrating from 0.10.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "example-hello"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "env_logger",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "rsbinder"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "env_logger",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "rsbinder-aidl"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "convert_case",
  "miette",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "rsbinder-macros"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "rsbinder-tools"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anstyle",
  "clap",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Jeff Kim <hiking90@gmail.com>"]
@@ -27,14 +27,14 @@ rust-version = "1.85"
 keywords = ["android", "binder", "aidl", "linux"]
 
 [workspace.dependencies]
-rsbinder = { version = "0.11.0", path = "rsbinder" }
+rsbinder = { version = "0.12.0", path = "rsbinder" }
 log = "0.4"
 env_logger = "0.11"
 anstyle = "1.0"
 tokio = { version = "1.52", default-features = false }
 async-trait = "0.1"
-rsbinder-aidl = { version = "0.11.0", path = "rsbinder-aidl" }
-rsbinder-macros = { version = "0.11.0", path = "rsbinder-macros" }
+rsbinder-aidl = { version = "0.12.0", path = "rsbinder-aidl" }
+rsbinder-macros = { version = "0.12.0", path = "rsbinder-macros" }
 pest = "2.8"
 pest_derive = "2.8"
 convert_case = "0.12"

--- a/rsbinder-aidl/src/error.rs
+++ b/rsbinder-aidl/src/error.rs
@@ -130,7 +130,11 @@ impl ParseError {
 }
 
 /// Semantic errors (type validation, transaction codes, etc.)
+///
+/// `#[non_exhaustive]`: new AIDL rules keep arriving, and each one a
+/// diagnostic. Match with a `_` arm so gaining one stays a minor release.
 #[derive(Error, Debug, Diagnostic)]
+#[non_exhaustive]
 pub enum SemanticError {
     #[error("Interface '{interface}': transaction code {code} conflict between '{method1}' and '{method2}'")]
     #[diagnostic(
@@ -292,6 +296,56 @@ pub enum SemanticError {
         #[source_code]
         src: NamedSource<String>,
         #[label("malformed @EnforcePermission argument")]
+        span: SourceSpan,
+    },
+
+    /// AOSP `AidlParcelable::CheckValid` (`aidl_language.cpp`) rejects a
+    /// `@FixedSize` parcelable or union that holds a field whose size is not
+    /// fixed. rsbinder generates the same wire format with or without the
+    /// annotation, so accepting this would leave a contract that only builds
+    /// here and is refused by AOSP's `aidl`.
+    #[error("the @FixedSize {kind} '{owner}' has a non-fixed size field named '{field}'")]
+    #[diagnostic(
+        code(aidl::fixed_size_non_fixed_field),
+        help(
+            "a @FixedSize member must be a primitive, an enum, a fixed-size array of \
+             those, or another @FixedSize parcelable/union — never String, IBinder, \
+             ParcelFileDescriptor, ParcelableHolder, List<T>, a variable-length array, \
+             or a @nullable type"
+        )
+    )]
+    FixedSizeNonFixedField {
+        kind: &'static str,
+        owner: String,
+        field: String,
+        #[source_code]
+        src: NamedSource<String>,
+        #[label("this field is not fixed size")]
+        span: SourceSpan,
+    },
+
+    /// AOSP enforces VINTF stability across a whole compilation: with
+    /// `aidl_interface { stability: "vintf" }` (`--stability vintf`) every
+    /// type loaded must be `@VintfStability` (`aidl.cpp`). rsbinder has no
+    /// compilation-wide stability mode, so it enforces the implication of
+    /// that rule — a VINTF type's reference closure is also VINTF.
+    #[error(
+        "@VintfStability {kind} '{owner}' references '{referenced}', which is not @VintfStability"
+    )]
+    #[diagnostic(
+        code(aidl::vintf_stability_leak),
+        help(
+            "annotate '{referenced}' with @VintfStability, or drop @VintfStability from \
+             '{owner}' — a VINTF interface may only carry VINTF-stable types"
+        )
+    )]
+    VintfStabilityLeak {
+        kind: &'static str,
+        owner: String,
+        referenced: String,
+        #[source_code]
+        src: NamedSource<String>,
+        #[label("'{referenced}' does not have VINTF level stability")]
         span: SourceSpan,
     },
 }

--- a/rsbinder-aidl/src/generator.rs
+++ b/rsbinder-aidl/src/generator.rs
@@ -11,12 +11,20 @@ use crate::error::{AidlError, DuplicateCodeRelated, SemanticError};
 use crate::parser::Direction;
 use crate::{add_indent, parser, Namespace};
 
+// `deprecated`: generated plumbing must name the item it deprecates; the allow
+// is module-scoped, so consumers outside the module still warn.
 const ENUM_TEMPLATE: &str = r##"
 pub mod {{mod}} {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     {{crate}}::declare_binder_enum! {
+        {%- if deprecated %}
+        {{ deprecated }}
+        {%- endif %}
         r#{{enum_name}} : [{{enum_type}}; {{enum_len}}] {
     {%- for member in members %}
+        {%- if member.2 %}
+            {{ member.2 }}
+        {%- endif %}
             r#{{ member.0 }} = {{ member.1 }},
     {%- endfor %}
         }
@@ -26,17 +34,26 @@ pub mod {{mod}} {
 
 const UNION_TEMPLATE: &str = r#"
 pub mod {{mod}} {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     #[derive(Debug)]
     {%- if derive|length > 0 %}
     #[derive({{ derive }})]
     {%- endif %}
+    {%- if deprecated %}
+    {{ deprecated }}
+    {%- endif %}
     pub enum r#{{union_name}} {
     {%- for member in members %}
+        {%- if member.5 %}
+        {{ member.5 }}
+        {%- endif %}
         r#{{ member.0 }}({{ member.1 }}),
     {%- endfor %}
     }
     {%- for member in const_members %}
+    {%- if member.3 %}
+    {{ member.3 }}
+    {%- endif %}
     pub const r#{{ member.0 }}: {{ member.1 }} = {{ member.2 }};
     {%- endfor %}
     impl Default for r#{{union_name}} {
@@ -107,16 +124,25 @@ pub mod {{mod}} {
 
 const PARCELABLE_TEMPLATE: &str = r#"
 pub mod {{mod}} {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     {%- for member in const_members %}
+    {%- if member.3 %}
+    {{ member.3 }}
+    {%- endif %}
     pub const r#{{ member.0 }}: {{ member.1 }} = {{ member.2 }};
     {%- endfor %}
     #[derive(Debug)]
     {%- if derive|length > 0 %}
     #[derive({{ derive }})]
     {%- endif %}
+    {%- if deprecated %}
+    {{ deprecated }}
+    {%- endif %}
     pub struct {{name}} {
     {%- for member in members %}
+        {%- if member.deprecated %}
+        {{ member.deprecated }}
+        {%- endif %}
         pub r#{{ member.identifier }}: {{ member.type_decl }},
     {%- endfor %}
     }
@@ -175,8 +201,11 @@ pub mod {{mod}} {
 
 const INTERFACE_TEMPLATE: &str = r#"
 pub mod {{mod}} {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     {%- for member in const_members %}
+    {%- if member.3 %}
+    {{ member.3 }}
+    {%- endif %}
     pub const r#{{ member.0 }}: {{ member.1 }} = {{ member.2 }};
     {%- endfor %}
     {%- if version %}
@@ -191,9 +220,15 @@ pub mod {{mod}} {
     /// responsibility).
     pub const HASH: &str = "{{ hash }}";
     {%- endif %}
+    {%- if deprecated %}
+    {{ deprecated }}
+    {%- endif %}
     pub trait {{name}}: {{crate}}::Interface + Send {
         fn descriptor() -> &'static str where Self: Sized { "{{ namespace }}" }
         {%- for member in fn_members %}
+        {%- if member.deprecated %}
+        {{ member.deprecated }}
+        {%- endif %}
         fn r#{{ member.identifier }}({{ member.args }}) -> {{crate}}::BinderResult<{{ member.return_type }}>;
         {%- endfor %}
         {%- if version %}
@@ -225,9 +260,15 @@ pub mod {{mod}} {
     /// A `type {{name}}AsyncTokio = dyn {{name}}Async<rsbinder::Tokio>;` alias is a
     /// handy way to avoid repeating the `<P>` turbofish. Requires the `async` (and,
     /// for `Tokio`, `tokio`) feature.
+    {%- if deprecated %}
+    {{ deprecated }}
+    {%- endif %}
     pub trait {{name}}Async<P>: {{crate}}::Interface + Send {
         fn descriptor() -> &'static str where Self: Sized { "{{ namespace }}" }
         {%- for member in fn_members %}
+        {%- if member.deprecated %}
+        {{ member.deprecated }}
+        {%- endif %}
         fn r#{{ member.identifier }}<'a>({{ member.args_async }}) -> {{crate}}::BoxFuture<'a, {{crate}}::BinderResult<{{ member.return_type }}>>;
         {%- endfor %}
         {%- if version %}
@@ -247,10 +288,16 @@ pub mod {{mod}} {
     /// Asynchronous **server** view of `{{name}}`: implement this (with
     /// `#[async_trait]`) on your service, then wrap it with
     /// [`{{bn_name}}::new_async_binder`] to publish it as a binder.
+    {%- if deprecated %}
+    {{ deprecated }}
+    {%- endif %}
     #[{{crate}}::__async_trait]
     pub trait {{name}}AsyncService: {{crate}}::Interface + Send {
         fn descriptor() -> &'static str where Self: Sized { "{{ namespace }}" }
         {%- for member in fn_members %}
+        {%- if member.deprecated %}
+        {{ member.deprecated }}
+        {%- endif %}
         async fn r#{{ member.identifier }}({{ member.args }}) -> {{crate}}::BinderResult<{{ member.return_type }}>;
         {%- endfor %}
     }
@@ -383,6 +430,9 @@ pub mod {{mod}} {
             {%- endif %}
             {%- if enabled_async %}
             r#async: {{ name }}Async,
+            {%- endif %}
+            {%- if is_vintf %}
+            stability: {{crate}}::Stability::Vintf,
             {%- endif %}
         }
     }
@@ -691,12 +741,14 @@ fn template() -> &'static tera::Tera {
 
 // Union has no render entry point — `decl_union` renders directly.
 
-/// One generated constant: `(identifier, type declaration, initializer)`.
+/// One generated constant: `(identifier, type declaration, initializer,
+/// deprecation attribute)`. The last element is the rendered
+/// `#[deprecated…]` line, or empty.
 ///
 /// A positional tuple, not a struct: the templates index it by position, so
 /// unlike [`InterfaceRender`] and friends its shape is fixed — growing it is a
 /// breaking change for any front-end that fills it.
-pub type ConstMember = (String, String, String);
+pub type ConstMember = (String, String, String, String);
 
 /// One parcelable field.
 ///
@@ -717,6 +769,8 @@ pub struct ParcelableMember {
     /// `Default`, which must unwrap to `UNEXPECTED_NULL` on write rather than
     /// emit a null marker.
     pub needs_unexpected_null: bool,
+    /// Rendered `#[deprecated…]` attribute for the field, or empty.
+    pub deprecated: String,
 }
 
 impl ParcelableMember {
@@ -732,14 +786,49 @@ impl ParcelableMember {
             init: init.into(),
             is_holder: false,
             needs_unexpected_null: false,
+            deprecated: String::new(),
         }
     }
 }
 
-/// One enum variant: `(identifier, discriminant)`.
+/// One enum variant: `(identifier, discriminant, deprecation attribute)`. The
+/// last element is the rendered `#[deprecated…]` line, or empty.
 ///
 /// Positional and therefore fixed in shape, as [`ConstMember`] is.
-pub type EnumMember = (String, i64);
+pub type EnumMember = (String, i64, String);
+
+/// Renders an AIDL `@deprecated` javadoc tag into the Rust attribute AOSP's
+/// Rust backend emits (`generate_rust.cpp` `GenerateDeprecated`): a bare
+/// `#[deprecated]` when the tag carries no note, `#[deprecated = "note"]`
+/// otherwise. `None` renders to the empty string.
+pub fn deprecated_attr(note: Option<&String>) -> String {
+    match note {
+        None => String::new(),
+        Some(note) if note.is_empty() => "#[deprecated]".to_string(),
+        Some(note) => format!("#[deprecated = {}]", quote_rust_string(note)),
+    }
+}
+
+/// Quotes `s` as a Rust string literal. The note comes from a comment, which
+/// the AIDL grammar does not constrain at all, so every character that cannot
+/// sit in a literal is escaped.
+fn quote_rust_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{{{:x}}}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
 
 /// AOSP `ClassName` (`aidl_to_cpp_common.cpp`): the `Bn`/`Bp` stem strips a
 /// leading `I` only when an uppercase letter follows, so `interface Foo3`
@@ -786,6 +875,8 @@ pub struct InterfaceRender {
     pub version: Option<i32>,
     /// Stable-AIDL `--hash <s>`, echoed verbatim. Independent of `version`.
     pub hash: Option<String>,
+    /// Rendered `#[deprecated…]` attribute for the interface, or empty.
+    pub deprecated: String,
 }
 
 /// `crate_name` defaults to `"rsbinder"`, not the empty string a derived
@@ -808,6 +899,7 @@ impl Default for InterfaceRender {
             is_vintf: false,
             version: None,
             hash: None,
+            deprecated: String::new(),
         }
     }
 }
@@ -824,6 +916,7 @@ impl Default for ParcelableRender {
             const_members: Vec::new(),
             nested: String::new(),
             is_vintf: false,
+            deprecated: String::new(),
         }
     }
 }
@@ -836,6 +929,7 @@ impl Default for EnumRender {
             name: String::new(),
             backing_type: String::new(),
             members: Vec::new(),
+            deprecated: String::new(),
         }
     }
 }
@@ -919,6 +1013,7 @@ pub fn render_interface(r: &InterfaceRender) -> Result<String, AidlError> {
     // its key is set, matching AOSP's per-flag conditional.
     context.insert("version", &r.version);
     context.insert("hash", &r.hash);
+    context.insert("deprecated", &r.deprecated);
 
     template()
         .render("interface", &context)
@@ -945,6 +1040,8 @@ pub struct ParcelableRender {
     pub const_members: Vec<ConstMember>,
     pub nested: String,
     pub is_vintf: bool,
+    /// Rendered `#[deprecated…]` attribute for the parcelable, or empty.
+    pub deprecated: String,
 }
 
 /// Render one parcelable module (`pub mod {module} { pub struct {name} … }`).
@@ -959,6 +1056,7 @@ pub fn render_parcelable(r: &ParcelableRender) -> Result<String, AidlError> {
     context.insert("const_members", &r.const_members);
     context.insert("nested", &r.nested);
     context.insert("is_vintf", &r.is_vintf);
+    context.insert("deprecated", &r.deprecated);
 
     template()
         .render("parcelable", &context)
@@ -981,6 +1079,8 @@ pub struct EnumRender {
     /// Backing Rust type (`i8` / `i32` / `i64`).
     pub backing_type: String,
     pub members: Vec<EnumMember>,
+    /// Rendered `#[deprecated…]` attribute for the enum, or empty.
+    pub deprecated: String,
 }
 
 /// Render one backed-enum module.
@@ -992,6 +1092,7 @@ pub fn render_enum(r: &EnumRender) -> Result<String, AidlError> {
     context.insert("enum_type", &r.backing_type);
     context.insert("enum_len", &r.members.len());
     context.insert("members", &r.members);
+    context.insert("deprecated", &r.deprecated);
 
     template()
         .render("enum", &context)
@@ -1073,6 +1174,8 @@ pub struct FnMembers {
     /// (AOSP `EX_SECURITY`) on permission denial. `None` when the
     /// method carries no `@EnforcePermission`.
     pub enforce_permission_check: Option<String>,
+    /// Rendered `#[deprecated…]` attribute for the method, or empty.
+    pub deprecated: String,
 }
 
 impl FnMembers {
@@ -1087,7 +1190,14 @@ impl FnMembers {
     }
 }
 
-fn make_fn_member(method: &parser::MethodDecl, crate_name: &str) -> Result<FnMembers, AidlError> {
+/// `vintf_owner` is `Some(interface name)` when the enclosing interface is
+/// `@VintfStability`, which makes every type in the method signature part of
+/// the VINTF reference closure.
+fn make_fn_member(
+    method: &parser::MethodDecl,
+    crate_name: &str,
+    vintf_owner: Option<&str>,
+) -> Result<FnMembers, AidlError> {
     let mut func_call_params = String::new();
     let mut args = "&self".to_string();
     let mut args_async = "&'a self".to_string();
@@ -1097,9 +1207,50 @@ fn make_fn_member(method: &parser::MethodDecl, crate_name: &str) -> Result<FnMem
     let mut transaction_params = String::new();
     let mut read_onto_params = Vec::new();
 
+    let mut arg_names = std::collections::HashSet::new();
+
     for arg in &method.arg_list {
         let generator = arg.to_generator()?;
         generator.ensure_resolvable()?;
+
+        // AOSP `AidlMethod::CheckValid`: duplicate argument names. Both would
+        // render as the same `_arg_<name>` binding, so without this the defect
+        // surfaces as rustc E0415 in the consumer's crate.
+        if !arg_names.insert(arg.identifier.as_str()) {
+            return Err(Generator::decl_error(
+                format!(
+                    "method '{}' has a duplicate argument name '{}'",
+                    method.identifier, arg.identifier
+                ),
+                generator.type_span(),
+            ));
+        }
+        // AOSP `AidlMethod::CheckValid`: `void` is a return type only.
+        if generator.is_void() {
+            return Err(Generator::decl_error(
+                format!(
+                    "'void' is an invalid type for the parameter '{}'",
+                    arg.identifier
+                ),
+                generator.type_span(),
+            ));
+        }
+        // AOSP `AidlArgument::CheckValid` (`aidl_language.cpp`):
+        // `AidlTypenames::GetArgumentAspect` hands `ParcelableHolder` an empty
+        // direction set, so `in`/`out`/`inout` are all refused — a holder is a
+        // field type only (b/156872582).
+        if generator.is_parcelable_holder() {
+            return Err(Generator::decl_error(
+                format!(
+                    "ParcelableHolder cannot be an argument type ('{}')",
+                    arg.identifier
+                ),
+                generator.type_span(),
+            ));
+        }
+        if let Some(owner) = vintf_owner {
+            Generator::ensure_vintf_closure(&generator, "interface", owner)?;
+        }
 
         let type_decl_for_func = generator.type_decl_for_func()?;
 
@@ -1188,6 +1339,22 @@ fn make_fn_member(method: &parser::MethodDecl, crate_name: &str) -> Result<FnMem
         };
     generator.ensure_resolvable()?;
 
+    // AOSP `AidlMethod::CheckValid`: a `ParcelableHolder` return value has no
+    // representation in the C++/NDK backends, so the contract is rejected
+    // rather than made unimplementable for a peer.
+    if generator.is_parcelable_holder() {
+        return Err(Generator::decl_error(
+            format!(
+                "method '{}': ParcelableHolder cannot be a return type",
+                method.identifier
+            ),
+            generator.type_span(),
+        ));
+    }
+    if let Some(owner) = vintf_owner {
+        Generator::ensure_vintf_closure(&generator, "interface", owner)?;
+    }
+
     let return_type = generator.type_declaration(false);
     let transaction_has_return = return_type != "()";
 
@@ -1213,6 +1380,7 @@ fn make_fn_member(method: &parser::MethodDecl, crate_name: &str) -> Result<FnMem
         transaction_code: method.intvalue.unwrap_or(0) as u32,
         has_explicit_code: method.intvalue.is_some(),
         enforce_permission_check,
+        deprecated: deprecated_attr(method.deprecated.as_ref()),
     })
 }
 
@@ -1519,6 +1687,124 @@ impl Generator {
         .into()
     }
 
+    /// AOSP `AidlVariableDeclaration::CheckValid` (`aidl_language.cpp`): no
+    /// declaration — parcelable field, union member, or interface constant —
+    /// may have type `void`. The array and nullable forms are already
+    /// rejected in `TypeGenerator::new_with_type`.
+    fn ensure_declarable(
+        generator: &crate::type_generator::TypeGenerator,
+        owner: &str,
+        identifier: &str,
+    ) -> Result<(), AidlError> {
+        if generator.is_void() {
+            return Err(Self::decl_error(
+                format!(
+                    "'{owner}': declaration '{identifier}' is void, but declarations \
+                     cannot be of void type"
+                ),
+                generator.type_span(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Builds the `(NamedSource, SourceSpan)` pair a declaration-level
+    /// diagnostic needs from a span in the current source.
+    fn diagnostic_at(span: Option<(usize, usize)>) -> (NamedSource<String>, SourceSpan) {
+        let (start, end) = span.unwrap_or((0, 0));
+        let source = parser::current_source_text();
+        let (start, end) = if source.is_empty() {
+            (start, end)
+        } else {
+            let start = start.min(source.len());
+            (start, end.clamp(start, source.len()))
+        };
+        (
+            NamedSource::new(parser::current_source_name(), source),
+            SourceSpan::new(start.into(), end - start),
+        )
+    }
+
+    /// AOSP `AidlParcelable::CheckValid`: every field of a `@FixedSize`
+    /// parcelable or union must itself be fixed size.
+    fn ensure_fixed_size_field(
+        generator: &crate::type_generator::TypeGenerator,
+        kind: &'static str,
+        owner: &str,
+        field: &str,
+    ) -> Result<(), AidlError> {
+        if generator.can_be_fixed_size() {
+            return Ok(());
+        }
+        let (src, span) = Self::diagnostic_at(generator.type_span());
+        Err(SemanticError::FixedSizeNonFixedField {
+            kind,
+            owner: owner.to_owned(),
+            field: field.to_owned(),
+            src,
+            span,
+        }
+        .into())
+    }
+
+    /// A constant's type must be one that has a constant form. See
+    /// [`TypeGenerator::is_supported_constant_type`] for how this relates to
+    /// AOSP's stricter set.
+    fn ensure_constant_type(
+        generator: &crate::type_generator::TypeGenerator,
+        owner: &str,
+        identifier: &str,
+    ) -> Result<(), AidlError> {
+        if generator.is_supported_constant_type() {
+            return Ok(());
+        }
+        Err(Self::decl_error(
+            format!(
+                "'{owner}': constant '{identifier}' has an unsupported type — a constant \
+                 must be a primitive or String (or an array of those)"
+            ),
+            generator.type_span(),
+        ))
+    }
+
+    /// A `@VintfStability` declaration may only name `@VintfStability` types —
+    /// the reference closure AOSP's compilation-wide `stability: "vintf"`
+    /// (`aidl.cpp`) implies, rsbinder having no such mode.
+    fn ensure_vintf_closure(
+        generator: &crate::type_generator::TypeGenerator,
+        kind: &'static str,
+        owner: &str,
+    ) -> Result<(), AidlError> {
+        for name in generator.referenced_user_types() {
+            let Some(lookup) = parser::lookup_decl_from_name(name, Namespace::AIDL) else {
+                continue;
+            };
+            if parser::is_vintf_scoped(&lookup.ns) {
+                continue;
+            }
+            // AOSP exempts a stable-API parcelable from the stability sweep
+            // (`aidl.cpp`, `IsStableApiParcelable`). For the Rust backend that
+            // is `@RustOnlyStableParcelable`, whose Rust type is supplied by
+            // `rust_type` rather than generated — there is no declaration to
+            // annotate `@VintfStability`.
+            if matches!(&lookup.decl, parser::Declaration::Parcelable(decl)
+                if !decl.rust_type.is_empty())
+            {
+                continue;
+            }
+            let (src, span) = Self::diagnostic_at(generator.type_span());
+            return Err(SemanticError::VintfStabilityLeak {
+                kind,
+                owner: owner.to_owned(),
+                referenced: lookup.ns.to_string(Namespace::AIDL),
+                src,
+                span,
+            }
+            .into());
+        }
+        Ok(())
+    }
+
     fn decl_interface(
         &self,
         arg_decl: &parser::InterfaceDecl,
@@ -1539,10 +1825,14 @@ impl Generator {
                 decl.name_span,
             ));
         }
+        // Scoped, not local: a nested declaration inherits `@VintfStability`
+        // from its enclosing type (AOSP `GetScopedAnnotation`). The
+        // declaration's own annotation is read directly so the answer never
+        // depends on the declaration map being populated.
         let is_vintf = parser::has_annotation(
             &decl.annotation_list,
             parser::AnnotationType::VintfStability,
-        );
+        ) || parser::is_vintf_scoped(&decl.namespace);
 
         decl.pre_process();
 
@@ -1564,6 +1854,8 @@ impl Generator {
         for constant in decl.constant_list.iter() {
             let generator = constant.r#type.to_generator()?;
             generator.ensure_resolvable()?;
+            Self::ensure_declarable(&generator, &decl.name, &constant.identifier)?;
+            Self::ensure_constant_type(&generator, &decl.name, &constant.identifier)?;
             const_members.push((
                 constant.const_identifier(),
                 generator.const_type_decl()?,
@@ -1571,13 +1863,15 @@ impl Generator {
                     constant.const_expr.as_ref(),
                     InitParam::builder().with_const(true),
                 )?,
+                deprecated_attr(constant.deprecated.as_ref()),
             ));
         }
 
         validate_transaction_codes(&decl)?;
 
+        let vintf_owner = is_vintf.then_some(decl.name.as_str());
         for method in decl.method_list.iter() {
-            fn_members.push(make_fn_member(method, self.get_crate_name())?);
+            fn_members.push(make_fn_member(method, self.get_crate_name(), vintf_owner)?);
         }
 
         let nested = &self.declarations(&decl.members, indent + 1)?;
@@ -1609,6 +1903,7 @@ impl Generator {
             // generator.
             version: self.version,
             hash: self.hash.clone(),
+            deprecated: deprecated_attr(decl.deprecated.as_ref()),
         })?;
 
         Ok(add_indent(indent, rendered.trim()))
@@ -1621,10 +1916,14 @@ impl Generator {
     ) -> Result<String, AidlError> {
         let mut decl = arg_decl.clone();
 
+        // Scoped, not local: a nested declaration inherits `@VintfStability`
+        // from its enclosing type (AOSP `GetScopedAnnotation`). The
+        // declaration's own annotation is read directly so the answer never
+        // depends on the declaration map being populated.
         let is_vintf = parser::has_annotation(
             &decl.annotation_list,
             parser::AnnotationType::VintfStability,
-        );
+        ) || parser::is_vintf_scoped(&decl.namespace);
 
         // An unstructured parcelable that names its `rust_type` is
         // representable: emit the alias and ignore the Java/NDK/C++ markers
@@ -1633,7 +1932,7 @@ impl Generator {
             let escaped = crate::escape_rust_keyword(&decl.name);
             let rendered = format!(r#"
 pub mod {mod} {{
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     pub type {name} = {rust_type};
 }}
 "#, mod = escaped, name = escaped, rust_type = decl.rust_type);
@@ -1676,12 +1975,34 @@ pub mod {mod} {{
         let mut members = Vec::new();
         let mut declarations = Vec::new();
 
+        let owner_name = decl.name.clone();
+        // Not scoped: a nested parcelable does not inherit `@FixedSize`.
+        let is_fixed_size =
+            parser::has_annotation(&decl.annotation_list, parser::AnnotationType::FixedSize);
+
         // Parse struct variables only.
         for decl in &decl.members {
             if let Some(var) = decl.is_variable() {
                 let generator = var.r#type.to_generator()?;
                 generator.ensure_resolvable()?;
                 generator.ensure_sized()?;
+                Self::ensure_declarable(&generator, &owner_name, &var.identifier)?;
+                if var.constant {
+                    Self::ensure_constant_type(&generator, &owner_name, &var.identifier)?;
+                }
+                if !var.constant {
+                    if is_fixed_size {
+                        Self::ensure_fixed_size_field(
+                            &generator,
+                            "parcelable",
+                            &owner_name,
+                            &var.identifier,
+                        )?;
+                    }
+                    if is_vintf {
+                        Self::ensure_vintf_closure(&generator, "parcelable", &owner_name)?;
+                    }
+                }
 
                 if var.constant {
                     constant_members.push((
@@ -1691,6 +2012,7 @@ pub mod {mod} {{
                             var.const_expr.as_ref(),
                             InitParam::builder().with_const(true),
                         )?,
+                        deprecated_attr(var.deprecated.as_ref()),
                     ));
                 } else {
                     let init_value = match generator.value_type {
@@ -1710,6 +2032,7 @@ pub mod {mod} {{
                         )?,
                         is_holder: matches!(generator.value_type, ValueType::Holder),
                         needs_unexpected_null: generator.is_option_but_not_nullable(),
+                        deprecated: deprecated_attr(var.deprecated.as_ref()),
                     })
                 }
             } else {
@@ -1735,6 +2058,7 @@ pub mod {mod} {{
             const_members: constant_members,
             nested: nested.trim().to_string(),
             is_vintf,
+            deprecated: deprecated_attr(decl.deprecated.as_ref()),
         })?;
 
         Ok(add_indent(indent, rendered.trim()))
@@ -1829,7 +2153,11 @@ pub mod {mod} {{
                         "{value} does not fit the '{backing}' backing type ({min}..={max})"
                     )));
                 }
-                members.push((enumerator.identifier.to_owned(), value));
+                members.push((
+                    enumerator.identifier.to_owned(),
+                    value,
+                    deprecated_attr(enumerator.deprecated.as_ref()),
+                ));
             }
         }
 
@@ -1844,6 +2172,7 @@ pub mod {mod} {{
                 .direction(&Direction::None)?
                 .type_declaration(true),
             members,
+            deprecated: deprecated_attr(decl.deprecated.as_ref()),
         })?;
 
         Ok(add_indent(indent, rendered.trim()))
@@ -1864,10 +2193,18 @@ pub mod {mod} {{
             ));
         }
 
+        // Scoped, not local: a nested declaration inherits `@VintfStability`
+        // from its enclosing type (AOSP `GetScopedAnnotation`). The
+        // declaration's own annotation is read directly so the answer never
+        // depends on the declaration map being populated.
         let is_vintf = parser::has_annotation(
             &decl.annotation_list,
             parser::AnnotationType::VintfStability,
-        );
+        ) || parser::is_vintf_scoped(&decl.namespace);
+
+        // Not scoped: a nested union does not inherit `@FixedSize`.
+        let is_fixed_size =
+            parser::has_annotation(&decl.annotation_list, parser::AnnotationType::FixedSize);
 
         let mut constant_members = Vec::new();
         let mut members = Vec::new();
@@ -1878,6 +2215,35 @@ pub mod {mod} {{
                 let generator = var.r#type.to_generator()?;
                 generator.ensure_resolvable()?;
                 generator.ensure_sized()?;
+                Self::ensure_declarable(&generator, &decl.name, &var.identifier)?;
+                if var.constant {
+                    Self::ensure_constant_type(&generator, &decl.name, &var.identifier)?;
+                }
+                if !var.constant {
+                    // AOSP `AidlUnionDecl::CheckValid`: a union member cannot be
+                    // a `ParcelableHolder` (b/170807936). Only fields are
+                    // restricted; a `const` never has a holder type anyway.
+                    if generator.is_parcelable_holder() {
+                        return Err(Self::decl_error(
+                            format!(
+                                "union '{}' cannot have a member of ParcelableHolder '{}'",
+                                decl.name, var.identifier
+                            ),
+                            generator.type_span(),
+                        ));
+                    }
+                    if is_fixed_size {
+                        Self::ensure_fixed_size_field(
+                            &generator,
+                            "union",
+                            &decl.name,
+                            &var.identifier,
+                        )?;
+                    }
+                    if is_vintf {
+                        Self::ensure_vintf_closure(&generator, "union", &decl.name)?;
+                    }
+                }
                 if var.constant {
                     constant_members.push((
                         var.const_identifier(),
@@ -1886,6 +2252,7 @@ pub mod {mod} {{
                             var.const_expr.as_ref(),
                             InitParam::builder().with_const(true),
                         )?,
+                        deprecated_attr(var.deprecated.as_ref()),
                     ));
                 } else {
                     // Honor an explicit `= EnumType.VARIANT` default; the union's
@@ -1912,6 +2279,7 @@ pub mod {mod} {{
                         // needs_unexpected_null: see
                         // `TypeGenerator::is_option_but_not_nullable` rustdoc.
                         generator.is_option_but_not_nullable(),
+                        deprecated_attr(var.deprecated.as_ref()),
                     ));
                 }
             } else {
@@ -1919,9 +2287,20 @@ pub mod {mod} {{
             }
         }
 
+        // AOSP `AidlUnionDecl::CheckValid` (`aidl_language.cpp`): a union needs
+        // at least one field. `const`-only members do not count — the rendered
+        // enum would be uninhabited, so its `Default` impl has nothing to
+        // return and the `write_to_parcel` match has no arm behind `&Self`.
+        if members.is_empty() {
+            return Err(Self::decl_error(
+                format!("the union '{}' has no fields", decl.name),
+                decl.name_span,
+            ));
+        }
+
         let mut seen_variants: std::collections::HashMap<&str, &str> =
             std::collections::HashMap::new();
-        for (variant, _, field, _, _) in &members {
+        for (variant, _, field, _, _, _) in &members {
             if let Some(previous) = seen_variants.insert(variant, field) {
                 return Err(Self::decl_error(
                     format!(
@@ -1950,6 +2329,7 @@ pub mod {mod} {{
         context.insert("const_members", &constant_members);
         context.insert("nested", &nested.trim());
         context.insert("is_vintf", &is_vintf);
+        context.insert("deprecated", &deprecated_attr(decl.deprecated.as_ref()));
 
         let rendered = template()
             .render("union", &context)

--- a/rsbinder-aidl/src/lib.rs
+++ b/rsbinder-aidl/src/lib.rs
@@ -55,6 +55,37 @@
 //! errors rather than being silently wrapped or truncated. See the project
 //! CHANGELOG for migration notes if upgrading from an earlier release.
 //!
+//! # Validation
+//!
+//! The generator enforces AOSP `aidl`'s type-placement rules, not just the
+//! ones it needs to emit code: a `@FixedSize` type's fields must all be fixed
+//! size, a `@VintfStability` type may only reference `@VintfStability` types,
+//! `ParcelableHolder` is not an
+//! array/`List`/`@nullable`/argument/return/union-member type, and `void` is a
+//! bare return type only. The `@FixedSize` and `@VintfStability` checks are
+//! contract-level — rsbinder would generate compiling code either way — so
+//! that an `.aidl` authored here is one AOSP's compiler also accepts; so are
+//! the argument, return-type and union-member forms of `ParcelableHolder`. The
+//! `void` placements and the array/`List`/`@nullable` forms of
+//! `ParcelableHolder` have no compiling Rust representation at all, so the
+//! check reports them as an AIDL diagnostic instead of a rustc error in the
+//! generated crate — as do a `union` with no fields, a duplicate argument
+//! name, and a type argument on a type that takes none (`String<int>`).
+//!
+//! A `@VintfStability` interface also declares that stability to the runtime,
+//! so the binder it publishes is accepted by a peer that requires VINTF.
+//!
+//! A `const` must have a primitive or `String` type, or an array of those.
+//! AOSP's set is narrower still (`{String, byte, int, long, float, double}`);
+//! `boolean`, `char` and constant arrays are deliberate rsbinder extensions,
+//! as `List<int>` is.
+//!
+//! # Deprecation
+//!
+//! A `/** @deprecated note */` javadoc block above a declaration, method,
+//! field, constant, or enumerator becomes `#[deprecated = "note"]` on the
+//! generated item, as in AOSP's Rust backend.
+//!
 //! Compatibility notes, supported AIDL constructs, and diagnostics examples
 //! live in the repository README and <https://hiking90.github.io/rsbinder/>.
 

--- a/rsbinder-aidl/src/parser.rs
+++ b/rsbinder-aidl/src/parser.rs
@@ -104,6 +104,7 @@ impl SourceGuard {
     pub fn new(filename: &str, source: &str) -> Self {
         CURRENT_SOURCE_NAME.with(|name| *name.borrow_mut() = filename.to_string());
         CURRENT_SOURCE_TEXT.with(|text| *text.borrow_mut() = source.to_string());
+        CURRENT_COMMENTS.with(|spans| *spans.borrow_mut() = scan_comments(source));
         SourceGuard
     }
 }
@@ -112,6 +113,7 @@ impl Drop for SourceGuard {
     fn drop(&mut self) {
         CURRENT_SOURCE_NAME.with(|name| name.borrow_mut().clear());
         CURRENT_SOURCE_TEXT.with(|text| text.borrow_mut().clear());
+        CURRENT_COMMENTS.with(|spans| spans.borrow_mut().clear());
     }
 }
 
@@ -123,6 +125,156 @@ pub fn current_source_name() -> String {
 /// Returns the source text of the currently active source context.
 pub fn current_source_text() -> String {
     CURRENT_SOURCE_TEXT.with(|text| text.borrow().clone())
+}
+
+/// One comment in the source, as [`scan_comments`] found it.
+#[derive(Debug, Clone, Copy)]
+struct CommentSpan {
+    start: usize,
+    end: usize,
+    /// `/* … */` (including `/** … */`). AOSP only reads block comments for
+    /// javadoc tags; a trailing `//` comment detaches the run entirely.
+    is_block: bool,
+}
+
+thread_local! {
+    // Comment index of the source currently being parsed, ascending by start
+    // offset. Built once per `SourceGuard` so `deprecated_at` is a lookup
+    // rather than a rescan per declaration.
+    static CURRENT_COMMENTS: RefCell<Vec<CommentSpan>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Finds every comment in `source`, skipping string and char literals so a
+/// `//` or `/*` inside one is not mistaken for a comment (the AIDL grammar's
+/// `C_STR` and `CHARVALUE` both admit backslash escapes).
+fn scan_comments(source: &str) -> Vec<CommentSpan> {
+    let bytes = source.as_bytes();
+    let mut spans = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                let start = i;
+                i += 2;
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                spans.push(CommentSpan {
+                    start,
+                    end: i,
+                    is_block: false,
+                });
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                let start = i;
+                i += 2;
+                while i < bytes.len() && !(bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/')) {
+                    i += 1;
+                }
+                // An unterminated block comment runs to end of input; the
+                // parser rejects the file either way.
+                i = (i + 2).min(bytes.len());
+                spans.push(CommentSpan {
+                    start,
+                    end: i,
+                    is_block: true,
+                });
+            }
+            quote @ (b'"' | b'\'') => {
+                i += 1;
+                while i < bytes.len() && bytes[i] != quote {
+                    // A backslash escapes the next byte, `\"` included.
+                    i += if bytes[i] == b'\\' { 2 } else { 1 };
+                }
+                i = (i + 1).min(bytes.len());
+            }
+            _ => i += 1,
+        }
+    }
+    spans
+}
+
+/// The `@deprecated` note attached to the item starting at byte offset
+/// `start`, or `None` when it is not deprecated. `Some("")` is a bare
+/// `@deprecated` with no note.
+///
+/// Mirrors AOSP `comments.cpp`: only the **last** comment of the run
+/// immediately preceding the item counts, and only when it is a block
+/// comment — so a trailing `//` line detaches the javadoc above it, exactly
+/// as in AOSP. `start` must be the item's first character *including* its
+/// annotations, since the comment precedes those.
+pub fn deprecated_at(start: usize) -> Option<String> {
+    let span = CURRENT_COMMENTS.with(|spans| {
+        let spans = spans.borrow();
+        let idx = spans.partition_point(|c| c.end <= start);
+        idx.checked_sub(1).map(|i| spans[i])
+    })?;
+    if !span.is_block {
+        return None;
+    }
+    CURRENT_SOURCE_TEXT.with(|text| {
+        let text = text.borrow();
+        // Only whitespace may sit between the comment and the item; anything
+        // else means the comment belongs to something before it.
+        let gap = text.get(span.end..start)?;
+        if !gap.chars().all(char::is_whitespace) {
+            return None;
+        }
+        find_deprecated(text.get(span.start..span.end)?)
+    })
+}
+
+/// AOSP `TrimmedLines` for a block comment: drop the `/*` and `*/` markers,
+/// then per line drop leading whitespace, one optional `*`, and one optional
+/// space, and trim the trailing whitespace.
+fn trimmed_block_lines(body: &str) -> Vec<&str> {
+    let stripped = body.strip_prefix("/*").unwrap_or(body);
+    let stripped = stripped.strip_suffix("*/").unwrap_or(stripped);
+    stripped
+        .split('\n')
+        .map(|line| {
+            let rest = line.trim_start();
+            let rest = rest.strip_prefix('*').unwrap_or(rest);
+            let rest = rest.strip_prefix(' ').unwrap_or(rest);
+            rest.trim_end()
+        })
+        .collect()
+}
+
+/// AOSP `BlockTags` + `FindDeprecated`: a line whose first non-space
+/// character is `@` opens a block tag whose name runs to the first
+/// non-alphabetic character; following non-tag lines extend its description.
+/// The first `@deprecated` wins.
+fn find_deprecated(body: &str) -> Option<String> {
+    let mut tag: Option<&str> = None;
+    let mut paragraph: Vec<&str> = Vec::new();
+
+    for line in trimmed_block_lines(body) {
+        let line = line.trim_start();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix('@') {
+            if tag == Some("deprecated") {
+                return Some(paragraph.join(" "));
+            }
+            let name_len = rest
+                .char_indices()
+                .find(|(_, c)| !c.is_ascii_alphabetic())
+                .map_or(rest.len(), |(i, _)| i);
+            let (name, after) = rest.split_at(name_len);
+            tag = Some(name);
+            paragraph.clear();
+            let after = after.strip_prefix(' ').unwrap_or(after);
+            if !after.is_empty() {
+                paragraph.push(after);
+            }
+        } else if tag.is_some() {
+            paragraph.push(line);
+        }
+    }
+
+    (tag == Some("deprecated")).then(|| paragraph.join(" "))
 }
 
 pub struct NamespaceGuard();
@@ -234,9 +386,13 @@ pub fn lookup_decl_from_name(name: &str, style: &str) -> Option<LookupDecl> {
             .map(|package| Namespace::new(package, Namespace::AIDL))
     });
 
-    // 1. the current declaration and its enclosing one (a package-less document's empty scope stays).
+    // 1. the current declaration and every enclosing one, outward. AOSP
+    //    `AidlDefinedType::ResolveName` recurses through `GetEnclosingScope()`
+    //    with no depth limit, so a type three levels deep still sees its
+    //    grandparent's siblings. The package guard and `pop()` terminate the
+    //    walk (a package-less document's empty scope stays a candidate).
     let mut curr_ns = current_namespace();
-    for _ in 0..2 {
+    loop {
         if package_ns.as_ref() == Some(&curr_ns) {
             break;
         }
@@ -339,6 +495,46 @@ fn value_members(ns: &Namespace) -> Option<Vec<Declaration>> {
         Some(Declaration::Union(u)) => Some(u.members.clone()),
         _ => None,
     })
+}
+
+/// Is the declaration at `ns` `@VintfStability`, directly or by inheritance
+/// from an enclosing declaration?
+///
+/// `@VintfStability` is a **scoped** annotation in AOSP: `GetScopedAnnotation`
+/// (`aidl_language.cpp`) walks from the type up through its enclosing types,
+/// so a nested declaration inside a `@VintfStability` parcelable is itself
+/// VINTF-stable without repeating the annotation. That matters on the wire —
+/// the stability a parcelable reports is what a `ParcelableHolder` records for
+/// it — so the lookup has to walk, not just read the type's own annotations.
+///
+/// Only declarations nest, so the walk stops at the package boundary of the
+/// document that declares `ns` — `DECLARATION_MAP` is keyed by
+/// `<package>.<name>`, so without that floor a type whose name matches a
+/// package segment (`package a; parcelable b;` beside `package a.b;`) would
+/// hand its annotation to every declaration in that package.
+pub fn is_vintf_scoped(ns: &Namespace) -> bool {
+    let floor = declaration_document_context(ns)
+        .and_then(|ctx| ctx.package)
+        .map_or(0, |package| {
+            Namespace::new(&package, Namespace::AIDL).ns.len()
+        });
+    let mut ns = ns.clone();
+    loop {
+        let found = DECLARATION_MAP.with(|map| {
+            map.borrow()
+                .get(&ns)
+                .map(|decl| has_annotation(decl.annotation_list(), AnnotationType::VintfStability))
+        });
+        match found {
+            Some(true) => return true,
+            Some(false) => {
+                if ns.ns.len() <= floor + 1 || ns.pop().is_none() {
+                    return false;
+                }
+            }
+            None => return false,
+        }
+    }
 }
 
 /// Whether a declaration stores its members by value, without cloning the
@@ -853,6 +1049,9 @@ pub struct VariableDecl {
     pub r#type: Type,
     pub identifier: String,
     pub const_expr: Option<ConstExpr>,
+    /// `@deprecated` note from the preceding javadoc block, if any. `Some("")`
+    /// is a bare tag. See [`deprecated_at`].
+    pub deprecated: Option<String>,
 }
 
 impl VariableDecl {
@@ -885,6 +1084,7 @@ pub struct InterfaceDecl {
     pub method_list: Vec<MethodDecl>,
     pub constant_list: Vec<VariableDecl>,
     pub members: Vec<Declaration>,
+    pub deprecated: Option<String>,
 }
 
 impl InterfaceDecl {
@@ -909,6 +1109,7 @@ pub struct ParcelableDecl {
     pub ndk_header: String,
     pub rust_type: String,
     pub members: Vec<Declaration>,
+    pub deprecated: Option<String>,
     // pub name_dict: Option<HashMap<String, ConstExpr>>,
 }
 
@@ -966,6 +1167,7 @@ pub struct MethodDecl {
     pub arg_list: Vec<Arg>,
     pub intvalue: Option<i64>,
     pub intvalue_span: Option<(usize, usize)>,
+    pub deprecated: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -1013,6 +1215,29 @@ impl Declaration {
             Declaration::Enum(decl) => &decl.name,
             Declaration::Union(decl) => &decl.name,
             _ => unreachable!(),
+        }
+    }
+
+    /// Records the `@deprecated` note resolved from the declaration's leading
+    /// javadoc. Set by the parse sites, which are the only place the
+    /// declaration's own start offset is still in hand.
+    pub fn set_deprecated(&mut self, deprecated: Option<String>) {
+        match self {
+            Declaration::Parcelable(decl) => decl.deprecated = deprecated,
+            Declaration::Interface(decl) => decl.deprecated = deprecated,
+            Declaration::Enum(decl) => decl.deprecated = deprecated,
+            Declaration::Union(decl) => decl.deprecated = deprecated,
+            Declaration::Variable(decl) => decl.deprecated = deprecated,
+        }
+    }
+
+    pub fn annotation_list(&self) -> &[Annotation] {
+        match self {
+            Declaration::Parcelable(decl) => &decl.annotation_list,
+            Declaration::Interface(decl) => &decl.annotation_list,
+            Declaration::Enum(decl) => &decl.annotation_list,
+            Declaration::Union(decl) => &decl.annotation_list,
+            Declaration::Variable(decl) => &decl.annotation_list,
         }
     }
 
@@ -1112,6 +1337,10 @@ pub enum AnnotationType {
     /// Rust backend generates normally.
     JavaOnlyStableParcelable,
     VintfStability,
+    /// `@FixedSize` — every field must itself be fixed size. Unlike
+    /// `@VintfStability` this is **not** scoped: AOSP reads it with the plain
+    /// `GetAnnotation`, so a nested declaration does not inherit it.
+    FixedSize,
 }
 
 /// Returns whether the annotation list contains the queried annotation.
@@ -1122,6 +1351,7 @@ pub fn has_annotation(annotation_list: &[Annotation], query_type: AnnotationType
         AnnotationType::JavaOnlyStableParcelable => {
             annotation.annotation == "@JavaOnlyStableParcelable"
         }
+        AnnotationType::FixedSize => annotation.annotation == "@FixedSize",
     })
 }
 
@@ -2074,21 +2304,26 @@ fn parse_interface_members(
     for pair in pairs {
         match pair.as_rule() {
             Rule::method_decl => {
-                interface
-                    .method_list
-                    .push(parse_method_decl(pair.into_inner())?);
+                let deprecated = deprecated_at(pair.as_span().start());
+                let mut method = parse_method_decl(pair.into_inner())?;
+                method.deprecated = deprecated;
+                interface.method_list.push(method);
             }
 
             Rule::constant_decl => {
-                interface
-                    .constant_list
-                    .push(parse_variable_decl(pair.into_inner(), true)?);
+                let deprecated = deprecated_at(pair.as_span().start());
+                let mut constant = parse_variable_decl(pair.into_inner(), true)?;
+                constant.deprecated = deprecated;
+                interface.constant_list.push(constant);
             }
 
             Rule::decl => {
-                interface
-                    .members
-                    .append(&mut parse_decl(pair.into_inner())?);
+                let deprecated = deprecated_at(pair.as_span().start());
+                let mut members = parse_decl(pair.into_inner())?;
+                for member in &mut members {
+                    member.set_deprecated(deprecated.clone());
+                }
+                interface.members.append(&mut members);
             }
 
             _ => unreachable!("Unexpected rule in parse_interface_members(): {}", pair),
@@ -2139,19 +2374,21 @@ fn parse_parcelable_members(
 
     for pair in pairs {
         match pair.as_rule() {
-            Rule::variable_decl => {
-                res.push(Declaration::Variable(parse_variable_decl(
-                    pair.into_inner(),
-                    false,
-                )?));
+            Rule::variable_decl | Rule::constant_decl => {
+                let constant = pair.as_rule() == Rule::constant_decl;
+                let deprecated = deprecated_at(pair.as_span().start());
+                let mut var = parse_variable_decl(pair.into_inner(), constant)?;
+                var.deprecated = deprecated;
+                res.push(Declaration::Variable(var));
             }
-            Rule::constant_decl => {
-                res.push(Declaration::Variable(parse_variable_decl(
-                    pair.into_inner(),
-                    true,
-                )?));
+            Rule::decl => {
+                let deprecated = deprecated_at(pair.as_span().start());
+                let mut members = parse_decl(pair.into_inner())?;
+                for member in &mut members {
+                    member.set_deprecated(deprecated.clone());
+                }
+                res.append(&mut members);
             }
-            Rule::decl => res.append(&mut parse_decl(pair.into_inner())?),
             _ => unreachable!("Unexpected rule in parse_parcelable_members(): {}", pair),
         }
     }
@@ -2259,6 +2496,7 @@ fn parse_parcelable_decl(
 pub struct Enumerator {
     pub identifier: String,
     pub const_expr: Option<ConstExpr>,
+    pub deprecated: Option<String>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -2282,6 +2520,7 @@ pub struct EnumDecl {
     /// runtime `Tag` struct itself is emitted by the union template in
     /// [`crate::generator`], not from this stub.
     pub tag_of_union: Option<Namespace>,
+    pub deprecated: Option<String>,
 }
 
 fn parse_enumerator(pairs: pest::iterators::Pairs<Rule>) -> Result<Enumerator, AidlError> {
@@ -2331,9 +2570,12 @@ fn parse_enum_decl(
                 enum_decl.name = pair.as_str().into();
                 enum_decl.name_span = Some((span.start(), span.end()));
             }
-            Rule::enumerator => enum_decl
-                .enumerator_list
-                .push(parse_enumerator(pair.into_inner())?),
+            Rule::enumerator => {
+                let deprecated = deprecated_at(pair.as_span().start());
+                let mut enumerator = parse_enumerator(pair.into_inner())?;
+                enumerator.deprecated = deprecated;
+                enum_decl.enumerator_list.push(enumerator);
+            }
             _ => unreachable!("Unexpected rule in parse_enum_decl(): {}", pair),
         }
     }
@@ -2349,6 +2591,7 @@ pub struct UnionDecl {
     pub name_span: Option<(usize, usize)>,
     pub type_params: Vec<String>,
     pub members: Vec<Declaration>,
+    pub deprecated: Option<String>,
 }
 
 fn parse_union_decl(
@@ -2689,7 +2932,12 @@ pub fn parse_document(ctx: &SourceContext) -> Result<Document, AidlError> {
                     }
 
                     Rule::decl => {
-                        document.decls.append(&mut parse_decl(pair.into_inner())?);
+                        let deprecated = deprecated_at(pair.as_span().start());
+                        let mut decls = parse_decl(pair.into_inner())?;
+                        for decl in &mut decls {
+                            decl.set_deprecated(deprecated.clone());
+                        }
+                        document.decls.append(&mut decls);
                     }
 
                     Rule::EOI => {}

--- a/rsbinder-aidl/src/type_generator.rs
+++ b/rsbinder-aidl/src/type_generator.rs
@@ -191,6 +191,24 @@ impl TypeGenerator {
                             aidl_type.name_span,
                         ));
                     }
+                    // `void` and `ParcelableHolder` have no element
+                    // representation: `Vec<()>` and
+                    // `Vec<ParcelableHolder>` have no `SerializeArray`
+                    // counterpart, so they would fail in rustc rather than
+                    // here. AOSP rejects both as `List` elements
+                    // (`aidl_language.cpp`, the `kListUsage` whitelist).
+                    if matches!(elem, ValueType::Void) {
+                        return Err(make_type_error(
+                            "List element type cannot be void",
+                            aidl_type.name_span,
+                        ));
+                    }
+                    if matches!(elem, ValueType::Holder) {
+                        return Err(make_type_error(
+                            "List element type cannot be ParcelableHolder",
+                            aidl_type.name_span,
+                        ));
+                    }
                     array_types.push(ArrayInfo::new_list(
                         &elem,
                         &Vec::new(),
@@ -219,6 +237,21 @@ impl TypeGenerator {
             _ => ValueType::UserDefined(aidl_type.name.to_owned()),
         };
 
+        // AOSP `AidlTypeSpecifier::CheckValid`: only `List`, `Map`, and a
+        // parameterizable user-defined type may carry type arguments. The
+        // arms above drop the generic on everything else, so `String<int>`
+        // would silently become a plain `String`. `ValueType::Array` here is
+        // the `List` arm; `UserDefined` covers both a generic parcelable and
+        // `Map` — which stays an unknown type, keeping its own diagnostic.
+        if aidl_type.generic.is_some()
+            && !matches!(value_type, ValueType::Array(_) | ValueType::UserDefined(_))
+        {
+            return Err(make_type_error(
+                format!("'{}' is not a generic type", aidl_type.name),
+                aidl_type.name_span,
+            ));
+        }
+
         Ok(Self {
             is_nullable: false,
             value_type,
@@ -231,6 +264,34 @@ impl TypeGenerator {
 
     pub fn new_with_type(_type: &Type) -> Result<Self, AidlError> {
         let mut this = Self::new(&_type.non_array_type)?;
+
+        let is_nullable = has_annotation(&_type.annotation_list, AnnotationType::IsNullable);
+        let is_array = !_type.array_types.is_empty();
+
+        // AOSP `AidlTypeSpecifier::CheckValid` (`aidl_language.cpp`): `void`
+        // is legal only as a bare method return type, and `ParcelableHolder`
+        // has no array or nullable form. Both would otherwise generate code
+        // that compiles here but has no counterpart in any AOSP backend.
+        if matches!(this.value_type, ValueType::Void) && (is_array || is_nullable) {
+            return Err(make_type_error(
+                "void type cannot be an array or nullable",
+                _type.non_array_type.name_span,
+            ));
+        }
+        if matches!(this.value_type, ValueType::Holder) {
+            if is_array {
+                return Err(make_type_error(
+                    "arrays of ParcelableHolder are not supported",
+                    _type.non_array_type.name_span,
+                ));
+            }
+            if is_nullable {
+                return Err(make_type_error(
+                    "ParcelableHolder cannot be nullable",
+                    _type.non_array_type.name_span,
+                ));
+            }
+        }
 
         if !_type.array_types.is_empty() {
             // An array of `List<T>` (`List<T>[]`): the non-array type is
@@ -465,6 +526,145 @@ impl TypeGenerator {
         } else {
             format!("Option<{type_name}>")
         }
+    }
+
+    /// Can a field of this type appear in a `@FixedSize` parcelable or union?
+    ///
+    /// Ports AOSP `AidlTypenames::CanBeFixedSize` (`aidl_typenames.cpp`): a
+    /// generic (`List<T>`), a `@nullable` type, and a variable-length array
+    /// are all variable size; primitives and enums are fixed; a parcelable or
+    /// union is fixed only if it is itself `@FixedSize`; every other builtin
+    /// (`String`, `IBinder`, `ParcelFileDescriptor`, `ParcelableHolder`) and
+    /// every interface handle is not. Must be invoked while the owning
+    /// declaration's `NamespaceGuard` is active: a `UserDefined` name that
+    /// fails to resolve is reported as non-fixed, which would reject valid
+    /// input.
+    pub fn can_be_fixed_size(&self) -> bool {
+        if self.is_nullable {
+            return false;
+        }
+        let element = match self.array_types.first() {
+            Some(info) => {
+                if info.is_list || !info.is_fixed() {
+                    return false;
+                }
+                &info.value_type
+            }
+            None => &self.value_type,
+        };
+        Self::value_type_can_be_fixed_size(element)
+    }
+
+    fn value_type_can_be_fixed_size(value_type: &ValueType) -> bool {
+        match value_type {
+            ValueType::Bool(_)
+            | ValueType::Byte(_)
+            | ValueType::Char(_)
+            | ValueType::Int32(_)
+            | ValueType::Int64(_)
+            | ValueType::Float(_)
+            | ValueType::Double(_) => true,
+            ValueType::UserDefined(name) => {
+                match lookup_decl_from_name(name, crate::Namespace::AIDL) {
+                    Some(lookup_decl) => match &lookup_decl.decl {
+                        Declaration::Enum(_) => true,
+                        // `@FixedSize` is not scoped: a nested declaration does
+                        // not inherit it from its enclosing type.
+                        Declaration::Parcelable(decl) => {
+                            has_annotation(&decl.annotation_list, AnnotationType::FixedSize)
+                        }
+                        Declaration::Union(decl) => {
+                            has_annotation(&decl.annotation_list, AnnotationType::FixedSize)
+                        }
+                        _ => false,
+                    },
+                    None => false,
+                }
+            }
+            _ => false,
+        }
+    }
+
+    /// Every user-defined type this generator names: the type itself, or the
+    /// element type when it is an array or a `List<T>`. Used to walk a
+    /// `@VintfStability` declaration's reference closure.
+    pub fn referenced_user_types(&self) -> Vec<&str> {
+        std::iter::once(&self.value_type)
+            .chain(self.array_types.iter().map(|info| &info.value_type))
+            .filter_map(|value_type| match value_type {
+                ValueType::UserDefined(name) => Some(name.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Can a `const` have this type?
+    ///
+    /// AOSP `AidlConstantDeclaration::CheckValid` admits exactly `{String,
+    /// byte, int, long, float, double}`. rsbinder deliberately allows more —
+    /// `boolean`, `char`, and constant arrays of those — and its test suite
+    /// pins that, so this enforces the part of AOSP's rule that is not an
+    /// extension: a constant's type must be one with a constant *form*.
+    ///
+    /// A handle (`IBinder`, `ParcelFileDescriptor`, `ParcelableHolder`) has no
+    /// literal to be initialized from, and a user-defined type is refused by
+    /// AOSP outright — which is also why the `@VintfStability` reference
+    /// closure need not walk constants: a constant can never name a type that
+    /// would have to be VINTF-stable.
+    pub fn is_supported_constant_type(&self) -> bool {
+        let element = match self.array_types.first() {
+            Some(info) => &info.value_type,
+            None => &self.value_type,
+        };
+        matches!(
+            element,
+            ValueType::Bool(_)
+                | ValueType::Byte(_)
+                | ValueType::Char(_)
+                | ValueType::Int32(_)
+                | ValueType::Int64(_)
+                | ValueType::Float(_)
+                | ValueType::Double(_)
+                | ValueType::String(_)
+        )
+    }
+
+    /// A bare `void`, or a `List<void>` whose element is one. Legal only as a
+    /// method return type — AOSP rejects it for parameters (`aidl_language.cpp`
+    /// `AidlMethod::CheckValid`), for field/constant declarations
+    /// (`AidlVariableDeclaration::CheckValid`), and as a `List` element
+    /// (`AidlTypeSpecifier::CheckValid`); `void[]` is rejected earlier, in
+    /// [`Self::new_with_type`], and `List<void>` in [`Self::new`].
+    pub fn is_void(&self) -> bool {
+        matches!(self.value_type, ValueType::Void)
+            || self
+                .array_types
+                .first()
+                .is_some_and(|info| matches!(info.value_type, ValueType::Void))
+    }
+
+    /// A bare `ParcelableHolder`. AOSP rejects it as a method argument, as a
+    /// method return type, and as a union member (`aidl_typenames.cpp`
+    /// `AidlTypenames::GetArgumentAspect`, which gives it an empty direction
+    /// set; `aidl_language.cpp` `AidlArgument::CheckValid`,
+    /// `AidlMethod::CheckValid`, `AidlUnionDecl::CheckValid`). The array form
+    /// is rejected earlier, in [`Self::new_with_type`], and the
+    /// `List<ParcelableHolder>` form in [`Self::new`].
+    ///
+    /// The predicate answers only "is the value type a holder", so it stays
+    /// true for a nullable one. That combination is reachable: the field-level
+    /// `@nullable ParcelableHolder` form is rejected in
+    /// [`Self::new_with_type`], but a method-level `@nullable` is applied
+    /// after construction (`generator.rs` calls [`Self::nullable_at`] on the
+    /// finished generator), and `nullable_at` rejects primitives only.
+    pub fn is_parcelable_holder(&self) -> bool {
+        matches!(self.value_type, ValueType::Holder)
+    }
+
+    /// Span of the type as written, for diagnostics raised by callers that
+    /// only hold the generator.
+    pub fn type_span(&self) -> Option<(usize, usize)> {
+        self.type_span
     }
 
     pub fn is_variable_array(&self) -> bool {

--- a/rsbinder-aidl/tests/test_annotation_lockins.rs
+++ b/rsbinder-aidl/tests/test_annotation_lockins.rs
@@ -8,8 +8,10 @@
 // specific. rsbinder-aidl matches the Rust backend's silent-ignore
 // behavior. These tests lock that in:
 //
-//   * `@FixedSize` (parcelable / union / type-param) — AOSP linter
-//     constraint; the wire format is the same as without.
+//   * `@FixedSize` (parcelable / union) — the wire format is the same as
+//     without. Note this is *recognition-only for codegen*, not for
+//     validation: `tests/test_aosp_placement_rules.rs` covers the AOSP
+//     `CanBeFixedSize` field check, which does reject contracts.
 //   * `@SensitiveData` (interface) — AOSP `generate_cpp.cpp:246` /
 //     `generate_rust.cpp:365` add `FLAG_CLEAR_BUF` to every method on
 //     the interface. rsbinder unconditionally emits `FLAG_CLEAR_BUF`
@@ -35,8 +37,11 @@ fn warnings_for(input: &str) -> Vec<String> {
 }
 
 // ---------------------------------------------------------------
-// @FixedSize — AOSP `aidl_language.cpp:189-192` — applies to
-// structured parcelable / union / type parameter; no codegen effect.
+// @FixedSize — AOSP `aidl_language.cpp` — applies to a structured
+// parcelable or union; no codegen effect. Its *field* constraint is
+// enforced separately (see `test_aosp_placement_rules.rs`); these
+// cases all satisfy it, so only the no-codegen-effect half is at
+// stake here.
 // ---------------------------------------------------------------
 
 #[test]

--- a/rsbinder-aidl/tests/test_aosp_placement_rules.rs
+++ b/rsbinder-aidl/tests/test_aosp_placement_rules.rs
@@ -1,0 +1,1042 @@
+// Copyright 2026 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Type-placement rules ported from AOSP `aidl`, and the `@deprecated`
+//! javadoc tag.
+//!
+//! The `@FixedSize` and `@VintfStability` rules are contract-level: rsbinder
+//! generates code that compiles either way, so without these checks an `.aidl`
+//! authored against rsbinder could be refused by AOSP's `aidl` — the two
+//! compilers must agree on what a valid contract is, not just on the wire
+//! format. So are the argument, return-type and union-member forms of
+//! `ParcelableHolder`. The `void` placements, the array/`List`/`@nullable`
+//! forms of `ParcelableHolder`, and the field-less `union` are not
+//! contract-level: they had no compiling Rust representation, so the check
+//! turns a rustc error in the generated crate into an AIDL diagnostic.
+//!
+//! Each rule cites the AOSP source it mirrors.
+
+use rsbinder_aidl::Builder;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Every case goes through `Builder::generate`, not `parse_document` +
+/// `Generator` directly, because only `Builder::generate` resets the parser's
+/// thread-local declaration map. Driving the generator directly leaves each
+/// case's types registered, so two cases in this file that reuse a type name
+/// resolve against each other and the suite becomes order-dependent — which
+/// `--test-threads=1` (one thread, one thread-local) would expose.
+fn run(input: &str) -> Result<String, String> {
+    static SEQ: AtomicU32 = AtomicU32::new(0);
+    let id = SEQ.fetch_add(1, Ordering::Relaxed);
+
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join(format!("placement_rules/{id}"));
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    let aidl = dir.join("Case.aidl");
+    std::fs::write(&aidl, input).expect("write aidl");
+
+    let output = PathBuf::from("case.rs");
+    match Builder::new()
+        .source(aidl)
+        .dest_dir(&dir)
+        .output(output.clone())
+        .generate()
+    {
+        Ok(()) => Ok(std::fs::read_to_string(dir.join(&output)).expect("read generated")),
+        Err(e) => Err(format!("{e}")),
+    }
+}
+
+/// Generate, expecting success, and return the rendered Rust.
+fn generate(input: &str) -> String {
+    run(input).unwrap_or_else(|e| panic!("expected generation to succeed, got {e}"))
+}
+
+/// Generate, expecting failure, and return the rendered message.
+fn expect_error(input: &str) -> String {
+    match run(input) {
+        Err(e) => e,
+        Ok(_) => panic!("expected an error, but generation succeeded"),
+    }
+}
+
+fn assert_error_contains(input: &str, needle: &str) {
+    let msg = expect_error(input);
+    assert!(
+        msg.contains(needle),
+        "expected error containing {needle:?}, got {msg:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// `void` placement — AOSP `aidl_language.cpp`:
+//   AidlTypeSpecifier::CheckValid       ("void type cannot be an array …")
+//   AidlVariableDeclaration::CheckValid ("declarations cannot be of void type")
+//   AidlMethod::CheckValid              ("'void' is an invalid type for the
+//                                        parameter …")
+// ---------------------------------------------------------------------------
+
+#[test]
+fn void_parameter_is_rejected() {
+    assert_error_contains(
+        r#"
+package test;
+interface IFoo {
+    void go(in void x);
+}
+        "#,
+        "'void' is an invalid type for the parameter 'x'",
+    );
+}
+
+#[test]
+fn void_field_is_rejected() {
+    assert_error_contains(
+        r#"
+package test;
+parcelable Foo {
+    void v;
+}
+        "#,
+        "declaration 'v' is void",
+    );
+}
+
+#[test]
+fn void_constant_is_rejected() {
+    assert_error_contains(
+        r#"
+package test;
+interface IFoo {
+    const void V = 1;
+    void go();
+}
+        "#,
+        "declaration 'V' is void",
+    );
+}
+
+#[test]
+fn void_array_is_rejected() {
+    assert_error_contains(
+        r#"
+package test;
+interface IFoo {
+    void[] go();
+}
+        "#,
+        "void type cannot be an array or nullable",
+    );
+}
+
+#[test]
+fn void_list_element_is_rejected() {
+    // A `List<T>` shares the array representation, so the `void[]` check above
+    // does not see this one. `Vec<()>` has no `DeserializeArray` counterpart:
+    // without the check the generated crate fails in rustc, not here.
+    assert_error_contains(
+        r#"
+package test;
+interface IFoo {
+    List<void> go();
+}
+        "#,
+        "List element type cannot be void",
+    );
+}
+
+#[test]
+fn void_return_type_is_accepted() {
+    let out = generate(
+        r#"
+package test;
+interface IFoo {
+    void go(in int x);
+}
+        "#,
+    );
+    assert!(out.contains("pub trait IFoo"), "{out}");
+}
+
+// ---------------------------------------------------------------------------
+// `ParcelableHolder` placement — AOSP `aidl_language.cpp`:
+//   AidlTypeSpecifier::CheckValid ("Arrays of ParcelableHolder are not
+//                                  supported", "cannot be nullable")
+//   AidlMethod::CheckValid        ("ParcelableHolder cannot be a return type")
+//   AidlUnionDecl::CheckValid     ("A union can't have a member of
+//                                  ParcelableHolder")
+//   AidlArgument::CheckValid      ("ParcelableHolder cannot be an argument
+//                                  type") — `aidl_typenames.cpp`
+//                                  `GetArgumentAspect` gives the holder an
+//                                  empty direction set.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parcelable_holder_array_is_rejected() {
+    assert_error_contains(
+        r#"
+package test;
+parcelable Foo {
+    ParcelableHolder[] hs;
+}
+        "#,
+        "arrays of ParcelableHolder are not supported",
+    );
+}
+
+#[test]
+fn parcelable_holder_list_element_is_rejected() {
+    // As with `List<void>`: the array check does not cover the `List` form,
+    // and `Vec<ParcelableHolder>` has no `SerializeArray` counterpart.
+    assert_error_contains(
+        r#"
+package test;
+parcelable Foo {
+    List<ParcelableHolder> hs;
+}
+        "#,
+        "List element type cannot be ParcelableHolder",
+    );
+}
+
+#[test]
+fn nullable_parcelable_holder_is_rejected() {
+    assert_error_contains(
+        r#"
+package test;
+parcelable Foo {
+    @nullable ParcelableHolder h;
+}
+        "#,
+        "ParcelableHolder cannot be nullable",
+    );
+}
+
+#[test]
+fn parcelable_holder_return_type_is_rejected() {
+    assert_error_contains(
+        r#"
+package test;
+interface IFoo {
+    ParcelableHolder get();
+}
+        "#,
+        "ParcelableHolder cannot be a return type",
+    );
+}
+
+#[test]
+fn parcelable_holder_union_member_is_rejected() {
+    assert_error_contains(
+        r#"
+package test;
+union Foo {
+    int a = 0;
+    ParcelableHolder h;
+}
+        "#,
+        "cannot have a member of ParcelableHolder 'h'",
+    );
+}
+
+#[test]
+fn parcelable_holder_in_parameter_is_rejected() {
+    assert_error_contains(
+        r#"
+package test;
+interface IFoo {
+    void go(in ParcelableHolder h);
+}
+        "#,
+        "ParcelableHolder cannot be an argument type ('h')",
+    );
+}
+
+#[test]
+fn parcelable_holder_out_parameter_is_rejected() {
+    // AOSP refuses every direction, not just `in`: the aspect's direction set
+    // is empty, so the check fires before the direction is ever consulted.
+    assert_error_contains(
+        r#"
+package test;
+interface IFoo {
+    void go(out ParcelableHolder h);
+}
+        "#,
+        "ParcelableHolder cannot be an argument type ('h')",
+    );
+}
+
+#[test]
+fn parcelable_holder_field_is_accepted() {
+    // The extension field of `ExtendableParcelable` — the whole point of the
+    // type — must keep working.
+    let out = generate(
+        r#"
+package test;
+parcelable Foo {
+    ParcelableHolder ext;
+    int a;
+}
+        "#,
+    );
+    assert!(out.contains("ParcelableHolder"), "{out}");
+}
+
+// ---------------------------------------------------------------------------
+// Field-less `union` — AOSP `aidl_language.cpp` `AidlUnionDecl::CheckValid`
+// ("The union '…' has no fields.").
+// ---------------------------------------------------------------------------
+
+#[test]
+fn union_without_members_is_rejected() {
+    assert_error_contains(
+        r#"
+package test;
+union Foo {
+}
+        "#,
+        "the union 'Foo' has no fields",
+    );
+}
+
+#[test]
+fn union_with_only_constants_is_rejected() {
+    // A `const` is not a field: the rendered enum would be uninhabited, so
+    // `Default::default()` has nothing to return and the `write_to_parcel`
+    // match — whose scrutinee is `&Self` — has no arm.
+    assert_error_contains(
+        r#"
+package test;
+union Foo {
+    const int A = 1;
+}
+        "#,
+        "the union 'Foo' has no fields",
+    );
+}
+
+#[test]
+fn union_with_one_field_and_a_constant_is_accepted() {
+    let out = generate(
+        r#"
+package test;
+union Foo {
+    const int A = 1;
+    int a = 0;
+}
+        "#,
+    );
+    assert!(out.contains("pub enum r#Foo"), "{out}");
+}
+
+// ---------------------------------------------------------------------------
+// `@FixedSize` — AOSP `aidl_language.cpp` `AidlParcelable::CheckValid` +
+// `aidl_typenames.cpp` `AidlTypenames::CanBeFixedSize`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fixed_size_rejects_string_field() {
+    assert_error_contains(
+        r#"
+package test;
+@FixedSize
+parcelable Foo {
+    int a = 0;
+    String s;
+}
+        "#,
+        "has a non-fixed size field named 's'",
+    );
+}
+
+#[test]
+fn fixed_size_rejects_variable_array() {
+    assert_error_contains(
+        r#"
+package test;
+@FixedSize
+parcelable Foo {
+    int[] a;
+}
+        "#,
+        "has a non-fixed size field named 'a'",
+    );
+}
+
+#[test]
+fn fixed_size_rejects_nullable_field() {
+    // `Inner` is fixed size on its own, so `@nullable` is the only violation
+    // here — the rule under test is the one that fires.
+    assert_error_contains(
+        r#"
+package test;
+@FixedSize
+parcelable Inner {
+    int x;
+}
+@FixedSize
+parcelable Foo {
+    @nullable Inner i;
+}
+        "#,
+        "has a non-fixed size field named 'i'",
+    );
+}
+
+#[test]
+fn fixed_size_rejects_non_fixed_parcelable_field() {
+    assert_error_contains(
+        r#"
+package test;
+parcelable Plain {
+    int x;
+}
+@FixedSize
+parcelable Foo {
+    Plain p;
+}
+        "#,
+        "has a non-fixed size field named 'p'",
+    );
+}
+
+#[test]
+fn fixed_size_union_is_checked_too() {
+    assert_error_contains(
+        r#"
+package test;
+@FixedSize
+union Foo {
+    int a = 0;
+    String s;
+}
+        "#,
+        "the @FixedSize union 'Foo' has a non-fixed size field named 's'",
+    );
+}
+
+#[test]
+fn fixed_size_accepts_primitives_enums_and_fixed_members() {
+    // Mirrors the AOSP `FixedSize.aidl` fixture: an enum, a fixed-size array,
+    // and a nested `@FixedSize` union are all fixed size.
+    let out = generate(
+        r#"
+package test;
+enum Kind { A = 1, B = 2 }
+@FixedSize
+union Inner {
+    int a = 0;
+    Kind k;
+}
+@FixedSize
+parcelable Foo {
+    boolean b;
+    char c;
+    double d;
+    Kind k;
+    Inner i;
+    int[3] arr;
+    int[2][3] matrix;
+}
+        "#,
+    );
+    assert!(out.contains("pub struct Foo"), "{out}");
+}
+
+#[test]
+fn fixed_size_is_not_inherited_by_nested_types() {
+    // AOSP reads `@FixedSize` with the plain `GetAnnotation`, not the scoped
+    // lookup `@VintfStability` uses, so the nested parcelable is unconstrained.
+    let out = generate(
+        r#"
+package test;
+@FixedSize
+parcelable Foo {
+    parcelable Inner {
+        String s;
+    }
+    int a;
+}
+        "#,
+    );
+    assert!(out.contains("pub struct Inner"), "{out}");
+}
+
+// ---------------------------------------------------------------------------
+// `@VintfStability` — AOSP enforces this compilation-wide via
+// `--stability vintf` (`aidl.cpp`); rsbinder enforces the reference closure
+// that rule implies. `@VintfStability` is scoped (`GetScopedAnnotation`), so a
+// nested declaration inherits it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn vintf_interface_rejects_non_vintf_parameter() {
+    assert_error_contains(
+        r#"
+package test;
+parcelable Plain {
+    int x;
+}
+@VintfStability
+interface IFoo {
+    void go(in Plain p);
+}
+        "#,
+        "references 'test.Plain', which is not @VintfStability",
+    );
+}
+
+#[test]
+fn vintf_interface_rejects_non_vintf_return_type() {
+    assert_error_contains(
+        r#"
+package test;
+parcelable Plain {
+    int x;
+}
+@VintfStability
+interface IFoo {
+    Plain go();
+}
+        "#,
+        "references 'test.Plain', which is not @VintfStability",
+    );
+}
+
+#[test]
+fn vintf_parcelable_rejects_non_vintf_field() {
+    assert_error_contains(
+        r#"
+package test;
+parcelable Plain {
+    int x;
+}
+@VintfStability
+parcelable Foo {
+    Plain f;
+}
+        "#,
+        "references 'test.Plain', which is not @VintfStability",
+    );
+}
+
+#[test]
+fn vintf_rejects_non_vintf_array_element() {
+    assert_error_contains(
+        r#"
+package test;
+enum Kind { A = 1 }
+@VintfStability
+parcelable Foo {
+    Kind[] ks;
+}
+        "#,
+        "references 'test.Kind', which is not @VintfStability",
+    );
+}
+
+#[test]
+fn vintf_closure_of_vintf_types_is_accepted() {
+    let out = generate(
+        r#"
+package test;
+@VintfStability
+parcelable Plain {
+    int x;
+}
+@VintfStability
+interface IFoo {
+    Plain go(in Plain[] p);
+}
+        "#,
+    );
+    assert!(out.contains("pub trait IFoo"), "{out}");
+}
+
+#[test]
+fn non_vintf_type_may_reference_a_vintf_type() {
+    // Only the VINTF direction is constrained.
+    let out = generate(
+        r#"
+package test;
+@VintfStability
+parcelable V {
+    int x;
+}
+interface IFoo {
+    void go(in V v);
+}
+        "#,
+    );
+    assert!(out.contains("pub trait IFoo"), "{out}");
+}
+
+#[test]
+fn builtin_types_are_not_part_of_the_vintf_closure() {
+    // `ParcelableHolder` is what a VINTF extendable parcelable exists for; it
+    // is a builtin, not a user-defined type, so it never trips the closure.
+    let out = generate(
+        r#"
+package test;
+@VintfStability
+parcelable Foo {
+    ParcelableHolder ext;
+    int a;
+    String s;
+    IBinder b;
+}
+        "#,
+    );
+    assert!(out.contains("pub struct Foo"), "{out}");
+}
+
+#[test]
+fn nested_type_inherits_vintf_stability() {
+    // AOSP `GetScopedAnnotation` walks to the enclosing type, so `Inner` is
+    // VINTF-stable without repeating the annotation — and must report that
+    // stability, which is what a `ParcelableHolder` records for it.
+    let out = generate(
+        r#"
+package test;
+@VintfStability
+parcelable Foo {
+    parcelable Inner {
+        int x;
+        ParcelableHolder ext;
+    }
+    Inner i;
+}
+        "#,
+    );
+    assert_eq!(
+        out.matches("fn stability(&self) -> rsbinder::Stability { rsbinder::Stability::Vintf }")
+            .count(),
+        2,
+        "both Foo and its nested Inner must report Vintf stability:\n{out}"
+    );
+    // The wire-visible half: the holder inside `Inner` records the inherited
+    // stability as its own byte.
+    assert_eq!(
+        out.matches("ParcelableHolder::new(rsbinder::Stability::Vintf)")
+            .count(),
+        1,
+        "nested Inner's holder must inherit Vintf stability (wire byte 1):\n{out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// `@deprecated` javadoc — AOSP `comments.cpp` `FindDeprecated` +
+// `generate_rust.cpp` `GenerateDeprecated`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deprecated_interface_and_method() {
+    let out = generate(
+        r#"
+package test;
+/** @deprecated use IBar */
+interface IFoo {
+    /** @deprecated gone in v2 */
+    void old();
+    void current();
+}
+        "#,
+    );
+    assert!(out.contains(r#"#[deprecated = "use IBar"]"#), "{out}");
+    assert!(out.contains(r#"#[deprecated = "gone in v2"]"#), "{out}");
+    // Exactly one method carries it.
+    assert_eq!(out.matches("gone in v2").count(), 1, "{out}");
+}
+
+#[test]
+fn deprecated_without_a_note_renders_bare() {
+    let out = generate(
+        r#"
+package test;
+/** @deprecated */
+parcelable Foo {
+    int a;
+}
+        "#,
+    );
+    assert!(out.contains("#[deprecated]\n"), "{out}");
+    assert!(!out.contains("#[deprecated ="), "{out}");
+}
+
+#[test]
+fn deprecated_note_spanning_lines_is_joined() {
+    let out = generate(
+        r#"
+package test;
+/**
+ * @deprecated first line
+ *     second line
+ */
+interface IFoo {
+    void go();
+}
+        "#,
+    );
+    assert!(
+        out.contains(r#"#[deprecated = "first line second line"]"#),
+        "{out}"
+    );
+}
+
+#[test]
+fn deprecated_applies_to_fields_constants_and_enumerators() {
+    let out = generate(
+        r#"
+package test;
+enum Kind {
+    A = 1,
+    /** @deprecated bad value */
+    B = 2,
+}
+parcelable Foo {
+    /** @deprecated bad field */
+    int a;
+    int b;
+}
+interface IFoo {
+    /** @deprecated bad const */
+    const int C = 1;
+    void go();
+}
+        "#,
+    );
+    assert!(out.contains(r#"#[deprecated = "bad value"]"#), "{out}");
+    assert!(out.contains(r#"#[deprecated = "bad field"]"#), "{out}");
+    assert!(out.contains(r#"#[deprecated = "bad const"]"#), "{out}");
+}
+
+#[test]
+fn deprecated_applies_to_union_and_its_members() {
+    let out = generate(
+        r#"
+package test;
+/** @deprecated old union */
+union Foo {
+    int a = 0;
+    /** @deprecated old member */
+    String s;
+}
+        "#,
+    );
+    assert!(out.contains(r#"#[deprecated = "old union"]"#), "{out}");
+    assert!(out.contains(r#"#[deprecated = "old member"]"#), "{out}");
+}
+
+#[test]
+fn deprecated_survives_intervening_annotations() {
+    // The javadoc precedes the annotations, so the item's span start (which
+    // includes them) must still find it.
+    let out = generate(
+        r#"
+package test;
+/** @deprecated annotated */
+@VintfStability
+parcelable Foo {
+    int a;
+}
+        "#,
+    );
+    assert!(out.contains(r#"#[deprecated = "annotated"]"#), "{out}");
+}
+
+#[test]
+fn a_trailing_line_comment_detaches_the_javadoc() {
+    // AOSP `GetValidComment`: only the *last* comment of the run counts, and
+    // only when it is a block comment.
+    let out = generate(
+        r#"
+package test;
+/** @deprecated ignored */
+// a line comment after the javadoc
+interface IFoo {
+    void go();
+}
+        "#,
+    );
+    assert!(!out.contains("#[deprecated"), "{out}");
+}
+
+#[test]
+fn a_block_comment_without_tags_is_not_deprecation() {
+    let out = generate(
+        r#"
+package test;
+/**
+ * Just documentation, no tags at all.
+ */
+interface IFoo {
+    void go();
+}
+        "#,
+    );
+    assert!(!out.contains("#[deprecated"), "{out}");
+}
+
+#[test]
+fn a_deprecated_looking_string_constant_is_not_a_comment() {
+    // The comment scanner must skip string literals: a `/*` inside one is
+    // data, not a comment opener. Were it treated as an opener, it would
+    // swallow the real javadoc below it up to the first `*/` and the tag
+    // would be lost.
+    let out = generate(
+        r#"
+package test;
+interface IFoo {
+    const String S = "/* oops";
+    /** @deprecated real */
+    void go();
+}
+        "#,
+    );
+    assert!(out.contains(r#"#[deprecated = "real"]"#), "{out}");
+}
+
+#[test]
+fn a_note_with_quotes_is_escaped() {
+    let out = generate(
+        r#"
+package test;
+/** @deprecated use "IBar" instead */
+interface IFoo {
+    void go();
+}
+        "#,
+    );
+    assert!(
+        out.contains(r#"#[deprecated = "use \"IBar\" instead"]"#),
+        "{out}"
+    );
+}
+
+#[test]
+fn generated_modules_allow_deprecated_internally() {
+    // The generated proxy/dispatch plumbing names the deprecated method, so
+    // the module-scoped allow has to be there or the output cannot build
+    // under `-D warnings`. It stops at the module boundary, so a consumer
+    // still sees the deprecation.
+    let out = generate(
+        r#"
+package test;
+interface IFoo {
+    /** @deprecated gone */
+    void old();
+}
+        "#,
+    );
+    assert!(out.contains(r#"#[deprecated = "gone"]"#), "{out}");
+    assert!(out.contains("deprecated)]"), "{out}");
+}
+
+// ---------------------------------------------------------------------------
+// Rules AOSP enforces that rsbinder had not ported at all. Each of these was a
+// silent divergence rather than a gap in the checks above.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn vintf_interface_declares_vintf_stability() {
+    // AOSP `generate_rust.cpp` emits `stability: …::Stability::Vintf` into
+    // `declare_binder_interface!` for a `@VintfStability` interface. Without
+    // it the binder registers with the default `System` stability, and a peer
+    // that requires VINTF refuses it — a wire-visible difference, not a
+    // cosmetic one.
+    let out = generate(
+        r#"
+package test;
+@VintfStability
+interface IFoo {
+    void go();
+}
+        "#,
+    );
+    assert!(
+        out.contains("stability: rsbinder::Stability::Vintf"),
+        "{out}"
+    );
+}
+
+#[test]
+fn non_vintf_interface_declares_no_stability() {
+    let out = generate(
+        r#"
+package test;
+interface IFoo {
+    void go();
+}
+        "#,
+    );
+    assert!(!out.contains("Stability::Vintf"), "{out}");
+}
+
+#[test]
+fn a_nested_type_resolves_against_a_grandparent_scope() {
+    // AOSP `AidlDefinedType::ResolveName` recurses through every enclosing
+    // scope. `C` is three levels deep and names `D`, which lives beside its
+    // grandparent `B` — legal AIDL that a two-level walk rejects as an
+    // unknown type.
+    let out = generate(
+        r#"
+package test;
+parcelable A {
+    parcelable D {
+        int x;
+    }
+    parcelable B {
+        parcelable C {
+            D field;
+        }
+    }
+}
+        "#,
+    );
+    assert!(out.contains("pub r#field: super::super::D::D"), "{out}");
+}
+
+#[test]
+fn duplicate_argument_name_is_rejected() {
+    // Both arguments render as the same `_arg_a` binding, so leaving this to
+    // the consumer's build surfaces it as rustc E0415 instead of an AIDL
+    // diagnostic. AOSP `AidlMethod::CheckValid` keeps an `argument_names` set.
+    assert_error_contains(
+        r#"
+package test;
+interface IFoo {
+    void m(int a, int a);
+}
+        "#,
+        "method 'm' has a duplicate argument name 'a'",
+    );
+}
+
+#[test]
+fn a_generic_on_a_non_generic_type_is_rejected() {
+    // AOSP `AidlTypeSpecifier::CheckValid`: only `List`, `Map`, and a
+    // parameterizable user-defined type take type arguments. The generic was
+    // being dropped, so `String<int>` silently became a plain `String`.
+    assert_error_contains(
+        r#"
+package test;
+parcelable Foo {
+    String<int> s;
+}
+        "#,
+        "'String' is not a generic type",
+    );
+}
+
+#[test]
+fn a_generic_user_defined_type_still_resolves() {
+    // The new gate must not touch a parameterizable parcelable — AOSP's
+    // `generic/Pair.aidl` fixture shape.
+    let out = generate(
+        r#"
+package test;
+parcelable Pair<A, B> {
+    int x;
+}
+parcelable Uses {
+    Pair<int, String> p;
+}
+        "#,
+    );
+    assert!(out.contains("pub struct Uses"), "{out}");
+}
+
+#[test]
+fn a_user_defined_constant_type_is_rejected() {
+    // AOSP `AidlConstantDeclaration::CheckValid` admits only `{String, byte,
+    // int, long, float, double}`. rsbinder keeps its `boolean`/`char`/array
+    // extensions but enforces the part that is not one — which is also what
+    // keeps a non-VINTF type out of a `@VintfStability` declaration through a
+    // constant, the one reference position the closure walk does not cover.
+    assert_error_contains(
+        r#"
+package test;
+enum Kind { A = 1 }
+@VintfStability
+interface IFoo {
+    const Kind C = Kind.A;
+    void go();
+}
+        "#,
+        "constant 'C' has an unsupported type",
+    );
+}
+
+#[test]
+fn a_binder_constant_type_is_rejected() {
+    assert_error_contains(
+        r#"
+package test;
+interface IFoo {
+    const IBinder C = 1;
+    void go();
+}
+        "#,
+        "constant 'C' has an unsupported type",
+    );
+}
+
+#[test]
+fn primitive_string_and_array_constants_still_work() {
+    // rsbinder deliberately allows more constant types than AOSP — `boolean`,
+    // `char`, and constant arrays. The narrower check must not take those away.
+    let out = generate(
+        r#"
+package test;
+interface IFoo {
+    const boolean B = true;
+    const char C = 'z';
+    const int I = 1;
+    const long L = 2;
+    const byte BY = 3;
+    const float F = 1.0f;
+    const double D = 2.0;
+    const String S = "s";
+    const int[] ARR = {1, 2, 3};
+    void go();
+}
+        "#,
+    );
+    assert!(out.contains("pub trait IFoo"), "{out}");
+}
+
+#[test]
+fn a_stable_api_parcelable_is_exempt_from_the_vintf_closure() {
+    // AOSP exempts a stable-API parcelable from the `--stability vintf` sweep
+    // (`IsStableApiParcelable`); for Rust that is `@RustOnlyStableParcelable`,
+    // whose type comes from `rust_type` and so has no declaration to annotate.
+    let out = generate(
+        r#"
+package test;
+@RustOnlyStableParcelable
+parcelable Dur rust_type "std::time::Duration";
+@VintfStability
+interface IFoo {
+    void go(in Dur d);
+}
+        "#,
+    );
+    assert!(out.contains("pub trait IFoo"), "{out}");
+}
+
+#[test]
+fn map_keeps_its_own_unsupported_diagnostic() {
+    // `Map` is generic, but it reaches the unknown-type path, and that message
+    // is the one the AOSP fixture sweep pins. The generic gate must not shadow
+    // it with "not a generic type", which would be actively misleading.
+    assert_error_contains(
+        r#"
+package test;
+parcelable Foo {
+    Map<String, int> m;
+}
+        "#,
+        "unknown type 'Map'",
+    );
+}

--- a/rsbinder-aidl/tests/test_arrays.rs
+++ b/rsbinder-aidl/tests/test_arrays.rs
@@ -40,7 +40,7 @@ parcelable StructuredParcelable {
         "##,
         r##"
 pub mod ITestService {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     pub trait ITestService: rsbinder::Interface + Send {
         fn descriptor() -> &'static str where Self: Sized { "android.aidl.fixedsizearray.ITestService" }
         fn r#ReverseBoolean(&self, _arg_input: &[bool], _arg_repeated: &mut Vec<bool>) -> rsbinder::BinderResult<Vec<bool>>;
@@ -232,7 +232,7 @@ pub mod ITestService {
     }
 }
 pub mod StructuredParcelable {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     #[derive(Debug)]
     pub struct StructuredParcelable {
         pub r#value: i32,
@@ -300,7 +300,7 @@ parcelable FixedSizeArrayExample {
         "##,
         r##"
 pub mod FixedSizeArrayExample {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     #[derive(Debug)]
     pub struct FixedSizeArrayExample {
         pub r#int2x3: [[i32; 3]; 2],
@@ -348,7 +348,7 @@ pub mod FixedSizeArrayExample {
         fn descriptor() -> &'static str { "android.aidl.fixedsizearray.FixedSizeArrayExample" }
     }
     pub mod IRepeatFixedSizeArray {
-        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
         pub trait IRepeatFixedSizeArray: rsbinder::Interface + Send {
             fn descriptor() -> &'static str where Self: Sized { "android.aidl.fixedsizearray.FixedSizeArrayExample.IRepeatFixedSizeArray" }
             fn r#Repeat2dParcelables(&self, _arg_input: &[[super::IntParcelable::IntParcelable; 3]; 2], _arg_repeated: &mut [[super::IntParcelable::IntParcelable; 3]; 2]) -> rsbinder::BinderResult<[[super::IntParcelable::IntParcelable; 3]; 2]>;
@@ -444,7 +444,7 @@ pub mod FixedSizeArrayExample {
         }
     }
     pub mod ByteEnum {
-        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
         rsbinder::declare_binder_enum! {
             r#ByteEnum : [i8; 1] {
                 r#A = 0,
@@ -452,7 +452,7 @@ pub mod FixedSizeArrayExample {
         }
     }
     pub mod IntParcelable {
-        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
         #[derive(Debug)]
         #[derive(Clone,Copy,PartialEq)]
         pub struct IntParcelable {
@@ -487,7 +487,7 @@ pub mod FixedSizeArrayExample {
         }
     }
     pub mod IEmptyInterface {
-        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
         pub trait IEmptyInterface: rsbinder::Interface + Send {
             fn descriptor() -> &'static str where Self: Sized { "android.aidl.fixedsizearray.FixedSizeArrayExample.IEmptyInterface" }
             fn getDefaultImpl() -> Option<IEmptyInterfaceDefaultRef> where Self: Sized {

--- a/rsbinder-aidl/tests/test_enum_references.rs
+++ b/rsbinder-aidl/tests/test_enum_references.rs
@@ -163,7 +163,7 @@ fn test_simple_enum_reference_in_same_enum() -> Result<(), Box<dyn Error>> {
         "##,
         r##"
 pub mod Status {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#Status : [i8; 5] {
             r#OK = 0,
@@ -202,7 +202,7 @@ fn test_enum_reference_across_enums() -> Result<(), Box<dyn Error>> {
         "##,
         r##"
 pub mod BaseEnum {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#BaseEnum : [i8; 2] {
             r#BASE_VALUE = 10,
@@ -211,7 +211,7 @@ pub mod BaseEnum {
     }
 }
 pub mod DerivedEnum {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#DerivedEnum : [i8; 4] {
             r#FROM_BASE = 10,
@@ -249,7 +249,7 @@ fn test_enum_reference_with_bitwise_operations() -> Result<(), Box<dyn Error>> {
         "##,
         r##"
 pub mod Flags {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#Flags : [i8; 5] {
             r#NONE = 0,
@@ -261,7 +261,7 @@ pub mod Flags {
     }
 }
 pub mod ExtendedFlags {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#ExtendedFlags : [i8; 3] {
             r#BASE_FLAGS = 7,
@@ -327,7 +327,7 @@ fn test_enum_reference_in_parcelable_default() -> Result<(), Box<dyn Error>> {
         "##,
         r##"
 pub mod Priority {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#Priority : [i8; 3] {
             r#LOW = 0,
@@ -337,7 +337,7 @@ pub mod Priority {
     }
 }
 pub mod Task {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     #[derive(Debug)]
     pub struct Task {
         pub r#name: String,
@@ -404,7 +404,7 @@ fn test_keymint_style_simple_reference() -> Result<(), Box<dyn Error>> {
         "##,
         r##"
 pub mod TagType {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#TagType : [i32; 3] {
             r#INVALID = 0,
@@ -414,7 +414,7 @@ pub mod TagType {
     }
 }
 pub mod Tag {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#Tag : [i32; 3] {
             r#INVALID = 0,
@@ -459,7 +459,7 @@ fn test_backing_type_annotations() -> Result<(), Box<dyn Error>> {
         "##,
         r##"
 pub mod ByteFlags {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#ByteFlags : [i8; 3] {
             r#NONE = 0,
@@ -469,7 +469,7 @@ pub mod ByteFlags {
     }
 }
 pub mod IntFlags {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#IntFlags : [i32; 4] {
             r#NONE = 0,
@@ -480,7 +480,7 @@ pub mod IntFlags {
     }
 }
 pub mod LongFlags {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#LongFlags : [i64; 3] {
             r#NONE = 0,
@@ -515,7 +515,7 @@ fn test_simple_bitwise_operations() -> Result<(), Box<dyn Error>> {
         "##,
         r##"
 pub mod BaseFlags {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#BaseFlags : [i8; 3] {
             r#NONE = 0,
@@ -525,7 +525,7 @@ pub mod BaseFlags {
     }
 }
 pub mod CombinedFlags {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#CombinedFlags : [i8; 3] {
             r#NONE = 0,

--- a/rsbinder-aidl/tests/test_enums_unions.rs
+++ b/rsbinder-aidl/tests/test_enums_unions.rs
@@ -114,7 +114,7 @@ fn test_unions() -> Result<(), Box<dyn Error>> {
             + UNION),
         r#"
 pub mod ByteEnum {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#ByteEnum : [i8; 3] {
             r#FOO = 1,
@@ -124,7 +124,7 @@ pub mod ByteEnum {
     }
 }
 pub mod Union {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     #[derive(Debug)]
     #[derive(Clone,PartialEq)]
     pub enum r#Union {
@@ -246,7 +246,7 @@ fn test_enums() -> Result<(), Box<dyn Error>> {
         BYTE_ENUM,
         r##"
 pub mod ByteEnum {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#ByteEnum : [i8; 3] {
             r#FOO = 1,
@@ -269,7 +269,7 @@ pub mod ByteEnum {
         "##,
         r##"
 pub mod BackendType {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#BackendType : [i8; 4] {
             r#CPP = 0,
@@ -286,7 +286,7 @@ pub mod BackendType {
         CONSTANT_EXPRESSION_ENUM,
         r##"
 pub mod ConstantExpressionEnum {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#ConstantExpressionEnum : [i32; 10] {
             r#decInt32_1 = 1,
@@ -309,12 +309,13 @@ pub mod ConstantExpressionEnum {
         INT_ENUM,
         r##"
 pub mod IntEnum {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#IntEnum : [i32; 4] {
             r#FOO = 1000,
             r#BAR = 2000,
             r#BAZ = 2001,
+            #[deprecated = "do not use this"]
             r#QUX = 2002,
         }
     }
@@ -326,7 +327,7 @@ pub mod IntEnum {
         LONG_ENUM,
         r##"
 pub mod LongEnum {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#LongEnum : [i64; 3] {
             r#FOO = 100000000000,
@@ -347,7 +348,7 @@ interface ITestService {
         "##),
         r##"
 pub mod ByteEnum {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#ByteEnum : [i8; 3] {
             r#FOO = 1,
@@ -357,7 +358,7 @@ pub mod ByteEnum {
     }
 }
 pub mod ITestService {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     pub trait ITestService: rsbinder::Interface + Send {
         fn descriptor() -> &'static str where Self: Sized { "ITestService" }
         fn r#RepeatByteEnum(&self, _arg_token: super::ByteEnum::ByteEnum) -> rsbinder::BinderResult<super::ByteEnum::ByteEnum>;
@@ -476,7 +477,7 @@ fn test_union_with_nested_enum() -> Result<(), Box<dyn Error>> {
         "#,
         r#"
 pub mod NestedUnion {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     #[derive(Debug)]
     pub enum r#NestedUnion {
         r#InnerField(Inner::Inner),
@@ -519,7 +520,7 @@ pub mod NestedUnion {
         }
     }
     pub mod Inner {
-        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
         rsbinder::declare_binder_enum! {
             r#Inner : [i32; 1] {
                 r#VALUE = 0,
@@ -549,7 +550,7 @@ fn test_union_with_nested_parcelable() -> Result<(), Box<dyn Error>> {
         "#,
         r#"
 pub mod OuterUnion {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     #[derive(Debug)]
     pub enum r#OuterUnion {
         r#SimpleField(i32),
@@ -602,7 +603,7 @@ pub mod OuterUnion {
         }
     }
     pub mod InnerData {
-        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
         #[derive(Debug)]
         pub struct InnerData {
             pub r#value: i32,
@@ -670,7 +671,7 @@ fn test_union_with_multiple_nested_types() -> Result<(), Box<dyn Error>> {
         "#,
         r#"
 pub mod MultiNestedUnion {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     #[derive(Debug)]
     pub enum r#MultiNestedUnion {
         r#RawValue(i32),
@@ -724,7 +725,7 @@ pub mod MultiNestedUnion {
         }
     }
     pub mod Status {
-        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
         rsbinder::declare_binder_enum! {
             r#Status : [i32; 2] {
                 r#OK = 0,
@@ -733,7 +734,7 @@ pub mod MultiNestedUnion {
         }
     }
     pub mod Metadata {
-        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
         #[derive(Debug)]
         pub struct Metadata {
             pub r#id: i32,

--- a/rsbinder-aidl/tests/test_interfaces.rs
+++ b/rsbinder-aidl/tests/test_interfaces.rs
@@ -42,7 +42,7 @@ parcelable ArrayOfInterfaces {
         "##,
         r##"
 pub mod ArrayOfInterfaces {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     #[derive(Debug)]
     pub struct ArrayOfInterfaces {
     }
@@ -70,7 +70,7 @@ pub mod ArrayOfInterfaces {
         fn descriptor() -> &'static str { "ArrayOfInterfaces" }
     }
     pub mod IEmptyInterface {
-        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
         pub trait IEmptyInterface: rsbinder::Interface + Send {
             fn descriptor() -> &'static str where Self: Sized { "ArrayOfInterfaces.IEmptyInterface" }
             fn getDefaultImpl() -> Option<IEmptyInterfaceDefaultRef> where Self: Sized {
@@ -116,7 +116,7 @@ pub mod ArrayOfInterfaces {
         }
     }
     pub mod IMyInterface {
-        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
         pub trait IMyInterface: rsbinder::Interface + Send {
             fn descriptor() -> &'static str where Self: Sized { "ArrayOfInterfaces.IMyInterface" }
             fn r#methodWithInterfaces(&self, _arg_iface: &rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>, _arg_nullable_iface: Option<&rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>, _arg_iface_array_in: &[rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>], _arg_iface_array_out: &mut Vec<Option<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>>, _arg_iface_array_inout: &mut Vec<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>, _arg_nullable_iface_array_in: Option<&[Option<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>]>, _arg_nullable_iface_array_out: &mut Option<Vec<Option<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>>>, _arg_nullable_iface_array_inout: &mut Option<Vec<Option<rsbinder::Strong<dyn super::IEmptyInterface::IEmptyInterface>>>>) -> rsbinder::BinderResult<Option<Vec<Option<String>>>>;

--- a/rsbinder-aidl/tests/test_parcelables.rs
+++ b/rsbinder-aidl/tests/test_parcelables.rs
@@ -113,7 +113,7 @@ parcelable VintfExtendableParcelable {
         "##,
         r#"
 pub mod VintfExtendableParcelable {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     #[derive(Debug)]
     pub struct VintfExtendableParcelable {
         pub r#ext: rsbinder::ParcelableHolder,
@@ -161,7 +161,7 @@ parcelable VintfParcelable {
         "##,
         r#"
 pub mod VintfParcelable {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     #[derive(Debug)]
     pub struct VintfParcelable {
         pub r#a: i32,
@@ -217,7 +217,7 @@ parcelable IServiceManager {
         "##,
         r#"
 pub mod IServiceManager {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     pub const r#DUMP_FLAG_PRIORITY_CRITICAL: i32 = 1;
     pub const r#DUMP_FLAG_PRIORITY_HIGH: i32 = 2;
     pub const r#DUMP_FLAG_PRIORITY_NORMAL: i32 = 4;
@@ -279,7 +279,7 @@ fn test_parcelable() -> Result<(), Box<dyn Error>> {
         "##,
         r#"
 pub mod ConnectionInfo {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     #[derive(Debug)]
     pub struct ConnectionInfo {
         pub r#ipAddress: String,
@@ -507,7 +507,7 @@ parcelable StructuredParcelable {
             + UNION),
         r#"
 pub mod StructuredParcelable {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     pub const r#BIT0: i32 = 1;
     pub const r#BIT1: i32 = 2;
     pub const r#BIT2: i32 = 4;
@@ -813,7 +813,7 @@ pub mod StructuredParcelable {
         fn descriptor() -> &'static str { "android.aidl.tests.StructuredParcelable" }
     }
     pub mod Empty {
-        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+        #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
         #[derive(Debug)]
         #[derive(Clone,PartialEq)]
         pub struct Empty {
@@ -844,7 +844,7 @@ pub mod StructuredParcelable {
     }
 }
 pub mod ConstantExpressionEnum {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#ConstantExpressionEnum : [i32; 10] {
             r#decInt32_1 = 1,
@@ -861,7 +861,7 @@ pub mod ConstantExpressionEnum {
     }
 }
 pub mod ByteEnum {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#ByteEnum : [i8; 3] {
             r#FOO = 1,
@@ -871,18 +871,19 @@ pub mod ByteEnum {
     }
 }
 pub mod IntEnum {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#IntEnum : [i32; 4] {
             r#FOO = 1000,
             r#BAR = 2000,
             r#BAZ = 2001,
+            #[deprecated = "do not use this"]
             r#QUX = 2002,
         }
     }
 }
 pub mod LongEnum {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, deprecated)]
     rsbinder::declare_binder_enum! {
         r#LongEnum : [i64; 3] {
             r#FOO = 100000000000,
@@ -892,7 +893,7 @@ pub mod LongEnum {
     }
 }
 pub mod Union {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     #[derive(Debug)]
     #[derive(Clone,PartialEq)]
     pub enum r#Union {
@@ -1017,7 +1018,7 @@ fn test_unstructured_parcelable() -> Result<(), Box<dyn Error>> {
         "#,
         r#"
 pub mod PersistableBundle {
-    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code)]
+    #![allow(clippy::all, unused_imports, non_upper_case_globals, non_snake_case, dead_code, deprecated)]
     pub type PersistableBundle = crate::persistable_bundle::PersistableBundle;
 }
         "#,

--- a/rsbinder/src/hub/mod.rs
+++ b/rsbinder/src/hub/mod.rs
@@ -130,6 +130,14 @@ macro_rules! impl_sm_module_body {
         /// (one attempt; not blocking). Use `wait_for_service` to block until
         /// the service appears, or `check_service` for an explicit
         /// non-blocking lookup.
+        // `getService` carries an `@deprecated` javadoc from Android 15 on
+        // ("use getService2"), which the AIDL backend renders as
+        // `#[deprecated]`. This module keeps calling it deliberately: the
+        // `Service` union `getService2` returns has a payload that varies by
+        // release train, so `servicemanager_15` never parses it (see that
+        // module's docs). Scoped to the call, not the crate, so a future
+        // deprecation elsewhere still warns.
+        #[allow(deprecated)]
         pub fn get_service(sm: &BpServiceManager, name: &str) -> Option<SIBinder> {
             match sm.getService(name) {
                 Ok(result) => result,
@@ -144,6 +152,9 @@ macro_rules! impl_sm_module_body {
         /// collapsing it to `None`, so a waiter can tell "not yet registered"
         /// (`Ok(None)`) from "service manager unreachable" (`Err`) — the
         /// distinction AOSP `realGetService` carries in its `Status`.
+        // See `get_service` for why the deprecated `getService` is the one
+        // this module calls.
+        #[allow(deprecated)]
         pub fn try_get_service(sm: &BpServiceManager, name: &str) -> Result<Option<SIBinder>> {
             sm.getService(name).map_err(|e| e.into())
         }
@@ -219,6 +230,9 @@ macro_rules! impl_sm_module_body {
             }
         }
 
+        // See `get_service` for why the deprecated `getService` is the one
+        // this module calls.
+        #[allow(deprecated)]
         pub fn get_interface<T: FromIBinder + ?Sized>(
             sm: &BpServiceManager,
             name: &str,


### PR DESCRIPTION
## Summary

Aligns what `rsbinder-aidl` accepts with what AOSP's `aidl` accepts, so an `.aidl` authored against rsbinder is one AOSP's compiler also takes, and emits the `@deprecated` javadoc tag that AOSP's Rust backend emits.

Every rule was checked against the AOSP sources (`aidl_language.cpp`, `aidl_typenames.cpp`, `aidl.cpp`, `comments.cpp`, `generate_rust.cpp`) and its golden Rust output, not from memory.

## Validation added

| Rule | AOSP source |
|---|---|
| `@FixedSize` fields must all be fixed size (not inherited by nested declarations) | `AidlTypenames::CanBeFixedSize` |
| A `@VintfStability` declaration may only reference `@VintfStability` types | `aidl.cpp` `--stability vintf` sweep |
| `ParcelableHolder` rejected as array/`List` element, `@nullable`, argument, return type, union member | `AidlTypeSpecifier`/`AidlMethod`/`AidlArgument`/`AidlUnionDecl::CheckValid` |
| `void` rejected as argument, field, constant, array/`List` element | `AidlMethod`/`AidlVariableDeclaration::CheckValid` |
| Field-less `union` rejected | `AidlUnionDecl::CheckValid` |
| Duplicate argument name rejected | `AidlMethod::CheckValid` |
| Type argument on a type that takes none (`String<int>`) rejected | `AidlTypeSpecifier::CheckValid` |
| Constant of a handle or user-defined type rejected | `AidlConstantDeclaration::CheckValid` |

AOSP enforces the `@VintfStability` rule compilation-wide through `aidl_interface { stability: "vintf" }`. rsbinder has no such mode, so it enforces the reference closure that rule implies — which fires on exactly the contracts AOSP refuses, and never on a non-VINTF type that merely uses a VINTF one. `@RustOnlyStableParcelable` is exempt, matching `IsStableApiParcelable`.

Only the `@FixedSize`, `@VintfStability` and argument/return/union forms of `ParcelableHolder` are contract-level. The rest generated Rust that never compiled, so the check turns a rustc error in the consumer's crate into an AIDL diagnostic.

rsbinder's deliberate extensions over AOSP are kept and still pinned by tests: `List<int>`, `const boolean`, `const char`, and constant arrays.

## Fixes

- **A declaration nested in a `@VintfStability` type now inherits that stability**, as AOSP's scoped annotation lookup (`GetScopedAnnotation`) does. Wire-visible: it is what a `ParcelableHolder` records for the type.
- **A `@VintfStability` interface now declares that stability to the runtime.** The generated `declare_binder_interface!` omitted the `stability:` field, so the macro fell back to `Stability::default()` — a sync service registered as `System`, and a peer requiring VINTF refused the binder. The annotation had no effect at all on the sync path.
- **The enclosing-scope walk in `lookup_decl_from_name` stopped after two levels**, so a type nested three deep could not name a type from a grandparent scope — legal AIDL that AOSP resolves, rejected here as an unknown type.

## `@deprecated` codegen

A `/** @deprecated note */` block above an interface, parcelable, union, enum, method, field, constant or enumerator becomes `#[deprecated = "note"]`, following AOSP's `FindDeprecated` rules: only the last comment of the preceding run counts, and only when it is a block comment. Generated modules carry a module-scoped `#![allow(deprecated)]` so the generated proxy and dispatch plumbing does not warn about the items it must name; callers outside the module still do.

## Breaking changes — workspace bumped to 0.12.0

`rsbinder-aidl` is a library consumed from `build.rs`, and 0.11.0 is published, so these need the 0.x breaking slot (`^0.11.0` would otherwise pull them in on a plain `cargo update`).

- **Previously accepted `.aidl` that AOSP also refuses now fails to build.** This is the one that matters most: it is a behavior change, so it reaches everyone who only calls `Builder` from a `build.rs`, not just users of the Rust API.
- `error::SemanticError` is now `#[non_exhaustive]` and gains two variants, appended so no existing variant's discriminant moves. An exhaustive `match` needs a `_` arm once; after that, a new diagnostic is a minor release.
- `render::ConstMember` and `render::EnumMember` each gain one element. These are positional tuple aliases a second front-end fills directly; the `#[non_exhaustive]` render structs gained a `deprecated` field but are built through `new()`/`Default`, so they keep compiling.
- `#[deprecated]` codegen can break a downstream `-D warnings` build.

Migration notes are in the CHANGELOG.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy -p rsbinder --all-targets --features android_15 -- -D warnings`
- `cargo test -p rsbinder-aidl` (21 binaries, including the AOSP fixture sweep; 54 new tests)
- `cargo test -p rsbinder-macros`
- `cargo fmt --all -- --check`
- `cargo build -p tests --tests` (compiles the vendored AOSP fixtures for real)

The `@VintfStability` interface fix was additionally verified by linking `rsbinder` from a throwaway crate and asserting `Binder::stability()` at runtime across all three `declare_binder_interface!` arms (plain proxy, versioned proxy-with-fields, nested interface) — a golden-string test cannot prove the macro matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Dm4bqWFSUpPsEvk1oERCN
